### PR TITLE
Add media bucket and dashboard service account infrastructure

### DIFF
--- a/packages/buckets/outputs.tf
+++ b/packages/buckets/outputs.tf
@@ -26,3 +26,23 @@ output "fc_versions_bucket_name" {
 output "fc_template_bucket_name" {
   value = google_storage_bucket.fc_template_bucket.name
 }
+
+output "media_bucket_name" {
+  value = google_storage_bucket.media_bucket.name
+}
+
+output "dashboard_service_account_email" {
+  description = "The email of the service account for dashboard operations"
+  value       = google_service_account.dashboard_service_account.email
+}
+
+output "dashboard_service_account_key" {
+  description = "The private key of the service account for dashboard operations"
+  value       = google_service_account_key.dashboard_service_key.private_key
+  sensitive   = true
+}
+
+output "dashboard_service_account_key_secret_name" {
+  description = "The name of the Secret Manager secret containing the dashboard service account key"
+  value       = google_secret_manager_secret.dashboard_service_account_key_secret.name
+}

--- a/packages/buckets/variables.tf
+++ b/packages/buckets/variables.tf
@@ -27,3 +27,8 @@ variable "fc_template_bucket_name" {
   type        = string
   description = "The name of the FC template bucket"
 }
+
+variable "prefix" {
+  type    = string
+  default = "e2b-"
+}


### PR DESCRIPTION
This PR adds the necessary GCP infrastructure for media storage and dashboard operations:

### Changes
- Created a new media bucket with CORS configuration and controlled public access
- Added a custom IAM role for limited object access (get only)
- Created a dashboard service account with appropriate permissions
- Set up secret management for the dashboard service account key
- Added necessary IAM bindings for service accounts

### Why
These changes enable secure media storage with controlled public access and establish the service account infrastructure needed for dashboard operations. The media bucket will be used for storing user-accessible content, while the dashboard service account provides the necessary permissions for the dashboard to interact with GCP resources.

In the upcoming version of the dashboard, the media bucket will be used for storing team profile pictures.

### Testing
- Verified bucket creation and permissions in GCP console
- Confirmed service account creation and key management