### PR TITLE
Add API server timeouts

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -35,11 +35,15 @@ import (
 )
 
 const (
-	serviceName          = "orchestration-api"
-	maxMultipartMemory   = 1 << 27 // 128 MiB
-	maxUploadLimit       = 1 << 28 // 256 MiB
+	serviceName        = "orchestration-api"
+	maxMultipartMemory = 1 << 27 // 128 MiB
+	maxUploadLimit     = 1 << 28 // 256 MiB
+
 	maxReadHeaderTimeout = 60 * time.Second
-	defaultPort          = 80
+	maxReadTimeout       = 75 * time.Second
+	maxWriteTimeout      = 75 * time.Second
+	
+	defaultPort = 80
 )
 
 func NewGinServer(ctx context.Context, apiStore *handlers.APIStore, swagger *openapi3.T, port int) *http.Server {
@@ -122,6 +126,8 @@ func NewGinServer(ctx context.Context, apiStore *handlers.APIStore, swagger *ope
 		Handler:           r,
 		Addr:              fmt.Sprintf("0.0.0.0:%d", port),
 		ReadHeaderTimeout: maxReadHeaderTimeout,
+		ReadTimeout:       maxReadTimeout,
+		WriteTimeout:      maxWriteTimeout,
 		BaseContext:       func(net.Listener) context.Context { return ctx },
 	}
 


### PR DESCRIPTION
Add API server timeouts. The values might need to be adjusted in the future. Right now set to 75 seconds, as the LB timeout is 65 seconds.

(More info: https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/)