### PR TITLE
Fix break in initial health loop in API

### DIFF
--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -132,7 +132,7 @@ func NewAPIStore(ctx context.Context) *APIStore {
 				if orch.NodeCount() != 0 {
 					zap.L().Info("Nodes are ready, setting API as healthy")
 					a.Healthy = true
-					break
+					return
 				}
 			}
 		}


### PR DESCRIPTION
# Description

Break was "caught" by select, resulting in infinite cycle