### PR TITLE
Add service permissions to deregister service

### DIFF
--- a/packages/cluster/scripts/run-consul.sh
+++ b/packages/cluster/scripts/run-consul.sh
@@ -415,6 +415,10 @@ function setup_dns_resolving {
     # Token is created on the leader node, so there's no problem with duplication
     touch dns-request-policy.hcl
     cat <<EOF >dns-request-policy.hcl
+service_prefix "" {
+  policy = "write"
+}
+
 node_prefix "" {
   policy = "read"
 }


### PR DESCRIPTION
Without this all services stays in consul and then DNS resolving is returning all nodes where the service ran.

Reproduce:
If you have multiple nodes and redeploy there will be multiple tasks for that service in consul, what's weird they stay healthy