### PR TITLE
Make sure API instance is marked as unhealthy before shutdown

### DIFF
--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/gin-contrib/cors v1.6.0
 	github.com/gin-contrib/size v0.0.0-20230212012657-e14a14094dc4
 	github.com/gin-gonic/gin v1.10.0
+	github.com/go-redis/cache/v8 v8.4.4
+	github.com/go-redis/redis/v8 v8.11.5
 	github.com/gogo/status v1.1.1
 	// https://github.com/grafana/loki/issues/2826. This is the equivalent of the main branch at 2023/11/27 (d62d4e37d1f3dba83cf10a1f6db82830794e1c05)
 	github.com/grafana/loki v0.0.0-20231124145642-d62d4e37d1f3
@@ -80,8 +82,6 @@ require (
 	github.com/go-openapi/spec v0.20.9 // indirect
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-openapi/validate v0.22.1 // indirect
-	github.com/go-redis/cache/v8 v8.4.4 // indirect
-	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -217,7 +217,7 @@ func main() {
 	// pass the signal context so that handlers know when shutdown is happening.
 	s := NewGinServer(ctx, apiStore, swagger, port)
 
-	//////////////////////////
+	// ////////////////////////
 	//
 	// Start the HTTP service
 
@@ -268,6 +268,13 @@ func main() {
 	go func() {
 		defer wg.Done()
 		<-signalCtx.Done()
+
+		// Start returning 503s for health checks
+		// to signal that the service is shutting down.
+		// This is a bit of a hack, but this way we can properly propagate
+		// the health status to the load balancer.
+		apiStore.Healthy = false
+		time.Sleep(15 * time.Second)
 
 		// if the parent context `ctx` is canceled the
 		// shutdown will return early. This should only happen

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -38,7 +38,7 @@ job "api" {
       # Allows to spawn new version of the service before killing the old one
       canary           = 1
       # Time to wait for the canary to be healthy
-      min_healthy_time = "5s"
+      min_healthy_time = "10s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
       healthy_deadline = "30s"
       # Whether to promote the canary if the rest of the group is not healthy
@@ -50,7 +50,7 @@ job "api" {
       driver       = "docker"
       # If we need more than 30s we will need to update the max_kill_timeout in nomad
       # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
-      kill_timeout = "15s"
+      kill_timeout = "30s"
       kill_signal  = "SIGTERM"
 
       resources {


### PR DESCRIPTION
# Description

Return unhealthy for health check before shutting down

If not set up during rolling update the old instance is shutdown while GCP load balancer still consider it as healthy, so it sends requests to the server, which doesn't accept any new connection anymore