### PR TITLE
Remove unnecessary cleanup method and fix cleanup order #140

### DIFF
--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -128,8 +128,8 @@ job "orchestration-api" {
       driver = "docker"
 
       resources {
+        memory_max = 4096
         memory     = 2048
-        memory_max = 2048
         cpu        = 1024
       }
 

--- a/packages/nomad/client-proxy.hcl
+++ b/packages/nomad/client-proxy.hcl
@@ -67,8 +67,9 @@ job "client-proxy" {
       driver = "docker"
 
       resources {
-        memory = 1024
-        cpu    = 128
+        max_memory = 2048
+        memory = 512
+        cpu    = 512
       }
 
       config {

--- a/packages/nomad/docker-reverse-proxy.hcl
+++ b/packages/nomad/docker-reverse-proxy.hcl
@@ -56,7 +56,7 @@ variable "google_service_account_secret" {
 job "docker-reverse-proxy" {
   datacenters = [var.gcp_zone]
 
-  priority = 90
+  priority = 85
 
   group "reverse-proxy" {
     network {
@@ -83,9 +83,9 @@ job "docker-reverse-proxy" {
       driver = "docker"
 
       resources {
-        memory     = 1024
-        memory_max = 1024
-        cpu        = 512
+        max_memory = 2048
+        memory = 512
+        cpu    = 1024
       }
 
       env {

--- a/packages/nomad/logs-collector.hcl
+++ b/packages/nomad/logs-collector.hcl
@@ -41,8 +41,6 @@ job "logs-collector" {
   priority = 85
 
   group "collector" {
-    count = 1
-
     network {
       port "health" {
         to = var.logs_health_port_number
@@ -90,8 +88,9 @@ job "logs-collector" {
       }
 
       resources {
-        memory = 256
-        cpu    = 256
+        max_memory = 2048
+        memory = 512
+        cpu    = 512
       }
 
       template {

--- a/packages/nomad/loki.hcl
+++ b/packages/nomad/loki.hcl
@@ -21,8 +21,6 @@ job "loki" {
   priority = 75
 
   group "loki-service" {
-    count = 1
-
     network {
       port "loki" {
         to = var.loki_service_port_number
@@ -56,9 +54,9 @@ job "loki" {
       }
 
       resources {
-        cpu    = 500
+        max_memory = 2048
         memory = 1024
-        memory_max = 2048
+        cpu    = 512
       }
 
       template {

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -46,7 +46,7 @@ job "orchestrator" {
   type = "system"
   datacenters = [var.gcp_zone]
 
-  priority = 85
+  priority = 90
 
   group "client-orchestrator" {
     network {

--- a/packages/nomad/otel-collector.hcl
+++ b/packages/nomad/otel-collector.hcl
@@ -45,8 +45,6 @@ job "otel-collector" {
   priority = 95
 
   group "collector" {
-    count = 1
-
     network {
       port "health" {
         to = 13133
@@ -102,8 +100,9 @@ job "otel-collector" {
       }
 
       resources {
-        memory = 256
-        cpu    = 256
+        max_memory = 2048
+        memory = 512
+        cpu    = 512
       }
 
       template {

--- a/packages/nomad/session-proxy.hcl
+++ b/packages/nomad/session-proxy.hcl
@@ -19,13 +19,10 @@ variable "session_proxy_service_name" {
 }
 
 job "session-proxy" {
+  type = "system"
   datacenters = [var.gcp_zone]
 
   priority = 80
-
-  meta {
-    label1 = "job"
-  }
 
   constraint {
     operator = "distinct_hosts"
@@ -33,12 +30,6 @@ job "session-proxy" {
   }
 
   group "session-proxy" {
-    count = var.client_cluster_size
-
-    meta {
-      label1 = "group"
-    }
-
     network {
       port "session" {
         static = var.session_proxy_port_number
@@ -78,8 +69,9 @@ job "session-proxy" {
       }
 
       resources {
-        memory = 1024
-        cpu    = 128
+        max_memory = 2048
+        memory = 512
+        cpu    = 512
       }
 
       template {


### PR DESCRIPTION
We called the sandbox cleanup twice when killing the sandbox. This PR removes that and improves the order in which the cleanup handler are called.