### PR TITLE
Change nomad connection and scraping limits

### DIFF
--- a/packages/cluster/scripts/run-consul.sh
+++ b/packages/cluster/scripts/run-consul.sh
@@ -258,11 +258,11 @@ EOF
     "enable_token_persistence": true
   },
   "telemetry": {
-    "prometheus_retention_time": "24h",
+    "prometheus_retention_time": "2h",
     "disable_hostname": true
   },
   "limits": {
-    "http_max_conns_per_client": 5000
+    "http_max_conns_per_client": 80
   },
   "advertise_addr": "$instance_ip_address",
   "bind_addr": "$instance_ip_address",

--- a/packages/cluster/scripts/run-nomad.sh
+++ b/packages/cluster/scripts/run-nomad.sh
@@ -234,7 +234,7 @@ plugin "docker" {
 log_level = "DEBUG"
 
 telemetry {
-  collection_interval = "1s"
+  collection_interval = "5s"
   disable_hostname = true
   prometheus_metrics = true
   publish_allocation_metrics = true
@@ -246,8 +246,8 @@ acl {
 }
 
 limits {
-  http_max_conns_per_client = 5000
-  rpc_max_conns_per_client = 5000
+  http_max_conns_per_client = 80
+  rpc_max_conns_per_client = 80
 }
 
 consul {


### PR DESCRIPTION
The current Nomad and Consul connection limits were increased to accomodate previous usage from custom task driver.

We also lowered scraping retention period.