### PR TITLE
Change update policy for dev clusters

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,7 @@ GCP_REGION=
 GCP_ZONE=
 
 # prod, staging, dev
+# Make sure to use exactly 'prod' for production environment
 TERRAFORM_ENVIRONMENT=
 # GCS bucket name
 TERRAFORM_STATE_BUCKET=

--- a/packages/cluster/api-cluster/main.tf
+++ b/packages/cluster/api-cluster/main.tf
@@ -48,7 +48,7 @@ resource "google_compute_instance_group_manager" "api_cluster" {
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
   # a rolling update.
   update_policy {
-    type                    = var.instance_group_update_policy_type
+    type                    = var.environment == "prod" ? "OPPORUNISTIC" : "PROACTIVE"
     minimal_action          = var.instance_group_update_policy_minimal_action
     max_surge_fixed         = var.instance_group_update_policy_max_surge_fixed
     max_surge_percent       = var.instance_group_update_policy_max_surge_percent

--- a/packages/cluster/build-cluster/main.tf
+++ b/packages/cluster/build-cluster/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance_group_manager" "build_cluster" {
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
   # a rolling update.
   update_policy {
-    type                    = var.instance_group_update_policy_type
+    type                    = var.environment == "prod" ? "OPPORUNISTIC" : "PROACTIVE"
     minimal_action          = var.instance_group_update_policy_minimal_action
     max_surge_fixed         = var.instance_group_update_policy_max_surge_fixed
     max_surge_percent       = var.instance_group_update_policy_max_surge_percent

--- a/packages/cluster/client/main.tf
+++ b/packages/cluster/client/main.tf
@@ -60,7 +60,7 @@ resource "google_compute_instance_group_manager" "client_cluster" {
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
   # a rolling update.
   update_policy {
-    type                    = var.instance_group_update_policy_type
+    type                    = var.environment == "prod" ? "OPPORUNISTIC" : "PROACTIVE"
     minimal_action          = var.instance_group_update_policy_minimal_action
     max_surge_fixed         = var.instance_group_update_policy_max_surge_fixed
     max_surge_percent       = var.instance_group_update_policy_max_surge_percent


### PR DESCRIPTION
Improves DX: When you change machine types, start script or something similar, you expect the change to happen right away. It can be confusing and annoying for development.