### PR TITLE
Increase memory during build when memory for the template is small

### DIFF
--- a/packages/template-manager/internal/build/rootfs.go
+++ b/packages/template-manager/internal/build/rootfs.go
@@ -255,6 +255,7 @@ func (r *Rootfs) createRootfsFile(ctx context.Context, tracer trace.Tracer) erro
 	telemetry.ReportEvent(childCtx, "created network")
 
 	pidsLimit := int64(200)
+	memory := int64(math.Max(float64(r.env.MemoryMB)/2, 512)) << ToMBShift
 
 	cont, err := r.client.ContainerCreate(childCtx, &container.Config{
 		Image:        r.dockerTag(),
@@ -271,10 +272,10 @@ func (r *Rootfs) createRootfsFile(ctx context.Context, tracer trace.Tracer) erro
 		// TODO: Network mode is causing problems with /etc/hosts - we want to find a way to fix this and enable network mode again
 		// NetworkMode: container.NetworkMode(network.ID),
 		Resources: container.Resources{
-			Memory:     r.env.MemoryMB << ToMBShift,
+			Memory:     memory,
 			CPUPeriod:  100000,
 			CPUQuota:   r.env.VCpuCount * 100000,
-			MemorySwap: r.env.MemoryMB << ToMBShift,
+			MemorySwap: memory,
 			PidsLimit:  &pidsLimit,
 		},
 	}, nil, &v1.Platform{}, "")


### PR DESCRIPTION
# Description

Increase memory for the part of the build when exporting rootfs

Before this change:
```
error | error creating rootfs for env 'ffj7ru56ykc5yfcflniu' during build 'ee6830b4-dd2f-4e6c-aa66-b14f91d8ab32': error creating rootfs file: container exited with status 137:
```

After I was able to build the template and start it:

```sh
~ E2B_DOMAIN=krindapana.dev e2b sbx sp ffj7ru56ykc5yfcflniu
Terminal connecting to template ffj7ru56ykc5yfcflniu with sandbox ID ildfkac242oujw2ntorzm-447dc250
user@d40650b7c9d8:~$ free -h
               total        used        free      shared  buff/cache   available
Mem:           106Mi        59Mi       5.3Mi       936Ki        51Mi        47Mi
Swap:          127Mi          0B       127Mi
user@d40650b7c9d8:~$ 
```