### PR TITLE
Remove template logs from API cache

### DIFF
--- a/packages/api/internal/handlers/template_build_logs.go
+++ b/packages/api/internal/handlers/template_build_logs.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	templateBuildLogsLimit       = 100
+	templateBuildLogsLimit       = 1_000
 	templateBuildOldestLogsLimit = 24 * time.Hour // 1 day
 )
 

--- a/packages/api/internal/handlers/template_build_logs.go
+++ b/packages/api/internal/handlers/template_build_logs.go
@@ -80,12 +80,10 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 
 	status := dockerBuild.GetStatus()
 
-	// Sanitize IDs
+	// Sanitize env ID
 	// https://grafana.com/blog/2021/01/05/how-to-escape-special-characters-with-lokis-logql/
-	buildIdSanitized := strings.ReplaceAll(buildUUID.String(), "`", "")
 	templateIdSanitized := strings.ReplaceAll(templateID, "`", "")
-
-	query := fmt.Sprintf("{source=\"logs-collector\", service=\"template-manager\", buildID=`%s` envID=`%s`}", buildIdSanitized, templateIdSanitized)
+	query := fmt.Sprintf("{source=\"logs-collector\", service=\"template-manager\", buildID=\"%s\", envID=`%s`}", buildUUID.String(), templateIdSanitized)
 	end := time.Now()
 	start := end.Add(-templateBuildOldestLogsLimit)
 

--- a/packages/api/internal/handlers/template_build_logs.go
+++ b/packages/api/internal/handlers/template_build_logs.go
@@ -101,6 +101,11 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	logs := make([]string, 0)
 	logsCrawled := 0
 
+	offset := 0
+	if params.LogsOffset != nil {
+		offset = int(*params.LogsOffset)
+	}
+
 	if res.Data.Result.Type() != loghttp.ResultTypeStream {
 		zap.L().Error("unexpected value type received from loki query fetch", zap.String("type", string(res.Data.Result.Type())))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Unexpected error during fetching logs")
@@ -112,7 +117,7 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 			logsCrawled++
 
 			// loki does not support offset pagination, so we need to skip logs manually
-			if logsCrawled <= int(*params.LogsOffset) {
+			if logsCrawled <= offset {
 				continue
 			}
 

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -71,18 +71,12 @@ func (tm *TemplateManager) CreateTemplate(
 
 	// Wait for the build to finish and save logs
 	for {
-		log, receiveErr := logs.Recv()
+		_, receiveErr := logs.Recv()
 		if receiveErr == io.EOF {
 			break
 		} else if receiveErr != nil {
 			// There was an error during the build
 			return fmt.Errorf("error when building env: %w", receiveErr)
-
-		}
-		logErr := buildCache.Append(templateID, buildID, log.Log)
-		if logErr != nil {
-			// There was an error saving the logs, the build wasn't found
-			return fmt.Errorf("error when saving docker build logs: %w", logErr)
 		}
 	}
 

--- a/packages/nomad/logs-collector.hcl
+++ b/packages/nomad/logs-collector.hcl
@@ -72,18 +72,17 @@ data_dir = "alloc/data/vector/"
 enabled = true
 address = "0.0.0.0:${logs_health_port_number}"
 
-[sources.envd]
+[sources.http_server]
 type = "http_server"
 address = "0.0.0.0:${logs_port_number}"
 encoding = "ndjson"
 path_key = "_path"
 
-[transforms.add_source_envd]
+[transforms.add_source_http_server]
 type = "remap"
-inputs = ["envd"]
+inputs = ["http_server"]
 source = """
 del(."_path")
-.service = "envd"
 .sandboxID = .instanceID
 .timestamp = parse_timestamp(.timestamp, format: "%Y-%m-%dT%H:%M:%S.%fZ") ?? now()
 if !exists(.envID) {
@@ -101,11 +100,17 @@ if !exists(.sandboxID) {
 if !exists(.envID) {
   .envID = "unknown"
 }
+if !exists(.buildID) {
+  .buildID = "unknown"
+}
+if !exists(.service) {
+  .service = "envd"
+ }
 """
 
 [transforms.internal_routing]
 type = "route"
-inputs = [ "add_source_envd" ]
+inputs = [ "add_source_http_server" ]
 
 [transforms.internal_routing.route]
 internal = '.internal == true'
@@ -128,6 +133,7 @@ source = "logs-collector"
 service = "{{ service }}"
 teamID = "{{ teamID }}"
 envID = "{{ envID }}"
+buildID = "{{ buildID }}"
 sandboxID = "{{ sandboxID }}"
 category = "{{ category }}"
 

--- a/packages/template-manager/internal/build/rootfs.go
+++ b/packages/template-manager/internal/build/rootfs.go
@@ -85,7 +85,7 @@ func NewRootfs(ctx context.Context, tracer trace.Tracer, env *Env, docker *clien
 
 		return nil, errMsg
 	}
-	_, _ = env.BuildLogsWriter.Write([]byte("Pulled Docker image.\n\n"))
+	_, _ = env.BuildLogsWriter.Write([]byte("Pulled Docker image.\n"))
 
 	err = rootfs.createRootfsFile(childCtx, tracer)
 	if err != nil {
@@ -175,18 +175,20 @@ type PostProcessor struct {
 
 // Start starts the post-processing.
 func (p *PostProcessor) Start() {
+	p.writer.Write([]byte(fmt.Sprintf("[%s] Start postprocessing\n", time.Now().Format(time.RFC3339))))
+
 	for {
-		msg := []byte(fmt.Sprintf("Postprocessing (%s)       \n", time.Now().Format(time.ANSIC)))
+		msg := []byte(fmt.Sprintf("[%s] Postprocessing\n", time.Now().Format(time.RFC3339)))
 
 		select {
 		case postprocessingErr := <-p.errChan:
 			if postprocessingErr != nil {
-				p.writer.Write([]byte(fmt.Sprintf("Postprocessing failed: %s\n", postprocessingErr)))
+				p.writer.Write([]byte(fmt.Sprintf("[%s] Postprocessing failed: %s\n", time.Now().Format(time.RFC3339), postprocessingErr)))
 				return
 			}
 
 			p.writer.Write(msg)
-			p.writer.Write([]byte("Postprocessing finished.                   \n"))
+			p.writer.Write([]byte(fmt.Sprintf("[%s] Postprocessing finished.\n", time.Now().Format(time.RFC3339))))
 
 			return
 		case <-p.ctx.Done():

--- a/packages/template-manager/internal/build/rootfs.go
+++ b/packages/template-manager/internal/build/rootfs.go
@@ -175,16 +175,13 @@ type PostProcessor struct {
 
 // Start starts the post-processing.
 func (p *PostProcessor) Start() {
-
-	now := time.Now()
 	for {
-		msg := []byte(fmt.Sprintf("Postprocessing (%s)       \r", time.Since(now).Round(time.Second)))
+		msg := []byte(fmt.Sprintf("Postprocessing (%s)       \n", time.Now().Format(time.ANSIC)))
 
 		select {
 		case postprocessingErr := <-p.errChan:
 			if postprocessingErr != nil {
 				p.writer.Write([]byte(fmt.Sprintf("Postprocessing failed: %s\n", postprocessingErr)))
-
 				return
 			}
 
@@ -194,7 +191,7 @@ func (p *PostProcessor) Start() {
 			return
 		case <-p.ctx.Done():
 			return
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(5 * time.Second):
 			p.writer.Write(msg)
 		}
 	}

--- a/packages/template-manager/internal/build/rootfs_test.go
+++ b/packages/template-manager/internal/build/rootfs_test.go
@@ -41,7 +41,7 @@ func TestPostProcessor_Start(t *testing.T) {
 			name: "test success",
 			fields: fields{
 				testErr:       nil,
-				shouldContain: "Postprocessing finished.  ",
+				shouldContain: "Postprocessing finished.",
 			},
 		},
 	}

--- a/packages/template-manager/internal/build/writer/writer.go
+++ b/packages/template-manager/internal/build/writer/writer.go
@@ -2,13 +2,16 @@ package writer
 
 import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
+	"go.uber.org/zap"
 )
 
 type BuildLogsWriter struct {
 	stream template_manager.TemplateService_TemplateCreateServer
+	logger *zap.Logger
 }
 
 func (w BuildLogsWriter) Write(p []byte) (n int, err error) {
+	w.logger.Info(string(p))
 	err = w.stream.Send(&template_manager.TemplateBuildLog{Log: string(p)})
 	if err != nil {
 		return 0, err
@@ -17,9 +20,10 @@ func (w BuildLogsWriter) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func New(stream template_manager.TemplateService_TemplateCreateServer) BuildLogsWriter {
+func New(stream template_manager.TemplateService_TemplateCreateServer, logger *zap.Logger) BuildLogsWriter {
 	writer := BuildLogsWriter{
 		stream: stream,
+		logger: logger,
 	}
 
 	return writer

--- a/packages/template-manager/internal/build/writer/writer.go
+++ b/packages/template-manager/internal/build/writer/writer.go
@@ -11,8 +11,9 @@ type BuildLogsWriter struct {
 }
 
 func (w BuildLogsWriter) Write(p []byte) (n int, err error) {
-	w.logger.Info(string(p))
-	err = w.stream.Send(&template_manager.TemplateBuildLog{Log: string(p)})
+	log := string(p)
+	w.logger.Info(log)
+	err = w.stream.Send(&template_manager.TemplateBuildLog{Log: log})
 	if err != nil {
 		return 0, err
 	}

--- a/packages/template-manager/internal/server/create_template.go
+++ b/packages/template-manager/internal/server/create_template.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -39,7 +41,11 @@ func (s *serverStore) TemplateCreate(templateRequest *template_manager.TemplateC
 		attribute.Bool("env.huge_pages", config.HugePages),
 	)
 
-	logsWriter := writer.New(stream)
+	loggerWithMetadata := s.logger.
+		With(zap.Field{Type: zapcore.StringType, Key: "envID", String: config.TemplateID}).
+		With(zap.Field{Type: zapcore.StringType, Key: "buildID", String: config.BuildID})
+
+	logsWriter := writer.New(stream, loggerWithMetadata)
 	template := &build.Env{
 		TemplateFiles: storage.NewTemplateFiles(
 			config.TemplateID,

--- a/packages/template-manager/internal/server/create_template.go
+++ b/packages/template-manager/internal/server/create_template.go
@@ -41,11 +41,13 @@ func (s *serverStore) TemplateCreate(templateRequest *template_manager.TemplateC
 		attribute.Bool("env.huge_pages", config.HugePages),
 	)
 
-	loggerWithMetadata := s.logger.
-		With(zap.Field{Type: zapcore.StringType, Key: "envID", String: config.TemplateID}).
-		With(zap.Field{Type: zapcore.StringType, Key: "buildID", String: config.BuildID})
+	logsWriter := writer.New(
+		stream,
+		s.buildLogger.
+			With(zap.Field{Type: zapcore.StringType, Key: "envID", String: config.TemplateID}).
+			With(zap.Field{Type: zapcore.StringType, Key: "buildID", String: config.BuildID}),
+	)
 
-	logsWriter := writer.New(stream, loggerWithMetadata)
 	template := &build.Env{
 		TemplateFiles: storage.NewTemplateFiles(
 			config.TemplateID,

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -30,6 +30,7 @@ type serverStore struct {
 	templatemanager.UnimplementedTemplateServiceServer
 	server             *grpc.Server
 	tracer             trace.Tracer
+	logger             *zap.Logger
 	dockerClient       *client.Client
 	legacyDockerClient *docker.Client
 	artifactRegistry   *artifactregistry.Client
@@ -83,6 +84,7 @@ func New(logger *zap.Logger) *grpc.Server {
 
 	templatemanager.RegisterTemplateServiceServer(s, &serverStore{
 		tracer:             otel.Tracer(constants.ServiceName),
+		logger:             logger,
 		dockerClient:       dockerClient,
 		legacyDockerClient: legacyClient,
 		artifactRegistry:   artifactRegistry,

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -31,13 +31,14 @@ type serverStore struct {
 	server             *grpc.Server
 	tracer             trace.Tracer
 	logger             *zap.Logger
+	buildLogger        *zap.Logger
 	dockerClient       *client.Client
 	legacyDockerClient *docker.Client
 	artifactRegistry   *artifactregistry.Client
 	templateStorage    *template.Storage
 }
 
-func New(logger *zap.Logger) *grpc.Server {
+func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
 	ctx := context.Background()
 	logger.Info("Initializing template manager")
 
@@ -85,6 +86,7 @@ func New(logger *zap.Logger) *grpc.Server {
 	templatemanager.RegisterTemplateServiceServer(s, &serverStore{
 		tracer:             otel.Tracer(constants.ServiceName),
 		logger:             logger,
+		buildLogger:        buildLogger,
 		dockerClient:       dockerClient,
 		legacyDockerClient: legacyClient,
 		artifactRegistry:   artifactRegistry,

--- a/packages/template-manager/main.go
+++ b/packages/template-manager/main.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
+	"go.uber.org/zap"
 	"log"
 	"net"
 	"os"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/constants"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/server"
@@ -67,6 +68,7 @@ func main() {
 	)
 	defer logger.Sync()
 	sbxlogger.SetSandboxLoggerExternal(logger)
+	zap.ReplaceGlobals(logger)
 
 	// used for logging template build output
 	buildLogger := sbxlogger.NewLogger(


### PR DESCRIPTION
Template build logs are pushed to Loki and API is using Loki directly to query them for user instead of local API cache.

**[Deploy]**
First template manager needs to be rolled so it will push logs to logger and also for back compatibility via grcp stream. Later api can be rolled later, there are no user-facing changes here or come breaking one.