### PR TITLE
Filter out snapshots from templates API endpoint

### DIFF
--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -65,6 +65,7 @@ func (db *DB) GetEnvs(ctx context.Context, teamID uuid.UUID) (result []*Template
 		Where(
 			env.TeamID(teamID),
 			env.HasBuildsWith(envbuild.StatusEQ(envbuild.StatusUploaded)),
+			env.Not(env.HasSnapshots()),
 		).
 		Order(models.Asc(env.FieldCreatedAt)).
 		WithEnvAliases().


### PR DESCRIPTION
Right now, snapshots envs are also listed when listing templates. This change filters them out.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR filters out snapshots from the templates API endpoint by modifying the query to exclude environments that have snapshots.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant DB as Database Query
    participant E as Environments

    C->>DB: Query Environments
    Note over DB: Filter Conditions:<br/>1. Match Team ID<br/>2. Has Uploaded Builds<br/>3. No Snapshots
    DB->>E: Apply Filters
    E-->>C: Return Filtered Environments
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/229/files#diff-72605933de264b01510f45a7ace429435b165b3c018bbd47a1be10abcf6622fc>packages/shared/pkg/db/envs.go</a></td><td>Added a filter to exclude environments with snapshots in the GetEnvs function.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


