### PR TITLE
Add swap and adjust OOM handling in sandbox

### DIFF
--- a/packages/template-manager/internal/build/provision.sh
+++ b/packages/template-manager/internal/build/provision.sh
@@ -41,7 +41,7 @@ ExecStart=/bin/bash -l -c "/usr/bin/envd"
 OOMPolicy=continue
 OOMScoreAdjust=-1000
 
-ExecStartPre=/bin/bash -c 'echo 1 > /proc/sys/vm/swappiness && swapon /swap/swapfile'
+ExecStartPre=/bin/bash -c 'echo 0 > /proc/sys/vm/swappiness && swapon /swap/swapfile'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR configures small swaps space (limited by free disk) and OOM handling of envd and start command to prevent the most frequent OOM during sandbox usage. For proper OOM handling the zram/zswap and other OOM handling techniques (envd child process oom adjust) should be explored.

After we merge this we should rebuild the templates:
- [ ] base
- [ ] code-interpreter
- [ ] code-interpreter-stateful