### PR TITLE
only cleanup telemetry once

### DIFF
--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -227,13 +227,6 @@ func main() {
 		logger.Info("waiting 15 seconds before shutting down http service")
 		time.Sleep(15 * time.Second)
 
-		logger.Info("shutting down telemetry")
-
-		err := cleanupTelemetry(ctx)
-		if err != nil {
-			logger.Error("error shutting down telemetry", zap.Error(err))
-		}
-
 		logger.Info("shutting down http service", zap.Int("port", port))
 
 		if err := server.Shutdown(ctx); err != nil {


### PR DESCRIPTION
cleanup telemetry called twice and one of the calls is in the wrong order of operations. Removing the extra call fixes this