### PR TITLE
Sort the sandboxes based on the start time

### DIFF
--- a/packages/api/internal/handlers/sandbox_logs.go
+++ b/packages/api/internal/handlers/sandbox_logs.go
@@ -3,7 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -78,8 +78,8 @@ func (a *APIStore) GetSandboxesSandboxIDLogs(
 		}
 
 		// Sort logs by timestamp (they are returned by the time they arrived in Loki)
-		sort.Slice(logs, func(i, j int) bool {
-			return logs[i].Timestamp.Before(logs[j].Timestamp)
+		slices.SortFunc(logs, func(a, b api.SandboxLog) int {
+			return a.Timestamp.Compare(b.Timestamp)
 		})
 
 		c.JSON(http.StatusOK, &api.SandboxLogs{

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -88,15 +88,7 @@ func (a *APIStore) GetSandboxes(c *gin.Context) {
 
 	// Sort sandboxes by start time descending
 	slices.SortFunc(sandboxes, func(a, b api.RunningSandbox) int {
-		if a.StartedAt.After(b.StartedAt) {
-			return -1
-		}
-
-		if a.StartedAt.Before(b.StartedAt) {
-			return 1
-		}
-
-		return 0
+                return a.StartedAt.Compare(b.StartedAt)
 	})
 
 	c.JSON(http.StatusOK, sandboxes)

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -2,7 +2,7 @@ package handlers
 
 import (
 	"net/http"
-	"sort"
+	"slices"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -87,8 +87,16 @@ func (a *APIStore) GetSandboxes(c *gin.Context) {
 	}
 
 	// Sort sandboxes by start time descending
-	sort.Slice(sandboxes, func(i, j int) bool {
-		return sandboxes[i].StartedAt.After(sandboxes[j].StartedAt)
+	slices.SortFunc(sandboxes, func(a, b api.RunningSandbox) int {
+		if a.StartedAt.After(b.StartedAt) {
+			return -1
+		}
+
+		if a.StartedAt.Before(b.StartedAt) {
+			return 1
+		}
+
+		return 0
 	})
 
 	c.JSON(http.StatusOK, sandboxes)

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -84,6 +85,11 @@ func (a *APIStore) GetSandboxes(c *gin.Context) {
 
 		sandboxes = append(sandboxes, instance)
 	}
+
+	// Sort sandboxes by start time descending
+	sort.Slice(sandboxes, func(i, j int) bool {
+		return sandboxes[i].StartedAt.After(sandboxes[j].StartedAt)
+	})
 
 	c.JSON(http.StatusOK, sandboxes)
 }

--- a/packages/shared/pkg/logs/logger.go
+++ b/packages/shared/pkg/logs/logger.go
@@ -44,8 +44,10 @@ func newSandboxLogExporter(serviceName string) *sandboxLogExporter {
 	}
 }
 
-var logsExporter *sandboxLogExporter
-var logsExporterMU = sync.Mutex{}
+var (
+	logsExporter   *sandboxLogExporter
+	logsExporterMU = sync.Mutex{}
+)
 
 func getSandboxLogExporter() *sandboxLogExporter {
 	logsExporterMU.Lock()
@@ -96,7 +98,7 @@ func (l *SandboxLogger) sendEvent(logger *zerolog.Event, format string, v ...int
 		Str("instanceID", l.instanceID).
 		Str("envID", l.envID).
 		Str("teamID", l.teamID).
-		Bool("internal", l.internal).
+		Bool("internal", l.internal). // if this is true, it's sent to internal loki else to grafana cloud
 		Msgf(format, v...)
 }
 
@@ -128,6 +130,7 @@ func (l *SandboxLogger) Infof(
 ) {
 	l.sendEvent(l.exporter.logger.Info(), format, v...)
 }
+
 func (l *SandboxLogger) Debugf(
 	format string,
 	v ...interface{},


### PR DESCRIPTION
# Description 
In order to return sorted running instances by start time, this PR updates the `APIStore.GetSandboxes` method in a way where the final returned slice is sorted descending by the `StartedAt` field. 

# Test
Tested in js-sdk https://github.com/e2b-dev/E2B/pull/489

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR updates the `APIStore.GetSandboxes` method to return running instances sorted in descending order by their `StartedAt` field. It also modifies the log sorting mechanism to use the new `slices` package for sorting.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant SandboxHandler
    participant Logger
    participant LogExporter

    Client->>SandboxHandler: Request Sandbox Logs
    SandboxHandler->>SandboxHandler: Sort logs by timestamp
    Note over SandboxHandler: Using slices.SortFunc

    Client->>SandboxHandler: List Sandboxes
    SandboxHandler->>SandboxHandler: Sort sandboxes by start time
    Note over SandboxHandler: Descending order

    Client->>Logger: Log event
    Logger->>LogExporter: Export log
    Note over Logger,LogExporter: Added internal flag<br/>for Loki routing
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/211/files#diff-e0a4804fc633994d7c448596eb7d4f8664a77bd90af250073468829fa1e1f0ec>packages/api/internal/handlers/sandbox_logs.go</a></td><td>Replaced <code>sort.Slice</code> with <code>slices.SortFunc</code> for sorting logs.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/211/files#diff-f5c746bbc38d41ead57f3d87554762308a14a7ea0aa187f09190fa505b00fa55>packages/api/internal/handlers/sandboxes_list.go</a></td><td>Added sorting of sandboxes by <code>StartedAt</code> using <code>slices.SortFunc</code>.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/211/files#diff-85e56636b464d5acd1e362402361322d08c7f99f8b82f9cefb5fe9d637cb7ccd>packages/shared/pkg/logs/logger.go</a></td><td>Refactored variable declarations for <code>logsExporter</code> and <code>logsExporterMU</code>.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->








