### PR TITLE
Deploy clickhouse on nomad

### DIFF
--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -44,8 +44,10 @@ job "clickhouse" {
           nofile = "262144:262144"
         }
 
+
         volumes = [
           "local/config.xml:/etc/clickhouse-server/config.d/gcs.xml",
+          "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
         ]
       }
 
@@ -83,6 +85,26 @@ job "clickhouse" {
 </clickhouse>
 EOF
         destination = "local/config.xml"
+      }
+
+      template {
+        data = <<EOF
+<?xml version="1.0"?>
+<clickhouse>
+    <users>
+        <${username}>
+            <password_sha256_hex>${password_sha256_hex}</password_sha256_hex>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </${username}>
+    </users>
+</clickhouse>
+EOF
+        destination = "local/users.xml"
       }
 
       resources {

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -47,7 +47,8 @@ job "clickhouse" {
 
         volumes = [
           "local/config.xml:/etc/clickhouse-server/config.d/gcs.xml",
-          "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
+          # disabled while testing but will pass password to orchestrator in the future
+          # "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
         ]
       }
 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -38,6 +38,13 @@ job "clickhouse" {
     task "clickhouse-server" {
       driver = "docker"
 
+
+      resources {
+        cpu    = 500
+        memory = 1024
+        max_memory = 2048
+      }
+
       config {
         image = "clickhouse/clickhouse-server:${clickhouse_version}"
         ports = ["clickhouse", "clickhouse_http"]
@@ -110,10 +117,6 @@ EOF
         destination = "local/users.xml"
       }
 
-      resources {
-        cpu    = 500
-        memory = 1024
-      }
     }
   }
 } 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -1,6 +1,8 @@
 job "clickhouse" {
   datacenters = ["${zone}"]
   type        = "service"
+  node_pool = "api"
+
 
   group "clickhouse" {
     count = 1

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -113,7 +113,6 @@ EOF
       resources {
         cpu    = 500
         memory = 1024
-        max_memory = 2048
       }
     }
   }

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -59,15 +59,15 @@ job "clickhouse" {
                 <support_batch_delete>false</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/</endpoint>
-                <access_key_id>{{ with secret "gcp/key/clickhouse" }}{{ .Data.hmac_key }}{{ end }}</access_key_id>
-                <secret_access_key>{{ with secret "gcp/key/clickhouse" }}{{ .Data.hmac_secret }}{{ end }}</secret_access_key>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
                 <metadata_path>/var/lib/clickhouse/disks/gcs/</metadata_path>
             </gcs>
             <gcs_cache>
                 <type>cache</type>
                 <disk>gcs</disk>
                 <path>/var/lib/clickhouse/disks/gcs_cache/</path>
-                <max_size>10Gi</max_size>
+                <max_size>4Gi</max_size>
             </gcs_cache>
         </disks>
         <policies>

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -1,0 +1,94 @@
+job "clickhouse" {
+  datacenters = ["${zone}"]
+  type        = "service"
+
+  group "clickhouse" {
+    count = 1
+
+    network {
+      port "clickhouse" {
+        to = 9000
+      }
+      
+      port "clickhouse_http" {
+        to = 8123
+      }
+    }
+
+    service {
+      name = "clickhouse"
+      port = "clickhouse"
+
+      check {
+        type     = "http"
+        path     = "/ping"
+        port     = "clickhouse_http"
+        interval = "10s"
+        timeout  = "5s"
+      }
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.clickhouse.rule=Host(`clickhouse.service.consul`)",
+      ]
+    }
+
+    task "clickhouse-server" {
+      driver = "docker"
+
+      config {
+        image = "clickhouse/clickhouse-server:${clickhouse_version}"
+        ports = ["clickhouse", "clickhouse_http"]
+
+        ulimit {
+          nofile = "262144:262144"
+        }
+
+        volumes = [
+          "local/config.xml:/etc/clickhouse-server/config.d/gcs.xml",
+        ]
+      }
+
+      template {
+        data = <<EOF
+<?xml version="1.0"?>
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <gcs>
+                <support_batch_delete>false</support_batch_delete>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/</endpoint>
+                <access_key_id>{{ with secret "gcp/key/clickhouse" }}{{ .Data.hmac_key }}{{ end }}</access_key_id>
+                <secret_access_key>{{ with secret "gcp/key/clickhouse" }}{{ .Data.hmac_secret }}{{ end }}</secret_access_key>
+                <metadata_path>/var/lib/clickhouse/disks/gcs/</metadata_path>
+            </gcs>
+            <gcs_cache>
+                <type>cache</type>
+                <disk>gcs</disk>
+                <path>/var/lib/clickhouse/disks/gcs_cache/</path>
+                <max_size>10Gi</max_size>
+            </gcs_cache>
+        </disks>
+        <policies>
+            <gcs_main>
+                <volumes>
+                    <main>
+                        <disk>gcs_cache</disk>
+                    </main>
+                </volumes>
+            </gcs_main>
+        </policies>
+    </storage_configuration>
+</clickhouse>
+EOF
+        destination = "local/config.xml"
+      }
+
+      resources {
+        cpu    = 2000
+        memory = 4096
+      }
+    }
+  }
+} 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -42,7 +42,6 @@ job "clickhouse" {
       resources {
         cpu    = 500
         memory = 1024
-        max_memory = 2048
       }
 
       config {

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -111,8 +111,9 @@ EOF
       }
 
       resources {
-        cpu    = 2000
-        memory = 4096
+        cpu    = 500
+        memory = 1024
+        max_memory = 2048
       }
     }
   }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -413,13 +413,13 @@ resource "random_password" "clickhouse_password" {
 # Add this with your other Nomad jobs
 resource "nomad_job" "clickhouse" {
   jobspec = templatefile("${path.module}/clickhouse.hcl", {
-    zone               = var.gcp_zone
-    clickhouse_version = "25.1.5.31" # Or make this a variable
-    gcs_bucket         = google_storage_bucket.clickhouse_bucket.name
-    gcs_folder         = "clickhouse-data"
-    hmac_key           = google_storage_hmac_key.clickhouse_hmac_key.access_id
-    hmac_secret        = google_storage_hmac_key.clickhouse_hmac_key.secret
-    username           = "clickhouse"
-    password           = sha256(random_password.clickhouse_password.result)
+    zone                = var.gcp_zone
+    clickhouse_version  = "25.1.5.31" # Or make this a variable
+    gcs_bucket          = google_storage_bucket.clickhouse_bucket.name
+    gcs_folder          = "clickhouse-data"
+    hmac_key            = google_storage_hmac_key.clickhouse_hmac_key.access_id
+    hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
+    username            = "clickhouse"
+    password_sha256_hex = sha256(random_password.clickhouse_password.result)
   })
 }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -377,3 +377,18 @@ resource "nomad_job" "loki" {
     }
   }
 }
+
+# Add this with your other data sources
+data "google_secret_manager_secret_version" "clickhouse_hmac" {
+  secret = var.clickhouse_hmac_secret_name
+}
+
+# Add this with your other Nomad jobs
+resource "nomad_job" "clickhouse" {
+  jobspec = templatefile("${path.module}/clickhouse.hcl", {
+    zone              = var.gcp_zone
+    clickhouse_version = "25.1.5.31" # Or make this a variable
+    gcs_bucket        = "your-clickhouse-bucket"
+    gcs_folder        = "clickhouse-data"
+  })
+}

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -403,6 +403,12 @@ resource "google_storage_hmac_key" "clickhouse_hmac_key" {
   service_account_email = google_service_account.clickhouse_service_account.email
 }
 
+# generate password
+resource "random_password" "clickhouse_password" {
+  length  = 32
+  special = false
+}
+
 
 # Add this with your other Nomad jobs
 resource "nomad_job" "clickhouse" {
@@ -413,5 +419,7 @@ resource "nomad_job" "clickhouse" {
     gcs_folder         = "clickhouse-data"
     hmac_key           = google_storage_hmac_key.clickhouse_hmac_key.access_id
     hmac_secret        = google_storage_hmac_key.clickhouse_hmac_key.secret
+    username           = "clickhouse"
+    password           = sha256(random_password.clickhouse_password.result)
   })
 }

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -202,3 +202,8 @@ variable "redis_port" {
     port = number
   })
 }
+
+variable "clickhouse_hmac_secret_name" {
+  description = "Name of the secret containing ClickHouse HMAC credentials"
+  type        = string
+}

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -202,8 +202,3 @@ variable "redis_port" {
     port = number
   })
 }
-
-variable "clickhouse_hmac_secret_name" {
-  description = "Name of the secret containing ClickHouse HMAC credentials"
-  type        = string
-}


### PR DESCRIPTION
This change adds clickhouse and corresponding gcs bucket and permissions for clickhouse to access the bucket to our nomad cluster 