### PR TITLE
Set sandbox healthy status to true by default

### DIFF
--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -69,12 +69,9 @@ func (s *Sandbox) Healthcheck(ctx context.Context, alwaysReport bool) {
 		}
 
 		if alwaysReport {
-			fmt.Println("This was called alwaysReport")
 			if ok {
-				fmt.Println("This was called alwaysReport ok")
 				sbxlogger.E(s).Healthcheck(sbxlogger.ReportSuccess)
 			} else {
-				fmt.Println("This was called alwaysReport not ok")
 				sbxlogger.E(s).Healthcheck(sbxlogger.ReportFail)
 				sbxlogger.I(s).Error("control healthcheck failed", zap.Error(err))
 			}

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -30,8 +30,9 @@ func (s *Sandbox) logHeathAndUsage(ctx *utils.LockableCancelableContext) {
 		metricsTicker.Stop()
 	}()
 
-	// Get metrics on sandbox startup
+	// Get metrics and health status on sandbox startup
 	go s.LogMetrics(ctx)
+	go s.Healthcheck(ctx, false)
 
 	for {
 		select {
@@ -68,9 +69,12 @@ func (s *Sandbox) Healthcheck(ctx context.Context, alwaysReport bool) {
 		}
 
 		if alwaysReport {
+			fmt.Println("This was called alwaysReport")
 			if ok {
+				fmt.Println("This was called alwaysReport ok")
 				sbxlogger.E(s).Healthcheck(sbxlogger.ReportSuccess)
 			} else {
+				fmt.Println("This was called alwaysReport not ok")
 				sbxlogger.E(s).Healthcheck(sbxlogger.ReportFail)
 				sbxlogger.I(s).Error("control healthcheck failed", zap.Error(err))
 			}

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -246,6 +246,8 @@ func NewSandbox(
 		healthcheckCtx: healthcheckCtx,
 		healthy:        atomic.Bool{}, // defaults to `false`
 	}
+	// By default, the sandbox should be healthy, if the status change we report it.
+	sbx.healthy.Store(true)
 
 	cleanup.AddPriority(func() error {
 		var errs []error


### PR DESCRIPTION
# Description

- If not we would report the first health check as a change in the status
- Runs the initial sandbox health check