### PR TITLE
Fix clock sync on start of the sandbox

### DIFF
--- a/packages/envd/internal/host/sync.go
+++ b/packages/envd/internal/host/sync.go
@@ -17,7 +17,7 @@ func updateClock() error {
 	defer cancel()
 
 	// The chronyc -a makestep is not immediately stepping the clock
-	err := exec.CommandContext(ctx, "/bin/bash", "-c", "/bin/date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)").Run()
+	err := exec.CommandContext(ctx, "/bin/bash", "-l", "-c", "date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)").Run()
 	if err != nil {
 		return fmt.Errorf("failed to update clock: %w", err)
 	}

--- a/packages/envd/internal/host/sync.go
+++ b/packages/envd/internal/host/sync.go
@@ -17,7 +17,7 @@ func updateClock() error {
 	defer cancel()
 
 	// The chronyc -a makestep is not immediately stepping the clock
-	err := exec.CommandContext(ctx, "/usr/bin/bash", "-c", "/usr/bin/date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)").Run()
+	err := exec.CommandContext(ctx, "/bin/bash", "-c", "/bin/date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)").Run()
 	if err != nil {
 		return fmt.Errorf("failed to update clock: %w", err)
 	}


### PR DESCRIPTION
In some distributions there isn't `bash` on `/usr/bin/bash` and `date` on `/usr/bin/date` which resulted in not syncing 