### PR TITLE
Fix mmap flush to the filesystem

### DIFF
--- a/packages/orchestrator/internal/sandbox/block/cache.go
+++ b/packages/orchestrator/internal/sandbox/block/cache.go
@@ -39,7 +39,7 @@ func NewCache(size, blockSize int64, filePath string, dirtyFile bool) (*Cache, e
 		return nil, fmt.Errorf("error allocating file: %w", err)
 	}
 
-	mm, err := mmap.MapRegion(f, int(size), unix.PROT_READ|unix.PROT_WRITE, mmap.RDWR|mmap.EXEC, 0)
+	mm, err := mmap.MapRegion(f, int(size), unix.PROT_READ|unix.PROT_WRITE, 0, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error mapping file: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/block/cache.go
+++ b/packages/orchestrator/internal/sandbox/block/cache.go
@@ -39,7 +39,7 @@ func NewCache(size, blockSize int64, filePath string, dirtyFile bool) (*Cache, e
 		return nil, fmt.Errorf("error allocating file: %w", err)
 	}
 
-	mm, err := mmap.MapRegion(f, int(size), unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC, mmap.RDWR|mmap.EXEC, 0)
+	mm, err := mmap.MapRegion(f, int(size), unix.PROT_READ|unix.PROT_WRITE, mmap.RDWR|mmap.EXEC, 0)
 	if err != nil {
 		return nil, fmt.Errorf("error mapping file: %w", err)
 	}


### PR DESCRIPTION
Flushing mmap with prot "unix.PROT_EXEC" doesn't flush the bytes to the filesystem file. This PR is trying to address that.

Size of sparse file on disk can be verified using command `du fileName` in build cache. Manually tested by successful start of a new sandbox. 