### PR TITLE
Fix data races in Nomad driver during sandbox start

### DIFF
--- a/packages/env-instance-task-driver/internal/driver.go
+++ b/packages/env-instance-task-driver/internal/driver.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
-	"github.com/txn2/txeh"
 	"go.opentelemetry.io/otel"
 
+	"github.com/e2b-dev/infra/packages/env-instance-task-driver/internal/instance"
 	"github.com/e2b-dev/infra/packages/shared/pkg/driver"
 )
 
@@ -20,7 +20,7 @@ const (
 )
 
 type DriverExtra struct {
-	hosts *txeh.Hosts
+	dns *instance.DNS
 }
 
 var (
@@ -44,14 +44,9 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 
 	configSpec := hclspec.NewObject(map[string]*hclspec.Spec{})
 
-	hosts, err := txeh.NewHostsDefault()
+	dns, err := instance.NewDNS()
 	if err != nil {
-		panic("Failed to initialize etc hosts handler")
-	}
-
-	err = hosts.Reload()
-	if err != nil {
-		panic("Failed to load etc hosts")
+		panic(err)
 	}
 
 	return &driver.Driver[*DriverExtra, *driver.TaskHandle[*extraTaskHandle]]{
@@ -67,7 +62,7 @@ func NewPlugin(logger hclog.Logger) drivers.DriverPlugin {
 		TaskConfigSpec:     taskConfigSpec,
 		Tasks:              driver.NewTaskStore[*driver.TaskHandle[*extraTaskHandle]](),
 		Extra: &DriverExtra{
-			hosts: hosts,
+			dns: dns,
 		},
 	}
 }

--- a/packages/env-instance-task-driver/internal/handle.go
+++ b/packages/env-instance-task-driver/internal/handle.go
@@ -18,13 +18,11 @@ type extraTaskHandle struct {
 }
 
 func (h *extraTaskHandle) GetDriverAttributes() map[string]string {
-	return map[string]string{
-		"Pid": h.Instance.FC.Pid,
-	}
+	return map[string]string{}
 }
 
-func (h *extraTaskHandle) Run(ctx context.Context, _ trace.Tracer) error {
-	return h.Instance.FC.Machine.Wait(ctx)
+func (h *extraTaskHandle) Run(_ context.Context, _ trace.Tracer) error {
+	return h.Instance.FC.Wait()
 }
 
 func (h *extraTaskHandle) shutdown(ctx context.Context, tracer trace.Tracer) error {

--- a/packages/env-instance-task-driver/internal/instance/dns.go
+++ b/packages/env-instance-task-driver/internal/instance/dns.go
@@ -1,0 +1,57 @@
+package instance
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/txn2/txeh"
+)
+
+type DNS struct {
+	hosts *txeh.Hosts
+	mu    sync.Mutex
+}
+
+func NewDNS() (*DNS, error) {
+	hosts, err := txeh.NewHostsDefault()
+	if err != nil {
+		return nil, fmt.Errorf("error initializing etc hosts handler: %w", err)
+	}
+
+	reloadErr := hosts.Reload()
+	if reloadErr != nil {
+		return nil, fmt.Errorf("error reloading etc hosts: %w", reloadErr)
+	}
+
+	return &DNS{
+		hosts: hosts,
+	}, nil
+}
+
+func (d *DNS) Add(ips *IPSlot) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.hosts.AddHost(ips.HostSnapshotIP(), ips.InstanceID)
+
+	err := d.hosts.Save()
+	if err != nil {
+		return fmt.Errorf("error adding env instance to etc hosts: %w", err)
+	}
+
+	return nil
+}
+
+func (d *DNS) Remove(ips *IPSlot) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.hosts.RemoveHost(ips.InstanceID)
+
+	err := d.hosts.Save()
+	if err != nil {
+		return fmt.Errorf("error removing env instance to etc hosts: %w", err)
+	}
+
+	return nil
+}

--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"github.com/go-openapi/strfmt"
@@ -29,9 +28,18 @@ type MmdsMetadata struct {
 }
 
 type FC struct {
-	Cmd     *exec.Cmd
-	Pid     string
-	Machine *firecracker.Machine
+	cmd            *exec.Cmd
+	stdout         *io.PipeReader
+	stderr         *io.PipeReader
+	uffdSocketPath *string
+	metadata       *MmdsMetadata
+	ctx            context.Context
+	socketPath     string
+	envPath        string
+}
+
+func (fc *FC) Wait() error {
+	return fc.cmd.Wait()
 }
 
 func newFirecrackerClient(socketPath string) *client.Firecracker {
@@ -43,7 +51,7 @@ func newFirecrackerClient(socketPath string) *client.Firecracker {
 	return httpClient
 }
 
-func loadSnapshot(
+func (fc *FC) loadSnapshot(
 	ctx context.Context,
 	tracer trace.Tracer,
 	socketPath,
@@ -128,14 +136,13 @@ func loadSnapshot(
 	return nil
 }
 
-func startFC(
+func NewFC(
 	ctx context.Context,
 	tracer trace.Tracer,
-	allocID string,
 	slot *IPSlot,
 	fsEnv *InstanceFiles,
 	mmdsMetadata *MmdsMetadata,
-) (*FC, error) {
+) *FC {
 	childCtx, childSpan := tracer.Start(ctx, "initialize-fc", trace.WithAttributes(
 		attribute.String("instance.id", slot.InstanceID),
 		attribute.Int("instance.slot.index", slot.SlotIdx),
@@ -194,21 +201,40 @@ func startFC(
 	cmd.Stderr = cmdStdoutWriter
 	cmd.Stdout = cmdStderrWriter
 
+	return &FC{
+		cmd:            cmd,
+		stdout:         cmdStdoutReader,
+		stderr:         cmdStderrReader,
+		ctx:            vmmCtx,
+		socketPath:     fsEnv.SocketPath,
+		envPath:        fsEnv.EnvPath,
+		metadata:       mmdsMetadata,
+		uffdSocketPath: fsEnv.UFFDSocketPath,
+	}
+}
+
+func (fc *FC) Start(
+	ctx context.Context,
+	tracer trace.Tracer,
+) error {
+	childCtx, childSpan := tracer.Start(ctx, "start-fc")
+	defer childSpan.End()
+
 	go func() {
 		defer func() {
-			readerErr := cmdStdoutReader.Close()
+			readerErr := fc.stdout.Close()
 			if readerErr != nil {
 				errMsg := fmt.Errorf("error closing vmm stdout reader: %w", readerErr)
-				telemetry.ReportError(vmmCtx, errMsg)
+				telemetry.ReportError(fc.ctx, errMsg)
 			}
 		}()
 
-		scanner := bufio.NewScanner(cmdStdoutReader)
+		scanner := bufio.NewScanner(fc.stdout)
 
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			telemetry.ReportEvent(vmmCtx, "vmm log",
+			telemetry.ReportEvent(fc.ctx, "vmm log",
 				attribute.String("type", "stdout"),
 				attribute.String("message", line),
 			)
@@ -217,79 +243,68 @@ func startFC(
 		readerErr := scanner.Err()
 		if readerErr != nil {
 			errMsg := fmt.Errorf("error reading vmm stdout: %w", readerErr)
-			telemetry.ReportError(vmmCtx, errMsg)
+			telemetry.ReportError(fc.ctx, errMsg)
 		} else {
-			telemetry.ReportEvent(vmmCtx, "vmm stdout reader closed")
+			telemetry.ReportEvent(fc.ctx, "vmm stdout reader closed")
 		}
 	}()
 
 	go func() {
 		defer func() {
-			readerErr := cmdStderrReader.Close()
+			readerErr := fc.stderr.Close()
 			if readerErr != nil {
 				errMsg := fmt.Errorf("error closing vmm stdout reader: %w", readerErr)
-				telemetry.ReportError(vmmCtx, errMsg)
+				telemetry.ReportError(fc.ctx, errMsg)
 			}
 		}()
 
-		scanner := bufio.NewScanner(cmdStderrReader)
+		scanner := bufio.NewScanner(fc.stderr)
 
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			telemetry.ReportEvent(vmmCtx, "vmm log",
+			telemetry.ReportEvent(fc.ctx, "vmm log",
 				attribute.String("type", "stderr"),
 				attribute.String("message", line),
 			)
 		}
 
-		readerErr := cmdStderrReader.Close()
+		readerErr := fc.stderr.Close()
 		if readerErr != nil {
 			errMsg := fmt.Errorf("error closing vmm stderr reader: %w", readerErr)
-			telemetry.ReportError(vmmCtx, errMsg)
+			telemetry.ReportError(fc.ctx, errMsg)
 		}
 	}()
 
-	prebootFcConfig := firecracker.Config{
-		DisableValidation: true,
-		SocketPath:        fsEnv.SocketPath,
-	}
-
-	m, err := firecracker.NewMachine(vmmCtx, prebootFcConfig, firecracker.WithProcessRunner(cmd))
+	err := fc.cmd.Start()
 	if err != nil {
-		errMsg := fmt.Errorf("failed creating machine: %w", err)
+		errMsg := fmt.Errorf("error starting fc process: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
 
-		return nil, errMsg
+		return errMsg
 	}
 
-	telemetry.ReportEvent(childCtx, "created vmm")
+	telemetry.ReportEvent(childCtx, "started fc process")
 
-	m.Handlers.Validation = m.Handlers.Validation.Clear()
-	m.Handlers.FcInit = m.Handlers.FcInit.Clear().
-		Append(
-			firecracker.StartVMMHandler,
-		)
-
-	err = m.Handlers.Run(childCtx, m)
+	// Wait for the FC process to start so we can use FC API
+	err = waitForSocket(fc.socketPath, socketWaitTimeout)
 	if err != nil {
-		errMsg := fmt.Errorf("failed to start preboot FC: %w", err)
-		telemetry.ReportCriticalError(childCtx, errMsg)
+		errMsg := fmt.Errorf("error waiting for fc socket: %w", err)
 
-		return nil, errMsg
+		return errMsg
 	}
 
-	telemetry.ReportEvent(childCtx, "started FC in preboot")
+	telemetry.ReportEvent(childCtx, "fc process created socket")
 
-	if err := loadSnapshot(
+	if err := fc.loadSnapshot(
 		childCtx,
 		tracer,
-		fsEnv.SocketPath,
-		fsEnv.EnvPath,
-		mmdsMetadata,
-		fsEnv.UFFDSocketPath,
+		fc.socketPath,
+		fc.envPath,
+		fc.metadata,
+		fc.uffdSocketPath,
 	); err != nil {
-		stopErr := m.StopVMM()
+		stopErr := fc.Stop(childCtx, tracer)
 		if stopErr != nil {
 			telemetry.ReportError(childCtx, fmt.Errorf("error stopping vmm: %w", stopErr))
 		}
@@ -297,14 +312,14 @@ func startFC(
 		errMsg := fmt.Errorf("failed to load snapshot: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
 
-		return nil, errMsg
+		return errMsg
 	}
 
 	telemetry.ReportEvent(childCtx, "loaded snapshot")
 
 	defer func() {
 		if err != nil {
-			stopErr := m.StopVMM()
+			stopErr := fc.Stop(childCtx, tracer)
 			if stopErr != nil {
 				errMsg := fmt.Errorf("error stopping machine after error: %w", stopErr)
 				telemetry.ReportError(childCtx, errMsg)
@@ -312,48 +327,28 @@ func startFC(
 		}
 	}()
 
-	pid, errpid := m.PID()
-	if errpid != nil {
-		errMsg := fmt.Errorf("failed getting pid for machine: %w", errpid)
-		telemetry.ReportCriticalError(childCtx, errMsg)
-
-		return nil, errMsg
-	}
-
-	telemetry.ReportEvent(childCtx, "got pid for FC")
-
-	fc := &FC{
-		Cmd:     cmd,
-		Pid:     strconv.Itoa(pid),
-		Machine: m,
-	}
-
 	telemetry.SetAttributes(
 		childCtx,
-		attribute.String("alloc.id", allocID),
-		attribute.String("instance.pid", fc.Pid),
-		attribute.String("instance.socket.path", fsEnv.SocketPath),
-		attribute.String("instance.env.id", mmdsMetadata.EnvID),
-		attribute.String("instance.env.path", fsEnv.EnvPath),
-		attribute.String("instance.build_dir.path", fsEnv.BuildDirPath),
-		attribute.String("instance.cmd", fc.Cmd.String()),
-		attribute.String("instance.cmd.dir", fc.Cmd.Dir),
-		attribute.String("instance.cmd.path", fc.Cmd.Path),
+		attribute.String("instance.socket.path", fc.socketPath),
+		attribute.String("instance.env.id", fc.metadata.EnvID),
+		attribute.String("instance.env.path", fc.envPath),
+		attribute.String("instance.cmd", fc.cmd.String()),
+		attribute.String("instance.cmd.dir", fc.cmd.Dir),
+		attribute.String("instance.cmd.path", fc.cmd.Path),
 	)
 
-	return fc, nil
+	return nil
 }
 
 func (fc *FC) Stop(ctx context.Context, tracer trace.Tracer) error {
 	childCtx, childSpan := tracer.Start(ctx, "stop-fc", trace.WithAttributes(
-		attribute.String("instance.pid", fc.Pid),
-		attribute.String("instance.cmd", fc.Cmd.String()),
-		attribute.String("instance.cmd.dir", fc.Cmd.Dir),
-		attribute.String("instance.cmd.path", fc.Cmd.Path),
+		attribute.String("instance.cmd", fc.cmd.String()),
+		attribute.String("instance.cmd.dir", fc.cmd.Dir),
+		attribute.String("instance.cmd.path", fc.cmd.Path),
 	))
 	defer childSpan.End()
 
-	err := fc.Cmd.Process.Kill()
+	err := fc.cmd.Process.Kill()
 	if err != nil {
 		errMsg := fmt.Errorf("failed to send KILL to FC process: %w", err)
 

--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -72,7 +72,7 @@ func loadSnapshot(
 	var backend *models.MemoryBackend
 
 	if uffdSocketPath != nil {
-		err := waitForSocket(*uffdSocketPath, socketReadyCheckInterval)
+		err := waitForSocket(*uffdSocketPath, socketWaitTimeout)
 		if err != nil {
 			telemetry.ReportCriticalError(childCtx, err)
 

--- a/packages/env-instance-task-driver/internal/instance/instance.go
+++ b/packages/env-instance-task-driver/internal/instance/instance.go
@@ -10,7 +10,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 
-	"github.com/txn2/txeh"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -52,7 +51,7 @@ func NewInstance(
 	ctx context.Context,
 	tracer trace.Tracer,
 	config *InstanceConfig,
-	hosts *txeh.Hosts,
+	dns *DNS,
 ) (*Instance, error) {
 	childCtx, childSpan := tracer.Start(ctx, "new-instance")
 	defer childSpan.End()
@@ -91,7 +90,7 @@ func NewInstance(
 
 	defer func() {
 		if err != nil {
-			ntErr := ips.RemoveNetwork(childCtx, tracer, hosts)
+			ntErr := ips.RemoveNetwork(childCtx, tracer, dns)
 			if ntErr != nil {
 				errMsg := fmt.Errorf("error removing network namespace after failed instance start: %w", ntErr)
 				telemetry.ReportError(childCtx, errMsg)
@@ -101,7 +100,7 @@ func NewInstance(
 		}
 	}()
 
-	err = ips.CreateNetwork(childCtx, tracer, hosts)
+	err = ips.CreateNetwork(childCtx, tracer, dns)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to create namespaces: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
@@ -239,12 +238,12 @@ syncLoop:
 func (i *Instance) CleanupAfterFCStop(
 	ctx context.Context,
 	tracer trace.Tracer,
-	hosts *txeh.Hosts,
+	dns *DNS,
 ) {
 	childCtx, childSpan := tracer.Start(ctx, "delete-instance")
 	defer childSpan.End()
 
-	err := i.Slot.RemoveNetwork(childCtx, tracer, hosts)
+	err := i.Slot.RemoveNetwork(childCtx, tracer, dns)
 	if err != nil {
 		errMsg := fmt.Errorf("cannot remove network when destroying task: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)

--- a/packages/env-instance-task-driver/internal/task.go
+++ b/packages/env-instance-task-driver/internal/task.go
@@ -128,7 +128,7 @@ func (de *DriverExtra) StartTask(
 			UFFDBinaryPath:        filepath.Join(cfg.Env["FC_VERSIONS_DIR"], taskConfig.FirecrackerVersion, cfg.Env["UFFD_BINARY_NAME"]),
 			FirecrackerBinaryPath: filepath.Join(cfg.Env["FC_VERSIONS_DIR"], taskConfig.FirecrackerVersion, cfg.Env["FC_BINARY_NAME"]),
 		},
-		de.hosts,
+		de.dns,
 	)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to create instance: %w", err)
@@ -169,7 +169,7 @@ func (de *DriverExtra) StartTask(
 			telemetry.ReportError(childCtx, errMsg)
 		}
 
-		instance.CleanupAfterFCStop(childCtx, tracer, de.hosts)
+		instance.CleanupAfterFCStop(childCtx, tracer, de.dns)
 
 		errMsg := fmt.Errorf("failed to set driver state: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
@@ -317,7 +317,7 @@ func (de *DriverExtra) DestroyTask(
 		telemetry.ReportEvent(childCtx, "shutdown task")
 	}
 
-	h.Extra.Instance.CleanupAfterFCStop(childCtx, tracer, de.hosts)
+	h.Extra.Instance.CleanupAfterFCStop(childCtx, tracer, de.dns)
 
 	telemetry.ReportEvent(childCtx, "cleanup after FC stop")
 

--- a/packages/env-instance-task-driver/main.go
+++ b/packages/env-instance-task-driver/main.go
@@ -50,6 +50,11 @@ func main() {
 		// Start of mock build for testing
 		consulToken := os.Getenv("CONSUL_TOKEN")
 
+		dns, err := instance.NewDNS()
+		if err != nil {
+			panic(err)
+		}
+
 		var wg sync.WaitGroup
 
 		for i := 0; i < *count; i++ {
@@ -58,7 +63,8 @@ func main() {
 			go func(in int, envID, instanceID string) {
 				defer wg.Done()
 				id := fmt.Sprintf("%s_%d", instanceID, in)
-				instance.MockInstance(envID, id, consulToken, time.Duration(*keepAlive)*time.Second)
+				fmt.Printf("\nSTARTING [%s]\n\n", id)
+				instance.MockInstance(envID, id, consulToken, dns, time.Duration(*keepAlive)*time.Second)
 			}(i, *envID, *instanceID)
 		}
 

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -12,15 +12,40 @@ import (
 
 var OTELTracingPrint = os.Getenv("OTEL_TRACING_PRINT") != "false"
 
+const DebugID = "debug_id"
+
+func getDebugID(ctx context.Context) *string {
+	if ctx.Value(DebugID) == nil {
+		return nil
+	}
+
+	value := ctx.Value(DebugID).(string)
+
+	return &value
+}
+
+func debugFormat(debugID *string, msg string) string {
+	if debugID == nil {
+		return msg
+	}
+
+	return fmt.Sprintf("[%s] %s", *debugID, msg)
+}
+
 func SetAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Printf("No attrs set")
+			msg = "No attrs set"
 		} else {
-			fmt.Printf("Attrs set: %v\n", attrs)
+			msg = fmt.Sprintf("Attrs set: %v\n", attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Print(debugFormat(debugID, msg))
 	}
 
 	span.SetAttributes(attrs...)
@@ -30,11 +55,16 @@ func ReportEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) 
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Printf("-> %s\n", name)
+			msg = fmt.Sprintf("-> %s\n", name)
 		} else {
-			fmt.Printf("-> %s - %v\n", name, attrs)
+			msg = fmt.Sprintf("-> %s - %v\n", name, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Print(debugFormat(debugID, msg))
 	}
 
 	span.AddEvent(name,
@@ -46,11 +76,16 @@ func ReportCriticalError(ctx context.Context, err error, attrs ...attribute.KeyV
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Fprintf(os.Stderr, "Critical error: %v\n", err)
+			msg = fmt.Sprintf("Critical error: %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Critical error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Critical error: %v - %v\n", err, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Fprint(os.Stderr, debugFormat(debugID, msg))
 	}
 
 	span.RecordError(err,
@@ -67,11 +102,16 @@ func ReportError(ctx context.Context, err error, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
 	if OTELTracingPrint {
+		var msg string
+
 		if len(attrs) == 0 {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			msg = fmt.Sprintf("Error: %v\n", err)
 		} else {
-			fmt.Fprintf(os.Stderr, "Error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Error: %v - %v\n", err, attrs)
 		}
+
+		debugID := getDebugID(ctx)
+		fmt.Fprint(os.Stderr, debugFormat(debugID, msg))
 	}
 
 	span.RecordError(err,

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -41,7 +41,7 @@ func SetAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
 		if len(attrs) == 0 {
 			msg = "No attrs set"
 		} else {
-			msg = fmt.Sprintf("Attrs set: %v\n", attrs)
+			msg = fmt.Sprintf("Attrs set: %#v\n", attrs)
 		}
 
 		debugID := getDebugID(ctx)
@@ -60,7 +60,7 @@ func ReportEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) 
 		if len(attrs) == 0 {
 			msg = fmt.Sprintf("-> %s\n", name)
 		} else {
-			msg = fmt.Sprintf("-> %s - %v\n", name, attrs)
+			msg = fmt.Sprintf("-> %s - %#v\n", name, attrs)
 		}
 
 		debugID := getDebugID(ctx)
@@ -81,7 +81,7 @@ func ReportCriticalError(ctx context.Context, err error, attrs ...attribute.KeyV
 		if len(attrs) == 0 {
 			msg = fmt.Sprintf("Critical error: %v\n", err)
 		} else {
-			msg = fmt.Sprintf("Critical error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Critical error: %v - %#v\n", err, attrs)
 		}
 
 		debugID := getDebugID(ctx)
@@ -107,7 +107,7 @@ func ReportError(ctx context.Context, err error, attrs ...attribute.KeyValue) {
 		if len(attrs) == 0 {
 			msg = fmt.Sprintf("Error: %v\n", err)
 		} else {
-			msg = fmt.Sprintf("Error: %v - %v\n", err, attrs)
+			msg = fmt.Sprintf("Error: %v - %#v\n", err, attrs)
 		}
 
 		debugID := getDebugID(ctx)


### PR DESCRIPTION
There is a race condition during sandbox start that may be affecting the networking and start of sandboxes when multiple are started at the same time. (If this is not causing the persistent 502 error then it is probably some thread network namespace switching.)

- [ ] Test thoroughly