### PR TITLE
Don't cache envd

### DIFF
--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -107,7 +107,7 @@ EOF
 # Mount envd buckets
 envd_dir="/fc-envd"
 mkdir -p $envd_dir
-gcsfuse -o=allow_other,ro --file-mode 755 --config-file $fuse_config --implicit-dirs "${FC_ENV_PIPELINE_BUCKET_NAME}" $envd_dir
+gcsfuse -o=allow_other,ro --file-mode 755 --implicit-dirs "${FC_ENV_PIPELINE_BUCKET_NAME}" $envd_dir
 
 # Mount kernels
 kernels_dir="/fc-kernels"


### PR DESCRIPTION
# Description

Envd is used only during build, which isn't high volume, is also quite small, and changes often. 
Other option would be to set reasonable ttl for this bucket

<!-- cal_description_begin -->
<details open>
<summary>:sparkles: <i><h3>Description by Callstackai</h3></i></summary>

This PR removes the `--config-file $fuse_config` option from the `gcsfuse` command in the `start-client.sh` script.



<details>
<summary><b>Diagrams of code changes</b></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Filesystem
    participant GCSBucket

    Client->>Filesystem: Create directory "/fc-envd"
    Client->>GCSBucket: Mount "${FC_ENV_PIPELINE_BUCKET_NAME}"
    GCSBucket-->>Filesystem: Mount as read-only with mode 755
    Note over Filesystem: Bucket mounted at /fc-envd
```

</details>


<details>
<summary><b>Files Changed</b></summary>
<table>
<tr><th>File</th><th>Summary</th></tr>
<tr><td><a href=https://github.com/e2b-dev/infra/pull/244/files#diff-0f10255f57832ea09b58a73f96a30d231425d26ba91caa8cd9ddc68ce583f476>packages/cluster/scripts/start-client.sh</a></td><td>Removed the config file option from the gcsfuse command.</td></tr>

</table>
</details>

*This PR includes files in programming languages that we currently do not support. We have not reviewed files with the extensions `.sh`. <a href=https://docs.callstack.ai/introduction>See list of supported languages.</a>*


</details>
<!-- cal_description_end -->


