### PR TITLE
Small oversight with template fields

### DIFF
--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -125,7 +125,6 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 		WithEnvAliases(func(query *models.EnvAliasQuery) {
 			query.Order(models.Asc(envalias.FieldID)) // TODO: remove once we have only 1 alias per env
 		}).
-		WithCreator().
 		WithBuilds(func(query *models.EnvBuildQuery) {
 			query.Where(envbuild.StatusEQ(envbuild.StatusSuccess)).Order(models.Desc(envbuild.FieldFinishedAt)).Limit(1)
 		}).Only(ctx)
@@ -140,11 +139,6 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 	aliases := make([]string, len(dbEnv.Edges.EnvAliases))
 	for i, alias := range dbEnv.Edges.EnvAliases {
 		aliases[i] = alias.ID
-	}
-
-	var createdBy *TemplateCreator
-	if dbEnv.Edges.Creator != nil {
-		createdBy = &TemplateCreator{Id: dbEnv.Edges.Creator.ID, Email: dbEnv.Edges.Creator.Email}
 	}
 
 	build = dbEnv.Edges.Builds[0]
@@ -162,7 +156,6 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 		LastSpawnedAt: dbEnv.LastSpawnedAt,
 		SpawnCount:    dbEnv.SpawnCount,
 		BuildCount:    dbEnv.BuildCount,
-		CreatedBy:     createdBy,
 	}, build, nil
 }
 

--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -99,6 +99,7 @@ func (db *DB) GetEnvs(ctx context.Context, teamID uuid.UUID) (result []*Template
 			Public:        item.Public,
 			Aliases:       &aliases,
 			CreatedAt:     item.CreatedAt,
+			UpdatedAt:     item.UpdatedAt,
 			LastSpawnedAt: item.LastSpawnedAt,
 			SpawnCount:    item.SpawnCount,
 			BuildCount:    item.BuildCount,
@@ -140,6 +141,11 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 		aliases[i] = alias.ID
 	}
 
+	var createdBy *TemplateCreator
+	if dbEnv.Edges.Creator != nil {
+		createdBy = &TemplateCreator{Id: dbEnv.Edges.Creator.ID, Email: dbEnv.Edges.Creator.Email}
+	}
+
 	build = dbEnv.Edges.Builds[0]
 	return &Template{
 		TemplateID:    dbEnv.ID,
@@ -155,6 +161,7 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 		LastSpawnedAt: dbEnv.LastSpawnedAt,
 		SpawnCount:    dbEnv.SpawnCount,
 		BuildCount:    dbEnv.BuildCount,
+		CreatedBy:     createdBy,
 	}, build, nil
 }
 

--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -125,6 +125,7 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 		WithEnvAliases(func(query *models.EnvAliasQuery) {
 			query.Order(models.Asc(envalias.FieldID)) // TODO: remove once we have only 1 alias per env
 		}).
+		WithCreator().
 		WithBuilds(func(query *models.EnvBuildQuery) {
 			query.Where(envbuild.StatusEQ(envbuild.StatusSuccess)).Order(models.Desc(envbuild.FieldFinishedAt)).Limit(1)
 		}).Only(ctx)


### PR DESCRIPTION
Some fields returned by API were not returned in GetEnvs method, oops 




<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds the `UpdatedAt` field to the return value of the `GetEnvs` method, ensuring that all relevant fields from the API are included.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant DB as Database
    participant Env as Environment Object
    
    DB->>Env: Get Environment Item
    Note over Env: Add UpdatedAt field
    Env->>DB: Store Environment with UpdatedAt
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/207/files#diff-72605933de264b01510f45a7ace429435b165b3c018bbd47a1be10abcf6622fc>packages/shared/pkg/db/envs.go</a></td><td>Added the <code>UpdatedAt</code> field to the <code>GetEnvs</code> method return value.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


