### PR TITLE
Cleanup Nomad job handling and drivers

### DIFF
--- a/packages/api/internal/nomad/client.go
+++ b/packages/api/internal/nomad/client.go
@@ -43,7 +43,17 @@ func InitNomadClient(logger *zap.SugaredLogger) *NomadClient {
 		cancel:      cancel,
 	}
 
-	go n.ListenToJobs(ctx)
+	index, err := n.GetStartingIndex(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		listenErr := n.ListenToJobs(ctx, index)
+		if listenErr != nil {
+			log.Fatalf("Error listening to Nomad jobs\n> %v\n", listenErr)
+		}
+	}()
 
 	return n
 }

--- a/packages/api/internal/nomad/client.go
+++ b/packages/api/internal/nomad/client.go
@@ -2,6 +2,7 @@ package nomad
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 )
+
+const streamRetryTime = 10 * time.Millisecond
 
 var (
 	nomadAddress = os.Getenv("NOMAD_ADDRESS")
@@ -43,10 +46,28 @@ func InitNomadClient(logger *zap.SugaredLogger) *NomadClient {
 		cancel:      cancel,
 	}
 
+	index, err := n.GetStartingIndex(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	go func() {
-		listenErr := n.ListenToJobs(ctx, 0)
-		if listenErr != nil {
-			log.Fatalf("Error listening to Nomad jobs\n> %v\n", listenErr)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				listenErr := n.ListenToJobs(ctx, index)
+				if listenErr != nil {
+					fmt.Fprintf(os.Stderr, "Error listening to Nomad jobs\n> %v\n", listenErr)
+
+					time.Sleep(streamRetryTime)
+
+					continue
+				}
+
+				return
+			}
 		}
 	}()
 

--- a/packages/api/internal/nomad/client.go
+++ b/packages/api/internal/nomad/client.go
@@ -43,13 +43,8 @@ func InitNomadClient(logger *zap.SugaredLogger) *NomadClient {
 		cancel:      cancel,
 	}
 
-	index, err := n.GetStartingIndex(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	go func() {
-		listenErr := n.ListenToJobs(ctx, index)
+		listenErr := n.ListenToJobs(ctx, 0)
 		if listenErr != nil {
 			log.Fatalf("Error listening to Nomad jobs\n> %v\n", listenErr)
 		}

--- a/packages/api/internal/nomad/jobs.go
+++ b/packages/api/internal/nomad/jobs.go
@@ -3,8 +3,7 @@ package nomad
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
+	"os"
 
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 
@@ -21,13 +20,11 @@ const (
 	jobRunningStatus = "running"
 
 	defaultTaskName = "start"
-
-	jobCheckInterval = 100 * time.Millisecond
 )
 
 type jobSubscriber struct {
 	subscribers *utils.Map[*jobSubscriber]
-	wait        chan api.AllocationListStub
+	wait        chan api.Allocation
 	jobID       string
 	taskState   string
 	taskName    string
@@ -37,11 +34,57 @@ func (s *jobSubscriber) close() {
 	s.subscribers.Remove(s.jobID)
 }
 
+func (n *NomadClient) GetStartingIndex(ctx context.Context) (uint64, error) {
+	_, meta, err := n.client.Jobs().List(nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get Nomad jobs: %w", err)
+	}
+
+	return meta.LastIndex, nil
+}
+
+func (n *NomadClient) ListenToJobs(ctx context.Context, index uint64) error {
+	topics := map[api.Topic][]string{
+		api.TopicAllocation: {"*"},
+	}
+
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	defer streamCancel()
+
+	eventCh, err := n.client.EventStream().Stream(streamCtx, topics, index, &api.QueryOptions{
+		Filter:     fmt.Sprintf("JobID contains \"%s\"", instanceJobNameWithSlash),
+		AllowStale: true,
+		Prefix:     instanceJobNameWithSlash,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get Nomad event stream: %w", err)
+	}
+
+	for event := range eventCh {
+		if event.IsHeartbeat() {
+			continue
+		}
+
+		for _, e := range event.Events {
+			alloc, allocErr := e.Allocation()
+			if allocErr != nil {
+				errMsg := fmt.Errorf("cannot retrieve allocations for '%s' job: %w", alloc.JobID, allocErr)
+				fmt.Fprint(os.Stderr, errMsg.Error())
+
+				continue
+			}
+
+			n.processAlloc(alloc)
+		}
+	}
+
+	return fmt.Errorf("nomad event stream closed")
+}
+
 func (n *NomadClient) newSubscriber(jobID, taskState, taskName string) *jobSubscriber {
 	sub := &jobSubscriber{
-		jobID: jobID,
-		// We add arbitrary buffer to the channel to avoid blocking the Nomad ListenToJobs goroutine
-		wait:        make(chan api.AllocationListStub, 10),
+		jobID:       jobID,
+		wait:        make(chan api.Allocation),
 		taskState:   taskState,
 		subscribers: n.subscribers,
 		taskName:    taskName,
@@ -52,54 +95,7 @@ func (n *NomadClient) newSubscriber(jobID, taskState, taskName string) *jobSubsc
 	return sub
 }
 
-func (n *NomadClient) ListenToJobs(ctx context.Context) {
-	ticker := time.NewTicker(jobCheckInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		// Loop with a ticker work differently than a loop with sleep.
-		// The ticker will tick every 100ms, but if the loop takes more than 100ms to run, the ticker will tick again immediately.
-		case <-ticker.C:
-			subscribers := n.subscribers.Items()
-
-			if len(subscribers) == 0 {
-				continue
-			}
-
-			filterParts := make([]string, len(subscribers))
-
-			var i int
-
-			for jobID := range subscribers {
-				filterParts[i] = jobID
-				i++
-			}
-
-			filterString := strings.Join(filterParts, "|")
-
-			allocs, _, err := n.client.Allocations().List(&api.QueryOptions{
-				Filter: fmt.Sprintf("JobID matches \"%s\"", filterString),
-			})
-			if err != nil {
-				n.logger.Errorf("Error getting jobs: %v", err)
-
-				return
-			}
-
-			for _, alloc := range allocs {
-				n.processAllocs(alloc)
-			}
-
-		case <-ctx.Done():
-			fmt.Println("Context canceled, stopping ListenToJobs")
-
-			return
-		}
-	}
-}
-
-func (n *NomadClient) processAllocs(alloc *api.AllocationListStub) {
+func (n *NomadClient) processAlloc(alloc *api.Allocation) {
 	sub, ok := n.subscribers.Get(alloc.JobID)
 
 	if !ok {
@@ -116,7 +112,7 @@ func (n *NomadClient) processAllocs(alloc *api.AllocationListStub) {
 		select {
 		case sub.wait <- *alloc:
 		default:
-			n.logger.Errorf("channel for job %s is full", alloc.JobID)
+			n.logger.Warnf("channel for job %s is full", alloc.JobID)
 		}
 	}
 
@@ -135,7 +131,7 @@ func (n *NomadClient) processAllocs(alloc *api.AllocationListStub) {
 		select {
 		case sub.wait <- *alloc:
 		default:
-			n.logger.Errorf("channel for job %s is full", alloc.JobID)
+			n.logger.Warnf("channel for job %s is full", alloc.JobID)
 		}
 	}
 }

--- a/packages/env-build-task-driver/internal/handle.go
+++ b/packages/env-build-task-driver/internal/handle.go
@@ -68,10 +68,5 @@ func (h *extraTaskHandle) Run(ctx context.Context, tracer trace.Tracer) error {
 
 func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
 	defer close(statsChannel)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		}
-	}
+	<-ctx.Done()
 }

--- a/packages/env-build-task-driver/internal/task.go
+++ b/packages/env-build-task-driver/internal/task.go
@@ -222,18 +222,17 @@ func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, 
 func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extraTaskHandle], ch chan *drivers.ExitResult) {
 	defer close(ch)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-driverCtx.Done():
-			return
-		case <-handle.Ctx.Done():
-			s := handle.TaskStatus()
-			if s.State == drivers.TaskStateExited {
-				ch <- handle.ExitResult
-			}
+	select {
+	case <-ctx.Done():
+		return
+	case <-driverCtx.Done():
+		return
+	case <-handle.Ctx.Done():
+		s := handle.TaskStatus()
+		if s.State == drivers.TaskStateExited {
+			ch <- handle.ExitResult
 		}
+		return
 	}
 }
 

--- a/packages/env-build-task-driver/internal/task.go
+++ b/packages/env-build-task-driver/internal/task.go
@@ -224,15 +224,12 @@ func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extra
 
 	select {
 	case <-ctx.Done():
-		return
 	case <-driverCtx.Done():
-		return
 	case <-handle.Ctx.Done():
 		s := handle.TaskStatus()
 		if s.State == drivers.TaskStateExited {
 			ch <- handle.ExitResult
 		}
-		return
 	}
 }
 

--- a/packages/env-build-task-driver/internal/task.go
+++ b/packages/env-build-task-driver/internal/task.go
@@ -214,23 +214,9 @@ func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, 
 	}
 
 	ch := make(chan *drivers.ExitResult)
-	go handleWait(ctx, driverCtx, handle, ch)
+	go driver.HandleWait(ctx, driverCtx, handle, ch)
 
 	return ch, nil
-}
-
-func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extraTaskHandle], ch chan *drivers.ExitResult) {
-	defer close(ch)
-
-	select {
-	case <-ctx.Done():
-	case <-driverCtx.Done():
-	case <-handle.Ctx.Done():
-		s := handle.TaskStatus()
-		if s.State == drivers.TaskStateExited {
-			ch <- handle.ExitResult
-		}
-	}
 }
 
 func (de *DriverExtra) StopTask(_ context.Context, _ trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, timeout time.Duration, signal string) error {

--- a/packages/env-instance-task-driver/Makefile
+++ b/packages/env-instance-task-driver/Makefile
@@ -38,7 +38,7 @@ update-driver-locally:
 	sudo supervisorctl restart nomad
 
 test:
-	sudo go run -race -gcflags=all="-N -l" main.go -env idnrwvs3vrde6hknozc0 -instance test-instance-1 -alive 60
+	sudo CONSUL_TOKEN=$(CONSUL_TOKEN) go run -race -gcflags=all="-N -l" main.go -env idnrwvs3vrde6hknozc0 -instance test-instance-1 -alive 2
 
 build-and-upload:
 	make build

--- a/packages/env-instance-task-driver/internal/driver.go
+++ b/packages/env-instance-task-driver/internal/driver.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
-	"github.com/txn2/txeh"
 	"go.opentelemetry.io/otel"
 
+	"github.com/e2b-dev/infra/packages/env-instance-task-driver/internal/instance"
 	"github.com/e2b-dev/infra/packages/shared/pkg/driver"
 )
 
@@ -20,7 +20,7 @@ const (
 )
 
 type DriverExtra struct {
-	hosts *txeh.Hosts
+	dns *instance.DNS
 }
 
 var (
@@ -44,14 +44,9 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 
 	configSpec := hclspec.NewObject(map[string]*hclspec.Spec{})
 
-	hosts, err := txeh.NewHostsDefault()
+	dns, err := instance.NewDNS()
 	if err != nil {
-		panic("Failed to initialize etc hosts handler")
-	}
-
-	err = hosts.Reload()
-	if err != nil {
-		panic("Failed to load etc hosts")
+		panic(err)
 	}
 
 	return &driver.Driver[*DriverExtra, *driver.TaskHandle[*extraTaskHandle]]{
@@ -67,7 +62,7 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 		TaskConfigSpec:     taskConfigSpec,
 		Tasks:              driver.NewTaskStore[*driver.TaskHandle[*extraTaskHandle]](),
 		Extra: &DriverExtra{
-			hosts: hosts,
+			dns: dns,
 		},
 	}
 }

--- a/packages/env-instance-task-driver/internal/handle.go
+++ b/packages/env-instance-task-driver/internal/handle.go
@@ -18,13 +18,11 @@ type extraTaskHandle struct {
 }
 
 func (h *extraTaskHandle) GetDriverAttributes() map[string]string {
-	return map[string]string{
-		"Pid": h.Instance.FC.Pid,
-	}
+	return map[string]string{}
 }
 
-func (h *extraTaskHandle) Run(ctx context.Context, _ trace.Tracer) error {
-	return h.Instance.FC.Machine.Wait(ctx)
+func (h *extraTaskHandle) Run(_ context.Context, _ trace.Tracer) error {
+	return h.Instance.FC.Wait()
 }
 
 func (h *extraTaskHandle) shutdown(ctx context.Context, tracer trace.Tracer) error {

--- a/packages/env-instance-task-driver/internal/handle.go
+++ b/packages/env-instance-task-driver/internal/handle.go
@@ -36,6 +36,8 @@ func (h *extraTaskHandle) Run(_ context.Context, _ trace.Tracer) error {
 		return errMsg
 	}
 
+	// TODO: Handle via wait here
+
 	for {
 		time.Sleep(processCheckInterval)
 
@@ -69,10 +71,5 @@ func (h *extraTaskHandle) shutdown(ctx context.Context, tracer trace.Tracer) err
 
 func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
 	defer close(statsChannel)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		}
-	}
+	<-ctx.Done()
 }

--- a/packages/env-instance-task-driver/internal/instance/dns.go
+++ b/packages/env-instance-task-driver/internal/instance/dns.go
@@ -1,0 +1,57 @@
+package instance
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/txn2/txeh"
+)
+
+type DNS struct {
+	hosts *txeh.Hosts
+	mu    sync.Mutex
+}
+
+func NewDNS() (*DNS, error) {
+	hosts, err := txeh.NewHostsDefault()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing etc hosts handler: %w", err)
+	}
+
+	reloadErr := hosts.Reload()
+	if reloadErr != nil {
+		return nil, fmt.Errorf("error reloading etc hosts: %w", reloadErr)
+	}
+
+	return &DNS{
+		hosts: hosts,
+	}, nil
+}
+
+func (d *DNS) Add(ips *IPSlot) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.hosts.AddHost(ips.HostSnapshotIP(), ips.InstanceID)
+
+	err := d.hosts.Save()
+	if err != nil {
+		return fmt.Errorf("error adding env instance to etc hosts: %w", err)
+	}
+
+	return nil
+}
+
+func (d *DNS) Remove(ips *IPSlot) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.hosts.RemoveHost(ips.InstanceID)
+
+	err := d.hosts.Save()
+	if err != nil {
+		return fmt.Errorf("error removing env instance to etc hosts: %w", err)
+	}
+
+	return nil
+}

--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -29,8 +29,9 @@ type MmdsMetadata struct {
 }
 
 type FC struct {
-	Cmd *exec.Cmd
-	Pid string
+	Cmd     *exec.Cmd
+	Pid     string
+	Machine *firecracker.Machine
 }
 
 func newFirecrackerClient(socketPath string) *client.Firecracker {
@@ -322,8 +323,9 @@ func startFC(
 	telemetry.ReportEvent(childCtx, "got pid for FC")
 
 	fc := &FC{
-		Cmd: cmd,
-		Pid: strconv.Itoa(pid),
+		Cmd:     cmd,
+		Pid:     strconv.Itoa(pid),
+		Machine: m,
 	}
 
 	telemetry.SetAttributes(

--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"github.com/go-openapi/strfmt"
@@ -29,9 +28,18 @@ type MmdsMetadata struct {
 }
 
 type FC struct {
-	Cmd     *exec.Cmd
-	Pid     string
-	Machine *firecracker.Machine
+	cmd            *exec.Cmd
+	stdout         *io.PipeReader
+	stderr         *io.PipeReader
+	uffdSocketPath *string
+	metadata       *MmdsMetadata
+	ctx            context.Context
+	socketPath     string
+	envPath        string
+}
+
+func (fc *FC) Wait() error {
+	return fc.cmd.Wait()
 }
 
 func newFirecrackerClient(socketPath string) *client.Firecracker {
@@ -43,7 +51,7 @@ func newFirecrackerClient(socketPath string) *client.Firecracker {
 	return httpClient
 }
 
-func loadSnapshot(
+func (fc *FC) loadSnapshot(
 	ctx context.Context,
 	tracer trace.Tracer,
 	socketPath,
@@ -72,7 +80,7 @@ func loadSnapshot(
 	var backend *models.MemoryBackend
 
 	if uffdSocketPath != nil {
-		err := waitForSocket(*uffdSocketPath, socketReadyCheckInterval)
+		err := waitForSocket(*uffdSocketPath, socketWaitTimeout)
 		if err != nil {
 			telemetry.ReportCriticalError(childCtx, err)
 
@@ -128,14 +136,13 @@ func loadSnapshot(
 	return nil
 }
 
-func startFC(
+func NewFC(
 	ctx context.Context,
 	tracer trace.Tracer,
-	allocID string,
 	slot *IPSlot,
 	fsEnv *InstanceFiles,
 	mmdsMetadata *MmdsMetadata,
-) (*FC, error) {
+) *FC {
 	childCtx, childSpan := tracer.Start(ctx, "initialize-fc", trace.WithAttributes(
 		attribute.String("instance.id", slot.InstanceID),
 		attribute.Int("instance.slot.index", slot.SlotIdx),
@@ -194,21 +201,40 @@ func startFC(
 	cmd.Stderr = cmdStdoutWriter
 	cmd.Stdout = cmdStderrWriter
 
+	return &FC{
+		cmd:            cmd,
+		stdout:         cmdStdoutReader,
+		stderr:         cmdStderrReader,
+		ctx:            vmmCtx,
+		socketPath:     fsEnv.SocketPath,
+		envPath:        fsEnv.EnvPath,
+		metadata:       mmdsMetadata,
+		uffdSocketPath: fsEnv.UFFDSocketPath,
+	}
+}
+
+func (fc *FC) Start(
+	ctx context.Context,
+	tracer trace.Tracer,
+) error {
+	childCtx, childSpan := tracer.Start(ctx, "start-fc")
+	defer childSpan.End()
+
 	go func() {
 		defer func() {
-			readerErr := cmdStdoutReader.Close()
+			readerErr := fc.stdout.Close()
 			if readerErr != nil {
 				errMsg := fmt.Errorf("error closing vmm stdout reader: %w", readerErr)
-				telemetry.ReportError(vmmCtx, errMsg)
+				telemetry.ReportError(fc.ctx, errMsg)
 			}
 		}()
 
-		scanner := bufio.NewScanner(cmdStdoutReader)
+		scanner := bufio.NewScanner(fc.stdout)
 
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			telemetry.ReportEvent(vmmCtx, "vmm log",
+			telemetry.ReportEvent(fc.ctx, "vmm log",
 				attribute.String("type", "stdout"),
 				attribute.String("message", line),
 			)
@@ -217,79 +243,68 @@ func startFC(
 		readerErr := scanner.Err()
 		if readerErr != nil {
 			errMsg := fmt.Errorf("error reading vmm stdout: %w", readerErr)
-			telemetry.ReportError(vmmCtx, errMsg)
+			telemetry.ReportError(fc.ctx, errMsg)
 		} else {
-			telemetry.ReportEvent(vmmCtx, "vmm stdout reader closed")
+			telemetry.ReportEvent(fc.ctx, "vmm stdout reader closed")
 		}
 	}()
 
 	go func() {
 		defer func() {
-			readerErr := cmdStderrReader.Close()
+			readerErr := fc.stderr.Close()
 			if readerErr != nil {
 				errMsg := fmt.Errorf("error closing vmm stdout reader: %w", readerErr)
-				telemetry.ReportError(vmmCtx, errMsg)
+				telemetry.ReportError(fc.ctx, errMsg)
 			}
 		}()
 
-		scanner := bufio.NewScanner(cmdStderrReader)
+		scanner := bufio.NewScanner(fc.stderr)
 
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			telemetry.ReportEvent(vmmCtx, "vmm log",
+			telemetry.ReportEvent(fc.ctx, "vmm log",
 				attribute.String("type", "stderr"),
 				attribute.String("message", line),
 			)
 		}
 
-		readerErr := cmdStderrReader.Close()
+		readerErr := fc.stderr.Close()
 		if readerErr != nil {
 			errMsg := fmt.Errorf("error closing vmm stderr reader: %w", readerErr)
-			telemetry.ReportError(vmmCtx, errMsg)
+			telemetry.ReportError(fc.ctx, errMsg)
 		}
 	}()
 
-	prebootFcConfig := firecracker.Config{
-		DisableValidation: true,
-		SocketPath:        fsEnv.SocketPath,
-	}
-
-	m, err := firecracker.NewMachine(vmmCtx, prebootFcConfig, firecracker.WithProcessRunner(cmd))
+	err := fc.cmd.Start()
 	if err != nil {
-		errMsg := fmt.Errorf("failed creating machine: %w", err)
+		errMsg := fmt.Errorf("error starting fc process: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
 
-		return nil, errMsg
+		return errMsg
 	}
 
-	telemetry.ReportEvent(childCtx, "created vmm")
+	telemetry.ReportEvent(childCtx, "started fc process")
 
-	m.Handlers.Validation = m.Handlers.Validation.Clear()
-	m.Handlers.FcInit = m.Handlers.FcInit.Clear().
-		Append(
-			firecracker.StartVMMHandler,
-		)
-
-	err = m.Handlers.Run(childCtx, m)
+	// Wait for the FC process to start so we can use FC API
+	err = waitForSocket(fc.socketPath, socketWaitTimeout)
 	if err != nil {
-		errMsg := fmt.Errorf("failed to start preboot FC: %w", err)
-		telemetry.ReportCriticalError(childCtx, errMsg)
+		errMsg := fmt.Errorf("error waiting for fc socket: %w", err)
 
-		return nil, errMsg
+		return errMsg
 	}
 
-	telemetry.ReportEvent(childCtx, "started FC in preboot")
+	telemetry.ReportEvent(childCtx, "fc process created socket")
 
-	if err := loadSnapshot(
+	if err := fc.loadSnapshot(
 		childCtx,
 		tracer,
-		fsEnv.SocketPath,
-		fsEnv.EnvPath,
-		mmdsMetadata,
-		fsEnv.UFFDSocketPath,
+		fc.socketPath,
+		fc.envPath,
+		fc.metadata,
+		fc.uffdSocketPath,
 	); err != nil {
-		stopErr := m.StopVMM()
+		stopErr := fc.Stop(childCtx, tracer)
 		if stopErr != nil {
 			telemetry.ReportError(childCtx, fmt.Errorf("error stopping vmm: %w", stopErr))
 		}
@@ -297,14 +312,14 @@ func startFC(
 		errMsg := fmt.Errorf("failed to load snapshot: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
 
-		return nil, errMsg
+		return errMsg
 	}
 
 	telemetry.ReportEvent(childCtx, "loaded snapshot")
 
 	defer func() {
 		if err != nil {
-			stopErr := m.StopVMM()
+			stopErr := fc.Stop(childCtx, tracer)
 			if stopErr != nil {
 				errMsg := fmt.Errorf("error stopping machine after error: %w", stopErr)
 				telemetry.ReportError(childCtx, errMsg)
@@ -312,48 +327,28 @@ func startFC(
 		}
 	}()
 
-	pid, errpid := m.PID()
-	if errpid != nil {
-		errMsg := fmt.Errorf("failed getting pid for machine: %w", errpid)
-		telemetry.ReportCriticalError(childCtx, errMsg)
-
-		return nil, errMsg
-	}
-
-	telemetry.ReportEvent(childCtx, "got pid for FC")
-
-	fc := &FC{
-		Cmd:     cmd,
-		Pid:     strconv.Itoa(pid),
-		Machine: m,
-	}
-
 	telemetry.SetAttributes(
 		childCtx,
-		attribute.String("alloc.id", allocID),
-		attribute.String("instance.pid", fc.Pid),
-		attribute.String("instance.socket.path", fsEnv.SocketPath),
-		attribute.String("instance.env.id", mmdsMetadata.EnvID),
-		attribute.String("instance.env.path", fsEnv.EnvPath),
-		attribute.String("instance.build_dir.path", fsEnv.BuildDirPath),
-		attribute.String("instance.cmd", fc.Cmd.String()),
-		attribute.String("instance.cmd.dir", fc.Cmd.Dir),
-		attribute.String("instance.cmd.path", fc.Cmd.Path),
+		attribute.String("instance.socket.path", fc.socketPath),
+		attribute.String("instance.env.id", fc.metadata.EnvID),
+		attribute.String("instance.env.path", fc.envPath),
+		attribute.String("instance.cmd", fc.cmd.String()),
+		attribute.String("instance.cmd.dir", fc.cmd.Dir),
+		attribute.String("instance.cmd.path", fc.cmd.Path),
 	)
 
-	return fc, nil
+	return nil
 }
 
 func (fc *FC) Stop(ctx context.Context, tracer trace.Tracer) error {
 	childCtx, childSpan := tracer.Start(ctx, "stop-fc", trace.WithAttributes(
-		attribute.String("instance.pid", fc.Pid),
-		attribute.String("instance.cmd", fc.Cmd.String()),
-		attribute.String("instance.cmd.dir", fc.Cmd.Dir),
-		attribute.String("instance.cmd.path", fc.Cmd.Path),
+		attribute.String("instance.cmd", fc.cmd.String()),
+		attribute.String("instance.cmd.dir", fc.cmd.Dir),
+		attribute.String("instance.cmd.path", fc.cmd.Path),
 	))
 	defer childSpan.End()
 
-	err := fc.Cmd.Process.Kill()
+	err := fc.cmd.Process.Kill()
 	if err != nil {
 		errMsg := fmt.Errorf("failed to send KILL to FC process: %w", err)
 

--- a/packages/env-instance-task-driver/internal/instance/mock_instance.go
+++ b/packages/env-instance-task-driver/internal/instance/mock_instance.go
@@ -3,14 +3,13 @@ package instance
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/txn2/txeh"
 	"go.opentelemetry.io/otel"
 )
 
-func MockInstance(envID, instanceID string, keepAlive time.Duration) {
+func MockInstance(envID, instanceID, consulToken string, keepAlive time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
 	defer cancel()
 
@@ -30,7 +29,7 @@ func MockInstance(envID, instanceID string, keepAlive time.Duration) {
 			InstanceID:            instanceID,
 			TraceID:               "test",
 			TeamID:                "test",
-			ConsulToken:           os.Getenv("CONSUL_TOKEN"),
+			ConsulToken:           consulToken,
 			LogsProxyAddress:      "",
 			NodeID:                "testtesttest",
 			EnvsDisk:              "/mnt/disks/fc-envs/v1",

--- a/packages/env-instance-task-driver/internal/instance/mock_instance.go
+++ b/packages/env-instance-task-driver/internal/instance/mock_instance.go
@@ -5,23 +5,20 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/txn2/txeh"
 	"go.opentelemetry.io/otel"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-func MockInstance(envID, instanceID, consulToken string, keepAlive time.Duration) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+func MockInstance(envID, instanceID, consulToken string, dns *DNS, keepAlive time.Duration) {
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), telemetry.DebugID, instanceID), time.Minute*3)
 	defer cancel()
 
-	tracer := otel.Tracer("test")
-
-	hosts, err := txeh.NewHostsDefault()
-	if err != nil {
-		panic("Failed to initialize etc hosts handler")
-	}
+	tracer := otel.Tracer(fmt.Sprintf("instance-%s", instanceID))
+	childCtx, _ := tracer.Start(ctx, "mock-instance")
 
 	instance, err := NewInstance(
-		ctx,
+		childCtx,
 		tracer,
 		&InstanceConfig{
 			EnvID:                 envID,
@@ -41,7 +38,7 @@ func MockInstance(envID, instanceID, consulToken string, keepAlive time.Duration
 			HugePages:             true,
 			FirecrackerBinaryPath: "/fc-versions/v1.7.0-dev_8bb88311/firecracker",
 		},
-		hosts,
+		dns,
 	)
 	if err != nil {
 		panic(err)
@@ -51,9 +48,9 @@ func MockInstance(envID, instanceID, consulToken string, keepAlive time.Duration
 
 	time.Sleep(keepAlive)
 
-	defer instance.CleanupAfterFCStop(ctx, tracer, hosts)
+	defer instance.CleanupAfterFCStop(childCtx, tracer, dns)
 
-	err = instance.FC.Stop(ctx, tracer)
+	err = instance.FC.Stop(childCtx, tracer)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/env-instance-task-driver/internal/instance/slot.go
+++ b/packages/env-instance-task-driver/internal/instance/slot.go
@@ -34,8 +34,6 @@ type IPSlot struct {
 	SlotIdx     int
 }
 
-const slotCheckWaitTime = 2
-
 func (ips *IPSlot) VpeerName() string {
 	return "eth0"
 }

--- a/packages/env-instance-task-driver/internal/task.go
+++ b/packages/env-instance-task-driver/internal/task.go
@@ -288,9 +288,7 @@ func handleWait(ctx context.Context, driverCtx context.Context, handle *driver.T
 
 	select {
 	case <-ctx.Done():
-		return
 	case <-driverCtx.Done():
-		return
 	case <-handle.Exited:
 		ch <- handle.TaskStatus().ExitResult.Copy()
 	}

--- a/packages/env-instance-task-driver/internal/task.go
+++ b/packages/env-instance-task-driver/internal/task.go
@@ -65,10 +65,17 @@ var taskConfigSpec = hclspec.NewObject(map[string]*hclspec.Spec{
 	"ConsulToken": hclspec.NewAttr("ConsulToken", "string", true),
 })
 
-func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
-	ctx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], logger hclog.Logger,
+func (de *DriverExtra) StartTask(
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	logger hclog.Logger,
+	cfg *drivers.TaskConfig,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
 ) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
-	ctx, span := tracer.Start(ctx, "start-env-instance-task-validation", trace.WithAttributes(
+	bgContext, bgCancel := context.WithCancel(driverCtx)
+	defer bgCancel()
+
+	ctx, span := tracer.Start(bgContext, "start-env-instance-task-validation", trace.WithAttributes(
 		attribute.String("alloc.id", cfg.AllocID),
 	))
 	defer span.End()
@@ -132,8 +139,11 @@ func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
 		return nil, nil, errMsg
 	}
 
+	runContext, cancelRunContext := context.WithCancel(driverCtx)
+
 	h := &driver.TaskHandle[*extraTaskHandle]{
-		Ctx:        childCtx,
+		Ctx:        runContext,
+		Cancel:     cancelRunContext,
 		TaskConfig: cfg,
 		TaskState:  drivers.TaskStateRunning,
 		StartedAt:  time.Now().Round(time.Millisecond),
@@ -171,13 +181,26 @@ func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
 
 	tasks.Set(cfg.ID, h)
 
-	go h.Run(context.Background(), tracer)
+	go func() {
+		defer cancelRunContext()
+		h.Run(runContext, tracer)
+	}()
 
 	return handle, nil, nil
 }
 
-func (de *DriverExtra) WaitTask(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string) (<-chan *drivers.ExitResult, error) {
-	validationCtx, validationSpan := tracer.Start(ctx, "wait-env-instance-task-validation", trace.WithAttributes(
+func (de *DriverExtra) WaitTask(
+	ctx,
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+) (<-chan *drivers.ExitResult, error) {
+	bgContext, bgCancel := context.WithCancel(ctx)
+	defer bgCancel()
+
+	validationCtx, validationSpan := tracer.Start(bgContext, "wait-env-instance-task-validation", trace.WithAttributes(
 		attribute.String("task.id", taskID),
 	))
 	defer validationSpan.End()
@@ -188,7 +211,7 @@ func (de *DriverExtra) WaitTask(ctx context.Context, driverCtx context.Context, 
 		return nil, drivers.ErrTaskNotFound
 	}
 
-	childCtx, childSpan := tracer.Start(ctx, "wait-env-instance-task",
+	_, childSpan := tracer.Start(ctx, "wait-env-instance-task",
 		trace.WithAttributes(
 			attribute.String("task.id", taskID),
 		),
@@ -200,13 +223,24 @@ func (de *DriverExtra) WaitTask(ctx context.Context, driverCtx context.Context, 
 	defer childSpan.End()
 
 	ch := make(chan *drivers.ExitResult)
-	go driver.HandleWait(childCtx, driverCtx, handle, ch)
+	go driver.HandleWait(ctx, driverCtx, handle, ch)
 
 	return ch, nil
 }
 
-func (de *DriverExtra) StopTask(ctx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, timeout time.Duration, signal string) error {
-	ctx, span := tracer.Start(ctx, "stop-env-instance-task-validation", trace.WithAttributes(
+func (de *DriverExtra) StopTask(
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	timeout time.Duration,
+	signal string,
+) error {
+	bgContext, bgCancel := context.WithCancel(driverCtx)
+	defer bgCancel()
+
+	ctx, span := tracer.Start(bgContext, "stop-env-instance-task-validation", trace.WithAttributes(
 		attribute.String("task.id", taskID),
 	))
 	defer span.End()
@@ -238,8 +272,18 @@ func (de *DriverExtra) StopTask(ctx context.Context, tracer trace.Tracer, tasks 
 	return nil
 }
 
-func (de *DriverExtra) DestroyTask(ctx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, force bool) error {
-	ctx, span := tracer.Start(ctx, "destroy-env-instance-task-validation", trace.WithAttributes(
+func (de *DriverExtra) DestroyTask(
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	force bool,
+) error {
+	bgContext, bgCancel := context.WithCancel(driverCtx)
+	defer bgCancel()
+
+	ctx, span := tracer.Start(bgContext, "destroy-env-instance-task-validation", trace.WithAttributes(
 		attribute.String("task.id", taskID),
 	))
 	defer span.End()
@@ -283,8 +327,16 @@ func (de *DriverExtra) DestroyTask(ctx context.Context, tracer trace.Tracer, tas
 	return nil
 }
 
-func (de *DriverExtra) TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error) {
-	h, ok := tasks.Get(taskID)
+func (de *DriverExtra) TaskStats(
+	ctx,
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	interval time.Duration,
+) (<-chan *structs.TaskResourceUsage, error) {
+	_, ok := tasks.Get(taskID)
 	if !ok {
 		telemetry.ReportCriticalError(ctx, drivers.ErrTaskNotFound)
 
@@ -292,7 +344,7 @@ func (de *DriverExtra) TaskStats(ctx context.Context, driverCtx context.Context,
 	}
 
 	statsChannel := make(chan *drivers.TaskResourceUsage)
-	go h.Extra.Stats(ctx, statsChannel, interval)
+	go driver.Stats(ctx, driverCtx, statsChannel, interval)
 
 	return statsChannel, nil
 }

--- a/packages/env-instance-task-driver/internal/task.go
+++ b/packages/env-instance-task-driver/internal/task.go
@@ -128,7 +128,7 @@ func (de *DriverExtra) StartTask(
 			UFFDBinaryPath:        filepath.Join(cfg.Env["FC_VERSIONS_DIR"], taskConfig.FirecrackerVersion, cfg.Env["UFFD_BINARY_NAME"]),
 			FirecrackerBinaryPath: filepath.Join(cfg.Env["FC_VERSIONS_DIR"], taskConfig.FirecrackerVersion, cfg.Env["FC_BINARY_NAME"]),
 		},
-		de.hosts,
+		de.dns,
 	)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to create instance: %w", err)
@@ -169,7 +169,7 @@ func (de *DriverExtra) StartTask(
 			telemetry.ReportError(childCtx, errMsg)
 		}
 
-		instance.CleanupAfterFCStop(childCtx, tracer, de.hosts)
+		instance.CleanupAfterFCStop(childCtx, tracer, de.dns)
 
 		errMsg := fmt.Errorf("failed to set driver state: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
@@ -317,7 +317,7 @@ func (de *DriverExtra) DestroyTask(
 		telemetry.ReportEvent(childCtx, "shutdown task")
 	}
 
-	h.Extra.Instance.CleanupAfterFCStop(childCtx, tracer, de.hosts)
+	h.Extra.Instance.CleanupAfterFCStop(childCtx, tracer, de.dns)
 
 	telemetry.ReportEvent(childCtx, "cleanup after FC stop")
 

--- a/packages/env-instance-task-driver/main.go
+++ b/packages/env-instance-task-driver/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
@@ -44,7 +45,9 @@ func main() {
 
 	if *envID != "" && *instanceID != "" {
 		// Start of mock build for testing
-		instance.MockInstance(*envID, *instanceID, time.Duration(*keepAlive)*time.Second)
+		consulToken := os.Getenv("CONSUL_TOKEN")
+
+		instance.MockInstance(*envID, *instanceID, consulToken, time.Duration(*keepAlive)*time.Second)
 	} else {
 		configurePlugin()
 	}

--- a/packages/shared/pkg/driver/driver.go
+++ b/packages/shared/pkg/driver/driver.go
@@ -23,11 +23,11 @@ type (
 )
 
 type ExtraDriver[TaskHandle HandleInterface] interface {
-	StartTask(cfg *drivers.TaskConfig, ctx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger) (*drivers.TaskHandle, *drivers.DriverNetwork, error)
-	WaitTask(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string) (<-chan *drivers.ExitResult, error)
-	StopTask(ctx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string, timeout time.Duration, signal string) error
-	DestroyTask(ctx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], logger hclog.Logger, taskID string, force bool) error
-	TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *TaskStore[TaskHandle], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error)
+	StartTask(driverCtx context.Context, tracer trace.Tracer, logger hclog.Logger, cfg *drivers.TaskConfig, tasks *TaskStore[TaskHandle]) (*drivers.TaskHandle, *drivers.DriverNetwork, error)
+	WaitTask(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, logger hclog.Logger, tasks *TaskStore[TaskHandle], taskID string) (<-chan *drivers.ExitResult, error)
+	StopTask(driverCtx context.Context, tracer trace.Tracer, logger hclog.Logger, tasks *TaskStore[TaskHandle], taskID string, timeout time.Duration, signal string) error
+	DestroyTask(driverCtx context.Context, tracer trace.Tracer, logger hclog.Logger, tasks *TaskStore[TaskHandle], taskID string, force bool) error
+	TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, logger hclog.Logger, tasks *TaskStore[TaskHandle], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error)
 }
 
 type Driver[Extra ExtraDriver[TaskHandle], TaskHandle HandleInterface] struct {
@@ -89,19 +89,19 @@ func (d *Driver[Extra, TaskHandle]) RecoverTask(handle *drivers.TaskHandle) erro
 }
 
 func (d *Driver[Extra, TaskHandle]) StartTask(config *drivers.TaskConfig) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
-	return d.Extra.StartTask(config, d.Ctx, d.Tracer, &d.Tasks, d.Logger)
+	return d.Extra.StartTask(d.Ctx, d.Tracer, d.Logger, config, &d.Tasks)
 }
 
 func (d *Driver[Extra, TaskHandle]) WaitTask(ctx context.Context, taskID string) (<-chan *drivers.ExitResult, error) {
-	return d.Extra.WaitTask(ctx, d.Ctx, d.Tracer, &d.Tasks, d.Logger, taskID)
+	return d.Extra.WaitTask(ctx, d.Ctx, d.Tracer, d.Logger, &d.Tasks, taskID)
 }
 
 func (d *Driver[Extra, TaskHandle]) StopTask(taskID string, timeout time.Duration, signal string) error {
-	return d.Extra.StopTask(d.Ctx, d.Tracer, &d.Tasks, d.Logger, taskID, timeout, signal)
+	return d.Extra.StopTask(d.Ctx, d.Tracer, d.Logger, &d.Tasks, taskID, timeout, signal)
 }
 
 func (d *Driver[Extra, TaskHandle]) DestroyTask(taskID string, force bool) error {
-	return d.Extra.DestroyTask(d.Ctx, d.Tracer, &d.Tasks, d.Logger, taskID, force)
+	return d.Extra.DestroyTask(d.Ctx, d.Tracer, d.Logger, &d.Tasks, taskID, force)
 }
 
 func (d *Driver[Extra, TaskHandle]) InspectTask(taskID string) (*drivers.TaskStatus, error) {
@@ -115,7 +115,7 @@ func (d *Driver[Extra, TaskHandle]) InspectTask(taskID string) (*drivers.TaskSta
 }
 
 func (d *Driver[Extra, TaskHandle]) TaskStats(ctx context.Context, taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error) {
-	return d.Extra.TaskStats(ctx, d.Ctx, d.Tracer, &d.Tasks, taskID, interval)
+	return d.Extra.TaskStats(ctx, d.Ctx, d.Tracer, d.Logger, &d.Tasks, taskID, interval)
 }
 
 func (d *Driver[Extra, TaskHandle]) TaskEvents(ctx context.Context) (<-chan *drivers.TaskEvent, error) {

--- a/packages/shared/pkg/driver/handle.go
+++ b/packages/shared/pkg/driver/handle.go
@@ -95,3 +95,14 @@ func (h *TaskHandle[Extra]) Run(ctx context.Context, tracer trace.Tracer) {
 
 	h.handleResult(nil)
 }
+
+func HandleWait[Extra extraTaskHandle](ctx, driverCtx context.Context, handle *TaskHandle[Extra], ch chan *drivers.ExitResult) {
+	defer close(ch)
+
+	select {
+	case <-ctx.Done():
+	case <-driverCtx.Done():
+	case <-handle.Exited:
+		ch <- handle.TaskStatus().ExitResult.Copy()
+	}
+}

--- a/packages/shared/pkg/driver/handle.go
+++ b/packages/shared/pkg/driver/handle.go
@@ -106,3 +106,11 @@ func HandleWait[Extra extraTaskHandle](ctx, driverCtx context.Context, handle *T
 		ch <- handle.TaskStatus().ExitResult.Copy()
 	}
 }
+
+func Stats(ctx, driverCtx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
+	defer close(statsChannel)
+	select {
+	case <-ctx.Done():
+	case <-driverCtx.Done():
+	}
+}

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -12,15 +12,40 @@ import (
 
 var OTELTracingPrint = os.Getenv("OTEL_TRACING_PRINT") != "false"
 
+const DebugID = "debug_id"
+
+func getDebugID(ctx context.Context) *string {
+	if ctx.Value(DebugID) == nil {
+		return nil
+	}
+
+	value := ctx.Value(DebugID).(string)
+
+	return &value
+}
+
+func debugFormat(debugID *string, msg string) string {
+	if debugID == nil {
+		return msg
+	}
+
+	return fmt.Sprintf("[%s] %s", *debugID, msg)
+}
+
 func SetAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Printf("No attrs set")
+			msg = "No attrs set"
 		} else {
-			fmt.Printf("Attrs set: %v\n", attrs)
+			msg = fmt.Sprintf("Attrs set: %#v\n", attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Print(debugFormat(debugID, msg))
 	}
 
 	span.SetAttributes(attrs...)
@@ -30,11 +55,16 @@ func ReportEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) 
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Printf("-> %s\n", name)
+			msg = fmt.Sprintf("-> %s\n", name)
 		} else {
-			fmt.Printf("-> %s - %v\n", name, attrs)
+			msg = fmt.Sprintf("-> %s - %#v\n", name, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Print(debugFormat(debugID, msg))
 	}
 
 	span.AddEvent(name,
@@ -46,11 +76,16 @@ func ReportCriticalError(ctx context.Context, err error, attrs ...attribute.KeyV
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Fprintf(os.Stderr, "Critical error: %v\n", err)
+			msg = fmt.Sprintf("Critical error: %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Critical error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Critical error: %v - %#v\n", err, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Fprint(os.Stderr, debugFormat(debugID, msg))
 	}
 
 	span.RecordError(err,
@@ -67,11 +102,16 @@ func ReportError(ctx context.Context, err error, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			msg = fmt.Sprintf("Error: %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Error: %v - %#v\n", err, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Fprint(os.Stderr, debugFormat(debugID, msg))
 	}
 
 	span.RecordError(err,

--- a/packages/template-delete-task-driver/internal/handle.go
+++ b/packages/template-delete-task-driver/internal/handle.go
@@ -2,14 +2,12 @@ package internal
 
 import (
 	"context"
-	"time"
 
 	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storages"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
-	"github.com/hashicorp/nomad/plugins/drivers"
 
 	"github.com/e2b-dev/infra/packages/template-delete-task-driver/internal/template"
 )
@@ -38,9 +36,4 @@ func (h *extraTaskHandle) Run(ctx context.Context, tracer trace.Tracer) error {
 	}
 
 	return nil
-}
-
-func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
-	defer close(statsChannel)
-	<-ctx.Done()
 }

--- a/packages/template-delete-task-driver/internal/handle.go
+++ b/packages/template-delete-task-driver/internal/handle.go
@@ -42,10 +42,5 @@ func (h *extraTaskHandle) Run(ctx context.Context, tracer trace.Tracer) error {
 
 func (h *extraTaskHandle) Stats(ctx context.Context, statsChannel chan *drivers.TaskResourceUsage, interval time.Duration) {
 	defer close(statsChannel)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		}
-	}
+	<-ctx.Done()
 }

--- a/packages/template-delete-task-driver/internal/task.go
+++ b/packages/template-delete-task-driver/internal/task.go
@@ -161,23 +161,9 @@ func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, 
 	}
 
 	ch := make(chan *drivers.ExitResult)
-	go handleWait(ctx, driverCtx, handle, ch)
+	go driver.HandleWait(ctx, driverCtx, handle, ch)
 
 	return ch, nil
-}
-
-func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extraTaskHandle], ch chan *drivers.ExitResult) {
-	defer close(ch)
-
-	select {
-	case <-ctx.Done():
-	case <-driverCtx.Done():
-	case <-handle.Ctx.Done():
-		s := handle.TaskStatus()
-		if s.State == drivers.TaskStateExited {
-			ch <- handle.ExitResult
-		}
-	}
 }
 
 func (de *DriverExtra) StopTask(_ context.Context, _ trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, timeout time.Duration, signal string) error {

--- a/packages/template-delete-task-driver/internal/task.go
+++ b/packages/template-delete-task-driver/internal/task.go
@@ -43,10 +43,17 @@ type (
 	}
 )
 
-func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
-	driverCtx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], logger hclog.Logger,
+func (de *DriverExtra) StartTask(
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	logger hclog.Logger,
+	cfg *drivers.TaskConfig,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
 ) (*drivers.TaskHandle, *drivers.DriverNetwork, error) {
-	ctx, span := tracer.Start(driverCtx, "start-task-validation", trace.WithAttributes(
+	bgContext, bgCancel := context.WithCancel(driverCtx)
+	defer bgCancel()
+
+	ctx, span := tracer.Start(bgContext, "start-task-validation", trace.WithAttributes(
 		attribute.String("alloc.id", cfg.AllocID),
 	))
 	defer span.End()
@@ -140,7 +147,6 @@ func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
 
 	go func() {
 		defer cancel()
-		h.Cancel = cancel
 
 		deleteContext, childDeleteSpan := tracer.Start(
 			trace.ContextWithSpanContext(cancellableContext, childSpan.SpanContext()),
@@ -154,7 +160,14 @@ func (de *DriverExtra) StartTask(cfg *drivers.TaskConfig,
 	return handle, nil, nil
 }
 
-func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string) (<-chan *drivers.ExitResult, error) {
+func (de *DriverExtra) WaitTask(
+	ctx,
+	driverCtx context.Context,
+	_ trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+) (<-chan *drivers.ExitResult, error) {
 	handle, ok := tasks.Get(taskID)
 	if !ok {
 		return nil, drivers.ErrTaskNotFound
@@ -166,7 +179,15 @@ func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, 
 	return ch, nil
 }
 
-func (de *DriverExtra) StopTask(_ context.Context, _ trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, timeout time.Duration, signal string) error {
+func (de *DriverExtra) StopTask(
+	_ context.Context,
+	_ trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	timeout time.Duration,
+	signal string,
+) error {
 	handle, ok := tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
@@ -177,7 +198,14 @@ func (de *DriverExtra) StopTask(_ context.Context, _ trace.Tracer, tasks *driver
 	return nil
 }
 
-func (de *DriverExtra) DestroyTask(_ context.Context, _ trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], _ hclog.Logger, taskID string, force bool) error {
+func (de *DriverExtra) DestroyTask(
+	_ context.Context,
+	_ trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	force bool,
+) error {
 	handle, ok := tasks.Get(taskID)
 	if !ok {
 		return drivers.ErrTaskNotFound
@@ -198,8 +226,16 @@ func (de *DriverExtra) DestroyTask(_ context.Context, _ trace.Tracer, tasks *dri
 	return nil
 }
 
-func (de *DriverExtra) TaskStats(ctx context.Context, driverCtx context.Context, tracer trace.Tracer, tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]], taskID string, interval time.Duration) (<-chan *structs.TaskResourceUsage, error) {
-	h, ok := tasks.Get(taskID)
+func (de *DriverExtra) TaskStats(
+	ctx context.Context,
+	driverCtx context.Context,
+	tracer trace.Tracer,
+	_ hclog.Logger,
+	tasks *driver.TaskStore[*driver.TaskHandle[*extraTaskHandle]],
+	taskID string,
+	interval time.Duration,
+) (<-chan *structs.TaskResourceUsage, error) {
+	_, ok := tasks.Get(taskID)
 	if !ok {
 		telemetry.ReportCriticalError(ctx, drivers.ErrTaskNotFound)
 
@@ -207,7 +243,7 @@ func (de *DriverExtra) TaskStats(ctx context.Context, driverCtx context.Context,
 	}
 
 	statsChannel := make(chan *drivers.TaskResourceUsage)
-	go h.Extra.Stats(ctx, statsChannel, interval)
+	go driver.Stats(ctx, driverCtx, statsChannel, interval)
 
 	return statsChannel, nil
 }

--- a/packages/template-delete-task-driver/internal/task.go
+++ b/packages/template-delete-task-driver/internal/task.go
@@ -169,18 +169,17 @@ func (de *DriverExtra) WaitTask(ctx, driverCtx context.Context, _ trace.Tracer, 
 func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extraTaskHandle], ch chan *drivers.ExitResult) {
 	defer close(ch)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-driverCtx.Done():
-			return
-		case <-handle.Ctx.Done():
-			s := handle.TaskStatus()
-			if s.State == drivers.TaskStateExited {
-				ch <- handle.ExitResult
-			}
+	select {
+	case <-ctx.Done():
+		return
+	case <-driverCtx.Done():
+		return
+	case <-handle.Ctx.Done():
+		s := handle.TaskStatus()
+		if s.State == drivers.TaskStateExited {
+			ch <- handle.ExitResult
 		}
+		return
 	}
 }
 

--- a/packages/template-delete-task-driver/internal/task.go
+++ b/packages/template-delete-task-driver/internal/task.go
@@ -171,15 +171,12 @@ func handleWait(ctx, driverCtx context.Context, handle *driver.TaskHandle[*extra
 
 	select {
 	case <-ctx.Done():
-		return
 	case <-driverCtx.Done():
-		return
 	case <-handle.Ctx.Done():
 		s := handle.TaskStatus()
 		if s.State == drivers.TaskStateExited {
 			ch <- handle.ExitResult
 		}
-		return
 	}
 }
 


### PR DESCRIPTION
The sudden restarts we are sometimes experiencing may be connected to how we are using Nomad. This PR should improve that.

- [x] Check that incomplete cleanup and 502 errors is not caused by this change