### PR TITLE
Envd metrics endpoint

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1748,6 +1748,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/ebitengine/purego v0.8.1 h1:sdRKd6plj7KYW33EH5As6YKfe8m9zbN9JMrOjNVF/BE=
+github.com/ebitengine/purego v0.8.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/efficientgo/core v1.0.0-rc.2 h1:7j62qHLnrZqO3V3UA0AqOGd5d5aXV3AX6m/NZBHp78I=

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -114,6 +114,17 @@ build-and-upload:
 .PHONY: generate
 generate:
 	go generate ./...
+	@if ! command -v buf >/dev/null 2>&1; then \
+		echo "buf is not installed. Do you want to install it?  (Y/n): "; \
+		read choice; \
+		if [ "$$choice" = "Y" ]; then \
+			go install github.com/bufbuild/buf/cmd/buf@latest && \
+			go install google.golang.org/protobuf/cmd/protoc-gen-go@latest && \
+			go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest; \
+		else \
+			exit 1; \
+		fi; \
+	fi
 	cd spec && buf generate
 
 .PHONY: init-generate

--- a/packages/envd/go.mod
+++ b/packages/envd/go.mod
@@ -31,8 +31,9 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/shirou/gopsutil/v4 v4.24.11 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
+	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/tools v0.20.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/packages/envd/go.sum
+++ b/packages/envd/go.sum
@@ -69,6 +69,8 @@ github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.33.0 h1:1cU2KZkvPxNyfgEmhHAz/1A9Bz+llsdYzklWFzgp0r8=
 github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
+github.com/shirou/gopsutil/v4 v4.24.11 h1:WaU9xqGFKvFfsUv94SXcUPD7rCkU0vr/asVdQOBZNj8=
+github.com/shirou/gopsutil/v4 v4.24.11/go.mod h1:s4D/wg+ag4rG0WO7AiTj2BeYCRhym0vM7DHbZRxnIT8=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -87,6 +89,8 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
 golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.20.0 h1:hz/CVckiOxybQvFw6h7b/q80NTr9IUQb4s1IIzW7KNY=

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"github.com/rs/zerolog"
 
+	"github.com/e2b-dev/infra/packages/envd/internal/host"
 	"github.com/e2b-dev/infra/packages/envd/internal/utils"
 )
 
@@ -26,4 +28,23 @@ func (a *API) GetHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "")
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (a *API) GetMetrics(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	a.logger.Trace().Msg("Get metrics")
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+
+	metrics, err := host.GetMetrics()
+	if err != nil {
+		a.logger.Error().Err(err).Msg("Failed to get metrics")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(metrics)
 }

--- a/packages/envd/internal/host/metrics.go
+++ b/packages/envd/internal/host/metrics.go
@@ -1,0 +1,37 @@
+package host
+
+import (
+	"math"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+type Metrics struct {
+	CPU float64 `json:"cpu_pct"`   // Percent rounded to 2 decimal places
+	Mem uint64  `json:"mem_bytes"` // Total virtual memory in bytes
+}
+
+func GetMetrics() (*Metrics, error) {
+	v, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+
+	cpuPcts, err := cpu.Percent(time.Second, false)
+	if err != nil {
+		return nil, err
+	}
+
+	cpuPct := cpuPcts[0]
+	cpuPctRounded := cpuPct
+	if cpuPct > 0 {
+		cpuPctRounded = math.Round(cpuPct*100) / 100
+	}
+
+	return &Metrics{
+		CPU: cpuPctRounded,
+		Mem: v.Total,
+	}, nil
+}

--- a/packages/envd/internal/host/metrics.go
+++ b/packages/envd/internal/host/metrics.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Metrics struct {
-	CPU float64 `json:"cpu_pct"`   // Percent rounded to 2 decimal places
-	Mem uint64  `json:"mem_bytes"` // Total virtual memory in bytes
+	CPU       float64 `json:"cpu_pct"`   // Percent rounded to 2 decimal places
+	Mem       uint64  `json:"mem_bytes"` // Total virtual memory in bytes
+	Timestamp int64   `json:"ts"`        // Unix Timestamp in UTC
 }
 
 func GetMetrics() (*Metrics, error) {
@@ -31,7 +32,8 @@ func GetMetrics() (*Metrics, error) {
 	}
 
 	return &Metrics{
-		CPU: cpuPctRounded,
-		Mem: v.Total,
+		CPU:       cpuPctRounded,
+		Mem:       v.Total,
+		Timestamp: time.Now().UTC().Unix(),
 	}, nil
 }

--- a/packages/envd/internal/host/metrics.go
+++ b/packages/envd/internal/host/metrics.go
@@ -20,7 +20,7 @@ func GetMetrics() (*Metrics, error) {
 		return nil, err
 	}
 
-	cpuPcts, err := cpu.Percent(time.Second, false)
+	cpuPcts, err := cpu.Percent(0, false)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -14,6 +14,17 @@ paths:
       responses:
         "204":
           description: The service is healthy
+          
+  /metrics:
+    get:
+      summary: Get the stats of the service
+      responses:
+        "200":
+          description: The resource usage metrics of the service
+          content:
+          application/json:
+              schema:
+                $ref: "#/components/schemas/Metrics"
 
   /init:
     post:
@@ -192,3 +203,14 @@ components:
       description: Environment variables to set
       additionalProperties:
           type: string
+    Metrics:
+      type: object
+      description: Resource usage metrics
+      properties:
+        cpu_pct:
+          type: number
+          format: float
+          description: CPU usage percentage
+        mem_bytes:
+          type: integer
+          description: Total virtual memory usage in bytes

--- a/packages/shared/Makefile
+++ b/packages/shared/Makefile
@@ -14,7 +14,7 @@ check-atlas:
 	@if ! command -v atlas >/dev/null 2>&1; then \
 		echo "Atlas is not installed. Do you want to install it?  (Y/n): "; \
 		read choice; \
-		if [ "$$choice" = "y" ]; then \
+		if [ "$$choice" = "Y" ]; then \
 			curl -sSf https://atlasgo.sh | ATLAS_VERSION=v0.25.0 sh; \
 		else \
 			exit 1; \


### PR DESCRIPTION
# Description
This PR adds a `/metrics` endpoint to the envd API. This is the first step in allowing the orchestrator to poll for metrics in individual sandboxes from within. 

# Test
```sh
cd packages/envd 
make generate
make run-envd &
curl localhost:49983/metrics

# should return something like this:
# {"cpu_pct":0.71,"mem_bytes":8217411584, "ts":1733364878}
```

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new `/metrics` endpoint to the envd API, allowing the orchestrator to poll for metrics from individual sandboxes. It includes the implementation of metrics retrieval and updates to the API interface and routing.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API Server
    participant Host System

    Client->>API Server: GET /metrics
    API Server->>Host System: GetMetrics()
    Note over Host System: Collect CPU usage<br/>and memory stats
    Host System-->>API Server: Return metrics data
    API Server-->>Client: 200 OK with JSON:<br/>{cpu_pct, mem_bytes, ts}
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247>go.work.sum</a></td><td>Updated dependencies to include 'github.com/ebitengine/purego'.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-aa3e50f41ec7af9a6a251f782a671abbd44315bdf79e5227fdbc9a0445e83977>packages/envd/Makefile</a></td><td>Added a check for the 'buf' command and instructions for installation if not present.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-4e4f4f65521ae20fe1c2f6903f502dbc9024b3426b60ddef3a758ed4bbf405e0>packages/envd/internal/api/api.gen.go</a></td><td>Updated the ServerInterface to include the new GetMetrics method.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-286e84d3d2e52386773b5d33c043b096bee2b855d8ab2cda77d8c0ea900286c2>packages/envd/internal/api/store.go</a></td><td>Implemented the GetMetrics method to retrieve and return service metrics.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-3ded2e8a5d413b21ee2d1ec43844c187a83df80365e19f1f1103a06c65c00a35>packages/envd/internal/host/metrics.go</a></td><td>Added a new file to define the Metrics struct and the GetMetrics function for metrics retrieval.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-401aad177456d3e8a7590e51c4b08abcc7f90cafb2036d898f1b564e39e5a65f>packages/envd/spec/envd.yaml</a></td><td>Updated the API specification to include the new /metrics endpoint.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/214/files#diff-d747b9cf80f73f93fdd10ab6df31b3bbfb21f0a0ecb1e183455d0ffccc083766>packages/shared/Makefile</a></td><td>Corrected the case sensitivity in the installation prompt for Atlas.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.sum`, `.yaml`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








