### PR TITLE
Use consul token for scraping metrics

### DIFF
--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -149,6 +149,8 @@ resource "nomad_job" "otel-collector" {
 
       grafana_api_key = data.google_secret_manager_secret_version.grafana_api_key.secret_data
 
+      consul_token = var.consul_acl_token_secret
+
       gcp_zone = var.gcp_zone
     }
   }

--- a/packages/nomad/otel-collector.hcl
+++ b/packages/nomad/otel-collector.hcl
@@ -30,6 +30,10 @@ variable "grafana_metrics_endpoint" {
   type = string
 }
 
+variable "consul_token" {
+  type = string
+}
+
 variables {
   otel_image = "otel/opentelemetry-collector-contrib:0.90.1"
 }
@@ -122,6 +126,7 @@ receivers:
             format: ['prometheus']
           consul_sd_configs:
           - services: ['nomad-client', 'nomad', 'api', 'client-proxy', 'session-proxy', 'otel-collector', 'logs-collector', 'docker-reverse-proxy']
+            token: "${var.consul_token}"
 
           relabel_configs:
           - source_labels: ['__meta_consul_tags']


### PR DESCRIPTION
Fix scraping of Consul metrics by using the Consul token in the request.