### PR TITLE
minor: build improvement for make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ENV := $(shell cat .last_used_env || echo "not-set")
--include .env.${ENV}
+ENV_FILE := $(PWD)/.env.${ENV}
+
+-include ${ENV_FILE}
 
 OTEL_TRACING_PRINT ?= false
 EXCLUDE_GITHUB ?= 1
@@ -43,7 +45,7 @@ init:
 	@ printf "Initializing Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
 	./scripts/confirm.sh $(ENV)
 	terraform init -input=false -backend-config="bucket=${TERRAFORM_STATE_BUCKET}"
-	$(MAKE) -C packages/cluster-disk-image init
+	$(MAKE) -C packages/cluster-disk-image init build
 	$(tf_vars) terraform apply -target=module.init -target=module.buckets -auto-approve -input=false -compact-warnings
 	gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
 
@@ -85,7 +87,7 @@ plan-without-jobs:
 	-input=false \
 	-compact-warnings \
 	-parallelism=20 \
-  	$(TARGET)
+	$(TARGET)
 
 .PHONY: destroy
 destroy:
@@ -97,27 +99,27 @@ destroy:
 	-parallelism=20 \
 	$$(terraform state list | grep module | cut -d'.' -f1,2 | grep -v -e "buckets" | uniq | awk '{print "-target=" $$0 ""}' | xargs)
 
-
 .PHONY: version
 version:
 	./scripts/increment-version.sh
 
 .PHONY: build-and-upload
-build-and-upload:
-	$(MAKE) -C packages/cluster-disk-image build
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/api build-and-upload
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/client-proxy build-and-upload
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/docker-reverse-proxy build-and-upload
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/orchestrator build-and-upload
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/template-manager build-and-upload
-	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/envd build-and-upload
+build-and-upload:build-and-upload/api
+build-and-upload:build-and-upload/client-proxy
+build-and-upload:build-and-upload/docker-reverse-proxy
+build-and-upload:build-and-upload/orchestrator
+build-and-upload:build-and-upload/template-manager
+build-and-upload:build-and-upload/envd
+build/%:
+	$(MAKE) -C packages/$(notdir $@) build
+build-and-upload/%:
+	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/$(notdir $@) build-and-upload
 
 .PHONY: copy-public-builds
 copy-public-builds:
 	gsutil cp -r gs://e2b-prod-public-builds/envd-v0.0.1 gs://$(GCP_PROJECT_ID)-fc-env-pipeline/envd-v0.0.1
 	gsutil cp -r gs://e2b-prod-public-builds/kernels/* gs://$(GCP_PROJECT_ID)-fc-kernels/
 	gsutil cp -r gs://e2b-prod-public-builds/firecrackers/* gs://$(GCP_PROJECT_ID)-fc-versions/
-
 
 @.PHONY: migrate
 migrate:
@@ -128,7 +130,7 @@ switch-env:
 	@ touch .last_used_env
 	@ printf "Switching from `tput setaf 1``tput bold`$(shell cat .last_used_env)`tput sgr0` to `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
 	@ echo $(ENV) > .last_used_env
-	@ . .env.${ENV}
+	@ . ${ENV_FILE}
 	terraform init -input=false -upgrade -reconfigure -backend-config="bucket=${TERRAFORM_STATE_BUCKET}"
 
 # Shortcut to importing resources into Terraform state (e.g. after creating resources manually or switching between different branches for the same environment)


### PR DESCRIPTION
These are small changes that I made while working that I thought might be useful for other people: 

- moved the `cluster-disk-image-build` task into the `init` target (this changes very rarely, rebuilding it explicitly when needed is safe as the build happens on the remote end.)

- created targets for `build/<package>` and `build-and-upload/<package>` so that we can just build only the component that we need when doing testing.

- made `build-and-upload` work through make's dependency system, so now you can run `make -j<n> build-and-upload` and make will attempt to build and upload in parallel. This off by default, and it's easy to overwhelm a system with these kinds of builds, _but_, if you have extra compute capacity on your local machine.... it makes things quicker.