### PR TITLE
use secret data instead of referencing secret by name to avoid data races

### DIFF
--- a/packages/init/outputs.tf
+++ b/packages/init/outputs.tf
@@ -15,31 +15,31 @@ output "nomad_acl_token_secret" {
 }
 
 output "grafana_api_key_secret_name" {
-  value = google_secret_manager_secret.grafana_api_key.name
+  value = google_secret_manager_secret_version.grafana_api_key.secret_data
 }
 
 output "grafana_logs_username_secret_name" {
-  value = google_secret_manager_secret.grafana_logs_username.name
+  value = google_secret_manager_secret_version.grafana_logs_username.secret_data
 }
 
 output "grafana_traces_username_secret_name" {
-  value = google_secret_manager_secret.grafana_traces_username.name
+  value = google_secret_manager_secret_version.grafana_traces_username.secret_data
 }
 
 output "grafana_metrics_username_secret_name" {
-  value = google_secret_manager_secret.grafana_metrics_username.name
+  value = google_secret_manager_secret_version.grafana_metrics_username.secret_data
 }
 
 output "grafana_logs_endpoint_secret_name" {
-  value = google_secret_manager_secret.grafana_logs_endpoint.name
+  value = google_secret_manager_secret_version.grafana_logs_endpoint.secret_data
 }
 
 output "grafana_traces_endpoint_secret_name" {
-  value = google_secret_manager_secret.grafana_traces_endpoint.name
+  value = google_secret_manager_secret_version.grafana_traces_endpoint.secret_data
 }
 
 output "grafana_metrics_endpoint_secret_name" {
-  value = google_secret_manager_secret.grafana_metrics_endpoint.name
+  value = google_secret_manager_secret_version.grafana_metrics_endpoint.secret_data
 }
 
 output "analytics_collector_host_secret_name" {

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -8,33 +8,6 @@ data "google_secret_manager_secret_version" "posthog_api_key" {
 }
 
 # Telemetry
-data "google_secret_manager_secret_version" "grafana_api_key" {
-  secret = var.grafana_api_key_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_traces_endpoint" {
-  secret = var.grafana_traces_endpoint_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_logs_endpoint" {
-  secret = var.grafana_logs_endpoint_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_metrics_endpoint" {
-  secret = var.grafana_metrics_endpoint_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_traces_username" {
-  secret = var.grafana_traces_username_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_logs_username" {
-  secret = var.grafana_logs_username_secret_name
-}
-
-data "google_secret_manager_secret_version" "grafana_metrics_username" {
-  secret = var.grafana_metrics_username_secret_name
-}
 
 data "google_secret_manager_secret_version" "analytics_collector_host" {
   secret = var.analytics_collector_host_secret_name
@@ -142,15 +115,15 @@ resource "nomad_job" "otel_collector" {
 
   hcl2 {
     vars = {
-      grafana_traces_endpoint  = data.google_secret_manager_secret_version.grafana_traces_endpoint.secret_data
-      grafana_logs_endpoint    = data.google_secret_manager_secret_version.grafana_logs_endpoint.secret_data
-      grafana_metrics_endpoint = data.google_secret_manager_secret_version.grafana_metrics_endpoint.secret_data
+      grafana_traces_endpoint  = var.grafana_traces_endpoint_secret_name
+      grafana_logs_endpoint    = var.grafana_logs_endpoint_secret_name
+      grafana_metrics_endpoint = var.grafana_metrics_endpoint_secret_name
 
-      grafana_traces_username  = data.google_secret_manager_secret_version.grafana_traces_username.secret_data
-      grafana_logs_username    = data.google_secret_manager_secret_version.grafana_logs_username.secret_data
-      grafana_metrics_username = data.google_secret_manager_secret_version.grafana_metrics_username.secret_data
+      grafana_traces_username  = var.grafana_traces_username_secret_name
+      grafana_logs_username    = var.grafana_logs_username_secret_name
+      grafana_metrics_username = var.grafana_metrics_username_secret_name
 
-      grafana_api_key = data.google_secret_manager_secret_version.grafana_api_key.secret_data
+      grafana_api_key = var.grafana_api_key_secret_name
 
       consul_token = var.consul_acl_token_secret
 
@@ -173,9 +146,9 @@ resource "nomad_job" "logs_collector" {
 
       loki_service_port_number = var.loki_service_port.port
 
-      grafana_api_key       = data.google_secret_manager_secret_version.grafana_api_key.secret_data
-      grafana_logs_endpoint = data.google_secret_manager_secret_version.grafana_logs_endpoint.secret_data
-      grafana_logs_username = data.google_secret_manager_secret_version.grafana_logs_username.secret_data
+      grafana_api_key       = var.grafana_api_key_secret_name
+      grafana_logs_endpoint = var.grafana_logs_endpoint_secret_name
+      grafana_logs_username = var.grafana_logs_username_secret_name
     }
   }
 }


### PR DESCRIPTION
okay! so now I have [intermediate step](https://github.com/e2b-dev/infra/pull/305/files)  and [local grafana w/o data races](https://github.com/e2b-dev/infra/pull/305/files) .  The changes should be merged as:


`main` <- `intermediate step`  <- `local grafana w/o races`


in the GitHub pr i'm branching off of `intermediate step` b/c of this.

I have tested locally going back and forth from `main` to `inter-step` and back without failure and `intermediate step` and `local-grafana` by running make plan and make apply w/o errors so i'm feeling pretty confident this will accomplish the task and also not break things in an annoying way