### PR TITLE
Add logs for pulling docker image during build

### DIFF
--- a/packages/template-manager/internal/build/rootfs.go
+++ b/packages/template-manager/internal/build/rootfs.go
@@ -75,6 +75,7 @@ func NewRootfs(ctx context.Context, tracer trace.Tracer, env *Env, docker *clien
 		env:          env,
 	}
 
+	_, _ = env.BuildLogsWriter.Write([]byte("Pulling Docker image...\n"))
 	err := rootfs.pullDockerImage(childCtx, tracer)
 	if err != nil {
 		errMsg := fmt.Errorf("error building docker image: %w", err)
@@ -83,6 +84,7 @@ func NewRootfs(ctx context.Context, tracer trace.Tracer, env *Env, docker *clien
 
 		return nil, errMsg
 	}
+	_, _ = env.BuildLogsWriter.Write([]byte("Pulled Docker image.\n\n"))
 
 	err = rootfs.createRootfsFile(childCtx, tracer)
 	if err != nil {


### PR DESCRIPTION
# Description

If the docker image is big (as Code interpreter one) it can take a minute (maybe even several) and there could be not logs.

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds logging for the process of pulling a Docker image during the build process, providing feedback on the status of the image pull.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant BuildLogsWriter
    participant Rootfs
    participant DockerSystem

    Rootfs->>BuildLogsWriter: Write("Pulling Docker image...")
    Rootfs->>DockerSystem: pullDockerImage()
    alt successful pull
        DockerSystem-->>Rootfs: image pulled
        Rootfs->>BuildLogsWriter: Write("Pulled Docker image.")
    else error
        DockerSystem-->>Rootfs: error
        Rootfs-->>BuildLogsWriter: error building docker image
    end
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/240/files#diff-08ee7bc4344973312025e609808c92c7852506254ec6a44ee4107802ae19fdfe>packages/template-manager/internal/build/rootfs.go</a></td><td>Added logs to indicate when a Docker image is being pulled and when it has been successfully pulled.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


