### PR TITLE
Improve self-hosted GCP guide

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -24,6 +24,11 @@ SERVER_MACHINE_TYPE=
 # e.g. 3
 SERVER_CLUSTER_SIZE=
 
+# eg e2-standard-2
+API_MACHINE_TYPE=
+# e.g. 1
+API_CLUSTER_SIZE=
+
 # your domain name, eg great-innovations.dev
 DOMAIN_NAME=
 

--- a/self-host.md
+++ b/self-host.md
@@ -61,7 +61,7 @@ Check if you can use config for terraform state management
 9. Get Cloudflare API Token: go to the [Cloudflare dashboard](https://dash.cloudflare.com/) -> Manage Account -> API Tokens -> Create Token -> Edit Zone DNS -> in "Zone Resources" select your domain and generate the token
 10. Get Postgres database connection string from your database 
     - e.g. [from Supabase](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection): Create a new project in Supabase and go to your project in Supabase -> Settings -> Database -> Connection Strings -> Postgres -> Direct 
-11. Run `make migration`
+11. Run `make migrate`
 12. Secrets are created and stored in GCP Secrets Manager. Once created, that is the source of truth--you will need to update values there to make changes. Create a secret value for the following secrets:
 - e2b-cloudflare-api-token
 - e2b-postgres-connection-string
@@ -73,7 +73,7 @@ Check if you can use config for terraform state management
     - `make prep-cluster` in `packages/shared` to create an initial user, etc. (You need to be logged in via [`e2b` CLI](https://www.npmjs.com/package/@e2b/cli?activetab=versions)). It will create a user with same information (access token, api key, etc.) as you have in E2B. 
     - You can also create a user in database, it will automatically also create a team, an API key and an access token. You will need to build template(s) for your cluster. Use [`e2b` CLI](https://www.npmjs.com/package/@e2b/cli?activetab=versions)) and run `E2B_DOMAIN<your-domain> e2b template build`.
 16. When using SDK pass domain when creating new `Sandbox` (`Sandbox(domain=<your-domain>, ...})`)
-16. To access the nomad web UI, go to nomad.<your-domain.com>. Go to sign in, and when prompted for an API token, you can find this in GCP Secrets Manager. From here, you can see nomad jobs and tasks for both client and server, including logging.
+16. To access the nomad web UI, go to [https://nomad.<your-domain.com>](https://nomad.<your-domain.com>). Go to sign in, and when prompted for an API token, you can find this in GCP Secrets Manager. From here, you can see nomad jobs and tasks for both client and server, including logging.
 17. Look inside packages/nomad for config files for your logging and monitoring agents.
 18. If any problems arise, open [a Github Issue on the repo](https://github.com/e2b-dev/infra/issues) and we'll look into it.
 


### PR DESCRIPTION
Improve the self-hosted guide for GCP. Changed the following:

- `make migration` should be `make migrate`
- Missing variables in .env.template
```
API_MACHINE_TYPE=
API_CLUSTER_SIZE=
```
- Improve Nomad UI link highlighting