### PR TITLE
Fix build cluster platform

### DIFF
--- a/packages/cluster/build-cluster/main.tf
+++ b/packages/cluster/build-cluster/main.tf
@@ -65,6 +65,7 @@ resource "google_compute_instance_template" "build" {
 
   instance_description = var.cluster_description
   machine_type         = var.machine_type
+  min_cpu_platform     = "Intel Skylake"
 
   labels = merge(
     var.labels,

--- a/packages/envd/internal/host/sync.go
+++ b/packages/envd/internal/host/sync.go
@@ -16,10 +16,12 @@ func updateClock() error {
 	ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
 	defer cancel()
 
-	// The chronyc -a makestep is not immediately stepping the clock
-	err := exec.CommandContext(ctx, "/bin/bash", "-l", "-c", "date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)").Run()
+	cmd := exec.CommandContext(ctx, "/bin/bash", "-l", "-c", "date -s @$(/usr/sbin/phc_ctl /dev/ptp0 get | cut -d' ' -f5)")
+
+	// Capture both stdout and stderr
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to update clock: %w", err)
+		return fmt.Errorf("failed to update clock: %w\nCommand output: %s", err, string(output))
 	}
 
 	return nil


### PR DESCRIPTION
The build cluster defaulted to Haswell CPU platform which caused incompatibility when building for Skylake we use elsewhere. It manifested as incorrectly working ptp0 device (so far).

I also added detailed error to the envd sync.