### PR TITLE
nomad: add configuration for deploying redis service

### DIFF
--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -83,6 +83,12 @@ variable "otel_collector_grpc_endpoint" {
   default = ""
 }
 
+variable "redis_url" {
+  type = string
+  default = ""
+}
+
+
 job "api" {
   datacenters = [var.gcp_zone]
   node_pool = "api"
@@ -133,6 +139,7 @@ job "api" {
         OTEL_COLLECTOR_GRPC_ENDPOINT  = var.otel_collector_grpc_endpoint
         TEMPLATE_BUCKET_NAME          = "skip"
         ADMIN_TOKEN                   = var.admin_token
+        REDIS_URL                     = var.redis_url
       }
 
       config {
@@ -142,16 +149,6 @@ job "api" {
         args = [
           "--port", "${var.api_port_number}",
         ]
-      }
-
-      template {
-	env = true
-	destination = "local/env.txt"
-	data = <<EOF
-{{ range nomadService "redis" }}
-REDIS_URL=redis://{{ .Address }}:{{ . Port }}
-{{ end }}
-EOF
       }
     }
   }

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -143,6 +143,16 @@ job "api" {
           "--port", "${var.api_port_number}",
         ]
       }
+
+      template {
+	env = true
+	destination = "local/env.txt"
+	data = <<EOF
+{{ range nomadService "redis" }}
+REDIS_URL=redis://{{ .Address }}:{{ . Port }}
+{{ end }}
+EOF
+      }
     }
   }
 }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -80,6 +80,16 @@ resource "nomad_job" "api" {
   }
 }
 
+resource "nomad_job" "redis" {
+  jobspec = file("${path.module}/redis.hcl")
+
+  hcl2 {
+    vars = {
+      gcp_zone = var.gcp_zone
+    }
+  }
+}
+
 resource "nomad_job" "docker_reverse_proxy" {
   jobspec = file("${path.module}/docker-reverse-proxy.hcl")
 

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -76,6 +76,7 @@ resource "nomad_job" "api" {
       otel_tracing_print            = var.otel_tracing_print
       nomad_token                   = var.nomad_acl_token_secret
       admin_token                   = data.google_secret_manager_secret_version.api_admin_token.secret_data
+      redis_url                     = "redis://redis.service.consul:${var.redis_port_number}"
     }
   }
 }

--- a/packages/nomad/redis.hcl
+++ b/packages/nomad/redis.hcl
@@ -1,0 +1,64 @@
+variable "gcp_zone" {
+  type    = string
+}
+
+variable "image_name" {
+  type    = string
+  default = "redis:7.4.2-alpine"
+}
+
+variable "redis_port_number" {
+  type    = number
+  default = 6379
+}
+
+variable "redis_port_name" {
+  type    = string
+  default = "redis"
+}
+
+job "redis" {
+  datacenters = [var.gcp_zone]
+  node_pool = "all"
+  type = "service"
+  priority = 95
+
+  group "redis" {
+    network {
+      port "redis" {
+        static = var.redis_port_number
+      }
+    }
+
+    service {
+      name = "redis"
+      port = var.redis_port_name
+
+      check {
+        type     = "tcp"
+        name     = "health"
+        interval = "10s"
+        timeout  = "2s"
+        port     = var.redis_port_number
+      }
+    }
+
+    task "start" {
+      driver = "docker"
+
+      resources {
+        memory_max = 4096
+        memory     = 2048
+        cpu        = 1024
+      }
+
+      config {
+        network_mode = "host"
+        image        = var.image_name
+        ports        = [var.redis_port_name]
+        args = [
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pulls from #245 but moves the redis service off of the same machines as the API service and onto a separate machine that can be accessed from different services.

This is pretty primitive, but good to keep is separate from changes to the API server code.

Currently, there is only one API server so the previous approach is to colocate the redis server and the API server would work, but wouldn't as soon as we had more than one machine running the API service. I'm also not sure that if we did a rolling restart of the API service (with one instance,) if it would necessarily continue to run on the same host. Regardless someone with more broad context for nomad and our nomad deployment might be more well suited to ironing these details out.

Apart from this we are discussing if we want to run a redis service ourselves or use a vendor-hosted service. (Either GCP or Redis Labs)