### PR TITLE
Enable monitoring on instance groups + collect logs for Consul and Nomad

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -112,6 +112,7 @@ module "cluster" {
 
   gcp_project_id             = var.gcp_project_id
   gcp_region                 = var.gcp_region
+  gcp_zone                   = var.gcp_zone
   google_service_account_key = module.init.google_service_account_key
 
   server_cluster_size = var.server_cluster_size

--- a/packages/cluster-disk-image/setup/gc-ops.config.yaml
+++ b/packages/cluster-disk-image/setup/gc-ops.config.yaml
@@ -1,10 +1,34 @@
 logging:
+  receivers:
+    nomad:
+      type: files
+      include_paths:
+          - /opt/nomad/log/*.log
+    consul:
+      type: systemd_journald
+  processors:
+    log_filter:
+      type: exclude_logs
+      match_any:
+          - '(jsonPayload._SYSTEMD_UNIT != "consul.service")'
   service:
     pipelines:
       default_pipeline:
-        receivers: []
+        receivers: [nomad]
+      pipeline_consul:
+        receivers: [consul]
+        processors: [log_filter]
 metrics:
   receivers:
     hostmetrics:
       type: hostmetrics
-      collection_interval: 300s
+      collection_interval: 30s
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern: []
+  service:
+    pipelines:
+      default_pipeline:
+        receivers: [hostmetrics]
+        processors: [metrics_filter]

--- a/packages/cluster/client/main.tf
+++ b/packages/cluster/client/main.tf
@@ -92,11 +92,18 @@ resource "google_compute_instance_template" "client" {
   machine_type         = var.machine_type
   min_cpu_platform     = "Intel Skylake"
 
-  labels                  = var.labels
+  labels = merge(
+    var.labels,
+    {
+      goog-ops-agent-policy = "v2-x86-template-1-2-0-${var.gcp_zone}"
+    }
+  )
   tags                    = concat([var.cluster_tag_name], var.custom_tags)
   metadata_startup_script = var.startup_script
   metadata = merge(
     {
+      enable-osconfig                          = "TRUE",
+      enable-guest-attributes                  = "TRUE",
       (var.metadata_key_name_for_cluster_size) = var.cluster_size
     },
     var.custom_metadata,

--- a/packages/cluster/client/variables.tf
+++ b/packages/cluster/client/variables.tf
@@ -3,6 +3,11 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "gcp_zone" {
+  description = "The GCP zone in which the server cluster will be created (e.g. us-central1-a)."
+  type        = string
+}
+
 variable "cluster_name" {
   description = "The name of the Nomad cluster (e.g. nomad-stage). This variable is used to namespace all resources created by this module."
   type        = string

--- a/packages/cluster/main.tf
+++ b/packages/cluster/main.tf
@@ -30,6 +30,17 @@ resource "google_project_iam_member" "network_viewer" {
   role    = "roles/compute.networkViewer"
 }
 
+resource "google_project_iam_member" "monitoring_editor" {
+  project = var.gcp_project_id
+  member  = "serviceAccount:${var.google_service_account_email}"
+  role    = "roles/monitoring.editor"
+}
+resource "google_project_iam_member" "logging_writer" {
+  project = var.gcp_project_id
+  member  = "serviceAccount:${var.google_service_account_email}"
+  role    = "roles/logging.logWriter"
+}
+
 variable "setup_files" {
   type = map(string)
   default = {
@@ -62,6 +73,7 @@ module "server_cluster" {
   cluster_name     = "${var.prefix}${var.server_cluster_name}"
   cluster_size     = var.server_cluster_size
   cluster_tag_name = var.cluster_tag_name
+  gcp_zone = var.gcp_zone
 
   machine_type = var.server_machine_type
   image_family = var.server_image_family
@@ -99,6 +111,7 @@ module "client_cluster" {
   cluster_name     = "${var.prefix}${var.client_cluster_name}"
   cluster_size     = var.client_cluster_size
   cluster_tag_name = var.cluster_tag_name
+  gcp_zone = var.gcp_zone
 
   machine_type = var.client_machine_type
   image_family = var.client_image_family

--- a/packages/cluster/scripts/run-consul.sh
+++ b/packages/cluster/scripts/run-consul.sh
@@ -141,25 +141,26 @@ function split_by_lines {
 
 function generate_consul_config {
   local -r server="${1}"
-  local -r config_dir="${2}"
-  local -r user="${3}"
-  local -r cluster_tag_name="${4}"
-  local -r cluster_size_instance_metadata_key_name="${5}"
-  local -r datacenter="${6}"
-  local -r enable_gossip_encryption="${7}"
-  local -r gossip_encryption_key="${8}"
-  local -r enable_rpc_encryption="${9}"
-  local -r verify_server_hostname="${10}"
-  local -r ca_path="${11}"
-  local -r cert_file_path="${12}"
-  local -r key_file_path="${13}"
-  local -r cleanup_dead_servers="${14}"
-  local -r last_contact_threshold="${15}"
-  local -r max_trailing_logs="${16}"
-  local -r server_stabilization_time="${17}"
-  local -r redundancy_zone_tag="${18}"
-  local -r disable_upgrade_migration="${19}"
-  local -r upgrade_version_tag=${20}
+  local -r consul_token="${2}"
+  local -r config_dir="${3}"
+  local -r user="${4}"
+  local -r cluster_tag_name="${5}"
+  local -r cluster_size_instance_metadata_key_name="${6}"
+  local -r datacenter="${7}"
+  local -r enable_gossip_encryption="${8}"
+  local -r gossip_encryption_key="${9}"
+  local -r enable_rpc_encryption="${10}"
+  local -r verify_server_hostname="${11}"
+  local -r ca_path="${12}"
+  local -r cert_file_path="${13}"
+  local -r key_file_path="${14}"
+  local -r cleanup_dead_servers="${15}"
+  local -r last_contact_threshold="${16}"
+  local -r max_trailing_logs="${17}"
+  local -r server_stabilization_time="${18}"
+  local -r redundancy_zone_tag="${19}"
+  local -r disable_upgrade_migration="${20}"
+  local -r upgrade_version_tag=${21}
   local -r config_path="$config_dir/$CONSUL_CONFIG_FILE"
 
   shift 20
@@ -255,7 +256,10 @@ EOF
   "acl": {
     "enabled": true,
     "default_policy": "deny",
-    "enable_token_persistence": true
+    "enable_token_persistence": true,
+    "tokens": {
+      "default": "$consul_token"
+    }
   },
   "telemetry": {
     "prometheus_retention_time": "24h",
@@ -627,6 +631,7 @@ function run {
     fi
 
     generate_consul_config "$server" \
+      "$consul_token" \
       "$config_dir" \
       "$user" \
       "$cluster_tag_name" \

--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -147,5 +147,5 @@ echo "- Allocating $overcommitment_hugepages huge pages ($overcommitment_hugepag
 echo $overcommitment_hugepages >/proc/sys/vm/nr_overcommit_hugepages
 
 # These variables are passed in via Terraform template interpolation
-/opt/consul/bin/run-consul.sh --client --cluster-tag-name "${CLUSTER_TAG_NAME}" --enable-gossip-encryption --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" &
+/opt/consul/bin/run-consul.sh --client --consul-token "${CONSUL_TOKEN}" --cluster-tag-name "${CLUSTER_TAG_NAME}" --enable-gossip-encryption --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" &
 /opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" &

--- a/packages/cluster/server/main.tf
+++ b/packages/cluster/server/main.tf
@@ -74,13 +74,19 @@ resource "google_compute_instance_template" "server" {
   metadata_startup_script = var.startup_script
   metadata = merge(
     {
+      enable-osconfig                          = "TRUE",
+      enable-guest-attributes                  = "TRUE",
       (var.metadata_key_name_for_cluster_size) = var.cluster_size,
     },
     var.custom_metadata,
   )
 
-  labels = var.labels
-
+  labels = merge(
+    var.labels,
+    {
+      goog-ops-agent-policy = "v2-x86-template-1-2-0-${var.gcp_zone}"
+    }
+  )
   scheduling {
     on_host_maintenance = "MIGRATE"
   }

--- a/packages/cluster/server/variables.tf
+++ b/packages/cluster/server/variables.tf
@@ -3,6 +3,11 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "gcp_zone" {
+  description = "The GCP zone in which the server cluster will be created (e.g. us-central1-a)."
+  type        = string
+}
+
 variable "cluster_name" {
   description = "The name of the server cluster (e.g. server-stage). This variable is used to namespace all resources created by this module."
   type        = string

--- a/packages/cluster/variables.tf
+++ b/packages/cluster/variables.tf
@@ -83,6 +83,10 @@ variable "gcp_region" {
   type = string
 }
 
+variable "gcp_zone" {
+  type = string
+}
+
 variable "network_name" {
   type    = string
   default = "default"

--- a/terraform.md
+++ b/terraform.md
@@ -11,6 +11,9 @@ Check if you can use config for terraform state management
    - [Certificate Manager API](https://console.cloud.google.com/apis/library/certificatemanager.googleapis.com)
    - [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com)
    - [Artifact Registry API](https://console.cloud.google.com/apis/library/artifactregistry.googleapis.com)
+   - [OS Config API](https://console.cloud.google.com/apis/library/osconfig.googleapis.com)
+   - [Stackdriver Monitoring API](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
+   - [Stackdriver Logging API](https://console.cloud.google.com/apis/library/logging.googleapis.com)
 6. You will need domain on cloudflare
 7. Run `make init`
 8. build cluster disk image [here](./packages/cluster-disk-image)


### PR DESCRIPTION
Enable monitoring for client and server managed instance groups via ops agent, so we have information about processes and their resource usage

Also export logs from nomad and consul