### PR TITLE
More lenient Loki config and stop timestamp manipulation

### DIFF
--- a/packages/nomad/logs-collector.hcl
+++ b/packages/nomad/logs-collector.hcl
@@ -78,10 +78,6 @@ address = "0.0.0.0:${logs_port_number}"
 encoding = "json"
 path_key = "_path"
 
-
-[log_schema]
-  timestamp_key = "_timestamp" 
-
 [transforms.add_source_envd]
 type = "remap"
 inputs = ["envd"]
@@ -111,16 +107,9 @@ source = '''
 del(.internal)
 '''
 
-[transforms.use_real_timestamp]
-type = "remap"
-inputs = [ "remove_internal" ]
-source = '''
-._timestamp = parse_timestamp(.timestamp, "%+") ?? now()
-'''
-
 [sinks.local_loki_logs]
 type = "loki"
-inputs = [ "use_real_timestamp" ]
+inputs = [ "remove_internal" ]
 endpoint = "http://loki.service.consul:${loki_service_port_number}"
 encoding.codec = "json"
 

--- a/packages/nomad/loki.hcl
+++ b/packages/nomad/loki.hcl
@@ -146,7 +146,7 @@ limits_config:
   per_stream_rate_limit_burst: "240MB"
   max_streams_per_user: 0
   max_global_streams_per_user: 10000
-  unordered_writes: false
+  unordered_writes: true
 
 EOF
 

--- a/packages/nomad/loki.hcl
+++ b/packages/nomad/loki.hcl
@@ -147,7 +147,7 @@ limits_config:
   max_streams_per_user: 0
   max_global_streams_per_user: 10000
   unordered_writes: true
-
+  reject_old_samples_max_age: 168h
 EOF
 
         destination = "local/loki-config.yml"


### PR DESCRIPTION
# Description 
- temporarily stop using app log timestamp and revert back to using Loki ones in logs collector 
- toggling [this flag](https://grafana.com/docs/loki/next/configure/#accept-out-of-order-writes) to allow out-of-order wirtes in Loki 
- increase the maximum accepted sample age before rejecting in Loki. 

# Test
- make plan & make apply
- spawn a sandbox
- get sandbox logs and metrics 