### PR TITLE
Fix broken provisioning for some Debian versions

### DIFF
--- a/packages/env-build-task-driver/internal/env/provision.sh
+++ b/packages/env-build-task-driver/internal/env/provision.sh
@@ -31,7 +31,7 @@ User=root
 Group=root
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
-ExecStart=/usr/bin/bash -l -c "/usr/bin/envd"
+ExecStart=/bin/bash -l -c "/usr/bin/envd"
 OOMPolicy=continue
 OOMScoreAdjust=-999
 
@@ -119,7 +119,7 @@ Type=simple
 Restart=no
 User=user
 Group=user
-ExecStart=/usr/bin/bash -l -c "{{ .StartCmd }}"
+ExecStart=/bin/bash -l -c "{{ .StartCmd }}"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- https://github.com/e2b-dev/infra/issues/73

> With some Debian versions used as the base for template the envd is not correctly started which results in SDK trying to reconnect until the timeout, then exiting.
> This problem also affects start cmd.

The problem was caused by too specific path to bash binary that was not used on some Debian versions.

- [x] Test the build