### PR TITLE
Prevent closed block cache usage

### DIFF
--- a/packages/orchestrator/internal/sandbox/block/cache.go
+++ b/packages/orchestrator/internal/sandbox/block/cache.go
@@ -137,10 +137,10 @@ func (m *Cache) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if m.isClosed() {
+	succ := m.closed.CompareAndSwap(false, true)
+	if !succ {
 		return NewErrCacheClosed(m.filePath)
 	}
-	m.closed.Store(true)
 
 	return errors.Join(
 		m.mmap.Unmap(),


### PR DESCRIPTION
Prevent the ability to call read/write methods on already closed block cache in orchestrator, as it might cause invalid reads/writes. This might be simulated by closing the build cache right after creation while fetchToCache is still running.