### PR TITLE
gRPC logging

### DIFF
--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -23,9 +23,9 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/nomad"
 	"github.com/e2b-dev/infra/packages/api/internal/nomad/cache/instance"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator"
-	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/db"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logging"
 	"github.com/e2b-dev/infra/packages/shared/pkg/models"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storages"
 )
@@ -56,7 +56,7 @@ func NewAPIStore() *APIStore {
 
 	tracer := otel.Tracer("api")
 
-	logger, err := utils.NewLogger(env.IsProduction())
+	logger, err := logging.New(env.IsProduction())
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error initializing logger\n: %v\n", err)
 		panic(err)

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -2,8 +2,11 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	consulapi "github.com/hashicorp/consul/api"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -27,10 +30,36 @@ type server struct {
 	consul    *consulapi.Client
 }
 
+// interceptorLogger adapts go-kit logger to interceptor logger.
+// This code is simple enough to be copied and not imported.
+func interceptorLogger(l *log.Logger) logging.Logger {
+	return logging.LoggerFunc(func(_ context.Context, lvl logging.Level, msg string, fields ...any) {
+		switch lvl {
+		case logging.LevelDebug:
+			msg = fmt.Sprintf("DEBUG :%v", msg)
+		case logging.LevelInfo:
+			msg = fmt.Sprintf("INFO :%v", msg)
+		case logging.LevelWarn:
+			msg = fmt.Sprintf("WARN :%v", msg)
+		case logging.LevelError:
+			msg = fmt.Sprintf("ERROR :%v", msg)
+		default:
+			panic(fmt.Sprintf("unknown level %v", lvl))
+		}
+		l.Println(append([]any{"msg", msg}, fields...))
+	})
+}
+
 func New() *grpc.Server {
+	logger := log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile)
+	opts := []logging.Option{
+		logging.WithLogOnEvents(logging.StartCall, logging.FinishCall),
+	}
+
 	s := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(
+			logging.UnaryServerInterceptor(interceptorLogger(logger), opts...),
 			recovery.UnaryServerInterceptor(),
 		),
 	)

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
-	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	consulapi "github.com/hashicorp/consul/api"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -55,7 +54,6 @@ func New() *grpc.Server {
 	s := grpc.NewServer(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(
-			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
 			grpc_zap.UnaryServerInterceptor(logger.Desugar(), opts...),
 			recovery.UnaryServerInterceptor(),
 		),

--- a/packages/shared/pkg/logging/logger.go
+++ b/packages/shared/pkg/logging/logger.go
@@ -19,7 +19,7 @@ func New(prod bool) (*zap.SugaredLogger, error) {
 			MessageKey:    "message",
 			LevelKey:      "level",
 			EncodeLevel:   zapcore.LowercaseLevelEncoder,
-			NameKey:       "logging",
+			NameKey:       "logger",
 			StacktraceKey: "stacktrace",
 		},
 		OutputPaths: []string{
@@ -37,7 +37,7 @@ func New(prod bool) (*zap.SugaredLogger, error) {
 
 	logger, err := config.Build()
 	if err != nil {
-		return nil, fmt.Errorf("error building logging: %w", err)
+		return nil, fmt.Errorf("error building logger: %w", err)
 	}
 
 	return logger.Sugar(), nil

--- a/packages/shared/pkg/logging/logger.go
+++ b/packages/shared/pkg/logging/logger.go
@@ -1,4 +1,4 @@
-package utils
+package logging
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func NewLogger(prod bool) (*zap.SugaredLogger, error) {
+func New(prod bool) (*zap.SugaredLogger, error) {
 	config := zap.Config{
 		Level:             zap.NewAtomicLevelAt(zap.InfoLevel),
 		Development:       !prod,
@@ -19,7 +19,7 @@ func NewLogger(prod bool) (*zap.SugaredLogger, error) {
 			MessageKey:    "message",
 			LevelKey:      "level",
 			EncodeLevel:   zapcore.LowercaseLevelEncoder,
-			NameKey:       "logger",
+			NameKey:       "logging",
 			StacktraceKey: "stacktrace",
 		},
 		OutputPaths: []string{
@@ -37,7 +37,7 @@ func NewLogger(prod bool) (*zap.SugaredLogger, error) {
 
 	logger, err := config.Build()
 	if err != nil {
-		return nil, fmt.Errorf("error building logger: %w", err)
+		return nil, fmt.Errorf("error building logging: %w", err)
 	}
 
 	return logger.Sugar(), nil


### PR DESCRIPTION
Add a basic logger to orchestrator

it logs every call to the `stdout`, except health checks and it has a following format
```
2024-04-16T19:41:43Z	info	finished unary call with code OK	{"grpc.start_time": "2024-04-16T19:41:43Z", "system": "grpc", "span.kind": "server", "grpc.service": "Sandbox", "grpc.method": "Create", "grpc.code": "OK", "grpc.time_ms": 109.469}
``` 