### PR TITLE
Try to fix NBD panic

### DIFF
--- a/packages/orchestrator/internal/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/internal/sandbox/nbd/dispatch.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"sync"
+
+	"go.uber.org/zap"
 )
 
 type Provider interface {
@@ -52,7 +54,6 @@ type Dispatch struct {
 	responseHeader   []byte
 	writeLock        sync.Mutex
 	prov             Provider
-	fatal            chan error
 	pendingResponses sync.WaitGroup
 	pendingMu        sync.Mutex
 }
@@ -60,7 +61,6 @@ type Dispatch struct {
 func NewDispatch(ctx context.Context, fp io.ReadWriteCloser, prov Provider) *Dispatch {
 	d := &Dispatch{
 		responseHeader: make([]byte, 16),
-		fatal:          make(chan error, 8),
 		fp:             fp,
 		prov:           prov,
 		ctx:            ctx,
@@ -228,7 +228,7 @@ func (d *Dispatch) cmdRead(cmdHandle uint64, cmdFrom uint64, cmdLength uint32) e
 	go func() {
 		err := performRead(cmdHandle, cmdFrom, cmdLength)
 		if err != nil {
-			d.fatal <- err
+			zap.L().Error("nbd error cmd read", zap.Error(err))
 		}
 
 		d.pendingResponses.Done()
@@ -263,7 +263,7 @@ func (d *Dispatch) cmdWrite(cmdHandle uint64, cmdFrom uint64, cmdData []byte) er
 		}
 		err := d.writeResponse(errorValue, cmdHandle, []byte{})
 		if err != nil {
-			d.fatal <- err
+			zap.L().Error("nbd error cmd write", zap.Error(err))
 		}
 
 		d.pendingResponses.Done()


### PR DESCRIPTION
There is a panic at the Wait() method in dispatch.go. 

The dispatcher might be nil when closing the `DirectPathMount`. This might occur if it errors out before assignment.

Also, the Wait() method might get stuck if pendingResponses are not "0". This should be possible only if the `fatal` channel gets full (8 errors) and no new errors can be inserted. Then it will not decrease pendingResponses and Wait will be deadlocked. This PR will log read/write error instead of filling up the channel (of size 8).

Tries to fix following panic:
`
panic caught: runtime error: invalid memory address or nil pointer dereference goroutine 61569791 [running]: github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.recoverFrom({0x19da760?, 0xe282d26270?}, {0x14ca120, 0x266a750}, 0xe287286b47?) /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:57 +0x65 github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1.1() /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:30 +0x67 panic({0x14ca120?, 0x266a750?}) /usr/local/go/src/runtime/panic.go:785 +0x132 go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1() /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.32.0/trace/span.go:422 +0x25 go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xe282d6c1e0, {0x0, 0x0, 0xe05f44f500?}) /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.32.0/trace/span.go:461 +0xb7b panic({0x14ca120?, 0x266a750?}) /usr/local/go/src/runtime/panic.go:785 +0x132 github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd.(*Dispatch).Wait(0xe06f95cf00?) /build/orchestrator/internal/sandbox/nbd/dispatch.go:74 +0x2c github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd.(*DirectPathMount).Close(0xe06f95cf50) /build/orchestrator/internal/sandbox/nbd/path_direct.go:136 +0x48 github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/rootfs.(*CowDevice).Close(0xe22af25980) /build/orchestrator/internal/sandbox/rootfs/cow.go:97 +0x31 github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox.NewSandbox.func3() /build/orchestrator/internal/sandbox/sandbox.go:139 +0x17 github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox.(*Cleanup).run(0xe06f95cd70) /build/orchestrator/internal/sandbox/cleanup.go:47 +0x17f sync.(*Once).doSlow(0xc0000522a0?, 0x0?) /usr/local/go/src/sync/once.go:76 +0xb4 sync.(*Once).Do(...) /usr/local/go/src/sync/once.go:67 github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox.(*Cleanup).Run(...) /build/orchestrator/internal/sandbox/cleanup.go:32 github.com/e2b-dev/infra/packages/orchestrator/internal/server.(*server).Create(0xc000980200, {0x19da760, 0xe282d26270}, 0xe22af25680) /build/orchestrator/internal/server/sandboxes.go:66 +0xc65 github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator._SandboxService_Create_Handler.func1({0x19da760?, 0xe282d26270?}, {0x16816c0?, 0xe22af25680?}) /build/shared/pkg/grpc/orchestrator/orchestrator_grpc.pb.go:157 +0xcb github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery.UnaryServerInterceptor.func1({0x19da760?, 0xe282d26270?}, {0x16816c0?, 0xe22af25680?}, 0x412885?, 0x78?) /go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/recovery/interceptors.go:34 +0x8a github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator._SandboxService_Create_Handler({0x164a140, 0xc000980200}, {0x19da760, 0xe282d26270}, 0xdfc47ac180, 0xc0002e7360) /build/shared/pkg/grpc/orchestrator/orchestrator_grpc.pb.go:159 +0x143 google.golang.org/grpc.(*Server).processUnaryRPC(0xc000293a00, {0x19da760, 0xe282d26180}, {0x19e4440, 0xc00037d040}, 0xe05f468360, 0xc000677ec0, 0x26a01c0, 0x0) /go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1394 +0xe2b google.golang.org/grpc.(*Server).handleStream(0xc000293a00, {0x19e4440, 0xc00037d040}, 0xe05f468360) /go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1805 +0xe8b google.golang.org/grpc.(*Server).serveStreams.func2.1() /go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1029 +0x7f created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 555 /go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1040 +0x125
`