### PR TITLE
Set our logger as a global one

### DIFF
--- a/packages/shared/pkg/logging/logger.go
+++ b/packages/shared/pkg/logging/logger.go
@@ -35,5 +35,6 @@ func New(isLocal bool) (*zap.SugaredLogger, error) {
 		return nil, fmt.Errorf("error building logger: %w", err)
 	}
 
+	zap.ReplaceGlobals(logger)
 	return logger.Sugar(), nil
 }


### PR DESCRIPTION
# Description

We can get our logger by calling `zap.L()`, there's no need to pass it around anymore