### PR TITLE
E2B-1536: move team slug & profile migrations to infra

### DIFF
--- a/packages/shared/migrations/20250205180205.sql
+++ b/packages/shared/migrations/20250205180205.sql
@@ -70,7 +70,7 @@ UPDATE teams
 SET slug =
   CASE
     WHEN t.slug_count = 1 THEN t.base_slug
-    ELSE t.base_slug || '-' || SUBSTRING(teams.id::text, 1, 8)
+    ELSE t.base_slug || '-' || SUBSTRING(teams.id::text, 1, 4)
   END
 FROM numbered_teams t
 WHERE teams.id = t.id;

--- a/packages/shared/migrations/20250205180205.sql
+++ b/packages/shared/migrations/20250205180205.sql
@@ -1,0 +1,109 @@
+/*
+This migration adds team slugs and profile pictures to support user-friendly URLs and team branding.
+
+It performs the following steps:
+
+1. Adds two new columns to the teams table:
+   - slug: A URL-friendly version of the team name (e.g. "acme-inc")
+   - profile_picture_url: URL to the team's profile picture
+
+2. Creates a slug generation function that:
+   - Takes a team name and converts it to a URL-friendly format
+   - Removes special characters, accents, and spaces
+   - Handles email addresses by only using the part before @
+   - Converts to lowercase and replaces spaces with hyphens
+
+3. Installs the unaccent PostgreSQL extension for proper accent handling
+
+4. Generates initial slugs for all existing teams:
+   - Uses the team name as base for the slug
+   - If multiple teams would have the same slug, appends part of the team ID
+     to ensure uniqueness
+
+5. Sets up automatic slug generation for new teams:
+   - Creates a trigger that runs before team insertion
+   - Generates a unique slug using random suffixes if needed
+   - Only generates a slug if one isn't explicitly provided
+
+6. Enforces slug uniqueness with a database constraint
+*/
+
+ALTER TABLE teams
+ADD COLUMN slug TEXT,
+ADD COLUMN profile_picture_url TEXT;
+
+CREATE OR REPLACE FUNCTION generate_team_slug(name TEXT)
+RETURNS TEXT AS $$
+DECLARE
+  base_name TEXT;
+BEGIN
+  base_name := SPLIT_PART(name, '@', 1);
+
+  RETURN LOWER(
+    REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        UNACCENT(TRIM(base_name)),
+        '[^a-zA-Z0-9\s-]',
+        '',
+        'g'
+      ),
+      '\s+',
+      '-',
+      'g'
+    )
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+WITH numbered_teams AS (
+  SELECT
+    id,
+    name,
+    generate_team_slug(name) as base_slug,
+    ROW_NUMBER() OVER (PARTITION BY generate_team_slug(name) ORDER BY created_at) as slug_count
+  FROM teams
+  WHERE slug IS NULL
+)
+UPDATE teams
+SET slug =
+  CASE
+    WHEN t.slug_count = 1 THEN t.base_slug
+    ELSE t.base_slug || '-' || SUBSTRING(teams.id::text, 1, 8)
+  END
+FROM numbered_teams t
+WHERE teams.id = t.id;
+
+CREATE OR REPLACE FUNCTION generate_team_slug_trigger()
+RETURNS TRIGGER AS $$
+DECLARE
+  base_slug TEXT;
+  test_slug TEXT;
+  suffix TEXT;
+BEGIN
+  IF NEW.slug IS NULL THEN
+    base_slug := generate_team_slug(NEW.name);
+    test_slug := base_slug;
+
+    WHILE EXISTS (SELECT 1 FROM teams WHERE slug = test_slug) LOOP
+      suffix := SUBSTRING(gen_random_uuid()::text, 33, 4);
+      test_slug := base_slug || '-' || suffix;
+    END LOOP;
+
+    NEW.slug := test_slug;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER team_slug_trigger
+BEFORE INSERT ON teams
+FOR EACH ROW
+EXECUTE FUNCTION generate_team_slug_trigger();
+
+ALTER TABLE teams
+ADD CONSTRAINT teams_slug_unique UNIQUE (slug);
+
+ALTER TABLE teams
+ALTER COLUMN slug SET NOT NULL;


### PR DESCRIPTION
## Overview

This PR adds a new migration file (`20250205180205.sql`) to the infrastructure repository to centralize our database migrations. The changes introduced by this migration will initially only be utilized in the dashboard repository.

## Expected Results

After applying migration `20250205180205.sql`, verify:

### Database Changes

- Teams Table Structure:
    - New column `slug` added
    - Data type: text
    - Not nullable
    - Has unique constraint
    - New column `profile_picture_url` added
    - Data type: text
    - Nullable allowed

### Function & Trigger Verification

- Unaccent extension is installed
- `generate_team_slug()` function exists and handles:
    - Special character removal
    - Accent removal
    - Email address parsing
    - Lowercase conversion
    - Space to hyphen conversion
- `generate_team_slug_trigger()` function exists
- Trigger `team_slug_trigger` is active on teams table

### Data Migration

- All existing teams have unique, non-null slugs generated
- Slugs follow the expected format:
    - Based on team name
    - URL-friendly
    - Unique across teams
    - Appends ID fragment for duplicates

## Testing Steps

1. Verify existing teams have valid slugs
2. Test inserting new team without slug (should auto-generate)
3. Test inserting new team with manual slug (should use provided)

*For testing on the `e2b-staging-ben` supabase project the following sql statements were used*

```jsx
-- Step 1: Verify existing teams have valid slugs
SELECT * FROM teams WHERE slug IS NOT NULL;

-- Step 2: Test inserting new team without slug (should auto-generate)
INSERT INTO teams (name, email, tier) 
VALUES ('New Team Without Slug', 'noslugteam@example.com', 'base_v1');
SELECT * FROM teams WHERE name = 'New Team Without Slug';

-- Clean up after test
DELETE FROM teams WHERE name = 'New Team Without Slug';

-- Step 3: Test inserting new team with manual slug (should use provided)
INSERT INTO teams (name, slug, email, tier) 
VALUES ('New Team With Manual Slug', 'manual-slug', 'manualslugteam@example.com', 'base_v1');
SELECT * FROM teams WHERE name = 'New Team With Manual Slug';

-- Clean up after test
DELETE FROM teams WHERE name = 'New Team With Manual Slug';
```

## Rollback Plan

If issues are encountered, execute the provided down-migration script to revert changes:

```sql
-- Remove NOT NULL constraint
ALTER TABLE teams
ALTER COLUMN slug DROP NOT NULL;

-- Remove unique constraint
ALTER TABLE teams
DROP CONSTRAINT teams_slug_unique;

-- Remove trigger
DROP TRIGGER IF EXISTS team_slug_trigger ON teams;

-- Remove trigger function
DROP FUNCTION IF EXISTS generate_team_slug_trigger;

-- Remove slug generation function
DROP FUNCTION IF EXISTS generate_team_slug;

-- Remove extension
DROP EXTENSION IF EXISTS unaccent;

-- Remove columns
ALTER TABLE teams
DROP COLUMN IF EXISTS slug,
DROP COLUMN IF EXISTS profile_picture_url;
```