### PR TITLE
Split out and test post processing in template build

### DIFF
--- a/packages/orchestrator/cmd/inspect-data/main.go
+++ b/packages/orchestrator/cmd/inspect-data/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	ctx := context.Background()
 
-	obj := gcs.NewObject(ctx, gcs.TemplateBucket, storagePath)
+	obj := gcs.NewObject(ctx, gcs.GetTemplateBucket(), storagePath)
 
 	size, err := obj.Size()
 	if err != nil {
@@ -67,7 +67,7 @@ func main() {
 
 	fmt.Printf("\nMETADATA\n")
 	fmt.Printf("========\n")
-	fmt.Printf("Storage path       %s/%s\n", gcs.TemplateBucket.BucketName(), storagePath)
+	fmt.Printf("Storage path       %s/%s\n", gcs.GetTemplateBucket().BucketName(), storagePath)
 	fmt.Printf("Build ID           %s\n", *buildId)
 	fmt.Printf("Size               %d B (%d MiB)\n", size, size/1024/1024)
 	fmt.Printf("Block size         %d B\n", blockSize)

--- a/packages/orchestrator/cmd/inspect-header/main.go
+++ b/packages/orchestrator/cmd/inspect-header/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	ctx := context.Background()
 
-	obj := gcs.NewObject(ctx, gcs.TemplateBucket, storagePath)
+	obj := gcs.NewObject(ctx, gcs.GetTemplateBucket(), storagePath)
 
 	h, err := header.Deserialize(obj)
 	if err != nil {
@@ -47,7 +47,7 @@ func main() {
 
 	fmt.Printf("\nMETADATA\n")
 	fmt.Printf("========\n")
-	fmt.Printf("Storage path       %s/%s\n", gcs.TemplateBucket.BucketName(), storagePath)
+	fmt.Printf("Storage path       %s/%s\n", gcs.GetTemplateBucket().BucketName(), storagePath)
 	fmt.Printf("Version            %d\n", h.Metadata.Version)
 	fmt.Printf("Generation         %d\n", h.Metadata.Generation)
 	fmt.Printf("Build ID           %s\n", h.Metadata.BuildId)

--- a/packages/orchestrator/cmd/simulate-headers-merge/main.go
+++ b/packages/orchestrator/cmd/simulate-headers-merge/main.go
@@ -52,8 +52,8 @@ func main() {
 
 	ctx := context.Background()
 
-	baseObj := gcs.NewObject(ctx, gcs.TemplateBucket, baseStoragePath)
-	diffObj := gcs.NewObject(ctx, gcs.TemplateBucket, diffStoragePath)
+	baseObj := gcs.NewObject(ctx, gcs.GetTemplateBucket(), baseStoragePath)
+	diffObj := gcs.NewObject(ctx, gcs.GetTemplateBucket(), diffStoragePath)
 
 	baseHeader, err := header.Deserialize(baseObj)
 	if err != nil {
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	fmt.Printf("\nBASE METADATA\n")
-	fmt.Printf("Storage path       %s/%s\n", gcs.TemplateBucket.BucketName(), baseStoragePath)
+	fmt.Printf("Storage path       %s/%s\n", gcs.GetTemplateBucket().BucketName(), baseStoragePath)
 	fmt.Printf("========\n")
 
 	for _, mapping := range baseHeader.Mapping {
@@ -97,7 +97,7 @@ func main() {
 	}
 
 	fmt.Printf("\nDIFF METADATA\n")
-	fmt.Printf("Storage path       %s/%s\n", gcs.TemplateBucket.BucketName(), diffStoragePath)
+	fmt.Printf("Storage path       %s/%s\n", gcs.GetTemplateBucket().BucketName(), diffStoragePath)
 	fmt.Printf("========\n")
 
 	onlyDiffMappings := make([]*header.BuildMap, 0)

--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -39,13 +39,13 @@ func NewCache(ctx context.Context) (*Cache, error) {
 
 	go cache.Start()
 
-	buildStore, err := build.NewDiffStore(gcs.TemplateBucket, ctx)
+	buildStore, err := build.NewDiffStore(gcs.GetTemplateBucket(), ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create build store: %w", err)
 	}
 
 	return &Cache{
-		bucket:     gcs.TemplateBucket,
+		bucket:     gcs.GetTemplateBucket(),
 		buildStore: buildStore,
 		cache:      cache,
 		ctx:        ctx,

--- a/packages/shared/pkg/storage/gcs/bucket.go
+++ b/packages/shared/pkg/storage/gcs/bucket.go
@@ -11,9 +11,6 @@ import (
 
 type BucketHandle = storage.BucketHandle
 
-var clientOnce sync.Once
-var client *storage.Client
-
 var getClient = sync.OnceValue(func() *storage.Client {
 	return utils.Must(newClient(context.Background()))
 })

--- a/packages/shared/pkg/storage/gcs/client.go
+++ b/packages/shared/pkg/storage/gcs/client.go
@@ -5,11 +5,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/storage"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
-
-var client = utils.Must(newClient(context.Background()))
 
 func newClient(ctx context.Context) (*storage.Client, error) {
 	client, err := storage.NewClient(ctx)

--- a/packages/shared/pkg/storage/template_build.go
+++ b/packages/shared/pkg/storage/template_build.go
@@ -27,7 +27,7 @@ func NewTemplateBuild(
 	files *TemplateFiles,
 ) *TemplateBuild {
 	return &TemplateBuild{
-		bucket:        gcs.TemplateBucket,
+		bucket:        gcs.GetTemplateBucket(),
 		memfileHeader: memfileHeader,
 		rootfsHeader:  rootfsHeader,
 		files:         files,

--- a/packages/template-manager/go.mod
+++ b/packages/template-manager/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/firecracker-microvm/firecracker-go-sdk v1.0.0
 	github.com/fsouza/go-dockerclient v1.12.0
 	github.com/go-openapi/strfmt v0.23.0
+	github.com/gogo/status v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/opencontainers/image-spec v1.1.0
@@ -69,6 +70,7 @@ require (
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
+	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/packages/template-manager/go.sum
+++ b/packages/template-manager/go.sum
@@ -429,7 +429,9 @@ github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblf
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
+github.com/gogo/googleapis v1.4.0 h1:zgVt4UpGxcqVOw97aRGxT4svlcmdK35fynLNctY32zI=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -438,6 +440,8 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/gogo/status v1.1.1 h1:DuHXlSFHNKqTQ+/ACf5Vs6r4X/dH2EgIzR9Vr+H65kg=
+github.com/gogo/status v1.1.1/go.mod h1:jpG3dM5QPcqu19Hg8lkUhBFBa3TcLs1DG7+2Jqci7oU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1200,6 +1204,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
+google.golang.org/genproto v0.0.0-20180518175338-11a468237815/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1230,6 +1235,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20241118233622-e639e219e697/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241118233622-e639e219e697 h1:LWZqQOEjDyONlF1H6afSWpAL/znlREo2tHfLoe+8LMA=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20241118233622-e639e219e697/go.mod h1:5uTbfoYQed2U9p3KIj2/Zzm02PYhndfdmML0qC3q3FU=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
+google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/packages/template-manager/internal/build/network_linux.go
+++ b/packages/template-manager/internal/build/network_linux.go
@@ -118,7 +118,7 @@ func (n *FCNetwork) setup(ctx context.Context, tracer trace.Tracer) error {
 	tapAttrs.Namespace = ns
 
 	tap := &netlink.Tuntap{
-		Mode:      netlink.TUNTAP_MODE_TUN,
+		Mode:      netlink.TUNTAP_MODE_TAP,
 		LinkAttrs: tapAttrs,
 	}
 

--- a/packages/template-manager/internal/build/network_linux.go
+++ b/packages/template-manager/internal/build/network_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package build
 
 import (
@@ -12,6 +15,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
+
 
 const (
 	fcTapAddress        = "169.254.0.22"
@@ -112,8 +116,9 @@ func (n *FCNetwork) setup(ctx context.Context, tracer trace.Tracer) error {
 	tapAttrs := netlink.NewLinkAttrs()
 	tapAttrs.Name = fcTapName
 	tapAttrs.Namespace = ns
+
 	tap := &netlink.Tuntap{
-		Mode:      netlink.TUNTAP_MODE_TAP,
+		Mode:      netlink.TUNTAP_MODE_TUN,
 		LinkAttrs: tapAttrs,
 	}
 

--- a/packages/template-manager/internal/build/network_other.go
+++ b/packages/template-manager/internal/build/network_other.go
@@ -1,0 +1,24 @@
+//go:build !linux
+// +build !linux
+
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type FCNetwork struct {
+	namespaceID string
+}
+
+// Cleanup is a no-op for non-Linux systems
+func (n *FCNetwork) Cleanup(ctx context.Context, tracer trace.Tracer) {
+}
+
+// NewFCNetwork returns an error
+func NewFCNetwork(ctx context.Context, tracer trace.Tracer, env *Env) (*FCNetwork, error) {
+	return nil, fmt.Errorf("network functionality is only supported on Linux")
+}

--- a/packages/template-manager/internal/build/rootfs_test.go
+++ b/packages/template-manager/internal/build/rootfs_test.go
@@ -1,0 +1,70 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// test writer that stores the written data
+type testWriter struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (w *testWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.data = append(w.data, p...)
+	return len(p), nil
+}
+
+func TestPostProcessor_Start(t *testing.T) {
+	type fields struct {
+		testErr       error
+		shouldContain string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+	}{
+		{
+			name: "test error",
+			fields: fields{
+				testErr:       errors.New("test error"),
+				shouldContain: "Postprocessing failed:",
+			},
+		},
+		{
+			name: "test success",
+			fields: fields{
+				testErr:       nil,
+				shouldContain: "Postprocessing finished.  ",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			tw := &testWriter{}
+			ctx := context.TODO()
+			errChan := make(chan error)
+
+			p := &PostProcessor{
+				ctx:     ctx,
+				writer:  tw,
+				errChan: errChan,
+			}
+			go p.Start()
+			p.stop(tt.fields.testErr)
+			close(errChan)
+
+			if !strings.Contains(string(tw.data), tt.fields.shouldContain) {
+				t.Errorf("expected data to contain %s, got %s", tt.fields.shouldContain, string(tw.data))
+			}
+
+		})
+	}
+}

--- a/packages/template-manager/internal/build/snapshot_linux.go
+++ b/packages/template-manager/internal/build/snapshot_linux.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package build
 
 import (

--- a/packages/template-manager/internal/build/snapshot_other.go
+++ b/packages/template-manager/internal/build/snapshot_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+// +build !linux
+
+package build
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+var fcAddr = "127.0.0.1:5150"
+
+type Snapshot struct {
+}
+
+func NewSnapshot(ctx context.Context, tracer trace.Tracer, env *Env, network *FCNetwork, rootfs *Rootfs) (*Snapshot, error) {
+	return nil, errors.New("snapshot is not supported on this platform")
+}

--- a/packages/template-manager/internal/template/storage.go
+++ b/packages/template-manager/internal/template/storage.go
@@ -14,7 +14,7 @@ type Storage struct {
 
 func NewStorage(ctx context.Context) *Storage {
 	return &Storage{
-		bucket: gcs.TemplateBucket,
+		bucket: gcs.GetTemplateBucket(),
 	}
 }
 


### PR DESCRIPTION
Looking to test `createRootFS`, so splitting out this routine into its own stuct to test. In order to test this locally on mac need to set build flags for linux. also refactors some behavior in `shared` to be able to run tests