### PR TITLE
fixed empty reader buffer after second try of calling envd init endpoint

### DIFF
--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -24,8 +24,7 @@ const (
 func doRequestWithInfiniteRetries(ctx context.Context, method, address string, requestBody []byte) (*http.Response, error) {
 	for {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
-		reqBody := bytes.NewReader(requestBody)
-		request, err := http.NewRequestWithContext(reqCtx, method, address, reqBody)
+		request, err := http.NewRequestWithContext(reqCtx, method, address, bytes.NewReader(requestBody))
 
 		if err != nil {
 			cancel()

--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -21,10 +21,12 @@ const (
 
 // doRequestWithInfiniteRetries does a request with infinite retries until the context is done.
 // The parent context should have a deadline or a timeout.
-func doRequestWithInfiniteRetries(ctx context.Context, method, address string, body io.Reader) (*http.Response, error) {
+func doRequestWithInfiniteRetries(ctx context.Context, method, address string, requestBody []byte) (*http.Response, error) {
 	for {
 		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
-		request, err := http.NewRequestWithContext(reqCtx, method, address, body)
+		reqBody := bytes.NewReader(requestBody)
+		request, err := http.NewRequestWithContext(reqCtx, method, address, reqBody)
+
 		if err != nil {
 			cancel()
 			return nil, err
@@ -85,7 +87,7 @@ func (s *Sandbox) initEnvd(ctx context.Context, tracer trace.Tracer, envVars map
 		return err
 	}
 
-	response, err := doRequestWithInfiniteRetries(childCtx, "POST", address, bytes.NewReader(envVarsJSON))
+	response, err := doRequestWithInfiniteRetries(childCtx, "POST", address, envVarsJSON)
 	if err != nil {
 		return fmt.Errorf("failed to init envd: %w", err)
 	}


### PR DESCRIPTION
there was bug when reader is provided to request loop that is trying to initialize envd but because its not running yet, some requests can fails. Reader buffer provided with JSON request body was read in first round that failed and later it was empty so envd service initialized with empty body, that means without environments.