### PR TITLE
Add a way to upload several files to a sandbox at once

### DIFF
--- a/packages/envd/internal/api/upload.go
+++ b/packages/envd/internal/api/upload.go
@@ -142,6 +142,7 @@ func resolvePath(part *multipart.Part, paths *UploadSuccess, u *user.User, param
 
 	return filePath, nil
 }
+
 func (a *API) PostFiles(w http.ResponseWriter, r *http.Request, params PostFilesParams) {
 	defer r.Body.Close()
 


### PR DESCRIPTION
# Description
[E2B-954](https://linear.app/e2b/issue/E2B-954/add-a-way-to-upload-several-files-to-a-sandbox-at-once)

For now, simply reusing `PostFiles` logic. 