### PR TITLE
Don't block on writing logs

### DIFF
--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -129,10 +129,12 @@ func (w *HTTPExporter) resumeProcessing() {
 
 func (w *HTTPExporter) Write(logs []byte) (int, error) {
 	logsCopy := make([]byte, len(logs))
-	copy(logsCopy, logs)
 
-	go w.addLogs(logsCopy)
+	go func(logs []byte) {
+		copy(logsCopy, logs)
 
+		w.addLogs(logsCopy)
+	}(logsCopy)
 	return len(logs), nil
 }
 

--- a/packages/shared/pkg/logs/exporter/exporter.go
+++ b/packages/shared/pkg/logs/exporter/exporter.go
@@ -85,7 +85,9 @@ func (w *HTTPExporter) Write(log []byte) (int, error) {
 	logsCopy := make([]byte, len(log))
 	copy(logsCopy, log)
 
-	w.logQueue <- logsCopy
+	go func(log []byte) {
+		w.logQueue <- log
+	}(logsCopy)
 
 	return len(log), nil
 }


### PR DESCRIPTION
# Description

Not sure about initial cause yet, but if there's a lot of logs, I think it can happen the buffer in `packages/shared/pkg/logs/exporter/exporter.go` gets full, blocking everything.

This exporter also sends each line separately, which can maybe result in some rate limiting? I explains why we see the start times incremented by 2 seconds, the timeout for http client is 2 seconds. I think we should be rewrite sandbox exporter, not sure if we want to do it before #321  