### PR TITLE
Manage start command in envd

### DIFF
--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"net/http"
 	"time"
 
@@ -36,7 +35,8 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	traceID := span.SpanContext().TraceID().String()
 	c.Set("traceID", traceID)
 
-	a.sandboxLogger.Info("Started creating sandbox", zap.String("instanceID", sandboxID), zap.String("teamID", team.ID.String()), zap.String("traceID", traceID))
+	sandboxLogger := a.sandboxLogger.With("instanceID", sandboxID, "teamID", team.ID.String(), "traceID", traceID)
+	sandboxLogger.Info("Started creating sandbox")
 
 	telemetry.ReportEvent(ctx, "Parsed body")
 
@@ -196,7 +196,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		attribute.String("instance.id", sandbox.SandboxID),
 	)
 
-	a.sandboxLogger.Info("Created sandbox", zap.String("instanceID", sandbox.SandboxID), zap.String("envID", env.TemplateID), zap.String("teamID", team.ID.String()), zap.String("traceID", traceID))
+	sandboxLogger.With("envID", env.TemplateID).Info("Sandbox created")
 
 	c.JSON(http.StatusCreated, &sandbox)
 }

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -3,8 +3,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logging/exporter"
-	"go.uber.org/zap/zapcore"
 	"net/http"
 	"os"
 	"time"
@@ -156,6 +154,12 @@ func NewAPIStore() *APIStore {
 
 	buildCache := builds.NewBuildCache(buildCounter)
 
+	sandboxLogger, err := logging.NewCollectorLogger()
+	if err != nil {
+		logger.Errorf("Error initializing sandbox logger\n: %v", err)
+		panic(err)
+	}
+
 	return &APIStore{
 		Ctx:             ctx,
 		orchestrator:    orch,
@@ -168,6 +172,7 @@ func NewAPIStore() *APIStore {
 		buildCache:      buildCache,
 		logger:          logger,
 		lokiClient:      lokiClient,
+		sandboxLogger:   sandboxLogger,
 	}
 }
 
@@ -320,44 +325,4 @@ func deleteInstance(
 	logger.Infof("Closed sandbox '%s' after %f seconds", info.Instance.SandboxID, duration)
 
 	return nil
-}
-
-func NewSandboxLogger() (*zap.SugaredLogger, error) {
-	cfg := zap.Config{
-		Level:    zap.NewAtomicLevelAt(zap.DebugLevel),
-		Encoding: "json",
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:       "timestamp",
-			MessageKey:    "message",
-			LevelKey:      "level",
-			EncodeLevel:   zapcore.LowercaseLevelEncoder,
-			NameKey:       "logger",
-			StacktraceKey: "stacktrace",
-		},
-	}
-
-	cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
-		// 2019-08-13T04:39:11Z
-	})
-
-	l, err := cfg.Build()
-	if err != nil {
-		return nil, fmt.Errorf("error building logger: %w", err)
-	}
-
-	// mmds is enabled, create a logger that sends logs with info from the FC's MMDS
-	var combinedLogger *zap.Logger
-
-	level := zap.DebugLevel
-
-	core := zapcore.NewCore(
-		zapcore.NewJSONEncoder(cfg.EncoderConfig),
-		zapcore.AddSync(exporter.NewHTTPLogsExporter(env.IsLocal())),
-		level,
-	)
-
-	combinedLogger = zap.New(core)
-
-	return combinedLogger.Sugar(), nil
 }

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -80,7 +80,7 @@ run-env:
 update-envd:
 	make build
 	make upload-local
-	gcloud compute ssh $$($(client)) --project $(GCP_PROJECT_ID) -- 'sudo rm -rf /fc-vm/envd && \
+	gcloud compute ssh $$($(client)) --project $(GCP_PROJECT_ID) --zone $(GCP_ZONE) -- 'sudo rm -rf /fc-vm/envd && \
 	sudo cp /mnt/disks/envs-pipeline/envd /fc-vm/envd'
 
 update-envd-locally:

--- a/packages/envd/internal/log/exporter/exporter.go
+++ b/packages/envd/internal/log/exporter/exporter.go
@@ -53,6 +53,8 @@ func printLog(logs []byte) {
 }
 
 func (w *HTTPLogsExporter) start() {
+	w.waitForMMDS()
+
 	for range w.triggers {
 		logs := w.getAllLogs()
 

--- a/packages/envd/internal/process/manager.go
+++ b/packages/envd/internal/process/manager.go
@@ -35,8 +35,8 @@ func (m *Manager) Get(id ID) (*Process, bool) {
 	return m.procs.Get(id)
 }
 
-func (m *Manager) Add(id ID, shell, cmd string, envVars *map[string]string, rootdir string) (*Process, error) {
-	proc, err := New(id, shell, cmd, envVars, rootdir, m.logger)
+func (m *Manager) Add(id ID, shell, cmd string, envVars *map[string]string, rootdir string, user string) (*Process, error) {
+	proc, err := New(id, shell, cmd, envVars, rootdir, m.logger, user)
 	if err != nil {
 		return nil, fmt.Errorf("error configuring new process with id '%s': %w", id, err)
 	}

--- a/packages/envd/internal/process/process.go
+++ b/packages/envd/internal/process/process.go
@@ -21,12 +21,17 @@ type Process struct {
 	ID     ID
 }
 
-func New(id ID, shell, cmdToExecute string, envVars *map[string]string, rootdir string, logger *zap.SugaredLogger) (*Process, error) {
+func New(id ID, shell, cmdToExecute string, envVars *map[string]string, rootdir string, logger *zap.SugaredLogger, activeUser string) (*Process, error) {
 	cmd := exec.Command(shell, "-l", "-c", cmdToExecute)
 
-	uid, gid, homedir, username, err := user.GetUser(user.DefaultUser)
+	usedUser := user.DefaultUser
+	if activeUser != "" {
+		usedUser = activeUser
+	}
+
+	uid, gid, homedir, username, err := user.GetUser(usedUser)
 	if err != nil {
-		return nil, fmt.Errorf("error getting user '%s': %w", user.DefaultUser, err)
+		return nil, fmt.Errorf("error getting user '%s': %w", usedUser, err)
 	}
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{}

--- a/packages/envd/internal/process/service.go
+++ b/packages/envd/internal/process/service.go
@@ -112,7 +112,7 @@ func (s *Service) scanRunCmdOut(pipe io.Reader, t output.OutType, process *Proce
 	}
 }
 
-func (s *Service) Start(id ID, cmd string, envVars *map[string]string, rootdir string) (ID, error) {
+func StartWithUser(s *Service, id ID, cmd string, envVars *map[string]string, rootdir string, user string) (ID, error) {
 	s.logger.Infow("Start process",
 		"processID", id,
 		"cmd", cmd,
@@ -133,7 +133,7 @@ func (s *Service) Start(id ID, cmd string, envVars *map[string]string, rootdir s
 			id = xid.New().String()
 		}
 
-		newProc, err := s.processes.Add(id, s.env.Shell, cmd, envVars, rootdir)
+		newProc, err := s.processes.Add(id, s.env.Shell, cmd, envVars, rootdir, user)
 		if err != nil {
 			s.logger.Errorw("Failed to create new process",
 				"processID", id,
@@ -290,6 +290,10 @@ func (s *Service) Start(id ID, cmd string, envVars *map[string]string, rootdir s
 	)
 
 	return proc.ID, nil
+}
+
+func (s *Service) Start(id ID, cmd string, envVars *map[string]string, rootdir string) (ID, error) {
+	return StartWithUser(s, id, cmd, envVars, rootdir, "")
 }
 
 func (s *Service) Stdin(id ID, data string) error {

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -203,7 +203,6 @@ func main() {
 	// The /file route used for downloading and uploading files via SDK.
 	router.HandleFunc("/file", createFileHandler(logger.Named("file")))
 
-	// TODO: Run the start command as root
 	// TODO: How to differentiate the start command from other running commands? Metadata? EnvVars?
 	if startCmdFlag != "" {
 		envVars := make(map[string]string)

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -203,6 +203,8 @@ func main() {
 	// The /file route used for downloading and uploading files via SDK.
 	router.HandleFunc("/file", createFileHandler(logger.Named("file")))
 
+	// TODO: Run the start command as root
+	// TODO: How to differentiate the start command from other running commands? Metadata? EnvVars?
 	if startCmdFlag != "" {
 		envVars := make(map[string]string)
 		_, err := processService.Start(startCmdID, startCmdFlag, &envVars, "/")

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -203,13 +203,9 @@ func main() {
 	// The /file route used for downloading and uploading files via SDK.
 	router.HandleFunc("/file", createFileHandler(logger.Named("file")))
 
-	// TODO: Right now the start cmd will be started during the build without access to the internet.
-	// Start the command passed via the -cmd flag.
 	if startCmdFlag != "" {
 		envVars := make(map[string]string)
 		_, err := processService.Start(startCmdID, startCmdFlag, &envVars, "/")
-		// TODO: Do we need to cache the process logs if they are not retrieved?
-		// TODO: Should we cache all process logs always?
 		if err != nil {
 			logger.Errorf(
 				"failed to start the command passed via the -cmd flag",

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -206,7 +206,8 @@ func main() {
 	// TODO: Right now the start cmd will be started during the build without access to the internet.
 	// Start the command passed via the -cmd flag.
 	if startCmdFlag != "" {
-		_, err := processService.Start(startCmdID, startCmdFlag, nil, "/")
+		envVars := make(map[string]string)
+		_, err := processService.Start(startCmdID, startCmdFlag, &envVars, "/")
 		// TODO: Do we need to cache the process logs if they are not retrieved?
 		// TODO: Should we cache all process logs always?
 		if err != nil {

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -183,20 +183,6 @@ func main() {
 		logger.Panicw("failed to register process service", "error", err)
 	}
 
-	// Start the command passed via the -cmd flag.
-	if startCmdFlag != "" {
-		_, err := processService.Start(startCmdID, startCmdFlag, nil, "/")
-		// TODO: Do we need to cache the process logs if they are not retrieved?
-		// TODO: Should we cache all process logs always?
-		if err != nil {
-			logger.Errorf(
-				"failed to start the command passed via the -cmd flag",
-				"cmd", startCmdFlag,
-				"err", err,
-			)
-		}
-	}
-
 	terminalService := terminal.NewService(logger.Named("terminal"), envConfig, clock)
 	if err := rpcServer.RegisterName("terminal", terminalService); err != nil {
 		logger.Panicw("failed to register terminal service", "error", err)
@@ -216,6 +202,21 @@ func main() {
 	router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)
 	// The /file route used for downloading and uploading files via SDK.
 	router.HandleFunc("/file", createFileHandler(logger.Named("file")))
+
+	// TODO: Right now the start cmd will be started during the build without access to the internet.
+	// Start the command passed via the -cmd flag.
+	if startCmdFlag != "" {
+		_, err := processService.Start(startCmdID, startCmdFlag, nil, "/")
+		// TODO: Do we need to cache the process logs if they are not retrieved?
+		// TODO: Should we cache all process logs always?
+		if err != nil {
+			logger.Errorf(
+				"failed to start the command passed via the -cmd flag",
+				"cmd", startCmdFlag,
+				"err", err,
+			)
+		}
+	}
 
 	server := &http.Server{
 		ReadTimeout:  serverTimeout,

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -207,7 +207,7 @@ func main() {
 	// TODO: How to differentiate the start command from other running commands? Metadata? EnvVars?
 	if startCmdFlag != "" {
 		envVars := make(map[string]string)
-		_, err := processService.Start(startCmdID, startCmdFlag, &envVars, "/")
+		_, err := process.StartWithUser(processService, startCmdID, startCmdFlag, &envVars, "/", "root")
 		if err != nil {
 			logger.Errorf(
 				"failed to start the command passed via the -cmd flag",

--- a/packages/fc-envs-disk/Makefile
+++ b/packages/fc-envs-disk/Makefile
@@ -9,4 +9,4 @@ FC_ENVS_SIZE := 512
 .PHONE: resize-fc-envs
 resize-fc-envs:
 	gcloud --project=$(GCP_PROJECT_ID) compute disks resize fc-envs --size $(FC_ENVS_SIZE) --zone "$(GCP_ZONE)"
-	gcloud compute ssh $$($(client)) --project $(GCP_PROJECT_ID) -- 'sudo xfs_growfs -d /dev/sdb'
+	gcloud compute ssh $$($(client)) --project $(GCP_PROJECT_ID) --zone $(GCP_ZONE) -- 'sudo xfs_growfs -d /dev/sdb'

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -38,6 +38,11 @@ variable "analytics_collector_host" {
   default = ""
 }
 
+variable "logs_collector_address" {
+  type    = string
+  default = ""
+}
+
 variable "analytics_collector_api_token" {
   type    = string
   default = ""
@@ -108,6 +113,7 @@ job "orchestration-api" {
         ANALYTICS_COLLECTOR_API_TOKEN = var.analytics_collector_api_token
         LOKI_ADDRESS                  = var.loki_address
         OTEL_TRACING_PRINT            = var.otel_tracing_print
+        LOGS_COLLECTOR_ADDRESS        = var.logs_collector_address
       }
 
       config {

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -63,6 +63,7 @@ resource "nomad_job" "api" {
       orchestrator_address          = "http://localhost:${var.orchestrator_port}"
       template_manager_address      = "http://localhost:${var.template_manager_port}"
       loki_address                  = "http://localhost:${var.loki_service_port.port}"
+      logs_collector_address        = "http://localhost:${var.logs_proxy_port.port}"
       gcp_zone                      = var.gcp_zone
       api_port_name                 = var.api_port.name
       api_port_number               = var.api_port.port

--- a/packages/shared/pkg/logging/collector.go
+++ b/packages/shared/pkg/logging/collector.go
@@ -1,0 +1,39 @@
+package logging
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logging/exporter"
+)
+
+func NewCollectorLogger() (*zap.SugaredLogger, error) {
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:       "timestamp",
+		MessageKey:    "message",
+		LevelKey:      "level",
+		EncodeLevel:   zapcore.LowercaseLevelEncoder,
+		NameKey:       "logger",
+		StacktraceKey: "stacktrace",
+	}
+
+	encoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
+		// 2019-08-13T04:39:11Z
+	})
+
+	level := zap.NewAtomicLevelAt(zap.InfoLevel)
+
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(encoderConfig),
+		zapcore.AddSync(exporter.NewHTTPLogsExporter(env.IsLocal())),
+		level,
+	)
+
+	logger := zap.New(core)
+
+	return logger.Sugar(), nil
+}

--- a/packages/shared/pkg/logging/exporter/exporter.go
+++ b/packages/shared/pkg/logging/exporter/exporter.go
@@ -1,0 +1,112 @@
+package exporter
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+var vectorAddress = os.Getenv("VECTOR_ADDRESS")
+
+type HTTPLogsExporter struct {
+	client   http.Client
+	triggers chan struct{}
+	logs     [][]byte
+	sync.Mutex
+	debug bool
+}
+
+func NewHTTPLogsExporter(debug bool) *HTTPLogsExporter {
+	exporter := &HTTPLogsExporter{
+		client: http.Client{
+			Timeout: 2 * time.Second,
+		},
+		triggers: make(chan struct{}, 1),
+		debug:    debug,
+	}
+
+	go exporter.start()
+
+	return exporter
+}
+
+func (w *HTTPLogsExporter) sendInstanceLogs(logs []byte, address string) error {
+	request, err := http.NewRequest("POST", address, bytes.NewBuffer(logs))
+	if err != nil {
+		return err
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := w.client.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	return nil
+}
+
+func (w *HTTPLogsExporter) start() {
+	for range w.triggers {
+		logs := w.getAllLogs()
+
+		if len(logs) == 0 {
+			continue
+		}
+
+		for _, logEntry := range logs {
+			if w.debug {
+				fmt.Printf("%v\n", string(logEntry))
+
+				continue
+			} else {
+				err := w.sendInstanceLogs(logs[0], vectorAddress)
+				if err != nil {
+					log.Fatalf("error sending logs: %v", err)
+				}
+			}
+		}
+	}
+}
+
+func (w *HTTPLogsExporter) resumeProcessing() {
+	select {
+	case w.triggers <- struct{}{}:
+	default:
+		// Exporter processing already triggered
+		// This is expected behavior if the exporter is already processing logs
+	}
+}
+
+func (w *HTTPLogsExporter) Write(logs []byte) (int, error) {
+	logsCopy := make([]byte, len(logs))
+	copy(logsCopy, logs)
+
+	go w.addLogs(logsCopy)
+
+	return len(logs), nil
+}
+
+func (w *HTTPLogsExporter) getAllLogs() [][]byte {
+	w.Lock()
+	defer w.Unlock()
+
+	logs := w.logs
+	w.logs = nil
+
+	return logs
+}
+
+func (w *HTTPLogsExporter) addLogs(logs []byte) {
+	w.Lock()
+	defer w.Unlock()
+
+	w.logs = append(w.logs, logs)
+
+	w.resumeProcessing()
+}

--- a/packages/shared/pkg/logging/exporter/exporter.go
+++ b/packages/shared/pkg/logging/exporter/exporter.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-var vectorAddress = os.Getenv("VECTOR_ADDRESS")
+var vectorAddress = os.Getenv("LOGS_COLLECTOR_ADDRESS")
 
 type HTTPLogsExporter struct {
 	client   http.Client

--- a/packages/template-manager/internal/build/provision.sh
+++ b/packages/template-manager/internal/build/provision.sh
@@ -37,7 +37,7 @@ User=root
 Group=root
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
-ExecStart=/bin/bash -l -c "/usr/bin/envd"
+ExecStart=/bin/bash -l -c "/usr/bin/envd" -cmd '{{ .StartCmd }}'"
 OOMPolicy=continue
 OOMScoreAdjust=-1000
 Environment="GOMEMLIMIT={{ .MemoryLimit }}MiB"

--- a/packages/template-manager/internal/build/provision.sh
+++ b/packages/template-manager/internal/build/provision.sh
@@ -37,7 +37,7 @@ User=root
 Group=root
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
-ExecStart=/bin/bash -l -c "/usr/bin/envd" -cmd '{{ .StartCmd }}'"
+ExecStart=/bin/bash -l -c "/usr/bin/envd -cmd '{{ .StartCmd }}'"
 OOMPolicy=continue
 OOMScoreAdjust=-1000
 Environment="GOMEMLIMIT={{ .MemoryLimit }}MiB"

--- a/packages/template-manager/internal/build/rootfs.go
+++ b/packages/template-manager/internal/build/rootfs.go
@@ -220,9 +220,9 @@ func (r *Rootfs) createRootfsFile(ctx context.Context, tracer trace.Tracer) erro
 		StartCmd    string
 		MemoryLimit int
 	}{
-		EnvID:       r.env.EnvID,
-		BuildID:     r.env.BuildID,
-		StartCmd:    strings.ReplaceAll(r.env.StartCmd, "\"", "\\\""),
+		EnvID:    r.env.EnvID,
+		BuildID:  r.env.BuildID,
+		StartCmd: strings.ReplaceAll(r.env.StartCmd, "'", "\\'"),
 		MemoryLimit: int(math.Min(float64(r.env.MemoryMB)/2, 512)),
 	})
 	if err != nil {


### PR DESCRIPTION
Right now the start cmd is managed by systemd. This PR changed it so it is managed by envd which allows us better control over it and also allows integration with logging.

Tasks
- [ ] Handle/communicate that the start cmd will be started during build without internet now
- [x] Modify old start cmd log handlers in SDKs
- [x] Permissions bug - use root for the start command
- [x] Fix start cmd not starting jupyter server (waiting...)