### PR TITLE
Fix UFFD and Firecracker killing in orchestrator

### DIFF
--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -34,4 +34,4 @@ build-and-upload: build upload
 
 .PHONY: test
 test:
-	sudo CONSUL_TOKEN=$(CONSUL_TOKEN) go run -race -gcflags=all="-N -l" main.go -env idnrwvs3vrde6hknozc0 -instance test-instance-1 -alive 60 -count 1
+	sudo CONSUL_TOKEN=$(CONSUL_TOKEN) go run -race -gcflags=all="-N -l" main.go -env idnrwvs3vrde6hknozc0 -instance test-instance-1 -alive 1 -count 1

--- a/packages/orchestrator/internal/constants/node.go
+++ b/packages/orchestrator/internal/constants/node.go
@@ -6,5 +6,5 @@ const shortNodeIDLength = 8
 
 var (
 	nodeID   = os.Getenv("NODE_ID")
-	ClientID = "test"
+	ClientID = nodeID[:shortNodeIDLength]
 )

--- a/packages/orchestrator/internal/constants/node.go
+++ b/packages/orchestrator/internal/constants/node.go
@@ -6,5 +6,5 @@ const shortNodeIDLength = 8
 
 var (
 	nodeID   = os.Getenv("NODE_ID")
-	ClientID = nodeID[:shortNodeIDLength]
+	ClientID = "test"
 )

--- a/packages/orchestrator/internal/sandbox/fc.go
+++ b/packages/orchestrator/internal/sandbox/fc.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -30,17 +31,24 @@ type MmdsMetadata struct {
 	TeamID     string `json:"teamID"`
 }
 
+
 type FC struct {
-	uffd           *exec.Cmd
-	cmd            *exec.Cmd
-	stdout         *io.PipeReader
-	stderr         *io.PipeReader
-	uffdSocketPath *string
-	metadata       *MmdsMetadata
-	ctx            context.Context
-	socketPath     string
-	envPath        string
-	id             string
+	ctx context.Context
+
+	cmd *exec.Cmd
+	pid int
+
+	stdout *io.PipeReader
+	stderr *io.PipeReader
+
+	metadata *MmdsMetadata
+
+	uffd *UFFD
+
+	id string
+
+	socketPath string
+	envPath    string
 }
 
 func (fc *FC) Wait() error {

--- a/packages/orchestrator/internal/sandbox/fc.go
+++ b/packages/orchestrator/internal/sandbox/fc.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
@@ -226,6 +227,10 @@ func newFC(
 		"-c",
 		rootfsMountCmd+kernelMountCmd+inNetNSCmd+fcCmd,
 	)
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // Create a new session
+	}
 
 	cmdStdoutReader, cmdStdoutWriter := io.Pipe()
 	cmdStderrReader, cmdStderrWriter := io.Pipe()

--- a/packages/orchestrator/internal/sandbox/fc.go
+++ b/packages/orchestrator/internal/sandbox/fc.go
@@ -64,7 +64,7 @@ func (fc *fc) wait() error {
 		return fmt.Errorf("process is nil")
 	}
 
-	// When we recover process and the current process is not parent of that process .Wait will usually not work and throw an error.
+	// When we recover process and the current process is not parent of that process. Wait will usually not work and throw an error.
 	for {
 		time.Sleep(processCheckInterval)
 

--- a/packages/orchestrator/internal/sandbox/files.go
+++ b/packages/orchestrator/internal/sandbox/files.go
@@ -27,7 +27,7 @@ const (
 	socketWaitTimeout = 2 * time.Second
 )
 
-type InstanceFiles struct {
+type SandboxFiles struct {
 	UFFDSocketPath *string
 
 	EnvPath      string
@@ -69,7 +69,7 @@ func waitForSocket(socketPath string, timeout time.Duration) error {
 	}
 }
 
-func newInstanceFiles(
+func newSandboxFiles(
 	ctx context.Context,
 	tracer trace.Tracer,
 	slot *IPSlot,
@@ -81,7 +81,7 @@ func newInstanceFiles(
 	firecrackerBinaryPath,
 	uffdBinaryPath string,
 	hugePages bool,
-) (*InstanceFiles, error) {
+) (*SandboxFiles, error) {
 	childCtx, childSpan := tracer.Start(ctx, "create-env-instance",
 		trace.WithAttributes(
 			attribute.String("env.id", envID),
@@ -160,7 +160,7 @@ func newInstanceFiles(
 		attribute.String("instance.firecracker.path", firecrackerBinaryPath),
 	)
 
-	return &InstanceFiles{
+	return &SandboxFiles{
 		EnvInstancePath:       envInstancePath,
 		BuildDirPath:          buildDirPath,
 		EnvPath:               envPath,
@@ -173,7 +173,11 @@ func newInstanceFiles(
 	}, nil
 }
 
-func (env *InstanceFiles) Cleanup(
+func (env *SandboxFiles) Ensure() {
+	// TODO: Split the newSandboxFile into a method that assembles the file names in the struct and a method that ensures they exist, to easy the recovery
+}
+
+func (env *SandboxFiles) Cleanup(
 	ctx context.Context,
 	tracer trace.Tracer,
 ) error {

--- a/packages/orchestrator/internal/sandbox/mock_instance.go
+++ b/packages/orchestrator/internal/sandbox/mock_instance.go
@@ -49,5 +49,5 @@ func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
 
 	defer instance.CleanupAfterFCStop(childCtx, tracer, consulClient, dns)
 
-	instance.fc.stop(childCtx, tracer)
+	instance.Stop(childCtx, tracer)
 }

--- a/packages/orchestrator/internal/sandbox/mock_instance.go
+++ b/packages/orchestrator/internal/sandbox/mock_instance.go
@@ -9,11 +9,12 @@ import (
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
 func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
-	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), telemetry.DebugID, instanceID), time.Second*30)
+	ctx, cancel := context.WithTimeout(context.WithValue(context.Background(), telemetry.DebugID, instanceID), time.Second*10)
 	defer cancel()
 
 	tracer := otel.Tracer(fmt.Sprintf("instance-%s", instanceID))
@@ -25,21 +26,18 @@ func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
 		childCtx,
 		tracer,
 		consulClient,
-		&InstanceConfig{
-			TemplateID:            envID,
-			SandboxID:             instanceID,
-			TraceID:               "test",
-			TeamID:                "test",
-			KernelVersion:         "vmlinux-5.10.186",
-			KernelMountDir:        "/fc-vm",
-			KernelsDir:            "/fc-kernels",
-			KernelName:            "vmlinux.bin",
-			UFFDBinaryPath:        "/fc-versions/v1.7.0-dev_8bb88311/uffd",
-			HugePages:             true,
-			FirecrackerBinaryPath: "/fc-versions/v1.7.0-dev_8bb88311/firecracker",
-		},
 		dns,
-		nil,
+		&orchestrator.SandboxConfig{
+			TemplateID:         envID,
+			FirecrackerVersion: "v1.7.0-dev_8bb88311",
+			KernelVersion:      "vmlinux-5.10.186",
+			TeamID:             "test-team",
+			BuildID:            "",
+			HugePages:          true,
+			MaxInstanceLength:  1,
+			SandboxID:          instanceID,
+		},
+		"trace-test-1",
 	)
 	if err != nil {
 		panic(err)
@@ -51,5 +49,5 @@ func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
 
 	defer instance.CleanupAfterFCStop(childCtx, tracer, consulClient, dns)
 
-	instance.fc.Stop(childCtx, tracer)
+	instance.fc.stop(childCtx, tracer)
 }

--- a/packages/orchestrator/internal/sandbox/mock_instance.go
+++ b/packages/orchestrator/internal/sandbox/mock_instance.go
@@ -3,8 +3,9 @@ package sandbox
 import (
 	"context"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/consul"
 	"time"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/consul"
 
 	"go.opentelemetry.io/otel"
 
@@ -20,7 +21,7 @@ func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
 
 	consulClient, err := consul.New(childCtx)
 
-	instance, err := New(
+	instance, err := NewSandbox(
 		childCtx,
 		tracer,
 		consulClient,
@@ -50,8 +51,5 @@ func MockInstance(envID, instanceID string, dns *DNS, keepAlive time.Duration) {
 
 	defer instance.CleanupAfterFCStop(childCtx, tracer, consulClient, dns)
 
-	err = instance.FC.Stop(childCtx, tracer)
-	if err != nil {
-		panic(err)
-	}
+	instance.fc.Stop(childCtx, tracer)
 }

--- a/packages/orchestrator/internal/sandbox/process.go
+++ b/packages/orchestrator/internal/sandbox/process.go
@@ -1,0 +1,38 @@
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+const processCheckInterval = 1 * time.Second
+
+func recoverProcess(pid int) (*os.Process, error) {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find process %d: %w", pid, err)
+	}
+
+	err = p.Signal(syscall.Signal(0))
+	if err != nil {
+		return nil, fmt.Errorf("failed to signal process %d: %w", pid, err)
+	}
+
+	_, err = checkIsRunning(p)
+	if err != nil {
+		return nil, fmt.Errorf("process %d is not running: %w", pid, err)
+	}
+
+	return p, nil
+}
+
+func checkIsRunning(p *os.Process) (bool, error) {
+	err := p.Signal(syscall.Signal(0))
+	if err != nil {
+		return false, fmt.Errorf("failed to signal process %d: %w", p.Pid, err)
+	}
+
+	return true, nil
+}

--- a/packages/orchestrator/internal/sandbox/process.go
+++ b/packages/orchestrator/internal/sandbox/process.go
@@ -10,11 +10,13 @@ import (
 const processCheckInterval = 1 * time.Second
 
 func recoverProcess(pid int) (*os.Process, error) {
+	// This is NOOP on Linux, it only returns the process struct with PID
 	p, err := os.FindProcess(pid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find process %d: %w", pid, err)
 	}
 
+	// Checks process existence
 	err = p.Signal(syscall.Signal(0))
 	if err != nil {
 		return nil, fmt.Errorf("failed to signal process %d: %w", pid, err)

--- a/packages/orchestrator/internal/sandbox/process.go
+++ b/packages/orchestrator/internal/sandbox/process.go
@@ -29,10 +29,16 @@ func recoverProcess(pid int) (*os.Process, error) {
 }
 
 func checkIsRunning(p *os.Process) (bool, error) {
-	err := p.Signal(syscall.Signal(0))
+	var ws syscall.WaitStatus
+	pid, err := syscall.Wait4(p.Pid, &ws, syscall.WNOHANG, nil)
 	if err != nil {
-		return false, fmt.Errorf("failed to signal process %d: %w", p.Pid, err)
+		return false, fmt.Errorf("failed to wait for process %d: %w", p.Pid, err)
 	}
 
-	return true, nil
+	if pid == 0 {
+		// Process has not exited
+		return true, nil
+	}
+
+	return false, nil // Process has exited
 }

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -26,8 +26,8 @@ const (
 	uffdBinaryName = "uffd"
 	fcBinaryName   = "firecracker"
 
-	WaitForUffd       = 80 * time.Millisecond
-	UffdCheckInterval = 10 * time.Millisecond
+	waitForUffd       = 80 * time.Millisecond
+	uffdCheckInterval = 10 * time.Millisecond
 )
 
 var logsProxyAddress = os.Getenv("LOGS_PROXY_ADDRESS")
@@ -257,7 +257,7 @@ func NewSandbox(
 	uffdWait:
 		for {
 			select {
-			case <-time.After(WaitForUffd):
+			case <-time.After(waitForUffd):
 				fmt.Printf("waiting for uffd to initialize")
 				return nil, fmt.Errorf("timeout waiting to uffd to initialize")
 			case <-childCtx.Done():
@@ -269,7 +269,7 @@ func NewSandbox(
 					break uffdWait
 				}
 
-				time.Sleep(UffdCheckInterval)
+				time.Sleep(uffdCheckInterval)
 			}
 		}
 	}

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -289,6 +289,10 @@ func NewSandbox(
 
 	err = fc.start(childCtx, tracer)
 	if err != nil {
+		if uffd != nil {
+			uffd.stop(childCtx, tracer)
+		}
+
 		errMsg := fmt.Errorf("failed to start FC: %w", err)
 		telemetry.ReportCriticalError(childCtx, errMsg)
 
@@ -307,6 +311,7 @@ func NewSandbox(
 	}
 
 	telemetry.ReportEvent(childCtx, "ensuring clock sync")
+
 	go func() {
 		backgroundCtx := context.Background()
 

--- a/packages/orchestrator/internal/sandbox/uffd.go
+++ b/packages/orchestrator/internal/sandbox/uffd.go
@@ -19,6 +19,7 @@ const (
 	SigkillWaitCheck = 100 * time.Millisecond
 )
 
+// uffdCloseLock is used to prevent multiple uffd processes from being closed at the same time, we had a suspicion that this could have been the cause of the infra restarts.
 var uffdCloseLock sync.Mutex
 
 type uffd struct {

--- a/packages/orchestrator/internal/sandbox/uffd.go
+++ b/packages/orchestrator/internal/sandbox/uffd.go
@@ -79,8 +79,6 @@ func (u *uffd) stop(ctx context.Context, tracer trace.Tracer) {
 	}
 	uffdCloseLock.Unlock()
 
-	time.Sleep(SigkillWait)
-
 killWait:
 	for {
 		select {
@@ -115,6 +113,15 @@ func newUFFD(
 ) *uffd {
 	memfilePath := filepath.Join(fsEnv.EnvPath, MemfileName)
 	cmd := exec.Command(fsEnv.UFFDBinaryPath, *fsEnv.UFFDSocketPath, memfilePath)
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // Create a new session
+		Credential: &syscall.Credential{
+			Uid: 1000, // UID for user "ubuntu"
+			Gid: 1000, // GID for user "ubuntu"
+		},
+	}
+
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/packages/orchestrator/internal/sandbox/uffd.go
+++ b/packages/orchestrator/internal/sandbox/uffd.go
@@ -1,0 +1,68 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"time"
+)
+
+var uffdCloseLock sync.Mutex
+
+type UFFD struct {
+	cmd            *exec.Cmd
+	uffdSocketPath *string
+	pid            int
+}
+
+func (u *UFFD) Start() error {
+	err := u.cmd.Start()
+	if err != nil {
+		return fmt.Errorf("failed to start uffd: %w", err)
+	}
+
+	u.pid = u.cmd.Process.Pid
+
+	return nil
+}
+
+func (u *UFFD) Stop() error {
+	uffdCloseLock.Lock()
+	err := u.cmd.Process.Signal(syscall.SIGTERM)
+	if err != nil {
+		uffdCloseLock.Unlock()
+		return fmt.Errorf("failed to send SIGINT to uffd: %w", err)
+	}
+	uffdCloseLock.Unlock()
+
+	time.Sleep(5 * time.Second)
+
+	uffdCloseLock.Lock()
+	err = u.cmd.Process.Kill()
+	if err != nil {
+		uffdCloseLock.Unlock()
+		return fmt.Errorf("failed to send SIGINT to uffd: %w", err)
+	}
+	uffdCloseLock.Unlock()
+
+	return nil
+}
+
+func NewUFFD(
+	ctx context.Context,
+	fsEnv *InstanceFiles,
+) (*UFFD, error) {
+	memfilePath := filepath.Join(fsEnv.EnvPath, MemfileName)
+	cmd := exec.CommandContext(vmmCtx, fsEnv.UFFDBinaryPath, *fsEnv.UFFDSocketPath, memfilePath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return &UFFD{
+		cmd:            cmd,
+		uffdSocketPath: fsEnv.UFFDSocketPath,
+	}, nil
+}

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -64,5 +64,6 @@ func New(logger *zap.Logger) *grpc.Server {
 	})
 
 	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
+
 	return s
 }

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -17,15 +16,6 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
-)
-
-const (
-	fcVersionsDir  = "/fc-versions"
-	kernelDir      = "/fc-kernels"
-	kernelMountDir = "/fc-vm"
-	kernelName     = "vmlinux.bin"
-	uffdBinaryName = "uffd"
-	fcBinaryName   = "firecracker"
 )
 
 func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequest) (*orchestrator.SandboxCreateResponse, error) {
@@ -43,21 +33,9 @@ func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 		childCtx,
 		s.tracer,
 		s.consul,
-		&sandbox.InstanceConfig{
-			TemplateID:            req.Sandbox.TemplateID,
-			SandboxID:             req.Sandbox.SandboxID,
-			TraceID:               childSpan.SpanContext().TraceID().String(),
-			TeamID:                req.Sandbox.TeamID,
-			KernelVersion:         req.Sandbox.KernelVersion,
-			KernelsDir:            kernelDir,
-			KernelMountDir:        kernelMountDir,
-			KernelName:            kernelName,
-			HugePages:             req.Sandbox.HugePages,
-			UFFDBinaryPath:        filepath.Join(fcVersionsDir, req.Sandbox.FirecrackerVersion, uffdBinaryName),
-			FirecrackerBinaryPath: filepath.Join(fcVersionsDir, req.Sandbox.FirecrackerVersion, fcBinaryName),
-		},
 		s.dns,
 		req.Sandbox,
+		childSpan.SpanContext().TraceID().String(),
 	)
 	if err != nil {
 		errMsg := fmt.Errorf("failed to create sandbox: %w", err)


### PR DESCRIPTION
This PR fixes UFFD and Firecracker process handling in the orchestrator, including starting, killing, and recovering.

The PR finishes the fix started in https://github.com/e2b-dev/infra/tree/soft-kill which should be fixing the unexpected restarting of the client.