### PR TITLE
Listen to and log sandbox process signals

### DIFF
--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -30,7 +30,6 @@ var sigsToListen = []os.Signal{
 	syscall.SIGWINCH,  // Window size change
 	syscall.SIGCHLD,   // Child process terminated
 	syscall.SIGQUIT,   // Quit signal
-	syscall.SIGURG,    // Urgent condition
 	syscall.SIGXCPU,   // CPU time limit exceeded
 	syscall.SIGXFSZ,   // File size limit exceeded
 	syscall.SIGVTALRM, // Virtual timer expired

--- a/packages/orchestrator/internal/sandbox/metrics.go
+++ b/packages/orchestrator/internal/sandbox/metrics.go
@@ -1,8 +1,45 @@
 package sandbox
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+)
+
 type SandboxMetrics struct {
 	Timestamp   int64   `json:"ts"`            // Unix Timestamp in UTC
 	CPUPercent  float64 `json:"cpu_pct"`       // Percent rounded to 2 decimal places
 	MemTotalMiB uint64  `json:"mem_total_mib"` // Total virtual memory in MiB
 	MemUsedMiB  uint64  `json:"mem_used_mib"`  // Used virtual memory in MiB
+}
+
+func (s *Sandbox) GetMetrics(ctx context.Context) (SandboxMetrics, error) {
+	address := fmt.Sprintf("http://%s:%d/metrics", s.slot.HostIP(), consts.DefaultEnvdServerPort)
+
+	request, err := http.NewRequestWithContext(ctx, "GET", address, nil)
+	if err != nil {
+		return SandboxMetrics{}, err
+	}
+
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return SandboxMetrics{}, err
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code: %d", response.StatusCode)
+		return SandboxMetrics{}, err
+	}
+
+	var metrics SandboxMetrics
+	err = json.NewDecoder(response.Body).Decode(&metrics)
+	if err != nil {
+		return SandboxMetrics{}, err
+	}
+
+	return metrics, nil
 }

--- a/packages/orchestrator/internal/sandbox/signal.go
+++ b/packages/orchestrator/internal/sandbox/signal.go
@@ -1,0 +1,23 @@
+package sandbox
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+func listenProcessSignals(
+	ctx context.Context, pid int, sigsToListen []os.Signal, callback func(sig os.Signal),
+) {
+	// Create a channel to receive signals
+	sigChan := make(chan os.Signal, 1)
+
+	// Specify the signals we want to listen to
+	signal.Notify(sigChan, sigsToListen...)
+
+	// Continuously listen for signals
+	for {
+		sig := <-sigChan
+		callback(sig)
+	}
+}

--- a/packages/shared/pkg/logs/logger.go
+++ b/packages/shared/pkg/logs/logger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -177,6 +178,15 @@ func (l *SandboxLogger) MemoryUsage(memoryMB float64) {
 			Msgf("Sandbox memory used %d %% of RAM", int(memoryMB/float64(l.memoryMiBMax)*100))
 		return
 	}
+}
+
+func (l *SandboxLogger) Signal(sig os.Signal) {
+	l.exporter.logger.Info().
+		Str("instanceID", l.instanceID).
+		Str("envID", l.envID).
+		Str("teamID", l.teamID).
+		Str("signal", sig.String()).
+		Msg("Signal received")
 }
 
 func (l *SandboxLogger) CPUPct(cpuPct float64) {


### PR DESCRIPTION
# Description
This is the first stab at listening to system signals from the orchestrator and logging them on a per sandbox basis. 
With the firecracker PID we add an event listener with a logging callback that logs based on the list of signals we want to know about. 

# Example
```sh
jonas@mac infra % e2b sbx lg -f insc237opthljodv104h8-a805a5ff | grep signal
[2024-12-07 02:37:46.980Z] INFO  { logger: 'orchestrator', message: 'Signal received', signal: 'child exited' }
```

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR introduces functionality to listen to system signals in the sandbox and log them accordingly. It adds a new method for logging signals and modifies the existing log metrics method to include signal listening.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant S as Sandbox
    participant M as Metrics Endpoint
    participant SL as Signal Listener
    participant L as Logger

    Note over S: Sandbox starts monitoring

    par Metrics Collection
        S->>M: GetMetrics()
        M-->>S: Return SandboxMetrics (CPU, Memory)
        S->>L: Log metrics data
    and Signal Monitoring
        S->>SL: Start listening for signals
        activate SL
        SL-->>SL: Monitor system signals
        SL->>L: Log received signals
        Note over SL: Monitors signals like<br/>SIGTERM, SIGINT, etc.
    end

    Note over S: Continuous monitoring<br/>with defined intervals
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/219/files#diff-c0bcc579e61d4919acfae49e073604fe0d725d5068ed04d382470a567d07d903>packages/orchestrator/internal/sandbox/checks.go</a></td><td>Added signal handling and logging functionality.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/219/files#diff-80a10f2022bc0014e30fc9f2afdd59fc7e857c595f357a8df7cd0dca071dedcf>packages/orchestrator/internal/sandbox/metrics.go</a></td><td>Restored the GetMetrics function to retrieve sandbox metrics.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/219/files#diff-d8f1ee772d68232c2eec9eaef018fb051aed7741b3aea31cebb68dfa3b370c14>packages/orchestrator/internal/sandbox/signal.go</a></td><td>New file created to handle process signals.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/219/files#diff-85e56636b464d5acd1e362402361322d08c7f99f8b82f9cefb5fe9d637cb7ccd>packages/shared/pkg/logs/logger.go</a></td><td>Added a method to log received signals.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.go`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


