### PR TITLE
Speed up orchestrator nodes discovery in API

### DIFF
--- a/packages/api/internal/cache/instance/instance.go
+++ b/packages/api/internal/cache/instance/instance.go
@@ -25,7 +25,6 @@ const (
 	InstanceExpiration = time.Second * 15
 	// Should we auto pause the instance by default instead of killing it,
 	InstanceAutoPauseDefault = false
-	CacheSyncTime            = time.Minute
 )
 
 var (

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -114,8 +114,8 @@ func NewAPIStore(ctx context.Context) *APIStore {
 	authCache := authcache.NewTeamAuthCache(dbClient)
 	templateSpawnCounter := utils.NewTemplateSpawnCounter(time.Minute, dbClient)
 
-	return &APIStore{
-		Healthy:              true,
+	a := &APIStore{
+		Healthy:              false,
 		orchestrator:         orch,
 		templateManager:      templateManager,
 		db:                   dbClient,
@@ -128,6 +128,19 @@ func NewAPIStore(ctx context.Context) *APIStore {
 		authCache:            authCache,
 		templateSpawnCounter: templateSpawnCounter,
 	}
+
+	go func() {
+		for {
+			if orch.NodeCount() != 0 {
+				a.Healthy = true
+				break
+			}
+
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	return a
 }
 
 func (a *APIStore) Close(ctx context.Context) error {

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -129,6 +129,7 @@ func NewAPIStore(ctx context.Context) *APIStore {
 		templateSpawnCounter: templateSpawnCounter,
 	}
 
+	// Wait till there's at least one, otherwise we can't create sandboxes yet
 	go func() {
 		for {
 			if orch.NodeCount() != 0 {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -19,6 +19,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
+const cacheSyncTime = 20 * time.Second
+
 func (o *Orchestrator) GetSandbox(sandboxID string) (*instance.InstanceInfo, error) {
 	item, err := o.instanceCache.Get(sandboxID)
 	if err != nil {
@@ -36,7 +38,7 @@ func (o *Orchestrator) keepInSync(ctx context.Context, instanceCache *instance.I
 			o.logger.Info("Stopping keepInSync")
 
 			return
-		case <-time.After(instance.CacheSyncTime):
+		case <-time.After(cacheSyncTime):
 			// Sleep for a while before syncing again
 
 			o.syncNodes(ctx, instanceCache)
@@ -45,7 +47,7 @@ func (o *Orchestrator) keepInSync(ctx context.Context, instanceCache *instance.I
 }
 
 func (o *Orchestrator) syncNodes(ctx context.Context, instanceCache *instance.InstanceCache) {
-	ctxTimeout, cancel := context.WithTimeout(ctx, 1*time.Minute)
+	ctxTimeout, cancel := context.WithTimeout(ctx, cacheSyncTime)
 	defer cancel()
 
 	spanCtx, span := o.tracer.Start(ctxTimeout, "keep-in-sync")

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/node"
@@ -19,7 +20,9 @@ import (
 )
 
 type GRPCClient struct {
-	Sandbox    orchestrator.SandboxServiceClient
+	Sandbox orchestrator.SandboxServiceClient
+	Health  grpc_health_v1.HealthClient
+
 	connection e2bgrpc.ClientConnInterface
 }
 
@@ -30,8 +33,9 @@ func NewClient(host string) (*GRPCClient, error) {
 	}
 
 	client := orchestrator.NewSandboxServiceClient(conn)
+	health := grpc_health_v1.NewHealthClient(conn)
 
-	return &GRPCClient{Sandbox: client, connection: conn}, nil
+	return &GRPCClient{Sandbox: client, Health: health, connection: conn}, nil
 }
 
 func (a *GRPCClient) Close() error {

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -3,11 +3,12 @@ package orchestrator
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/connectivity"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/grpc/connectivity"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/jellydator/ttlcache/v3"
@@ -182,4 +183,8 @@ func (t *Node) InsertBuild(buildID string) {
 	// Set the build in the cache for 2 minutes, it should get updated with the correct time from the orchestrator during sync
 	t.buildCache.Set(buildID, struct{}{}, 2*time.Minute)
 	return
+}
+
+func (o *Orchestrator) NodeCount() int {
+	return o.nodes.Count()
 }

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -40,7 +40,7 @@ job "api" {
       # Time to wait for the canary to be healthy
       min_healthy_time = "10s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
-      healthy_deadline = "30s"
+      healthy_deadline = "60s"
       # Whether to promote the canary if the rest of the group is not healthy
       auto_promote     = true
     }


### PR DESCRIPTION
# Description
- Change period for check from 1 min to 20s
- Wait till some node is loaded on start of API
- Add health check for connected nodes
- Increase time for API to start