### PR TITLE
Add basic orchestrator healthcheck

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2646,6 +2646,7 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/ebitengine/purego v0.8.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/efficientgo/core v1.0.0-rc.2 h1:7j62qHLnrZqO3V3UA0AqOGd5d5aXV3AX6m/NZBHp78I=
@@ -2785,6 +2786,8 @@ github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
+github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
+github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -3445,6 +3448,7 @@ github.com/loopholelabs/silo v0.1.2 h1:8eHwTzwvcGEY6uT/UG8as+u1l6XU36cAgYWfd2otq
 github.com/loopholelabs/silo v0.1.2/go.mod h1:FQWZ+cc3ZrzxulTetHlVD+1rGWswln8NdOaAPcjPwn0=
 github.com/lovoo/gcloud-opentracing v0.3.0/go.mod h1:ZFqk2y38kMDDikZPAK7ynTTGuyt17nSPdS3K5e+ZTBY=
 github.com/lufia/iostat v1.1.0/go.mod h1:rEPNA0xXgjHQjuI5Cy05sLlS2oRcSlWHRLrvh/AQ+Pg=
+github.com/lufia/plan9stats v0.0.0-20240909124753-873cd0166683/go.mod h1:ilwx/Dta8jXAgpFYFvSWEMwxmbWXyiUHkd5FwyKhb5k=
 github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star v0.6.1/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/lyft/protoc-gen-star/v2 v2.0.1/go.mod h1:RcCdONR2ScXaYnQC5tUzxzlpA3WVYF7/opLeUgcQs/o=
@@ -3798,6 +3802,7 @@ github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77
 github.com/pojntfx/panrpc/go v0.0.0-20240727035459-583758c47d9f h1:p7S+CWrOTh9M+QADrmedIuLevSmkbJTeNJvMOzTf8eY=
 github.com/pojntfx/panrpc/go v0.0.0-20240727035459-583758c47d9f/go.mod h1:G9YawT9jiXDf6z7WEv7KMIca+A41mjm8KL8AfBxN37U=
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
+github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 h1:0XM1XL/OFFJjXsYXlG30spTkV/E9+gmd5GD1w2HE8xM=
 github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8cTqKc=
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
@@ -3936,6 +3941,7 @@ github.com/shirou/gopsutil/v3 v3.23.8/go.mod h1:7hmCaBn+2ZwaZOr6jmPBZDfawwMGuo1i
 github.com/shirou/gopsutil/v3 v3.23.12 h1:z90NtUkp3bMtmICZKpC4+WaknU1eXtp5vtbQ11DgpE4=
 github.com/shirou/gopsutil/v3 v3.23.12/go.mod h1:1FrWgea594Jp7qmjHUUPlJDTPgcsb9mGnXDxavtikzM=
 github.com/shirou/gopsutil/v4 v4.24.5/go.mod h1:aoebb2vxetJ/yIDZISmduFvVNPHqXQ9SEJwRXxkf0RA=
+github.com/shirou/gopsutil/v4 v4.24.10/go.mod h1:s4D/wg+ag4rG0WO7AiTj2BeYCRhym0vM7DHbZRxnIT8=
 github.com/shoenig/go-landlock v1.2.0 h1:BumCuPbR7VkTB6cNZvhaDC0Apbv0zVpu2saV48mr120=
 github.com/shoenig/go-landlock v1.2.0/go.mod h1:S848L96G6iny3xexNb4sXUrKwEDIy5ul8hk1NBWoYws=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
@@ -4050,6 +4056,8 @@ github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
 github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
+github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
+github.com/tklauser/numcpus v0.9.0/go.mod h1:SN6Nq1O3VychhC1npsWostA+oW+VOQTxZrS604NSRyI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4dN7GR16kFc5fp3d1RIYzJW5onx8Ybykw2YQFA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -4166,6 +4174,7 @@ github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDf
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
+github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
@@ -4633,6 +4642,7 @@ golang.org/x/sys v0.0.0-20200107162124-548cf772de50/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200831180312-196b9ba8737a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -167,7 +167,7 @@ func run() int {
 	flag.Parse()
 
 	if !env.IsLocal() {
-		otlpCleanup := telemetry.InitOTLPExporter(ctx, serviceName, commitSHA)
+		otlpCleanup := telemetry.InitOTLPExporter(ctx, serviceName, commitSHA, "no")
 		defer otlpCleanup(ctx)
 	}
 

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -149,7 +149,7 @@ func run() int {
 	signalCtx, sigCancel := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer sigCancel()
 
-	stopOtlp := telemetry.InitOTLPExporter(ctx, ServiceName, commitSHA)
+	stopOtlp := telemetry.InitOTLPExporter(ctx, ServiceName, commitSHA, "no")
 	defer func() {
 		err := stopOtlp(ctx)
 		if err != nil {

--- a/packages/orchestrator/go.mod
+++ b/packages/orchestrator/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/loopholelabs/userfaultfd-go v0.1.2
 	github.com/miekg/dns v1.1.63
 	github.com/pojntfx/go-nbd v0.3.2
+	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.10.0
 	github.com/vishvananda/netlink v1.3.0
 	github.com/vishvananda/netns v0.0.5

--- a/packages/orchestrator/go.sum
+++ b/packages/orchestrator/go.sum
@@ -883,6 +883,7 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=

--- a/packages/orchestrator/go.sum
+++ b/packages/orchestrator/go.sum
@@ -884,6 +884,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
+github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -1119,6 +1120,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=

--- a/packages/orchestrator/internal/server/healthcheck.go
+++ b/packages/orchestrator/internal/server/healthcheck.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/meters"
+)
+
+const healthcheckFrequency = 5 * time.Second
+const healthcheckTimeout = 30 * time.Second
+
+type Status string
+
+const (
+	Healthy   Status = "healthy"
+	Unhealthy Status = "unhealthy"
+)
+
+type Healthcheck struct {
+	version    string
+	server     *server
+	grpc       *grpc.Server
+	grpcHealth *health.Server
+
+	// TODO: Replace with status from SQL Lite
+	status  Status
+	lastRun time.Time
+	mu      sync.RWMutex
+
+	sandboxCounter metric.Int64Gauge
+}
+
+func NewHealthcheck(server *server, grpc *grpc.Server, grpcHealth *health.Server, version string) (*Healthcheck, error) {
+	sandboxCounter, err := meters.GetGauge(meters.OrchestratorSandboxCountMeterName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Healthcheck{
+		version:    version,
+		server:     server,
+		grpc:       grpc,
+		grpcHealth: grpcHealth,
+
+		status:  Unhealthy,
+		lastRun: time.Now(),
+		mu:      sync.RWMutex{},
+
+		sandboxCounter: sandboxCounter,
+	}, nil
+}
+
+func (h *Healthcheck) Start(ctx context.Context, listener net.Listener) {
+	ticker := time.NewTicker(healthcheckFrequency)
+	defer ticker.Stop()
+
+	routeMux := http.NewServeMux()
+	routeMux.HandleFunc("/health", h.healthHandler)
+	httpServer := &http.Server{
+		Handler: routeMux,
+	}
+
+	go func() {
+		zap.L().Info("Starting health server")
+		if err := httpServer.Serve(listener); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err := h.report(ctx)
+			if err != nil {
+				zap.L().Error("Error reporting healthcheck", zap.Error(err))
+			}
+		}
+	}
+}
+
+func (h *Healthcheck) report(ctx context.Context) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	childCtx, cancel := context.WithTimeout(ctx, healthcheckTimeout)
+	defer cancel()
+
+	// Update last run on report
+	h.lastRun = time.Now()
+
+	// Report sandbox count
+	sbxCount := h.server.sandboxes.Count()
+	h.sandboxCounter.Record(childCtx, int64(sbxCount))
+
+	// Report health
+	c, err := h.grpcHealth.Check(childCtx, &healthpb.HealthCheckRequest{
+		// Empty string is the default service name
+		Service: "",
+	})
+	zap.L().Info("grpc health", zap.Any("c", c), zap.Error(err))
+	if err != nil {
+		h.status = Unhealthy
+		return err
+	}
+
+	switch c.GetStatus() {
+	case healthpb.HealthCheckResponse_SERVING:
+		h.status = Healthy
+	default:
+		h.status = Unhealthy
+	}
+
+	return nil
+}
+
+type HealthResponse struct {
+	Status  Status `json:"status"`
+	Version string `json:"version"`
+}
+
+func (h *Healthcheck) healthHandler(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	response := HealthResponse{
+		Status:  h.status,
+		Version: h.version,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/packages/orchestrator/internal/server/healthcheck.go
+++ b/packages/orchestrator/internal/server/healthcheck.go
@@ -83,7 +83,7 @@ func (h *Healthcheck) Start(ctx context.Context, listener net.Listener) {
 
 // report updates the health status.
 // This function is run in a goroutine every healthcheckFrequency for the reason of having
-// longer running tasks that might me too slow or resource intensive to be run
+// longer running tasks that might be too slow or resource intensive to be run
 // in the healthcheck http handler directly.
 func (h *Healthcheck) report(ctx context.Context) error {
 	h.mu.Lock()

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -194,7 +194,7 @@ func (srv *Service) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to listen on port %d: %w", srv.port, err)
 	}
 
-	// New HTTP server mux
+	// Reuse the same TCP port between grpc and HTTP requests
 	m := cmux.New(lis)
 	// Match HTTP requests.
 	httpL := m.Match(cmux.HTTP1Fast())

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -54,8 +54,10 @@ func main() {
 	// there's a panic.
 	defer wg.Wait()
 
+	clientID := consul.GetClientID()
+
 	if !env.IsLocal() {
-		shutdown := telemetry.InitOTLPExporter(ctx, server.ServiceName, "no")
+		shutdown := telemetry.InitOTLPExporter(ctx, server.ServiceName, commitSHA, clientID)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -5,14 +5,15 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"log"
 	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
 	"syscall"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/consul"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -102,7 +103,7 @@ func main() {
 	clientID := consul.GetClientID()
 	sessionProxy := proxy.New(proxyPort)
 
-	srv, err := server.New(ctx, port, clientID, sessionProxy)
+	srv, err := server.New(ctx, port, clientID, commitSHA, sessionProxy)
 	if err != nil {
 		zap.L().Fatal("failed to create server", zap.Error(err))
 	}

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -102,7 +102,6 @@ func main() {
 
 	log.Println("Starting orchestrator", "commit", commitSHA)
 
-	clientID := consul.GetClientID()
 	sessionProxy := proxy.New(proxyPort)
 
 	srv, err := server.New(ctx, port, clientID, commitSHA, sessionProxy)

--- a/packages/shared/pkg/meters/main.go
+++ b/packages/shared/pkg/meters/main.go
@@ -63,11 +63,11 @@ var upDownCounterUnits = map[UpDownCounterType]string{
 	ActiveConnectionsCounterMeterName:      "{connection}",
 }
 
-var gaugeDesc = map[ObservableUpDownCounterType]string{
+var observableUpDownCounterDesc = map[ObservableUpDownCounterType]string{
 	OrchestratorSandboxCountMeterName: "Counter of running sandboxes on the orchestrator.",
 }
 
-var gaugeUnits = map[ObservableUpDownCounterType]string{
+var observableUpDownCounterUnits = map[ObservableUpDownCounterType]string{
 	OrchestratorSandboxCountMeterName: "{sandbox}",
 }
 
@@ -115,7 +115,7 @@ func GetObservableUpDownCounter(name ObservableUpDownCounterType, callback metri
 		return counter, nil
 	}
 
-	counter, err := meter.Int64ObservableUpDownCounter(string(name), metric.WithDescription(gaugeDesc[name]), metric.WithUnit(gaugeUnits[name]), metric.WithInt64Callback(callback))
+	counter, err := meter.Int64ObservableUpDownCounter(string(name), metric.WithDescription(observableUpDownCounterDesc[name]), metric.WithUnit(observableUpDownCounterUnits[name]), metric.WithInt64Callback(callback))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/shared/pkg/meters/main.go
+++ b/packages/shared/pkg/meters/main.go
@@ -17,18 +17,25 @@ type UpDownCounterType string
 
 const (
 	SandboxCountMeterName                              UpDownCounterType = "api.env.instance.running"
-	BuildCounterMeterName                                                = "api.env.build.running"
-	NewNetworkSlotSPoolCounterMeterName                                  = "orchestrator.network.slots_pool.new"
-	ReusedNetworkSlotSPoolCounterMeterName                               = "orchestrator.network.slots_pool.reused"
-	NBDkSlotSReadyPoolCounterMeterName                                   = "orchestrator.nbd.slots_pool.read"
-	ActiveConnectionsCounterMeterName                                    = "client_proxy.connections.active"
-	OrchestratorProxyActiveConnectionsCounterMeterName                   = "orchestrator.proxy.connections.active"
+	BuildCounterMeterName                              UpDownCounterType = "api.env.build.running"
+	NewNetworkSlotSPoolCounterMeterName                UpDownCounterType = "orchestrator.network.slots_pool.new"
+	ReusedNetworkSlotSPoolCounterMeterName             UpDownCounterType = "orchestrator.network.slots_pool.reused"
+	NBDkSlotSReadyPoolCounterMeterName                 UpDownCounterType = "orchestrator.nbd.slots_pool.read"
+	ActiveConnectionsCounterMeterName                  UpDownCounterType = "client_proxy.connections.active"
+	OrchestratorProxyActiveConnectionsCounterMeterName UpDownCounterType = "orchestrator.proxy.connections.active"
+)
+
+type GaugeType string
+
+const (
+	OrchestratorSandboxCountMeterName GaugeType = "orchestrator.env.sandbox.running"
 )
 
 var meter = otel.GetMeterProvider().Meter("nomad")
 var meterLock = sync.Mutex{}
 var counters = make(map[CounterType]metric.Int64Counter)
 var upDownCounters = make(map[UpDownCounterType]metric.Int64UpDownCounter)
+var gauges = make(map[GaugeType]metric.Int64Gauge)
 
 var counterDesc = map[CounterType]string{
 	SandboxCreateMeterName: "Number of currently waiting requests to create a new sandbox",
@@ -54,6 +61,14 @@ var upDownCounterUnits = map[UpDownCounterType]string{
 	NewNetworkSlotSPoolCounterMeterName:    "{slot}",
 	NBDkSlotSReadyPoolCounterMeterName:     "{slot}",
 	ActiveConnectionsCounterMeterName:      "{connection}",
+}
+
+var gaugeDesc = map[GaugeType]string{
+	OrchestratorSandboxCountMeterName: "Counter of running sandboxes on the orchestrator.",
+}
+
+var gaugeUnits = map[GaugeType]string{
+	OrchestratorSandboxCountMeterName: "{sandbox}",
 }
 
 func GetCounter(name CounterType) (metric.Int64Counter, error) {
@@ -88,6 +103,24 @@ func GetUpDownCounter(name UpDownCounterType) (metric.Int64UpDownCounter, error)
 	}
 
 	upDownCounters[name] = counter
+
+	return counter, nil
+}
+
+func GetGauge(name GaugeType) (metric.Int64Gauge, error) {
+	meterLock.Lock()
+	defer meterLock.Unlock()
+
+	if counter, ok := gauges[name]; ok {
+		return counter, nil
+	}
+
+	counter, err := meter.Int64Gauge(string(name), metric.WithDescription(gaugeDesc[name]), metric.WithUnit(gaugeUnits[name]))
+	if err != nil {
+		return nil, err
+	}
+
+	gauges[name] = counter
 
 	return counter, nil
 }

--- a/packages/shared/pkg/telemetry/otel.go
+++ b/packages/shared/pkg/telemetry/otel.go
@@ -37,10 +37,11 @@ type client struct {
 }
 
 // InitOTLPExporter initializes an OTLP exporter, and configures the corresponding trace providers.
-func InitOTLPExporter(ctx context.Context, serviceName, serviceVersion string) func(ctx context.Context) error {
+func InitOTLPExporter(ctx context.Context, serviceName, serviceVersion string, instanceID string) func(ctx context.Context) error {
 	attributes := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),
 		semconv.ServiceVersion(serviceVersion),
+		semconv.ServiceInstanceID(instanceID),
 		semconv.TelemetrySDKName("otel"),
 		semconv.TelemetrySDKLanguageGo,
 	}

--- a/packages/template-manager/main.go
+++ b/packages/template-manager/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	if !env.IsLocal() {
-		shutdown := telemetry.InitOTLPExporter(ctx, constants.ServiceName, "no")
+		shutdown := telemetry.InitOTLPExporter(ctx, constants.ServiceName, "no", "no")
 		defer shutdown(context.TODO())
 	}
 


### PR DESCRIPTION
Adds:
- HTTP Endpoint "/health" reporting 
```
{
    "status": "healthy",
    "version": "6fe34854"
}
```
- Orchestrator count metric (async updown counter) "orchestrator.env.sandbox.running"
- OTEL InstanceID