### PR TITLE
Use dynamic service discovery for client dns routing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,7 +183,6 @@ module "nomad" {
   logs_proxy_address                        = "http://${module.cluster.logs_proxy_ip}"
   api_port                                  = var.api_port
   environment                               = var.environment
-  docker_contexts_bucket_name               = module.buckets.envs_docker_context_bucket_name
   google_service_account_key                = module.init.google_service_account_key
   api_docker_image_digest                   = module.api.api_docker_image_digest
   api_secret                                = module.api.api_secret

--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -24,6 +24,7 @@ require (
 	go.opentelemetry.io/otel v1.32.0
 	go.opentelemetry.io/otel/trace v1.32.0
 	go.uber.org/zap v1.26.0
+	github.com/go-redis/redis/v8 v8.11.5
 )
 
 require (
@@ -80,7 +81,6 @@ require (
 	github.com/go-openapi/spec v0.20.9 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
-	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect

--- a/packages/api/internal/dns/server.go
+++ b/packages/api/internal/dns/server.go
@@ -16,6 +16,7 @@ import (
 
 const ttl = 0
 
+// This allows us to return a different error message when the sandbox is not found instead of generic 502 Bad Gateway
 const defaultRoutingIP = "127.0.0.1"
 
 type DNS struct {
@@ -84,12 +85,12 @@ func (d *DNS) handleDNSRequest(w resolver.ResponseWriter, r *resolver.Msg) {
 	}
 }
 
-func (d *DNS) Start(_ context.Context, address string, port int) error {
+func (d *DNS) Start(_ context.Context, address string, port string) error {
 	mux := resolver.NewServeMux()
 
 	mux.HandleFunc(".", d.handleDNSRequest)
 
-	server := resolver.Server{Addr: fmt.Sprintf("%s:%d", address, port), Net: "udp", Handler: mux}
+	server := resolver.Server{Addr: fmt.Sprintf("%s:%s", address, port), Net: "udp", Handler: mux}
 
 	err := server.ListenAndServe()
 	if err != nil {

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 	"github.com/go-redis/redis/v8"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"go.opentelemetry.io/otel/trace"
@@ -40,6 +41,7 @@ func New(
 	}
 
 	dnsServer := dns.New(redisClient)
+	port := utils.RequiredEnv("DNS_PORT", "Local DNS server resolving IPs for sandboxes")
 
 	if env.IsLocal() {
 		logger.Info("Running locally, skipping starting DNS server")
@@ -47,7 +49,7 @@ func New(
 		go func() {
 			logger.Info("Starting DNS server")
 
-			if err := dnsServer.Start(ctx, "127.0.0.4", 53); err != nil {
+			if err := dnsServer.Start(ctx, "0.0.0.0", port); err != nil {
 				logger.Panic("Failed starting DNS server", zap.Error(err))
 			}
 		}()

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 	"github.com/go-redis/redis/v8"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"go.opentelemetry.io/otel/trace"
@@ -15,6 +14,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/dns"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 type Orchestrator struct {

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -206,6 +206,7 @@ resource "google_compute_url_map" "orch_map" {
     name            = "api-paths"
     default_service = google_compute_backend_service.default["api"].self_link
   }
+
   path_matcher {
     name            = "docker-reverse-proxy-paths"
     default_service = google_compute_backend_service.default["docker-reverse-proxy"].self_link

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -18,6 +18,7 @@ job "api" {
     service {
       name = "api"
       port = "${port_number}"
+      task = "start"
 
       check {
         type     = "http"

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -92,8 +92,8 @@ job "api" {
       config {
         network_mode = "host"
         image        = "${api_docker_image}"
-        ports = ["${port_name}"]
-        args = [
+        ports        = ["${port_name}"]
+        args         = [
           "--port", "${port_number}",
         ]
       }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -75,6 +75,7 @@ resource "nomad_job" "api" {
     nomad_acl_token               = var.nomad_acl_token_secret
     admin_token                   = data.google_secret_manager_secret_version.api_admin_token.secret_data
     redis_url                     = "redis://redis.service.consul:${var.redis_port.port}"
+    dns_port_number               = var.api_dns_port_number
   })
 }
 
@@ -119,7 +120,7 @@ resource "nomad_job" "client_proxy" {
       client_proxy_health_port_number = var.client_proxy_health_port.port
       client_proxy_health_port_name   = var.client_proxy_health_port.name
       client_proxy_health_port_path   = var.client_proxy_health_port.path
-      load_balancer_conf              = templatefile("${path.module}/proxies/client.conf", { domain_name_escaped = replace(var.domain_name, ".", "\\.") })
+      load_balancer_conf              = templatefile("${path.module}/proxies/client.conf", { dns_port = var.api_dns_port_number })
       nginx_conf                      = file("${path.module}/proxies/nginx.conf")
     }
   }

--- a/packages/nomad/proxies/client.conf
+++ b/packages/nomad/proxies/client.conf
@@ -30,7 +30,7 @@ server {
   listen 3002;
 
   # DNS server resolved addreses as to <sandbox-id> <ip-address>
-  resolver 127.0.0.4 valid=0s;
+  resolver api.service.consul:${dns_port} valid=0s;
   resolver_timeout 5s;
 
   proxy_set_header Host $host;

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -55,8 +55,9 @@ variable "api_machine_count" {
   type = number
 }
 
-variable "docker_contexts_bucket_name" {
-  type = string
+variable "api_dns_port_number" {
+  type    = number
+  default = 5353
 }
 
 variable "custom_envs_repository_name" {


### PR DESCRIPTION
# Description

Use consul service discovery for sandbox DNS, this will allow us to swap API servers without problems with resolving DNS in client proxy