### PR TITLE
Handle failed connection to template manager during build

### DIFF
--- a/packages/api/internal/handlers/template_start_build.go
+++ b/packages/api/internal/handlers/template_start_build.go
@@ -140,8 +140,22 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 			build.RAMMB,
 		)
 		if buildErr != nil {
-			err = fmt.Errorf("error when building env: %w", buildErr)
+			buildErr = fmt.Errorf("error when building env: %w", buildErr)
 			telemetry.ReportCriticalError(buildContext, buildErr)
+
+			dbErr := a.db.EnvBuildSetStatus(ctx, templateID, buildUUID, envbuild.StatusFailed)
+			if dbErr != nil {
+				dbErr = fmt.Errorf("error when setting build status: %w", err)
+				telemetry.ReportCriticalError(ctx, dbErr)
+			}
+
+			// Save the error in the logs
+			buildErr = a.buildCache.Append(templateID, buildUUID, fmt.Sprintf("Build failed: %s\n", buildErr))
+			cacheErr := a.buildCache.SetDone(templateID, buildUUID, api.TemplateBuildStatusError)
+			if cacheErr != nil {
+				cacheErr = fmt.Errorf("error when setting build done in logs: %w", cacheErr)
+				telemetry.ReportCriticalError(ctx, cacheErr)
+			}
 
 			return
 		}

--- a/packages/api/internal/handlers/template_start_build.go
+++ b/packages/api/internal/handlers/template_start_build.go
@@ -145,7 +145,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 
 			dbErr := a.db.EnvBuildSetStatus(ctx, templateID, buildUUID, envbuild.StatusFailed)
 			if dbErr != nil {
-				dbErr = fmt.Errorf("error when setting build status: %w", err)
+				dbErr = fmt.Errorf("error when setting build status: %w", dbErr)
 				telemetry.ReportCriticalError(ctx, dbErr)
 			}
 

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -94,7 +94,7 @@ func (tm *TemplateManager) CreateTemplate(
 
 	diskSize, parseErr := strconv.ParseInt(rootfsSizeStr[0], 10, 64)
 	if parseErr != nil {
-		return fmt.Errorf("error when parsing rootfs size: %w", err)
+		return fmt.Errorf("error when parsing rootfs size: %w", parseErr)
 	}
 
 	envdVersion, ok := trailer[storage.EnvdVersionKey]

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -16,8 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/db"
-	template_manager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
-	"github.com/e2b-dev/infra/packages/shared/pkg/models/envbuild"
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -77,52 +76,35 @@ func (tm *TemplateManager) CreateTemplate(
 			break
 		} else if receiveErr != nil {
 			// There was an error during the build
-			errMsg := fmt.Errorf("error when building env: %w", receiveErr)
-			handleBuildErr(ctx, db, buildCache, templateID, buildID, errMsg)
+			return fmt.Errorf("error when building env: %w", receiveErr)
 
-			return errMsg
 		}
 		logErr := buildCache.Append(templateID, buildID, log.Log)
 		if logErr != nil {
 			// There was an error saving the logs, the build wasn't found
-			errMsg := fmt.Errorf("error when saving docker build logs: %w", logErr)
-			handleBuildErr(ctx, db, buildCache, templateID, buildID, errMsg)
-
-			return errMsg
+			return fmt.Errorf("error when saving docker build logs: %w", logErr)
 		}
 	}
 
 	trailer := logs.Trailer()
 	rootfsSizeStr, ok := trailer[storage.RootfsSizeKey]
 	if !ok {
-		errMsg := fmt.Errorf("rootfs size not found in trailer")
-		handleBuildErr(ctx, db, buildCache, templateID, buildID, errMsg)
-
-		return errMsg
+		return fmt.Errorf("rootfs size not found in trailer")
 	}
 
 	diskSize, parseErr := strconv.ParseInt(rootfsSizeStr[0], 10, 64)
 	if parseErr != nil {
-		parseErr = fmt.Errorf("error when parsing rootfs size: %w", err)
-		handleBuildErr(ctx, db, buildCache, templateID, buildID, parseErr)
-
-		return parseErr
+		return fmt.Errorf("error when parsing rootfs size: %w", err)
 	}
 
 	envdVersion, ok := trailer[storage.EnvdVersionKey]
 	if !ok {
-		errMsg := fmt.Errorf("envd version not found in trailer")
-		handleBuildErr(ctx, db, buildCache, templateID, buildID, errMsg)
-
-		return errMsg
+		return fmt.Errorf("envd version not found in trailer")
 	}
 
 	err = db.FinishEnvBuild(childCtx, templateID, buildID, diskSize, envdVersion[0])
 	if err != nil {
-		err = fmt.Errorf("error when finishing build: %w", err)
-		handleBuildErr(ctx, db, buildCache, templateID, buildID, err)
-
-		return err
+		return fmt.Errorf("error when finishing build: %w", err)
 	}
 
 	telemetry.ReportEvent(childCtx, "created new environment", attribute.String("env.id", templateID))
@@ -136,31 +118,4 @@ func (tm *TemplateManager) CreateTemplate(
 	telemetry.ReportEvent(childCtx, "Template build started")
 
 	return nil
-}
-
-func handleBuildErr(
-	ctx context.Context,
-	db *db.DB,
-	buildCache *builds.BuildCache,
-	templateID string,
-	buildID uuid.UUID,
-	buildErr error,
-) {
-	telemetry.ReportCriticalError(ctx, buildErr)
-
-	err := db.EnvBuildSetStatus(ctx, templateID, buildID, envbuild.StatusFailed)
-	if err != nil {
-		err = fmt.Errorf("error when setting build status: %w", err)
-		telemetry.ReportCriticalError(ctx, err)
-	}
-
-	// Save the error in the logs
-	buildErr = buildCache.Append(templateID, buildID, fmt.Sprintf("Build failed: %s\n", buildErr))
-
-	cacheErr := buildCache.SetDone(templateID, buildID, api.TemplateBuildStatusError)
-	if cacheErr != nil {
-		err = fmt.Errorf("error when setting build done in logs: %w", cacheErr)
-		telemetry.ReportCriticalError(ctx, cacheErr)
-	}
-	return
 }


### PR DESCRIPTION
# Description

Fixes a bug when the request to the template manager fails, causing the build not to cancel and the CLI to remain stuck indefinitely.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR handles failed connections to the template manager during the build process, ensuring that the build is canceled properly and the CLI does not remain stuck indefinitely.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Handler
    participant BuildCache
    participant DB
    participant Telemetry

    Note over Handler: Template Build Error Occurs

    Handler->>Telemetry: Report Critical Error
    Handler->>DB: Set Build Status to Failed
    
    alt DB Error
        DB-->>Telemetry: Report Critical Error (DB)
    end

    Handler->>BuildCache: Append Build Error Logs
    alt Cache Append Error
        BuildCache-->>Telemetry: Report Critical Error (Cache Append)
    end

    Handler->>BuildCache: Set Build Status to Error
    alt Cache Status Error
        BuildCache-->>Telemetry: Report Critical Error (Cache Status)
    end

    Note over Handler: Return Error
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/238/files#diff-c2f8a164633595256cba6fc61b20d4068b42d1b90d744ffd79590e19e6e48880>packages/api/internal/handlers/template_start_build.go</a></td><td>Added error handling for failed builds, including logging and updating the build status.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/238/files#diff-3363a1a259686560f89db93ae0985c0eccf3dbca14e244894b011bb947ceef85>packages/api/internal/template-manager/create_template.go</a></td><td>Refactored error handling to return errors directly instead of using a separate function.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->






