### PR TITLE
Use Nomad stream for getting job allocations

### DIFF
--- a/packages/api/internal/nomad/client.go
+++ b/packages/api/internal/nomad/client.go
@@ -43,7 +43,17 @@ func InitNomadClient(logger *zap.SugaredLogger) *NomadClient {
 		cancel:      cancel,
 	}
 
-	go n.ListenToJobs(ctx)
+	index, err := n.GetStartingIndex(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		listenErr := n.ListenToJobs(ctx, index)
+		if listenErr != nil {
+			log.Fatalf("Error listening to Nomad jobs\n> %v\n", listenErr)
+		}
+	}()
 
 	return n
 }

--- a/packages/api/internal/nomad/jobs.go
+++ b/packages/api/internal/nomad/jobs.go
@@ -83,9 +83,8 @@ func (n *NomadClient) ListenToJobs(ctx context.Context, index uint64) error {
 
 func (n *NomadClient) newSubscriber(jobID, taskState, taskName string) *jobSubscriber {
 	sub := &jobSubscriber{
-		jobID: jobID,
-		// We add arbitrary buffer to the channel to avoid blocking the Nomad ListenToJobs goroutine
-		wait:        make(chan api.Allocation, 10),
+		jobID:       jobID,
+		wait:        make(chan api.Allocation),
 		taskState:   taskState,
 		subscribers: n.subscribers,
 		taskName:    taskName,
@@ -113,7 +112,7 @@ func (n *NomadClient) processAlloc(alloc *api.Allocation) {
 		select {
 		case sub.wait <- *alloc:
 		default:
-			n.logger.Errorf("channel for job %s is full", alloc.JobID)
+			n.logger.Warnf("channel for job %s is full", alloc.JobID)
 		}
 	}
 
@@ -132,7 +131,7 @@ func (n *NomadClient) processAlloc(alloc *api.Allocation) {
 		select {
 		case sub.wait <- *alloc:
 		default:
-			n.logger.Errorf("channel for job %s is full", alloc.JobID)
+			n.logger.Warnf("channel for job %s is full", alloc.JobID)
 		}
 	}
 }

--- a/packages/api/internal/nomad/jobs.go
+++ b/packages/api/internal/nomad/jobs.go
@@ -78,7 +78,7 @@ func (n *NomadClient) ListenToJobs(ctx context.Context, index uint64) error {
 		}
 	}
 
-	return nil
+	return fmt.Errorf("nomad event stream closed")
 }
 
 func (n *NomadClient) newSubscriber(jobID, taskState, taskName string) *jobSubscriber {


### PR DESCRIPTION
Switch from polling Nomad to using stream. This improves API/Nomad performance when handling multiple sandbox requests.

- [ ] Check long term stream performance