### PR TITLE
Add missing DNS request token

### DIFF
--- a/packages/cluster/scripts/start-api.sh
+++ b/packages/cluster/scripts/start-api.sh
@@ -66,5 +66,7 @@ systemctl restart systemd-resolved
     --consul-token "${CONSUL_TOKEN}" \
     --cluster-tag-name "${CLUSTER_TAG_NAME}" \
     --enable-gossip-encryption \
-    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" &
+    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" \
+    --dns-request-token "${CONSUL_DNS_REQUEST_TOKEN}" &
+
 /opt/nomad/bin/run-nomad.sh --consul-token "${CONSUL_TOKEN}" &

--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -226,7 +226,9 @@ echo $overcommitment_hugepages >/proc/sys/vm/nr_overcommit_hugepages
     --consul-token "${CONSUL_TOKEN}" \
     --cluster-tag-name "${CLUSTER_TAG_NAME}" \
     --enable-gossip-encryption \
-    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" &
+    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" \
+    --dns-request-token "${CONSUL_DNS_REQUEST_TOKEN}" &
+
 /opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" &
 
 # Add alias for ssh-ing to sbx

--- a/packages/cluster/server/main.tf
+++ b/packages/cluster/server/main.tf
@@ -74,8 +74,8 @@ resource "google_compute_instance_template" "server" {
   metadata_startup_script = var.startup_script
   metadata = merge(
     {
-      enable-osconfig         = "TRUE",
-      enable-guest-attributes = "TRUE",
+      enable-osconfig                          = "TRUE",
+      enable-guest-attributes                  = "TRUE",
       (var.metadata_key_name_for_cluster_size) = var.cluster_size,
     },
     var.custom_metadata,


### PR DESCRIPTION
# Description

The DNS records weren't updated on the node, causing issues if the node with e.g. template manager was replaced

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds a missing DNS request token to the startup scripts for both API and client, ensuring proper DNS record updates on the node.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Cluster Scripts
    participant Consul
    participant GCP Instance

    Cluster Scripts->>Consul: Add gossip encryption key
    Cluster Scripts->>Consul: Add DNS request token
    
    GCP Instance->>GCP Instance: Enable OS Config
    GCP Instance->>GCP Instance: Enable Guest Attributes
    
    Note over Cluster Scripts,Consul: Enhanced security configuration
    Note over GCP Instance: Additional GCP features enabled
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/239/files#diff-1c090c03c7c594f20b0edd4e954dc1ab213e4f3a6e15fb3cd58bb10a8d8e9611>packages/cluster/scripts/start-api.sh</a></td><td>Added DNS request token to the API startup script.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/239/files#diff-0f10255f57832ea09b58a73f96a30d231425d26ba91caa8cd9ddc68ce583f476>packages/cluster/scripts/start-client.sh</a></td><td>Added DNS request token to the client startup script.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/239/files#diff-2420fa615a5c15ccff10a8941a2d50292031945e0bf9aaefafebb0994be55dc7>packages/cluster/server/main.tf</a></td><td>Minor formatting changes in the metadata section.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.sh`, `.tf`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


