### PR TITLE
Fix missing MMDS in some sandboxes

### DIFF
--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -1,7 +1,6 @@
 package instance
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -119,19 +118,19 @@ func (fc *FC) loadSnapshot(
 	}
 	telemetry.ReportEvent(childCtx, "snapshot loaded")
 
-	go func() {
-		mmdsConfig := operations.PutMmdsParams{
-			Context: childCtx,
-			Body:    metadata,
-		}
+	mmdsConfig := operations.PutMmdsParams{
+		Context: childCtx,
+		Body:    metadata,
+	}
 
-		_, err = httpClient.Operations.PutMmds(&mmdsConfig)
-		if err != nil {
-			telemetry.ReportCriticalError(childCtx, err)
-		} else {
-			telemetry.ReportEvent(childCtx, "mmds data set")
-		}
-	}()
+	_, err = httpClient.Operations.PutMmds(&mmdsConfig)
+	if err != nil {
+		telemetry.ReportCriticalError(childCtx, err)
+
+		return err
+	}
+
+	telemetry.ReportEvent(childCtx, "mmds data set")
 
 	return nil
 }

--- a/packages/env-instance-task-driver/internal/instance/fc.go
+++ b/packages/env-instance-task-driver/internal/instance/fc.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"

--- a/packages/env-instance-task-driver/internal/instance/mock_instance.go
+++ b/packages/env-instance-task-driver/internal/instance/mock_instance.go
@@ -11,7 +11,7 @@ import (
 )
 
 func MockInstance(envID, instanceID, consulToken string, dns *DNS, keepAlive time.Duration) {
-	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), telemetry.DebugID, instanceID), time.Minute*3)
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), telemetry.DebugID, instanceID), time.Second*30)
 	defer cancel()
 
 	tracer := otel.Tracer(fmt.Sprintf("instance-%s", instanceID))


### PR DESCRIPTION
This moves MMDS setup from a goroutine — errors in MMDS setup will also cancel the sandbox spawn.

Fixes https://github.com/e2b-dev/infra/issues/123