### PR TITLE
Return correct errors for not found template

### DIFF
--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -78,7 +78,10 @@ func (c *TemplateCache) Get(ctx context.Context, aliasOrEnvID string, teamID uui
 	if item == nil {
 		envDB, build, err = c.db.GetEnv(ctx, aliasOrEnvID)
 		if err != nil {
-			return nil, nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: fmt.Sprintf("error when getting template: %v", err), Err: err}
+			if models.IsNotFound(err) == true {
+				return nil, nil, &api.APIError{Code: http.StatusNotFound, ClientMsg: fmt.Sprintf("template '%s' not found", aliasOrEnvID), Err: err}
+			}
+			return nil, nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: fmt.Sprintf("error while getting template: %v", err), Err: err}
 		}
 
 		c.aliasCache.cache.Set(envDB.TemplateID, envDB.TemplateID, templateInfoExpiration)

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -61,11 +61,9 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	// Check if team has access to the environment
 	env, build, checkErr := a.templateCache.Get(ctx, cleanedAliasOrEnvID, teamInfo.Team.ID, true)
 	if checkErr != nil {
-		errMsg := fmt.Errorf("error when checking team access: %s", checkErr.Err)
-		telemetry.ReportCriticalError(ctx, errMsg)
+		telemetry.ReportCriticalError(ctx, checkErr.Err)
 
-		a.sendAPIStoreError(c, checkErr.Code, fmt.Sprintf("Error when checking team access: %s", checkErr.ClientMsg))
-
+		a.sendAPIStoreError(c, checkErr.Code, checkErr.ClientMsg)
 		return
 	}
 	templateSpan.End()

--- a/packages/shared/pkg/db/envs.go
+++ b/packages/shared/pkg/db/envs.go
@@ -132,7 +132,7 @@ func (db *DB) GetEnv(ctx context.Context, aliasOrEnvID string) (result *Template
 
 	notFound := models.IsNotFound(err)
 	if notFound {
-		return nil, nil, fmt.Errorf("template '%s' not found", aliasOrEnvID)
+		return nil, nil, fmt.Errorf("template '%s' not found: %w", aliasOrEnvID, err)
 	} else if err != nil {
 		return nil, nil, fmt.Errorf("failed to get env '%s': %w", aliasOrEnvID, err)
 	}


### PR DESCRIPTION
<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR improves error handling for template retrieval by returning specific errors for not found templates and adjusting error reporting in the API handler.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid

sequenceDiagram
    participant Client
    participant Handler
    participant Cache
    participant DB

    Client->>Handler: Request template (aliasOrEnvID)
    Handler->>Cache: Get(aliasOrEnvID)
    
    alt Cache miss
        Cache->>DB: GetEnv(aliasOrEnvID)
        
        alt Template not found
            DB-->>Cache: NotFound error
            Cache-->>Handler: APIError(404, "template not found")
            Handler-->>Client: 404 Status + Error message
        else Other DB error
            DB-->>Cache: Error
            Cache-->>Handler: APIError(500, "error while getting template")
            Handler-->>Client: 500 Status + Error message
        end
    end

```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/243/files#diff-16f8663e89449113e324e2efe70025fbc7c6b9a807936375932dae736a56ede2>packages/api/internal/cache/templates/cache.go</a></td><td>Updated error handling to return a specific not found error for templates.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/243/files#diff-bac89a876b6864b29f6176ee85f19a9e84ffdd0fd3a34ca4db450ab0956fe396>packages/api/internal/handlers/sandbox_create.go</a></td><td>Modified error reporting to streamline the error message sent to the API store.</td></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/243/files#diff-72605933de264b01510f45a7ace429435b165b3c018bbd47a1be10abcf6622fc>packages/shared/pkg/db/envs.go</a></td><td>Enhanced error message for not found templates to include the original error.</td></tr>

</table>
</details>

</details>
<!-- cal_description_end -->


