### PR TITLE
Revert back to using Loki entry timestamp 

### DIFF
--- a/packages/api/internal/handlers/sandbox_logs.go
+++ b/packages/api/internal/handlers/sandbox_logs.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"slices"
@@ -71,17 +70,8 @@ func (a *APIStore) GetSandboxesSandboxIDLogs(
 
 		for _, stream := range value {
 			for _, entry := range stream.Entries {
-				var entryLine struct {
-					Timestamp time.Time `json:"timestamp"`
-				}
-				if err := json.Unmarshal([]byte(entry.Line), &entryLine); err != nil {
-					errMsg := fmt.Errorf("error unmarshaling entry line for timestamp: %w", err)
-					telemetry.ReportCriticalError(ctx, errMsg)
-					a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error processing logs for sandbox '%s'", sandboxID))
-					return
-				}
 				logs = append(logs, api.SandboxLog{
-					Timestamp: entryLine.Timestamp,
+					Timestamp: entry.Timestamp,
 					Line:      entry.Line,
 				})
 			}

--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -60,13 +60,12 @@ func (a *APIStore) getSandboxesSandboxIDMetrics(
 	for _, stream := range value {
 		for _, entry := range stream.Entries {
 
-				var metric struct {
-					Timestamp   time.Time `json:"timestamp"`
-					CPUUsedPct  float32   `json:"cpuUsedPct"`
-					CPUCount    int32     `json:"cpuCount"`
-					MemTotalMiB int64     `json:"memTotalMiB"`
-					MemUsedMiB  int64     `json:"memUsedMiB"`
-				}
+			var metric struct {
+				CPUUsedPct  float32 `json:"cpuUsedPct"`
+				CPUCount    int32   `json:"cpuCount"`
+				MemTotalMiB int64   `json:"memTotalMiB"`
+				MemUsedMiB  int64   `json:"memUsedMiB"`
+			}
 
 			err := json.Unmarshal([]byte(entry.Line), &metric)
 			if err != nil {
@@ -77,7 +76,7 @@ func (a *APIStore) getSandboxesSandboxIDMetrics(
 			}
 
 			metrics = append(metrics, api.SandboxMetric{
-				Timestamp:   metric.Timestamp,
+				Timestamp:   entry.Timestamp,
 				CpuUsedPct:  metric.CPUUsedPct,
 				CpuCount:    metric.CPUCount,
 				MemTotalMiB: metric.MemTotalMiB,


### PR DESCRIPTION
instead of log line timestamp in api logs and metrics handler to go from:

```
[0001-01-01 00:00:00.000Z] INFO  { category: 'default', logger: 'orchestrator', message: 'Sandbox created with - end time: 2025-02-20
19:06:49 +00:00' }
```
to:

````
[2025-02-20 19:02:51.338Z] INFO  { category: 'default', logger: 'orchestrator', message: 'Sandbox created with - end time: 2025-02-20
19:07:51 +00:00' }
```

this is cause by the changes in logs-collector: https://github.com/e2b-dev/infra/pull/314