### PR TITLE
Fix sync error in orchestration API

### DIFF
--- a/packages/api/internal/cache/instance/instance.go
+++ b/packages/api/internal/cache/instance/instance.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	InstanceExpiration = time.Second * 15
-	CacheSyncTime      = time.Minute * 3
+	CacheSyncTime      = time.Second * 30
 )
 
 type InstanceInfo struct {


### PR DESCRIPTION
This PR cleans up orchestration API and fixes a bug that returned empty sandboxes in the list of sandboxes from orchestrator.