### PR TITLE
api(minor): clean up several logging related oddities

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -248,7 +248,7 @@ func main() {
 			log.Printf("http service (%d) shutdown error: %v", port, err)
 		}
 	case <-ctx.Done():
-		log.Println("http service (%d) shutdown outside of signal", port)
+		log.Printf("http service (%d) shutdown outside of signal", port)
 	}
 
 	// call cleanup explicitly because defers do not run on os.Exit

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -248,7 +248,7 @@ func main() {
 			log.Printf("http service (%d) shutdown error: %v", port, err)
 		}
 	case <-ctx.Done():
-		log.Printf("http service (%d) shutdown outside of signal", port)
+		log.Printf("http service (%d) shutdown outside of signal\n", port)
 	}
 
 	// call cleanup explicitly because defers do not run on os.Exit

--- a/packages/shared/pkg/logging/collector.go
+++ b/packages/shared/pkg/logging/collector.go
@@ -1,8 +1,6 @@
 package logging
 
 import (
-	"time"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -18,12 +16,8 @@ func NewCollectorLogger() (*zap.SugaredLogger, error) {
 		EncodeLevel:   zapcore.LowercaseLevelEncoder,
 		NameKey:       "logger",
 		StacktraceKey: "stacktrace",
+		EncodeTime:    zapcore.RFC3339TimeEncoder,
 	}
-
-	encoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
-		// 2019-08-13T04:39:11Z
-	})
 
 	level := zap.NewAtomicLevelAt(zap.InfoLevel)
 

--- a/packages/shared/pkg/logging/logger.go
+++ b/packages/shared/pkg/logging/logger.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"fmt"
-	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -21,6 +20,7 @@ func New(isLocal bool) (*zap.SugaredLogger, error) {
 			EncodeLevel:   zapcore.LowercaseLevelEncoder,
 			NameKey:       "logger",
 			StacktraceKey: "stacktrace",
+			EncodeTime:    zapcore.RFC3339TimeEncoder,
 		},
 		OutputPaths: []string{
 			"stdout",
@@ -29,11 +29,6 @@ func New(isLocal bool) (*zap.SugaredLogger, error) {
 			"stderr",
 		},
 	}
-
-	config.EncoderConfig.EncodeTime = zapcore.TimeEncoder(func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
-		enc.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
-		// 2019-08-13T04:39:11Z
-	})
 
 	logger, err := config.Build()
 	if err != nil {


### PR DESCRIPTION
I stumbled across these logging issues as I was working, and thought it was easier to push a small patch than outline them in another way. 

The time format defined in the logging encoders was RFC3339 (or equivalent given that it was always UTC.) and there's already a library function for this operation.

I didn't change [this occurance](https://github.com/tychoish/infra/blob/logging-formatting-cleanup/packages/api/internal/handlers/sandbox.go#L105) which appears to mostly be for human consumption (and therefore the extra spaces are desireable. Having said that, this almost certianly should be coerced into UTC.)