### PR TITLE
Improve analytics reporting in the API

### DIFF
--- a/packages/api/internal/cache/instance/instance.go
+++ b/packages/api/internal/cache/instance/instance.go
@@ -176,7 +176,7 @@ func NewCache(
 			zap.L().Error("Error deleting instance", zap.Error(err))
 		}
 
-		instanceCache.UpdateCounters(instanceInfo, -1, false)
+		instanceCache.UpdateCounters(ctx, instanceInfo, -1, false)
 	})
 
 	go cache.Start(ctx)

--- a/packages/api/internal/cache/instance/monitoring.go
+++ b/packages/api/internal/cache/instance/monitoring.go
@@ -7,14 +7,14 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-func (c *InstanceCache) UpdateCounters(instance *InstanceInfo, value int64, newlyCreated bool) {
+func (c *InstanceCache) UpdateCounters(ctx context.Context, instance *InstanceInfo, value int64, newlyCreated bool) {
 	attributes := []attribute.KeyValue{
 		attribute.String("team_id", instance.TeamID.String()),
 	}
 
 	if value > 0 && newlyCreated {
-		c.createdCounter.Add(context.Background(), value, metric.WithAttributes(attributes...))
+		c.createdCounter.Add(ctx, value, metric.WithAttributes(attributes...))
 	}
 
-	c.sandboxCounter.Add(context.Background(), value, metric.WithAttributes(attributes...))
+	c.sandboxCounter.Add(ctx, value, metric.WithAttributes(attributes...))
 }

--- a/packages/api/internal/cache/instance/operations.go
+++ b/packages/api/internal/cache/instance/operations.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -59,7 +60,7 @@ func (c *InstanceCache) GetInstances(teamID *uuid.UUID) (instances []*InstanceIn
 // Add the instance to the cache and start expiration timer.
 // If the instance already exists we do nothing - it was loaded from Orchestrator.
 // TODO: Any error here should delete the sandbox
-func (c *InstanceCache) Add(instance *InstanceInfo, newlyCreated bool) error {
+func (c *InstanceCache) Add(ctx context.Context, instance *InstanceInfo, newlyCreated bool) error {
 	sbxlogger.I(instance).Debug("Adding sandbox to cache",
 		zap.Bool("newly_created", newlyCreated),
 		zap.Time("start_time", instance.StartTime),
@@ -97,7 +98,7 @@ func (c *InstanceCache) Add(instance *InstanceInfo, newlyCreated bool) error {
 	}
 
 	c.Set(instance.Instance.SandboxID, instance)
-	c.UpdateCounters(instance, 1, newlyCreated)
+	c.UpdateCounters(ctx, instance, 1, newlyCreated)
 
 	// Release the reservation if it exists
 	c.reservations.release(instance.Instance.SandboxID)

--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -6,9 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	analyticscollector "github.com/e2b-dev/infra/packages/api/internal/analytics_collector"
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 )
@@ -78,18 +76,5 @@ func (c *InstanceCache) Sync(ctx context.Context, instances []*InstanceInfo, nod
 				zap.L().Error("error adding instance to cache", zap.Error(err))
 			}
 		}
-	}
-}
-
-// ReportNodeAnalytics sends running instances event to analytics
-func (c *InstanceCache) ReportNodeAnalytics(ctx context.Context, instances []*InstanceInfo) {
-	instanceIds := make([]string, len(instances))
-	for i, instance := range instances {
-		instanceIds[i] = instance.Instance.SandboxID
-	}
-
-	_, err := c.analytics.RunningInstances(ctx, &analyticscollector.RunningInstancesEvent{InstanceIds: instanceIds, Timestamp: timestamppb.Now()})
-	if err != nil {
-		zap.L().Error("error sending running instances event to analytics", zap.Error(err))
 	}
 }

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -1,0 +1,70 @@
+package orchestrator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	analyticscollector "github.com/e2b-dev/infra/packages/api/internal/analytics_collector"
+	"github.com/e2b-dev/infra/packages/api/internal/cache/instance"
+)
+
+const (
+	// syncAnalyticsTime if this value is updated, it should be correctly updated in analytics too.
+	syncAnalyticsTime = 3 * time.Minute
+)
+
+func (o *Orchestrator) startNodeAnalytics(ctx context.Context) {
+	ticker := time.NewTicker(syncAnalyticsTime)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			o.reportNodesAnalytics(ctx)
+		}
+	}
+}
+
+func (o *Orchestrator) reportNodesAnalytics(parentCtx context.Context) {
+	ctx, cancel := context.WithTimeout(parentCtx, syncAnalyticsTime)
+	defer cancel()
+
+	// Group running sandboxes by the Node.ID, split to work in parallel
+	sandboxes := o.instanceCache.Items()
+	sbxsByNode := make(map[string][]*instance.InstanceInfo)
+	for _, sbx := range sandboxes {
+		nodeID := sbx.Node.ID
+		sbxsByNode[nodeID] = append(sbxsByNode[nodeID], sbx)
+	}
+
+	var wg sync.WaitGroup
+	for _, ns := range sbxsByNode {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			reportNodeAnalytics(ctx, o.analytics, ns)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// reportNodeAnalytics sends running instances event to analytics, should be scoped by the node.
+func reportNodeAnalytics(ctx context.Context, analytics *analyticscollector.Analytics, instances []*instance.InstanceInfo) {
+	instanceIds := make([]string, len(instances))
+	for idx, i := range instances {
+		instanceIds[idx] = i.Instance.SandboxID
+	}
+
+	_, err := analytics.Client.RunningInstances(ctx, &analyticscollector.RunningInstancesEvent{InstanceIds: instanceIds, Timestamp: timestamppb.Now()})
+	if err != nil {
+		zap.L().Error("error sending running instances event to analytics", zap.Error(err))
+	}
+}

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -19,14 +19,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-// cacheSyncTime is the time to sync the cache with the actual instances in Orchestrator
+// cacheSyncTime is the time to sync the cache with the actual instances in Orchestrator.
 const cacheSyncTime = 20 * time.Second
-
-// syncAnalyticsTime if this value is updated, it should be correctly updated in analytics too.
-const syncAnalyticsTime = 3 * time.Minute
-
-// lastSyncAnalyticsTime is the last time the analytics were synced, global variable for now
-var lastSyncAnalyticsTime = time.Now()
 
 // reportTimeout is the timeout for the analytics report
 // This timeout is also set in the CloudRun for Analytics Collector, there it is 3 minutes.
@@ -152,12 +146,6 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 	}
 
 	node.SyncBuilds(builds)
-
-	// Sync the analytics only every syncAnalyticsTime, as sync nodes are run more often
-	if lastSyncAnalyticsTime.Add(syncAnalyticsTime).Before(time.Now()) {
-		lastSyncAnalyticsTime = time.Now()
-		instanceCache.ReportNodeAnalytics(ctx, activeInstances)
-	}
 }
 
 func (o *Orchestrator) getDeleteInstanceFunction(

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -19,8 +19,14 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-// cacheSyncTime if this value is updated, it should be correctly updated in analytics too.
-const cacheSyncTime = 3 * time.Minute
+// cacheSyncTime is the time to sync the cache with the actual instances in Orchestrator
+const cacheSyncTime = 20 * time.Second
+
+// syncAnalyticsTime if this value is updated, it should be correctly updated in analytics too.
+const syncAnalyticsTime = 3 * time.Minute
+
+// lastSyncAnalyticsTime is the last time the analytics were synced, global variable for now
+var lastSyncAnalyticsTime = time.Now()
 
 // reportTimeout is the timeout for the analytics report
 // This timeout is also set in the CloudRun for Analytics Collector, there it is 3 minutes.
@@ -147,7 +153,11 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 
 	node.SyncBuilds(builds)
 
-	instanceCache.ReportNodeAnalytics(ctx, activeInstances)
+	// Sync the analytics only every syncAnalyticsTime, as sync nodes are run more often
+	if lastSyncAnalyticsTime.Add(syncAnalyticsTime).Before(time.Now()) {
+		lastSyncAnalyticsTime = time.Now()
+		instanceCache.ReportNodeAnalytics(ctx, activeInstances)
+	}
 }
 
 func (o *Orchestrator) getDeleteInstanceFunction(

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -137,7 +137,7 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 		return
 	}
 
-	instanceCache.Sync(activeInstances, node.Info.ID)
+	instanceCache.Sync(ctx, activeInstances, node.Info.ID)
 
 	builds, buildsErr := o.listCachedBuilds(ctx, node.Info.ID)
 	if buildsErr != nil {
@@ -146,6 +146,8 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 	}
 
 	node.SyncBuilds(builds)
+
+	instanceCache.ReportNodeAnalytics(ctx, activeInstances)
 }
 
 func (o *Orchestrator) getDeleteInstanceFunction(

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -217,7 +217,7 @@ func (o *Orchestrator) CreateSandbox(
 		autoPause,
 	)
 
-	cacheErr := o.instanceCache.Add(instanceInfo, true)
+	cacheErr := o.instanceCache.Add(childCtx, instanceInfo, true)
 	if cacheErr != nil {
 		errMsg := fmt.Errorf("error when adding instance to cache: %w", cacheErr)
 		telemetry.ReportError(ctx, errMsg)

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	// cacheHookTimeout is the timeout for all requests inside cache insert/delete hooks
+	// cacheHookTimeout is the timeout for all requests inside cache insert/delete hooks.
 	cacheHookTimeout = 5 * time.Minute
 
 	statusLogInterval = time.Second * 20
@@ -89,6 +89,7 @@ func New(
 		})
 	} else {
 		go o.keepInSync(ctx, cache)
+		go o.startNodeAnalytics(ctx)
 	}
 
 	go o.startStatusLogging(ctx)


### PR DESCRIPTION
Linear issue + parent issue description.

This PR should improve analytics reporting. It should do it async in the creation/deletion cases, and synchronously in the SyncNodes case.

Also, it changes the sync nodes interval back to 3 minutes (from 20 seconds).