### PR TITLE
Add placeholder stats channel for tasks

### DIFF
--- a/packages/env-build-task-driver/internal/handle.go
+++ b/packages/env-build-task-driver/internal/handle.go
@@ -3,12 +3,14 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/docker/docker/client"
 	"github.com/e2b-dev/infra/packages/env-build-task-driver/internal/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	docker "github.com/fsouza/go-dockerclient"
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/plugins/drivers"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -62,4 +64,14 @@ func (h *extraTaskHandle) Run(ctx context.Context, tracer trace.Tracer) error {
 	telemetry.ReportEvent(ctx, fmt.Sprintf("building env '%s' with build id '%s' successful", h.env.EnvID, h.env.BuildID))
 
 	return nil
+}
+
+func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
+	defer close(statsChannel)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/packages/env-build-task-driver/internal/task.go
+++ b/packages/env-build-task-driver/internal/task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 	"go.opentelemetry.io/otel/attribute"
@@ -261,4 +262,18 @@ func (de *DriverExtra) DestroyTask(_ context.Context, _ trace.Tracer, tasks *dri
 	tasks.Delete(taskID)
 
 	return nil
+}
+
+func (de *DriverExtra) TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error) {
+	h, ok := tasks.Get(taskID)
+	if !ok {
+		telemetry.ReportCriticalError(ctx, drivers.ErrTaskNotFound)
+
+		return nil, drivers.ErrTaskNotFound
+	}
+
+	statsChannel := make(chan *drivers.TaskResourceUsage)
+	go h.Extra.Stats(ctx, statsChannel, interval)
+
+	return statsChannel, nil
 }

--- a/packages/env-instance-task-driver/internal/handle.go
+++ b/packages/env-instance-task-driver/internal/handle.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/env-instance-task-driver/internal/instance"
+	"github.com/hashicorp/nomad/plugins/drivers"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -64,4 +65,14 @@ func (h *extraTaskHandle) shutdown(ctx context.Context, tracer trace.Tracer) err
 		return errMsg
 	}
 	return nil
+}
+
+func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
+	defer close(statsChannel)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
 }

--- a/packages/shared/pkg/driver/driver.go
+++ b/packages/shared/pkg/driver/driver.go
@@ -27,6 +27,7 @@ type ExtraDriver[TaskHandle HandleInterface] interface {
 	WaitTask(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string) (<-chan *drivers.ExitResult, error)
 	StopTask(ctx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string, timeout time.Duration, signal string) error
 	DestroyTask(ctx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string, force bool) error
+	TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error)
 }
 
 type Driver[Extra ExtraDriver[TaskHandle], TaskHandle HandleInterface] struct {
@@ -114,12 +115,7 @@ func (d *Driver[Extra, TaskHandle]) InspectTask(taskID string) (*drivers.TaskSta
 }
 
 func (d *Driver[Extra, TaskHandle]) TaskStats(ctx context.Context, taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error) {
-	_, ok := d.Tasks.Get(taskID)
-	if !ok {
-		return nil, drivers.ErrTaskNotFound
-	}
-
-	return nil, drivers.DriverStatsNotImplemented
+	return d.Extra.TaskStats(ctx, d.Ctx, d.Tracer, &d.Tasks, taskID, interval)
 }
 
 func (d *Driver[Extra, TaskHandle]) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {

--- a/packages/template-delete-task-driver/internal/handle.go
+++ b/packages/template-delete-task-driver/internal/handle.go
@@ -2,12 +2,14 @@ package internal
 
 import (
 	"context"
+	"time"
 
 	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storages"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/hashicorp/nomad/plugins/drivers"
 
 	"github.com/e2b-dev/infra/packages/template-delete-task-driver/internal/template"
 )
@@ -36,4 +38,14 @@ func (h *extraTaskHandle) Run(ctx context.Context, tracer trace.Tracer) error {
 	}
 
 	return nil
+}
+
+func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
+	defer close(statsChannel)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		}
+	}
 }


### PR DESCRIPTION
Right now we are not using Nomad for monitoring resource usage of tasks, but Nomad still keeps throwing errors every second even though the TaskStats if flagged as NotImplemented.