### PR TITLE
Automatically reconnect to newly deployed template manager

### DIFF
--- a/packages/api/internal/handlers/template_start_build.go
+++ b/packages/api/internal/handlers/template_start_build.go
@@ -11,6 +11,7 @@ import (
 	"github.com/posthog/posthog-go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/shared/pkg/models"
@@ -141,6 +142,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 		)
 		if buildErr != nil {
 			buildErr = fmt.Errorf("error when building env: %w", buildErr)
+			a.logger.Error("build failed", zap.Error(buildErr))
 			telemetry.ReportCriticalError(buildContext, buildErr)
 
 			dbErr := a.db.EnvBuildSetStatus(buildContext, templateID, buildUUID, envbuild.StatusFailed)

--- a/packages/shared/pkg/grpc/connection.go
+++ b/packages/shared/pkg/grpc/connection.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"regexp"
+	"strings"
+
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"regexp"
-	"strings"
 )
 
 var regex = regexp.MustCompile(`http[s]?://`)
@@ -29,6 +31,8 @@ func GetConnection(host string, safe bool, options ...grpc.DialOption) (ClientCo
 
 		return &DummyConn{}, nil
 	}
+
+	options = append(options, grpc.WithConnectParams(grpc.ConnectParams{Backoff: backoff.DefaultConfig}))
 
 	host = regex.ReplaceAllString(host, "")
 	if strings.HasPrefix(host, "localhost") || !safe {


### PR DESCRIPTION
# Description

If the template manager was moved, the connection became stale and building wasn't working 