### PR TITLE
Add metrics to allow us set up alerts for error rate and slowing requests

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 
 	customMiddleware "github.com/e2b-dev/infra/packages/shared/pkg/gin_utils/middleware"
+	metricsMiddleware "github.com/e2b-dev/infra/packages/shared/pkg/gin_utils/middleware/otel/metrics"
 	tracingMiddleware "github.com/e2b-dev/infra/packages/shared/pkg/gin_utils/middleware/otel/tracing"
 )
 
@@ -49,7 +50,7 @@ func NewGinServer(apiStore *handlers.APIStore, swagger *openapi3.T, port int) *h
 			"/templates/:templateID/builds/:buildID/logs",
 			"/templates/:templateID/builds/:buildID/status",
 		),
-		// customMiddleware.IncludeRoutes(metricsMiddleware.Middleware(serviceName), "/instances"),
+		customMiddleware.IncludeRoutes(metricsMiddleware.Middleware(serviceName), "/sandboxes"),
 		customMiddleware.ExcludeRoutes(gin.LoggerWithWriter(gin.DefaultWriter),
 			"/health",
 			"/sandboxes/:sandboxID/refreshes",

--- a/packages/shared/pkg/gin_utils/middleware/otel/metrics/config.go
+++ b/packages/shared/pkg/gin_utils/middleware/otel/metrics/config.go
@@ -35,9 +35,6 @@ var DefaultAttributes = func(serverName, route string, request *http.Request) []
 		semconv.HTTPMethodKey.String(request.Method),
 	}
 
-	if serverName != "" {
-		attrs = append(attrs, semconv.HTTPServerNameKey.String(serverName))
-	}
 	if route != "" {
 		attrs = append(attrs, semconv.HTTPRouteKey.String(route))
 	}

--- a/packages/shared/pkg/gin_utils/middleware/otel/metrics/otelrecorder.go
+++ b/packages/shared/pkg/gin_utils/middleware/otel/metrics/otelrecorder.go
@@ -28,7 +28,7 @@ func GetRecorder(metricsPrefix string) Recorder {
 	meter := otel.Meter("api-metrics", metric.WithInstrumentationVersion(SemVersion()))
 
 	totalDuration, _ := meter.Float64Histogram(
-		metricName("http.server.test.request_duration_4"),
+		metricName("http.server.duration"),
 		metric.WithDescription("Time Taken by request"),
 		metric.WithUnit("s"),
 	)

--- a/packages/shared/pkg/gin_utils/middleware/otel/metrics/otelrecorder.go
+++ b/packages/shared/pkg/gin_utils/middleware/otel/metrics/otelrecorder.go
@@ -30,7 +30,7 @@ func GetRecorder(metricsPrefix string) Recorder {
 	totalDuration, _ := meter.Float64Histogram(
 		metricName("http.server.duration"),
 		metric.WithDescription("Time Taken by request"),
-		metric.WithUnit("s"),
+		metric.WithUnit("ms"),
 	)
 
 	return &otelRecorder{
@@ -40,5 +40,5 @@ func GetRecorder(metricsPrefix string) Recorder {
 
 // ObserveHTTPRequestDuration measures the duration of an HTTP request.
 func (r *otelRecorder) ObserveHTTPRequestDuration(ctx context.Context, duration time.Duration, attributes []attribute.KeyValue) {
-	r.totalDuration.Record(ctx, float64(duration/time.Second), metric.WithAttributes(attributes...))
+	r.totalDuration.Record(ctx, float64(duration/time.Millisecond), metric.WithAttributes(attributes...))
 }


### PR DESCRIPTION
# Description

This will allow us to set alerts for error rate and set up alert once the requests get slow hence we should know of some problems earlier than when everything goes bad

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR adds metrics to monitor error rates and request durations, enabling alerts for performance issues.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant GinRouter
    participant MetricsMiddleware
    participant OtelRecorder
    participant OpenTelemetry

    Client->>GinRouter: HTTP Request to /sandboxes
    GinRouter->>MetricsMiddleware: Process Request
    MetricsMiddleware->>MetricsMiddleware: Start Timer
    MetricsMiddleware->>GinRouter: Continue Request Chain
    GinRouter-->>MetricsMiddleware: Complete Request
    MetricsMiddleware->>OtelRecorder: Record Duration
    OtelRecorder->>OpenTelemetry: Record http.server.duration (ms)
    MetricsMiddleware-->>Client: HTTP Response
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/242/files#diff-67d1b8117fb66e8f1be66e37b0bf6d7f6b84981d730c7b115f90bafc6c9241a8>packages/api/main.go</a></td><td>Added metrics middleware to the Gin server for monitoring.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/242/files#diff-aba64b8569157cd5b5c4d9ef3e7a6c29fbaf31486d23c9808e32c77ae4a02250>packages/shared/pkg/gin_utils/middleware/otel/metrics/config.go</a></td><td>Removed unnecessary server name attribute from default attributes.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/242/files#diff-5785d436817b74a4047d87029e37dea82a28c91bb1aeeb7f39b152f635eb83fb>packages/shared/pkg/gin_utils/middleware/otel/metrics/middleware.go</a></td><td>Cleaned up middleware code by removing unused environment and team ID logging.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/242/files#diff-ba50012ed1ab44b3649ae57bab608d7afbdc2b6659ef73265be1a2e9dd6fad43>packages/shared/pkg/gin_utils/middleware/otel/metrics/otelrecorder.go</a></td><td>Updated metrics to record request duration in milliseconds instead of seconds.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


