### PR TITLE
Make envd timeout a variable

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -28,7 +28,11 @@ runs:
       shell: bash
 
     - name: Start Services
+      env:
+        ENVD_TIMEOUT: "60s"
       run: |
+        echo "ENVD_TIMEOUT=${ENVD_TIMEOUT}" >> .env.test
+        
         mkdir -p ~/logs
         make -C packages/orchestrator run-debug 2>&1 | tee ~/logs/orchestrator.log &
         make -C packages/api run 2>&1 | tee ~/logs/api.log &

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -42,6 +42,7 @@ run-debug:
 	GODEBUG=madvdontneed=1 \
 	NODE_ID="test-client" \
 	TEMPLATE_BUCKET_NAME=$(TEMPLATE_BUCKET_NAME) \
+	ENVD_TIMEOUT=$(ENVD_TIMEOUT) \
 	./bin/orchestrator
 
 .PHONY: upload

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -272,7 +272,7 @@ func NewSandbox(
 		return errors.Join(errs...)
 	})
 
-	// Ensure the syncing takes at most 60 seconds.
+	// Ensure the syncing takes at most envdTimeout seconds.
 	syncCtx, syncCancel := context.WithTimeoutCause(childCtx, envdTimeout, fmt.Errorf("syncing took too long"))
 	defer syncCancel()
 

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -25,6 +25,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/stats"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/uffd"
+	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -32,6 +33,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+var envdTimeout = utils.Must(time.ParseDuration(env.GetEnv("ENVD_TIMEOUT", "10s")))
 
 var httpClient = http.Client{
 	Timeout: 10 * time.Second,
@@ -270,7 +273,7 @@ func NewSandbox(
 	})
 
 	// Ensure the syncing takes at most 60 seconds.
-	syncCtx, syncCancel := context.WithTimeoutCause(childCtx, 60*time.Second, fmt.Errorf("syncing took too long"))
+	syncCtx, syncCancel := context.WithTimeoutCause(childCtx, envdTimeout, fmt.Errorf("syncing took too long"))
 	defer syncCancel()
 
 	// Sync envds.


### PR DESCRIPTION
Adds a variable for envd timeout. The default is 10s when not set. It is used in the integration testing, there it's set to 60s.