### PR TITLE
Fix cache eviction and sync node synchronization

### DIFF
--- a/packages/api/internal/cache/instance/lifecycle_cache_test.go
+++ b/packages/api/internal/cache/instance/lifecycle_cache_test.go
@@ -185,7 +185,6 @@ func TestLifecycleCacheHasEvicting(t *testing.T) {
 
 	// Wait for eviction to complete
 	<-evictCalled
-	time.Sleep(100 * time.Millisecond)
 
 	assert.False(t, cache.Has("test", true))
 	assert.False(t, cache.Has("test", false))

--- a/packages/api/internal/cache/instance/operations.go
+++ b/packages/api/internal/cache/instance/operations.go
@@ -29,11 +29,9 @@ func (c *InstanceCache) CountForTeam(teamID uuid.UUID) (count uint) {
 	return count
 }
 
-// Exists Check if the instance exists in the cache.
+// Exists Check if the instance exists in the cache or is being evicted.
 func (c *InstanceCache) Exists(instanceID string) bool {
-	_, exists := c.cache.Get(instanceID)
-
-	return exists
+	return c.cache.Has(instanceID, true)
 }
 
 // Get the item from the cache.


### PR DESCRIPTION
Fixes synchronization issue between orchestrator sandboxes state and API cache state. This change will check in the exists method also for items that are being evicted, so they won't be added while the eviction is happening.