### PR TITLE
Set default IS_SANDBOX env var upon envd init

### DIFF
--- a/packages/envd/README.md
+++ b/packages/envd/README.md
@@ -4,10 +4,10 @@ Daemon that runs inside a sandbox and allows interacting with the sandbox via ca
 
 ## Development
 
-Run the following command to start a Docker container and run the envd daemon inside:
+Run the following command to (re)build the envd daemon and start a Docker container and run the it inside:
 
 ```bash
-make run-envd
+make build && make start-docker
 ```
 
 You can use E2B SDKs with env var `E2B_DEBUG=true` or with a debug parameter set to true when creating or connecting to a sandbox to connect to the envd started with this command locally.

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -3,10 +3,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/envd/internal/host"
-	"github.com/e2b-dev/infra/packages/envd/internal/logs"
 	"io"
 	"net/http"
+
+	"github.com/e2b-dev/infra/packages/envd/internal/host"
+	"github.com/e2b-dev/infra/packages/envd/internal/logs"
 )
 
 func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
@@ -35,6 +36,10 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+
+	// Set this env var to indicate that we are in a sandbox
+	// This is set after the user providced env vars are set to ensure that is not overriden upon initialization.
+	a.envVars.Store("E2B_SANDBOX", "true")
 
 	a.logger.Debug().Str(string(logs.OperationIDKey), operationID).Msg("Syncing host")
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -37,10 +37,6 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Set this env var to indicate that we are in a sandbox
-	// This is set after the user providced env vars are set to ensure that is not overriden upon initialization.
-	a.envVars.Store("E2B_SANDBOX", "true")
-
 	a.logger.Debug().Str(string(logs.OperationIDKey), operationID).Msg("Syncing host")
 
 	go func() {

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -128,6 +128,8 @@ func main() {
 
 	envVars := utils.NewMap[string, string]()
 
+	envVars.Store("E2B_SANDBOX", "true")
+
 	processLogger := l.With().Str("logger", "process").Logger()
 	processService := processRpc.Handle(m, &processLogger, envVars)
 


### PR DESCRIPTION
# Description
Set a  `E2B_SANDBOX=true` env var inside the sandbox as soon as it envd inits. 
Users will then be able to get this env var from the code running inside the sandbox (as if they were trying to get any other env var) and tell if the code is running inside the sandbox.

# Test
Going to try this test in `js-sdk`, cannot do it on local host. 
```js
sandboxTest.skipIf(isDebug)('default env vars present', async ({ sandbox }) => {
  const result = await sandbox.commands.run('echo $E2B_SANDBOX')
  assert.equal(result?.stdout[0].trim(), 'true')
})

```

And in `code-interpreter` 

```js
sandboxTest.skipIf(isDebug)('default env vars present', async ({ sandbox }) => {
  const result = await sandbox.runCode('import os; os.getenv("E2B_SANDBOX")')

  expect(result.results[0].text.trim()).toEqual('true')
})
```

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR sets a default environment variable `E2B_SANDBOX=true` upon initializing the envd daemon, allowing users to check if the code is running inside a sandbox.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant User
    participant Docker
    participant EnvD
    participant Sandbox

    User->>Docker: make build
    User->>Docker: make start-docker
    Docker->>EnvD: Start envd daemon
    EnvD->>Sandbox: Initialize
    Note over Sandbox: Set E2B_SANDBOX=true
    Sandbox-->>EnvD: Initialization complete
    EnvD-->>User: Ready for connections
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/236/files#diff-81cf58b031a71bffa959659add64a05135d86d22910ece87217b1d2b5dff121e>packages/envd/README.md</a></td><td>Updated instructions for starting the envd daemon to include rebuilding the daemon.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/236/files#diff-ac5804412140df213186ea0b6c79b837f6dfb6824a65dff4e6cdac7d5ef6a787>packages/envd/internal/api/init.go</a></td><td>No significant changes; imports were reordered.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/236/files#diff-e5cfdaf8d2af9c0bc1401f62098c2768acad24ba196a5f9b3a84ff3d0280fd47>packages/envd/main.go</a></td><td>Added a line to store the environment variable <code>E2B_SANDBOX</code> with a value of <code>true</code>.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.md`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->






