### PR TITLE
Allow to shorten sandbox duration

### DIFF
--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -42,7 +42,7 @@ func (c *InstanceCache) KeepAliveFor(instanceID string, duration time.Duration, 
 	} else {
 		maxAllowedTTL := getMaxAllowedTTL(instance.StartTime, duration, instance.MaxInstanceLength)
 
-		newEndTime := item.ExpiresAt()
+		newEndTime := item.ExpiresAt().Add(maxAllowedTTL)
 		instance.EndTime = newEndTime
 
 		item = c.cache.Set(instanceID, instance, maxAllowedTTL)

--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -24,14 +24,14 @@ func getMaxAllowedTTL(startTime time.Time, duration, maxInstanceLength time.Dura
 }
 
 // KeepAliveFor the instance's expiration timer.
-func (c *InstanceCache) KeepAliveFor(instanceID string, duration time.Duration) (*InstanceInfo, error) {
+func (c *InstanceCache) KeepAliveFor(instanceID string, duration time.Duration, allowShorter bool) (*InstanceInfo, error) {
 	item, err := c.Get(instanceID)
 	if err != nil {
 		return nil, err
 	}
 
 	instance := item.Value()
-	if item.ExpiresAt().After(time.Now().Add(duration)) {
+	if !allowShorter && item.ExpiresAt().After(time.Now().Add(duration)) {
 		return &instance, nil
 	}
 

--- a/packages/api/internal/handlers/sandbox_refresh.go
+++ b/packages/api/internal/handlers/sandbox_refresh.go
@@ -41,7 +41,7 @@ func (a *APIStore) PostSandboxesSandboxIDRefreshes(
 		duration = instance.InstanceExpiration
 	}
 
-	info, err := a.instanceCache.KeepAliveFor(sandboxID, duration)
+	info, err := a.instanceCache.KeepAliveFor(sandboxID, duration, false)
 	if err != nil {
 		errMsg := fmt.Errorf("error when refreshing instance: %w", err)
 		telemetry.ReportCriticalError(ctx, errMsg)

--- a/packages/api/internal/handlers/sandbox_timeout.go
+++ b/packages/api/internal/handlers/sandbox_timeout.go
@@ -37,7 +37,7 @@ func (a *APIStore) PostSandboxesSandboxIDTimeout(
 		duration = time.Duration(body.Timeout) * time.Second
 	}
 
-	info, err := a.instanceCache.KeepAliveFor(sandboxID, duration)
+	info, err := a.instanceCache.KeepAliveFor(sandboxID, duration, true)
 	if err != nil {
 		errMsg := fmt.Errorf("error setting sandbox timeout: %w", err)
 		telemetry.ReportCriticalError(ctx, errMsg)


### PR DESCRIPTION
- The timeout of the sandbox can be set to shorter period