### PR TITLE
chore: plumb contexts to DNS methods

### DIFF
--- a/packages/api/internal/dns/server.go
+++ b/packages/api/internal/dns/server.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -27,11 +28,11 @@ func New() *DNS {
 	}
 }
 
-func (d *DNS) Add(sandboxID, ip string) {
+func (d *DNS) Add(_ context.Context, sandboxID, ip string) {
 	d.records.Insert(d.hostname(sandboxID), ip)
 }
 
-func (d *DNS) Remove(sandboxID, ip string) {
+func (d *DNS) Remove(_ context.Context, sandboxID, ip string) {
 	d.records.RemoveCb(d.hostname(sandboxID), func(key string, v string, exists bool) bool {
 		return v == ip
 	})
@@ -80,7 +81,7 @@ func (d *DNS) handleDNSRequest(w resolver.ResponseWriter, r *resolver.Msg) {
 	}
 }
 
-func (d *DNS) Start(address string, port int) error {
+func (d *DNS) Start(_ context.Context, address string, port int) error {
 	mux := resolver.NewServeMux()
 
 	mux.HandleFunc(".", d.handleDNSRequest)

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -147,7 +147,7 @@ func (o *Orchestrator) getDeleteInstanceFunction(ctx context.Context, posthogCli
 			node.CPUUsage.Add(-info.VCpu)
 			node.RamUsage.Add(-info.RamMB)
 
-			o.dns.Remove(info.Instance.SandboxID, node.Info.IPAddress)
+			o.dns.Remove(ctx, info.Instance.SandboxID, node.Info.IPAddress)
 		}
 
 		req := &orchestrator.SandboxDeleteRequest{SandboxId: info.Instance.SandboxID}
@@ -179,7 +179,7 @@ func (o *Orchestrator) getInsertInstanceFunction(ctx context.Context, logger *za
 			node.CPUUsage.Add(info.VCpu)
 			node.RamUsage.Add(info.RamMB)
 
-			o.dns.Add(info.Instance.SandboxID, node.Info.IPAddress)
+			o.dns.Add(ctx, info.Instance.SandboxID, node.Info.IPAddress)
 		}
 
 		_, err := o.analytics.Client.InstanceStarted(ctx, &analyticscollector.InstanceStartedEvent{

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -47,7 +47,7 @@ func New(
 		go func() {
 			fmt.Printf("Starting DNS server\n")
 
-			dnsErr := dnsServer.Start("127.0.0.4", 53)
+			dnsErr := dnsServer.Start(ctx, "127.0.0.4", 53)
 			if dnsErr != nil {
 				log.Fatalf("Failed running DNS server: %v\n", dnsErr)
 			}


### PR DESCRIPTION
This is another task pulling a part of #245. 

This presupposes a specific solution (e.g. making redis be the backing (or extra layer) of the routing table/dns records.) but I wanted to avoid mixing "add contexts" from other changes, as this is a very simple PR mechanically despite that touches more lines than (perhaps) it should.