### PR TITLE
Fix sandbox logs timestamps

### DIFF
--- a/packages/nomad/logs-collector.hcl
+++ b/packages/nomad/logs-collector.hcl
@@ -85,6 +85,7 @@ source = """
 del(."_path")
 .service = "envd"
 .sandboxID = .instanceID
+.timestamp = parse_timestamp(.timestamp, format: "%Y-%m-%dT%H:%M:%S.%fZ") ?? now()
 if !exists(.envID) {
   .envID = "unknown"
 }

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -81,7 +81,7 @@ func GetEncoderConfig(lineEnding string) zapcore.EncoderConfig {
 		EncodeLevel:   zapcore.LowercaseLevelEncoder,
 		NameKey:       "logger",
 		StacktraceKey: "stacktrace",
-		EncodeTime:    zapcore.ISO8601TimeEncoder,
+		EncodeTime:    zapcore.RFC3339NanoTimeEncoder,
 		LineEnding:    lineEnding,
 	}
 }


### PR DESCRIPTION
Fixes timestamps in sandbox logs, so the timestamp corresponds to the time of creation and not the time of http sent.