### PR TITLE
Cleanup metrics and temporarily increase the interval

### DIFF
--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -29,9 +29,6 @@ func (s *Sandbox) logHeathAndUsage(ctx *utils.LockableCancelableContext) {
 	// Get metrics on sandbox startup
 	go s.LogMetrics(ctx)
 
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-
 	for {
 		select {
 		case <-healthTicker.C:

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	healthCheckInterval      = 10 * time.Second
-	metricsCheckInterval     = 2 * time.Second
+	healthCheckInterval      = 20 * time.Second
+	metricsCheckInterval     = 60 * time.Second
 	minEnvdVersionForMetrcis = "0.1.5"
 )
 


### PR DESCRIPTION
- Remove unused ticker
- Add separate context timeout for healtcheck/metrics before sandbox kill to prevent
- Increase the interval of metrics to check if the flooding and RAM hogging in API is related (we can increase if everything is ok). We should also check the logs exporter implementation to see if the logs can get buffered there.


Related changes (removing stat with uncancelled goroutine) were already introduced via 2af377419058eeae47e4547215bc7ad5bb1298c3