### PR TITLE
Handle error when creating transaction

### DIFF
--- a/packages/shared/pkg/db/snapshot.go
+++ b/packages/shared/pkg/db/snapshot.go
@@ -33,6 +33,9 @@ func (db *DB) NewSnapshotBuild(
 	teamID uuid.UUID,
 ) (*models.EnvBuild, error) {
 	tx, err := db.Client.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start transaction: %w", err)
+	}
 	defer tx.Rollback()
 
 	s, err := tx.


### PR DESCRIPTION
# Description

When there's problem with creating new transaction (connection pool exhausted?) handle the error