### PR TITLE
Optimize DB queries for pause / resume

### DIFF
--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -38,8 +38,8 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 			return
 		}
 
-		var notFoundErr db.ErrNotFound
-		if errors.Is(err, notFoundErr) {
+		var errNotFound db.ErrNotFound
+		if errors.Is(err, errNotFound) {
 			zap.L().Debug("Snapshot not found", zap.String("sandboxID", sandboxID))
 			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Error pausing sandbox - snapshot for sandbox '%s' was not found", sandboxID))
 			return

--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -38,8 +38,8 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 			return
 		}
 
-		var notFoundErr db.NotFoundError
-		if errors.As(err, &notFoundErr) {
+		var notFoundErr db.ErrNotFound
+		if errors.Is(err, notFoundErr) {
 			zap.L().Debug("Snapshot not found", zap.String("sandboxID", sandboxID))
 			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Error pausing sandbox - snapshot for sandbox '%s' was not found", sandboxID))
 			return

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -106,8 +106,8 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 	snap, build, err := a.db.GetLastSnapshot(ctx, sandboxID, teamInfo.Team.ID)
 	if err != nil {
-		var notFoundError db.NotFoundError
-		if errors.As(err, &notFoundError) {
+		var notFoundError db.ErrNotFound
+		if errors.Is(err, notFoundError) {
 			zap.L().Debug("Snapshot not found", zap.String("sandboxID", sandboxID))
 			a.sendAPIStoreError(c, http.StatusNotFound, err.Error())
 

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -106,8 +106,8 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 	snap, build, err := a.db.GetLastSnapshot(ctx, sandboxID, teamInfo.Team.ID)
 	if err != nil {
-		var notFoundError db.ErrNotFound
-		if errors.Is(err, notFoundError) {
+		var errNotFound db.ErrNotFound
+		if errors.Is(err, errNotFound) {
 			zap.L().Debug("Snapshot not found", zap.String("sandboxID", sandboxID))
 			a.sendAPIStoreError(c, http.StatusNotFound, err.Error())
 

--- a/packages/shared/pkg/db/errors.go
+++ b/packages/shared/pkg/db/errors.go
@@ -1,0 +1,20 @@
+package db
+
+type NotFoundError error
+type TemplateNotFound struct{ NotFoundError }
+
+func (TemplateNotFound) Error() string {
+	return "Template not found"
+}
+
+type SnapshotNotFound struct{ NotFoundError }
+
+func (SnapshotNotFound) Error() string {
+	return "Snapshot not found"
+}
+
+type BuildNotFound struct{ NotFoundError }
+
+func (BuildNotFound) Error() string {
+	return "Build not found"
+}

--- a/packages/shared/pkg/db/errors.go
+++ b/packages/shared/pkg/db/errors.go
@@ -1,19 +1,19 @@
 package db
 
-type NotFoundError error
-type TemplateNotFound struct{ NotFoundError }
+type ErrNotFound error
+type TemplateNotFound struct{ ErrNotFound }
 
 func (TemplateNotFound) Error() string {
 	return "Template not found"
 }
 
-type SnapshotNotFound struct{ NotFoundError }
+type SnapshotNotFound struct{ ErrNotFound }
 
 func (SnapshotNotFound) Error() string {
 	return "Snapshot not found"
 }
 
-type BuildNotFound struct{ NotFoundError }
+type BuildNotFound struct{ ErrNotFound }
 
 func (BuildNotFound) Error() string {
 	return "Build not found"


### PR DESCRIPTION
It's little bit annoying with `entgo`, I have to get back to the conversion to `sqlc`.

But to the point, the original query was pulling all env_builds and joining them in memory. Now there should be only 3 queries, each fetching only 1 record 


```sql
SELECT "public"."snapshots"."id", "public"."snapshots"."created_at", "public"."snapshots"."base_env_id", "public"."snapshots"."env_id", "public"."snapshots"."sandbox_id", "public"."snapshots"."metadata" FROM "public"."snapshots" WHERE "public"."snapshots"."sandbox_id" = $1 LIMIT 2 args=[<sandbox ID>]

SELECT "public"."env_builds"."id", "public"."env_builds"."created_at", "public"."env_builds"."updated_at", "public"."env_builds"."finished_at", "public"."env_builds"."env_id", "public"."env_builds"."status", "public"."env_builds"."dockerfile", "public"."env_builds"."start_cmd", "public"."env_builds"."vcpu", "public"."env_builds"."ram_mb", "public"."env_builds"."free_disk_size_mb", "public"."env_builds"."total_disk_size_mb", "public"."env_builds"."kernel_version", "public"."env_builds"."firecracker_version", "public"."env_builds"."envd_version" FROM "public"."env_builds" WHERE "public"."env_builds"."status" = $1 ORDER BY "public"."env_builds"."finished_at" DESC LIMIT 2 args=[success]

SELECT "public"."envs"."id", "public"."envs"."created_at", "public"."envs"."updated_at", "public"."envs"."team_id", "public"."envs"."created_by", "public"."envs"."public", "public"."envs"."build_count", "public"."envs"."spawn_count", "public"."envs"."last_spawned_at" FROM "public"."envs" WHERE ("public"."envs"."id" IN (SELECT "public"."env_builds"."env_id" FROM "public"."env_builds" WHERE "public"."env_builds"."status" = $1) AND "public"."envs"."id" IN (SELECT "public"."snapshots"."env_id" FROM "public"."snapshots" WHERE "public"."snapshots"."sandbox_id" = $2)) AND "public"."envs"."team_id" = $3 LIMIT 2 args=[success <sandbox ID> <team ID>]

SELECT "public"."env_builds"."id", "public"."env_builds"."created_at", "public"."env_builds"."updated_at", "public"."env_builds"."finished_at", "public"."env_builds"."env_id", "public"."env_builds"."status", "public"."env_builds"."dockerfile", "public"."env_builds"."start_cmd", "public"."env_builds"."vcpu", "public"."env_builds"."ram_mb", "public"."env_builds"."free_disk_size_mb", "public"."env_builds"."total_disk_size_mb", "public"."env_builds"."kernel_version", "public"."env_builds"."firecracker_version", "public"."env_builds"."envd_version" FROM "public"."env_builds" WHERE "public"."env_builds"."status" = $1 AND "public"."env_builds"."env_id" IN ($2) ORDER BY "public"."env_builds"."finished_at" DESC LIMIT 2 args=[success <snapshot env id>]

SELECT "public"."snapshots"."id", "public"."snapshots"."created_at", "public"."snapshots"."env_id", "public"."snapshots"."env_id", "public"."snapshots"."sandbox_id", "public"."snapshots"."metadata" FROM "public"."snapshots" WHERE "public"."snapshots"."sandbox_id" = $1 AND "public"."snapshots"."env_id" IN ($2) LIMIT 2 args=[<sandbox ID> <snapshot env id>]
```

Avg time taken: 2.486495375s (based on 10 cycles)

vs new queries

```sql
SELECT "public"."snapshots"."id", "public"."snapshots"."created_at", "public"."snapshots"."base_env_id", "public"."snapshots"."env_id", "public"."snapshots"."sandbox_id", "public"."snapshots"."metadata" FROM "public"."snapshots" WHERE "public"."snapshots"."sandbox_id" = $1 LIMIT 2 args=[<sandbox ID>]

SELECT "public"."env_builds"."id", "public"."env_builds"."created_at", "public"."env_builds"."updated_at", "public"."env_builds"."finished_at", "public"."env_builds"."env_id", "public"."env_builds"."status", "public"."env_builds"."dockerfile", "public"."env_builds"."start_cmd", "public"."env_builds"."vcpu", "public"."env_builds"."ram_mb", "public"."env_builds"."free_disk_size_mb", "public"."env_builds"."total_disk_size_mb", "public"."env_builds"."kernel_version", "public"."env_builds"."firecracker_version", "public"."env_builds"."envd_version" FROM "public"."env_builds" WHERE "public"."env_builds"."status" = $1 AND "public"."env_builds"."env_id" = $2 ORDER BY "public"."env_builds"."finished_at" DESC LIMIT 2 args=[success <env id>]

SELECT "public"."envs"."id", "public"."envs"."created_at", "public"."envs"."updated_at", "public"."envs"."team_id", "public"."envs"."created_by", "public"."envs"."public", "public"."envs"."build_count", "public"."envs"."spawn_count", "public"."envs"."last_spawned_at" FROM "public"."envs" WHERE "public"."envs"."id" = $1 AND "public"."envs"."team_id" = $2 LIMIT 2 args=[<env id> <team id>]
```

Avg time taken: 1.490353416s (based on 10 cycles)
