### PR TITLE
Batch requests for update template spawn count

### DIFF
--- a/packages/api/internal/batcher/batcher.go
+++ b/packages/api/internal/batcher/batcher.go
@@ -61,7 +61,6 @@ func (b *Batcher) batch() {
 		if count == 0 {
 			continue
 		}
-		log.Printf("updating spawn count for env %s: %d", env, count)
 
 		err := b.db.Client.Env.UpdateOneID(env).AddSpawnCount(count).Exec(b.ctx)
 		if err != nil {

--- a/packages/api/internal/batcher/batcher.go
+++ b/packages/api/internal/batcher/batcher.go
@@ -18,11 +18,14 @@ type Batcher struct {
 }
 
 func NewBatcher(ctx context.Context, db *db.DB) *Batcher {
-	return &Batcher{
+	b := &Batcher{
 		db:        db,
 		ctx:       ctx,
 		templates: make(map[string]int64),
 	}
+	go b.Loop()
+
+	return b
 }
 
 // UpdateTemplateSpawnCount updates the spawn count for the given environment.
@@ -56,6 +59,7 @@ func (b *Batcher) batch() {
 		if count == 0 {
 			continue
 		}
+		log.Printf("updating spawn count for env %s: %d", env, count)
 
 		err := b.db.Client.Env.UpdateOneID(env).AddSpawnCount(count).Exec(b.ctx)
 		if err != nil {

--- a/packages/api/internal/batcher/batcher.go
+++ b/packages/api/internal/batcher/batcher.go
@@ -1,0 +1,67 @@
+package batcher
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/db"
+)
+
+type Batcher struct {
+	db        *db.DB
+	templates map[string]int64
+	ctx       context.Context
+
+	mu sync.Mutex
+}
+
+func NewBatcher(ctx context.Context, db *db.DB) *Batcher {
+	return &Batcher{
+		db:        db,
+		ctx:       ctx,
+		templates: make(map[string]int64),
+	}
+}
+
+// UpdateTemplateSpawnCount updates the spawn count for the given environment.
+func (b *Batcher) UpdateTemplateSpawnCount(templateID string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.templates[templateID]; !ok {
+		b.templates[templateID] = 0
+	}
+
+	b.templates[templateID]++
+}
+
+func (b *Batcher) Loop() {
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-ticker.C:
+			b.batch()
+		case <-b.ctx.Done():
+			ticker.Stop()
+			return
+		}
+	}
+}
+
+func (b *Batcher) batch() {
+	b.mu.Lock()
+	for env, count := range b.templates {
+		if count == 0 {
+			continue
+		}
+
+		err := b.db.Client.Env.UpdateOneID(env).AddSpawnCount(count).Exec(b.ctx)
+		if err != nil {
+			log.Printf("failed to update spawn count for env %s: %v", env, err)
+		}
+
+		delete(b.templates, env)
+	}
+}

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -234,10 +233,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	telemetry.ReportEvent(ctx, "Created analytics event")
 
 	go func() {
-		err = a.db.UpdateEnvLastUsed(context.Background(), env.TemplateID)
-		if err != nil {
-			a.logger.Errorf("Error when updating last used for env: %s", err)
-		}
+		a.batcher.UpdateTemplateSpawnCount(env.TemplateID)
 	}()
 
 	telemetry.SetAttributes(ctx,

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -62,7 +62,7 @@ func NewAPIStore() *APIStore {
 		panic(err)
 	}
 
-	dbClient, err := db.NewClient(ctx)
+	dbClient, err := db.NewClient(ctx, 50)
 	if err != nil {
 		logger.Errorf("Error initializing Supabase client\n: %v", err)
 		panic(err)

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -133,7 +133,7 @@ func NewAPIStore() *APIStore {
 	templateCache := templatecache.NewTemplateCache(dbClient)
 	authCache := authcache.NewTeamAuthCache(dbClient)
 
-	batcherClient := batcher.NewBatcher(ctx, dbClient)
+	batcherClient := batcher.New(ctx, dbClient)
 	return &APIStore{
 		Ctx:             ctx,
 		batcher:         batcherClient,
@@ -153,6 +153,9 @@ func NewAPIStore() *APIStore {
 }
 
 func (a *APIStore) Close() {
+	// Needs to be before DB, as it uses the DB
+	a.batcher.Close()
+
 	a.db.Close()
 
 	err := a.analytics.Close()

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -18,6 +18,7 @@ import (
 
 	analyticscollector "github.com/e2b-dev/infra/packages/api/internal/analytics_collector"
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/batcher"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
 	"github.com/e2b-dev/infra/packages/api/internal/cache/builds"
 	"github.com/e2b-dev/infra/packages/api/internal/cache/instance"
@@ -32,6 +33,7 @@ import (
 type APIStore struct {
 	Ctx             context.Context
 	analytics       *analyticscollector.Analytics
+	batcher         *batcher.Batcher
 	posthog         *PosthogClient
 	Tracer          trace.Tracer
 	instanceCache   *instance.InstanceCache
@@ -131,8 +133,10 @@ func NewAPIStore() *APIStore {
 	templateCache := templatecache.NewTemplateCache(dbClient)
 	authCache := authcache.NewTeamAuthCache(dbClient)
 
+	batcherClient := batcher.NewBatcher(ctx, dbClient)
 	return &APIStore{
 		Ctx:             ctx,
+		batcher:         batcherClient,
 		orchestrator:    orch,
 		templateManager: templateManager,
 		db:              dbClient,

--- a/packages/docker-reverse-proxy/internal/handlers/store.go
+++ b/packages/docker-reverse-proxy/internal/handlers/store.go
@@ -21,7 +21,7 @@ type APIStore struct {
 
 func NewStore(ctx context.Context) *APIStore {
 	authCache := cache.New()
-	database, err := db.NewClient(ctx)
+	database, err := db.NewClient(ctx, 5)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/packages/shared/pkg/db/client.go
+++ b/packages/shared/pkg/db/client.go
@@ -19,7 +19,7 @@ type DB struct {
 
 var databaseURL = os.Getenv("POSTGRES_CONNECTION_STRING")
 
-func NewClient(ctx context.Context) (*DB, error) {
+func NewClient(ctx context.Context, connectionCount int) (*DB, error) {
 	if databaseURL == "" {
 		return nil, fmt.Errorf("database URL is empty")
 	}
@@ -31,7 +31,7 @@ func NewClient(ctx context.Context) (*DB, error) {
 
 	// Get the underlying sql.DB object of the driver.
 	db := drv.DB()
-	db.SetMaxOpenConns(20)
+	db.SetMaxOpenConns(connectionCount)
 
 	client := models.NewClient(models.Driver(drv))
 

--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -193,7 +193,3 @@ func (db *DB) EnvBuildSetStatus(
 
 	return nil
 }
-
-func (db *DB) UpdateEnvLastUsed(ctx context.Context, envID string) (err error) {
-	return db.Client.Env.UpdateOneID(envID).AddSpawnCount(1).SetLastSpawnedAt(time.Now()).Exec(ctx)
-}


### PR DESCRIPTION
# Description

Batcher will make only 1 update per template every minute instead of 1 request per each sandbox

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces a new batching feature for updating template spawn counts, allowing only one update per template every minute. It includes the implementation of a `Batcher` struct and its associated methods.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant API
    participant Batcher
    participant DB

    Note over API,DB: Initialization
    API->>Batcher: New(ctx, db)
    activate Batcher
    Batcher-->>API: batcher instance
    Note over Batcher: Starts background loop

    Note over API,DB: Template Spawn Count Update
    API->>Batcher: UpdateTemplateSpawnCount(templateID)
    activate Batcher
    Batcher->>Batcher: Increment counter in memory
    deactivate Batcher

    Note over Batcher,DB: Every minute
    loop Background batch process
        Batcher->>DB: Update spawn counts in bulk
        DB-->>Batcher: Update confirmation
        Batcher->>Batcher: Clear processed counts
    end

    Note over API,DB: Shutdown
    API->>Batcher: Close()
    activate Batcher
    Batcher->>DB: Final batch update
    Batcher->>Batcher: Cancel context
    deactivate Batcher
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-54b7bbb5bb2c00bad2b137befe3e3156770981e7dbc863b0bd1abd0fbf598615>packages/api/internal/batcher/batcher.go</a></td><td>Added a new Batcher struct to handle batch updates for template spawn counts.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-bac89a876b6864b29f6176ee85f19a9e84ffdd0fd3a34ca4db450ab0956fe396>packages/api/internal/handlers/sandbox_create.go</a></td><td>Updated the sandbox creation handler to use the new batcher for updating template spawn counts.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-5287095ee3603063cfe1d0d68a589932bcd45b23ca4d7a46310370814b0650c2>packages/api/internal/handlers/store.go</a></td><td>Modified the APIStore to include a batcher instance.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-160cb56c31eadff152f1f422eb6b9628d494171d0aa030da26507e8cd9723ae3>packages/docker-reverse-proxy/internal/handlers/store.go</a></td><td>Adjusted database client initialization to set a connection count.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-ae153465a12220fe2470f7cf10ada67e786220951c66ae5be9252c148d17fd15>packages/shared/pkg/db/client.go</a></td><td>Updated the NewClient function to accept a connection count parameter.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/218/files#diff-72605933de264b01510f45a7ace429435b165b3c018bbd47a1be10abcf6622fc>packages/shared/pkg/db/envs.go</a></td><td>Removed the UpdateEnvLastUsed function as it is no longer needed.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.go`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->








