### PR TITLE
Set file descriptors' limits

### DIFF
--- a/packages/cluster/scripts/run-nomad.sh
+++ b/packages/cluster/scripts/run-nomad.sh
@@ -285,6 +285,7 @@ numprocs=1
 autostart=true
 autorestart=true
 stopsignal=INT
+minfds=65536
 user=$nomad_user
 EOF
 }
@@ -456,15 +457,15 @@ function run {
 
   generate_supervisor_config "$SUPERVISOR_CONFIG_PATH" "$config_dir" "$data_dir" "$bin_dir" "$log_dir" "$user" "$use_sudo"
 
-# TODO: Let client wait for Nomad servers to start
-#  if [[ "$client" == "true" ]]; then
-#     log_info "Waiting for Nomad servers to start"
-#     while test -z "$(curl -s http://127.0.0.1:4646/v1/agent/leader)"
-#     do
-#       log_info "Nomad servers not yet started. Waiting for 1 second."
-#       sleep 1
-#     done
-#  fi
+  # TODO: Let client wait for Nomad servers to start
+  #  if [[ "$client" == "true" ]]; then
+  #     log_info "Waiting for Nomad servers to start"
+  #     while test -z "$(curl -s http://127.0.0.1:4646/v1/agent/leader)"
+  #     do
+  #       log_info "Nomad servers not yet started. Waiting for 1 second."
+  #       sleep 1
+  #     done
+  #  fi
 
   start_nomad
 

--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 # Inspired by https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
+ulimit -n 65536
+export GOMAXPROCS='nproc'
+
 # --- Mount the persistent disk with Firecracker environments.
 # See https://cloud.google.com/compute/docs/disks/add-persistent-disk#create_disk
 

--- a/packages/cluster/scripts/start-server.sh
+++ b/packages/cluster/scripts/start-server.sh
@@ -9,6 +9,9 @@ set -e
 # Inspired by https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
+ulimit -n 65536
+export GOMAXPROCS='nproc'
+
 gsutil cp "gs://${SCRIPTS_BUCKET}/run-consul-${RUN_CONSUL_FILE_HASH}.sh" /opt/consul/bin/run-consul.sh
 gsutil cp "gs://${SCRIPTS_BUCKET}/run-nomad-${RUN_NOMAD_FILE_HASH}.sh" /opt/nomad/bin/run-nomad.sh
 
@@ -16,4 +19,3 @@ chmod +x /opt/consul/bin/run-consul.sh /opt/nomad/bin/run-nomad.sh
 
 /opt/consul/bin/run-consul.sh --server --cluster-tag-name "${CLUSTER_TAG_NAME}" --consul-token "${CONSUL_TOKEN}" --enable-gossip-encryption --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}"
 /opt/nomad/bin/run-nomad.sh --server --num-servers "${NUM_SERVERS}" --consul-token "${CONSUL_TOKEN}" --nomad-token "${NOMAD_TOKEN}"
-

--- a/packages/envd/internal/clock/service.go
+++ b/packages/envd/internal/clock/service.go
@@ -43,5 +43,5 @@ func (s *Service) Wait() {
 	s.mu.RLock()
 	s.mu.RUnlock()
 
-	s.logger.Debug("Clock sync lock passsed")
+	s.logger.Debug("Clock sync lock passed")
 }


### PR DESCRIPTION
Ensure that Nomad and Consul have at least 65536 as the limit for file descriptors.