### PR TITLE
Fix upload path for FC versions

### DIFF
--- a/.github/workflows/fc-versions.yml
+++ b/.github/workflows/fc-versions.yml
@@ -34,3 +34,4 @@ jobs:
           path: "./packages/fc-versions/builds"
           destination: "${{ secrets.gcp_project_id }}-fc-versions"
           gzip: false
+          parent: false


### PR DESCRIPTION
When we ran the GHA for uploading fc-versions there was a redundant `builds/` top level directory that contained all the versioned directories. The versioned directories should have been on the top level in the bucket.

This change to GHA should fix it — the only strange thing being that we had the same code for uploading fc-kernels, but there was no incorrect `builds/` directory there.