### PR TITLE
Prevent problem if closing sandbox gets stuck

### DIFF
--- a/packages/api/internal/cache/instance/instance.go
+++ b/packages/api/internal/cache/instance/instance.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jellydator/ttlcache/v3"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	analyticscollector "github.com/e2b-dev/infra/packages/api/internal/analytics_collector"
 	"github.com/e2b-dev/infra/packages/api/internal/api"

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -155,19 +155,21 @@ func (s *server) Delete(ctx context.Context, in *orchestrator.SandboxDeleteReque
 		return nil, status.New(codes.NotFound, errMsg.Error()).Err()
 	}
 
-	sbx.Healthcheck(ctx, true)
-
 	// Don't allow connecting to the sandbox anymore.
 	s.dns.Remove(in.SandboxId)
+
+	// Remove the sandbox from the cache to prevent loading it again in API during the time the instance is stopping.
+	// Old comment:
+	// 	Ensure the sandbox is removed from cache.
+	// 	Ideally we would rely only on the goroutine defer.
+	s.sandboxes.Remove(in.SandboxId)
+
+	sbx.Healthcheck(ctx, true)
 
 	err := sbx.Stop()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error stopping sandbox '%s': %v\n", in.SandboxId, err)
 	}
-
-	// Ensure the sandbox is removed from cache.
-	// Ideally we would rely only on the goroutine defer.
-	s.sandboxes.Remove(in.SandboxId)
 
 	return &emptypb.Empty{}, nil
 }


### PR DESCRIPTION
Remove the sandbox from cache prior ending the sandbox itself

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR modifies the sandbox deletion process to ensure the sandbox is removed from the cache before stopping it, preventing potential issues if the sandbox gets stuck.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Server
    participant DNS
    participant Cache
    participant Sandbox

    Client->>Server: StopSandbox(sandboxId)
    Server->>DNS: Remove(sandboxId)
    Server->>Cache: Remove(sandboxId)
    Server->>Sandbox: Healthcheck(ctx, true)
    Server->>Sandbox: Stop()
    Server->>Client: Return Empty Response
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/232/files#diff-2ec9d602a87e26312ede1d987a89dcd8e1262a46d5c50d0b637d636646cdfa25>packages/orchestrator/internal/server/sandboxes.go</a></td><td>Updated the sandbox deletion logic to remove the sandbox from cache before stopping it.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


