### PR TITLE
Replace Nginx based session proxy with orchestrator proxy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -219,6 +219,7 @@ module "nomad" {
 
   # Orchestrator
   orchestrator_port           = var.orchestrator_port
+  orchestrator_proxy_port     = var.orchestrator_proxy_port
   fc_env_pipeline_bucket_name = module.buckets.fc_env_pipeline_bucket_name
 
   # Template manager

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -112,7 +112,7 @@ func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http
 		zap.L().Debug("Proxying request", zap.String("sandbox_id", sandboxID), zap.String("node", node))
 		targetUrl := &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("%s:%d", node, orchestratorProxyPort),
+			Host:   fmt.Sprintf("%s:%d", node, sandboxPort),
 		}
 
 		// Proxy the request

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	ServiceName      = "client-proxy"
-	dnsServer        = "api.service.consul:5353"
-	healthCheckPort  = 3001
-	port             = 3002
-	sandboxPort      = 3003 // legacy session proxy port
-	sandboxProxyPort = 5007 // orchestrator proxy port
-	maxRetries       = 3
+	ServiceName           = "client-proxy"
+	dnsServer             = "api.service.consul:5353"
+	healthCheckPort       = 3001
+	port                  = 3002
+	sandboxPort           = 3003 // legacy session proxy port
+	orchestratorProxyPort = 5007 // orchestrator proxy port
+	maxRetries            = 3
 )
 
 var commitSHA string
@@ -112,7 +112,7 @@ func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http
 		zap.L().Debug("Proxying request", zap.String("sandbox_id", sandboxID), zap.String("node", node))
 		targetUrl := &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("%s:%d", node, sandboxProxyPort),
+			Host:   fmt.Sprintf("%s:%d", node, orchestratorProxyPort),
 		}
 
 		// Proxy the request

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -28,12 +28,13 @@ import (
 )
 
 const (
-	ServiceName     = "client-proxy"
-	dnsServer       = "api.service.consul:5353"
-	healthCheckPort = 3001
-	port            = 3002
-	sandboxPort     = 3003
-	maxRetries      = 3
+	ServiceName      = "client-proxy"
+	dnsServer        = "api.service.consul:5353"
+	healthCheckPort  = 3001
+	port             = 3002
+	sandboxPort      = 3003 // legacy session proxy port
+	sandboxProxyPort = 5007 // orchestrator proxy port
+	maxRetries       = 3
 )
 
 var commitSHA string
@@ -111,7 +112,7 @@ func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http
 		zap.L().Debug("Proxying request", zap.String("sandbox_id", sandboxID), zap.String("node", node))
 		targetUrl := &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("%s:%d", node, sandboxPort),
+			Host:   fmt.Sprintf("%s:%d", node, sandboxProxyPort),
 		}
 
 		// Proxy the request

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -324,6 +324,7 @@ resource "nomad_job" "orchestrator" {
   jobspec = templatefile("${path.module}/orchestrator.hcl", {
     gcp_zone         = var.gcp_zone
     port             = var.orchestrator_port
+    proxy_port       = var.orchestrator_proxy_port
     environment      = var.environment
     consul_acl_token = var.consul_acl_token_secret
 

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -25,6 +25,11 @@ job "orchestrator" {
       }
     }
 
+    service {
+      name = "orchestrator-proxy"
+      port = "${proxy_port}"
+    }
+
     task "start" {
       driver = "raw_exec"
 
@@ -45,7 +50,7 @@ job "orchestrator" {
 
       config {
         command = "/bin/bash"
-        args    = ["-c", " chmod +x local/orchestrator && local/orchestrator --port ${port}"]
+        args    = ["-c", " chmod +x local/orchestrator && local/orchestrator --port ${port} --proxy-port ${proxy_port}"]
       }
 
       artifact {

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -185,6 +185,10 @@ variable "orchestrator_port" {
   type = number
 }
 
+variable "orchestrator_proxy_port" {
+  type = number
+}
+
 variable "fc_env_pipeline_bucket_name" {
   type = string
 }

--- a/packages/orchestrator/cmd/mock-sandbox/mock.go
+++ b/packages/orchestrator/cmd/mock-sandbox/mock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"log"
 	"os"
 	"os/signal"
@@ -14,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/dns"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
@@ -52,6 +52,8 @@ func main() {
 	}()
 
 	dnsServer := dns.New()
+	proxyServer := proxy.New(3333)
+
 	go func() {
 		log.Printf("Starting DNS server")
 
@@ -88,6 +90,7 @@ func main() {
 			*buildId,
 			*sandboxId+"-"+strconv.Itoa(v),
 			dnsServer,
+			proxyServer,
 			time.Duration(*keepAlive)*time.Second,
 			networkPool,
 			templateCache,

--- a/packages/orchestrator/cmd/mock-sandbox/mock.go
+++ b/packages/orchestrator/cmd/mock-sandbox/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"log"
 	"os"
 	"os/signal"
@@ -104,6 +105,7 @@ func mockSandbox(
 	buildId,
 	sandboxId string,
 	dns *dns.DNS,
+	proxy *proxy.SessionProxy,
 	keepAlive time.Duration,
 	networkPool *network.Pool,
 	templateCache *template.Cache,
@@ -128,6 +130,7 @@ func mockSandbox(
 		childCtx,
 		tracer,
 		dns,
+		proxy,
 		networkPool,
 		templateCache,
 		&orchestrator.SandboxConfig{

--- a/packages/orchestrator/cmd/mock-sandbox/mock.go
+++ b/packages/orchestrator/cmd/mock-sandbox/mock.go
@@ -108,7 +108,7 @@ func mockSandbox(
 	buildId,
 	sandboxId string,
 	dns *dns.DNS,
-	proxy *proxy.SessionProxy,
+	proxy *proxy.SandboxProxy,
 	keepAlive time.Duration,
 	networkPool *network.Pool,
 	templateCache *template.Cache,

--- a/packages/orchestrator/cmd/mock-snapshot/mock.go
+++ b/packages/orchestrator/cmd/mock-snapshot/mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"log"
 	"os"
 	"os/signal"
@@ -113,6 +114,7 @@ func mockSnapshot(
 	buildId,
 	sandboxId string,
 	dns *dns.DNS,
+	proxy *proxy.SessionProxy,
 	keepAlive time.Duration,
 	networkPool *network.Pool,
 	templateCache *template.Cache,
@@ -137,6 +139,7 @@ func mockSnapshot(
 		childCtx,
 		tracer,
 		dns,
+		proxy,
 		networkPool,
 		templateCache,
 		&orchestrator.SandboxConfig{
@@ -234,7 +237,7 @@ func mockSnapshot(
 		return fmt.Errorf("failed to add snapshot to template cache: %w", err)
 	}
 
-	fmt.Println("Add snapshot to template cache time: ", time.Since(snapshotTime).Milliseconds())
+	fmt.Println("AddSandbox snapshot to template cache time: ", time.Since(snapshotTime).Milliseconds())
 
 	start = time.Now()
 
@@ -242,6 +245,7 @@ func mockSnapshot(
 		childCtx,
 		tracer,
 		dns,
+		proxy,
 		networkPool,
 		templateCache,
 		&orchestrator.SandboxConfig{

--- a/packages/orchestrator/cmd/mock-snapshot/mock.go
+++ b/packages/orchestrator/cmd/mock-snapshot/mock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"log"
 	"os"
 	"os/signal"
@@ -15,6 +14,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/dns"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
@@ -52,6 +52,7 @@ func main() {
 		cancel()
 	}()
 
+	proxyServer := proxy.New(3333)
 	dnsServer := dns.New()
 	go func() {
 		log.Printf("Starting DNS server")
@@ -91,6 +92,7 @@ func main() {
 			*buildId,
 			*sandboxId+"-"+strconv.Itoa(v),
 			dnsServer,
+			proxyServer,
 			time.Duration(*keepAlive)*time.Second,
 			networkPool,
 			templateCache,

--- a/packages/orchestrator/cmd/mock-snapshot/mock.go
+++ b/packages/orchestrator/cmd/mock-snapshot/mock.go
@@ -239,7 +239,7 @@ func mockSnapshot(
 		return fmt.Errorf("failed to add snapshot to template cache: %w", err)
 	}
 
-	fmt.Println("AddSandbox snapshot to template cache time: ", time.Since(snapshotTime).Milliseconds())
+	fmt.Println("Add snapshot to template cache time: ", time.Since(snapshotTime).Milliseconds())
 
 	start = time.Now()
 

--- a/packages/orchestrator/cmd/mock-snapshot/mock.go
+++ b/packages/orchestrator/cmd/mock-snapshot/mock.go
@@ -116,7 +116,7 @@ func mockSnapshot(
 	buildId,
 	sandboxId string,
 	dns *dns.DNS,
-	proxy *proxy.SessionProxy,
+	proxy *proxy.SandboxProxy,
 	keepAlive time.Duration,
 	networkPool *network.Pool,
 	templateCache *template.Cache,

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -1,0 +1,184 @@
+package proxy
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"github.com/e2b-dev/infra/packages/shared/pkg/meters"
+	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
+	"go.uber.org/zap"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+//go:embed proxy_browser_502.html
+var proxyBrowser502PageHtml string
+
+var browserIdentityKeywords = []string{
+	"mozilla", "chrome", "safari", "firefox", "edge", "opera", "msie",
+}
+
+type SessionProxy struct {
+	sandboxes *smap.Map[string]
+	server    *http.Server
+}
+
+func New(port uint) *SessionProxy {
+	server := &http.Server{Addr: fmt.Sprintf(":%d", port)}
+
+	return &SessionProxy{
+		server:    server,
+		sandboxes: smap.New[string](),
+	}
+}
+
+func (p *SessionProxy) AddSandbox(sandboxID, ip string) {
+	p.sandboxes.Insert(sandboxID, ip)
+}
+
+func (p *SessionProxy) RemoveSandbox(sandboxID string) {
+	p.sandboxes.Remove(sandboxID)
+}
+
+func (p *SessionProxy) Start() error {
+	// similar values to our old the nginx configuration
+	serverTransport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          1024,              // Matches worker_connections
+		MaxIdleConnsPerHost:   8192,              // Matches keepalive_requests
+		IdleConnTimeout:       620 * time.Second, // Matches keepalive_timeout
+		TLSHandshakeTimeout:   10 * time.Second,  // Similar to client_header_timeout
+		ResponseHeaderTimeout: 24 * time.Hour,    // Matches proxy_read_timeout
+		DisableKeepAlives:     false,             // Allow keep-alive
+	}
+
+	p.server.Handler = http.HandlerFunc(p.proxyHandler(serverTransport))
+	return p.server.ListenAndServe()
+}
+
+func (p *SessionProxy) Shutdown(ctx context.Context) {
+	err := p.server.Shutdown(ctx)
+	if err != nil {
+		zap.L().Error("failed to shutdown proxy server", zap.Error(err))
+	}
+}
+
+func (p *SessionProxy) proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http.Request) {
+	activeConnections, err := meters.GetUpDownCounter(meters.ActiveConnectionsCounterMeterName)
+	if err != nil {
+		zap.L().Error("failed to create active connections counter", zap.Error(err))
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if activeConnections != nil {
+			activeConnections.Add(r.Context(), 1)
+			defer func() {
+				activeConnections.Add(r.Context(), -1)
+			}()
+		}
+
+		// Extract sandbox id from the host (<port>-<sandbox id>-<old client id>.e2b.dev)
+		hostSplit := strings.Split(r.Host, "-")
+		if len(hostSplit) < 2 {
+			zap.L().Warn("invalid host to proxy", zap.String("host", r.Host))
+			http.Error(w, "Invalid host", http.StatusBadRequest)
+			return
+		}
+
+		sandboxID := hostSplit[1]
+		sandboxPortRaw := hostSplit[0]
+		sandboxPort, sandboxPortErr := strconv.ParseUint(sandboxPortRaw, 10, 64)
+		if sandboxPortErr != nil {
+			zap.L().Warn("invalid sandbox port", zap.String("sandbox_port", sandboxPortRaw))
+			http.Error(w, "Invalid sandbox port", http.StatusBadRequest)
+		}
+
+		sbxIp, sbxFound := p.sandboxes.Get(sandboxID)
+		if !sbxFound {
+			zap.L().Warn("sandbox not found", zap.String("sandbox_id", sandboxID))
+			http.Error(w, "Sandbox not found", http.StatusNotFound)
+			return
+		}
+
+		logger := zap.L().With(zap.String("sandbox_id", sandboxID), zap.String("sandbox_ip", sbxIp), zap.Uint64("sandbox_req_port", sandboxPort), zap.String("sandbox_port_path", r.URL.Path))
+
+		// We've resolved the node to proxy the request to
+		logger.Debug("Proxying request")
+		targetUrl := &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("%s:%d", sbxIp, sandboxPort),
+		}
+
+		// Proxy the request
+		proxy := httputil.NewSingleHostReverseProxy(targetUrl)
+		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			logger.Error("Reverse proxy error")
+
+			if p.isBrowser(r.UserAgent()) {
+				w.WriteHeader(http.StatusBadGateway)
+				w.Header().Add("Content-Type", "text/html")
+				w.Write(p.buildHtmlClosedPortError(sandboxID, r.Host, sandboxPort))
+				return
+			}
+
+			w.WriteHeader(http.StatusBadGateway)
+			w.Header().Add("Content-Type", "application/json")
+			w.Write(p.buildJsonClosedPortError(sandboxID, sandboxPort))
+		}
+
+		proxy.ModifyResponse = func(resp *http.Response) error {
+			if resp.StatusCode >= 500 {
+				logger.Error("Backend responded with error", zap.Int("status_code", resp.StatusCode))
+			} else {
+				logger.Info("Backend responded", zap.Int("status_code", resp.StatusCode))
+			}
+
+			return nil
+		}
+
+		proxy.Transport = transport
+		proxy.ServeHTTP(w, r)
+	}
+}
+
+func (p *SessionProxy) buildHtmlClosedPortError(sandboxId string, host string, port uint64) []byte {
+	replacements := map[string]string{
+		"{{sandbox_id}}":   sandboxId,
+		"{{sandbox_port}}": strconv.FormatUint(port, 10),
+		"{{sandbox_host}}": host,
+	}
+
+	adjustedErrTemplate := proxyBrowser502PageHtml
+	for placeholder, value := range replacements {
+		adjustedErrTemplate = strings.ReplaceAll(adjustedErrTemplate, placeholder, value)
+	}
+
+	return []byte(adjustedErrTemplate)
+}
+
+func (p *SessionProxy) buildJsonClosedPortError(sandboxId string, port uint64) []byte {
+	response := map[string]interface{}{
+		"error":      "The sandbox is running but port is not open",
+		"sandbox_id": sandboxId,
+		"port":       port,
+	}
+
+	responseBytes, _ := json.Marshal(response)
+	return responseBytes
+}
+
+func (p *SessionProxy) isBrowser(userAgent string) bool {
+	userAgent = strings.ToLower(userAgent)
+	for _, keyword := range browserIdentityKeywords {
+		if strings.Contains(userAgent, keyword) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -83,7 +83,7 @@ func (p *SandboxProxy) Shutdown(ctx context.Context) {
 }
 
 func (p *SandboxProxy) proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http.Request) {
-	activeConnections, err := meters.GetUpDownCounter(meters.ActiveConnectionsCounterMeterName)
+	activeConnections, err := meters.GetUpDownCounter(meters.OrchestratorProxyActiveConnectionsCounterMeterName)
 	if err != nil {
 		zap.L().Error("failed to create active connections counter", zap.Error(err))
 	}

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -6,8 +6,6 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/shared/pkg/meters"
-	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 	"go.uber.org/zap"
 	"html/template"
 	"net/http"
@@ -17,6 +15,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/meters"
+	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 )
 
 //go:embed proxy_browser_502.html
@@ -32,9 +33,9 @@ type htmlTemplateData struct {
 }
 
 type jsonTemplateData struct {
-	error      string
-	sandbox_id string
-	port       uint64
+	Error     string `json:"error"`
+	SandboxId string `json:"sandbox_id"`
+	Port      uint64 `json:"port"`
 }
 
 type SandboxProxy struct {
@@ -181,9 +182,9 @@ func (p *SandboxProxy) buildHtmlClosedPortError(sandboxId string, host string, p
 
 func (p *SandboxProxy) buildJsonClosedPortError(sandboxId string, port uint64) []byte {
 	response := jsonTemplateData{
-		error:      "The sandbox is running but port is not open",
-		sandbox_id: sandboxId,
-		port:       port,
+		Error:     "The sandbox is running but port is not open",
+		SandboxId: sandboxId,
+		Port:      port,
 	}
 
 	responseBytes, _ := json.Marshal(response)

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -34,7 +34,7 @@ type htmlTemplateData struct {
 
 type jsonTemplateData struct {
 	Error     string `json:"error"`
-	SandboxId string `json:"sandbox_id"`
+	SandboxId string `json:"sandboxId"`
 	Port      uint64 `json:"port"`
 }
 

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -69,7 +69,7 @@ func (p *SandboxProxy) Start() error {
 		IdleConnTimeout:       620 * time.Second, // Matches keepalive_timeout
 		TLSHandshakeTimeout:   10 * time.Second,  // Similar to client_header_timeout
 		ResponseHeaderTimeout: 24 * time.Hour,    // Matches proxy_read_timeout
-		DisableKeepAlives:     false,             // Allow keep-alive
+		DisableKeepAlives:     true,              // Disable keep-alives, envd doesn't support idle connections
 	}
 
 	p.server.Handler = http.HandlerFunc(p.proxyHandler(serverTransport))

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -131,7 +131,7 @@ func (p *SandboxProxy) proxyHandler(transport *http.Transport) func(w http.Respo
 		// Proxy the request
 		proxy := httputil.NewSingleHostReverseProxy(targetUrl)
 		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-			logger.Error("Reverse proxy error")
+			logger.Error("Reverse proxy error", zap.Error(err))
 
 			if p.isBrowser(r.UserAgent()) {
 				res, resErr := p.buildHtmlClosedPortError(sandboxID, r.Host, sandboxPort)

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -26,9 +26,9 @@ var browserRegex = regexp.MustCompile(`(?i)mozilla|chrome|safari|firefox|edge|op
 var browserTemplate = template.Must(template.New("template").Parse(proxyBrowser502PageHtml))
 
 type htmlTemplateData struct {
-	sandboxId   string
-	sandboxHost string
-	sandboxPort string
+	SandboxId   string
+	SandboxHost string
+	SandboxPort string
 }
 
 type jsonTemplateData struct {
@@ -169,7 +169,7 @@ func (p *SandboxProxy) proxyHandler(transport *http.Transport) func(w http.Respo
 
 func (p *SandboxProxy) buildHtmlClosedPortError(sandboxId string, host string, port uint64) ([]byte, error) {
 	htmlResponse := new(bytes.Buffer)
-	htmlVars := htmlTemplateData{sandboxId: sandboxId, sandboxHost: host, sandboxPort: strconv.FormatUint(port, 10)}
+	htmlVars := htmlTemplateData{SandboxId: sandboxId, SandboxHost: host, SandboxPort: strconv.FormatUint(port, 10)}
 
 	err := browserTemplate.Execute(htmlResponse, htmlVars)
 	if err != nil {

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -43,8 +43,8 @@ func (p *SandboxProxy) AddSandbox(sandboxID, ip string) {
 	p.sandboxes.Insert(sandboxID, ip)
 }
 
-func (p *SandboxProxy) RemoveSandbox(sandboxID string) {
-	p.sandboxes.Remove(sandboxID)
+func (p *SandboxProxy) RemoveSandbox(sandboxID string, ip string) {
+	p.sandboxes.RemoveCb(sandboxID, func(k string, v string, ok bool) bool { return ok && v == ip })
 }
 
 func (p *SandboxProxy) Start() error {

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -21,8 +22,7 @@ import (
 //go:embed proxy_browser_502.html
 var proxyBrowser502PageHtml string
 
-var browserIdentityKeywords = []string{
-	"mozilla", "chrome", "safari", "firefox", "edge", "opera", "msie",
+var browserRegex = regexp.MustCompile(`(?i)mozilla|chrome|safari|firefox|edge|opera|msie`)
 var browserTemplate = template.Must(template.New("template").Parse(proxyBrowser502PageHtml))
 
 type htmlTemplateData struct {
@@ -191,12 +191,5 @@ func (p *SandboxProxy) buildJsonClosedPortError(sandboxId string, port uint64) [
 }
 
 func (p *SandboxProxy) isBrowser(userAgent string) bool {
-	userAgent = strings.ToLower(userAgent)
-	for _, keyword := range browserIdentityKeywords {
-		if strings.Contains(userAgent, keyword) {
-			return true
-		}
-	}
-
-	return false
+	return browserRegex.MatchString(userAgent)
 }

--- a/packages/orchestrator/internal/proxy/proxy_browser_502.html
+++ b/packages/orchestrator/internal/proxy/proxy_browser_502.html
@@ -1,0 +1,23 @@
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Closed Port Error</title>
+    <style>:root{--brand:#ff8800;--error:#dc2626;--error-light:#fef2f2;--text:#1a1a1a;--background:#ffffff;--border:#e5e7eb;--details-bg:#f9fafb;--code-text:#374151;--muted-text:#6b7280}@media (prefers-color-scheme:dark){:root{--error:#ef4444;--error-light:#2a0f0f;--text:#e5e7eb;--background:#121212;--border:#2f2f2f;--details-bg:#1c1c1c;--code-text:#d1d5db;--muted-text:#9ca3af}}*{margin:0;padding:0;box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;background:#f5f5f5;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:1rem;color:var(--text)}@media (prefers-color-scheme:dark){body{background:#0a0a0a}}.error-card{background:var(--background);border-radius:12px;box-shadow:0 4px 6px -1px rgb(0 0 0 / .1),0 2px 4px -2px rgb(0 0 0 / .1);width:100%;max-width:600px;padding:1.5rem 2rem 2rem;position:relative}.logo{position:absolute;top:1rem;right:1.5rem;width:40px;height:40px;border-radius:50%;overflow:hidden}.error-header{margin-bottom:1.5rem;padding-right:3.5rem}.error-title{display:inline-block;color:var(--error);font-size:.9375rem;font-weight:500;margin-bottom:1rem;padding:.25rem .5rem;background:var(--error-light);border-radius:4px}.error-message{font-size:1.125rem;line-height:1.5;color:var(--error);font-weight:400;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif}.error-details{background:var(--details-bg);border:1px solid var(--border);border-radius:8px;padding:1rem;margin-top:1.5rem}.error-code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:.875rem;color:var(--code-text)}.sandbox-url{color:var(--muted-text);font-size:.875rem;display:block;margin-bottom:.5rem}.highlight{font-weight:700}.help-text{margin-top:1.5rem;font-size:.875rem;color:var(--muted-text)}.debug-link{display:block;margin-top:2rem;color:var(--brand);text-decoration:none;font-size:.875rem}.debug-link:hover{text-decoration:underline}@media (max-width:640px){.error-card{margin:1rem;padding:1.25rem 1.5rem 1.5rem}.logo{top:.75rem;right:1rem;width:32px;height:32px}.error-header{padding-right:2.5rem}}</style>
+</head>
+<body>
+<main class="error-card">
+    <img src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Symbol%20Gradient-Kr5pnWlK3ZhzBcRGf6Am4cNbJvY1Ge.svg" alt="Logo" class="logo">
+    <div class="error-header">
+        <h1 class="error-title">Closed Port Error</h1>
+        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">$dbk_session_id</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">$dbk_port</span>.</p>
+    </div>
+    <div class="error-details">
+        <span class="sandbox-url">$host</span>
+        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">$dbk_port</span></div>
+    </div>
+    <p class="help-text">Please ensure that your service is properly configured and running on the specified port.</p>
+    <a class="debug-link" href="https://e2b.dev/docs/sdk-reference/cli/v1.0.9/sandbox#e2b-sandbox-logs">Check the sandbox logs for more information →</a>
+</main>
+</body>
+</html>

--- a/packages/orchestrator/internal/proxy/proxy_browser_502.html
+++ b/packages/orchestrator/internal/proxy/proxy_browser_502.html
@@ -10,11 +10,11 @@
     <img src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Symbol%20Gradient-Kr5pnWlK3ZhzBcRGf6Am4cNbJvY1Ge.svg" alt="Logo" class="logo">
     <div class="error-header">
         <h1 class="error-title">Closed Port Error</h1>
-        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">{{sandbox_id}}</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">{{sandbox_port}}</span>.</p>
+        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">{{.sandboxId}}</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">{{.sandboxPort}}</span>.</p>
     </div>
     <div class="error-details">
-        <span class="sandbox-url">{{sandbox_host}}</span>
-        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">{{sandbox_port}}</span></div>
+        <span class="sandbox-url">{{.sandboxHost}}</span>
+        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">{{.sandboxPort}}</span></div>
     </div>
     <p class="help-text">Please ensure that your service is properly configured and running on the specified port.</p>
     <a class="debug-link" href="https://e2b.dev/docs/sdk-reference/cli/v1.0.9/sandbox#e2b-sandbox-logs">Check the sandbox logs for more information →</a>

--- a/packages/orchestrator/internal/proxy/proxy_browser_502.html
+++ b/packages/orchestrator/internal/proxy/proxy_browser_502.html
@@ -10,11 +10,11 @@
     <img src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Symbol%20Gradient-Kr5pnWlK3ZhzBcRGf6Am4cNbJvY1Ge.svg" alt="Logo" class="logo">
     <div class="error-header">
         <h1 class="error-title">Closed Port Error</h1>
-        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">$dbk_session_id</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">$dbk_port</span>.</p>
+        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">{{sandbox_id}}</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">{{sandbox_port}}</span>.</p>
     </div>
     <div class="error-details">
-        <span class="sandbox-url">$host</span>
-        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">$dbk_port</span></div>
+        <span class="sandbox-url">{{sandbox_host}}</span>
+        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">{{sandbox_port}}</span></div>
     </div>
     <p class="help-text">Please ensure that your service is properly configured and running on the specified port.</p>
     <a class="debug-link" href="https://e2b.dev/docs/sdk-reference/cli/v1.0.9/sandbox#e2b-sandbox-logs">Check the sandbox logs for more information →</a>

--- a/packages/orchestrator/internal/proxy/proxy_browser_502.html
+++ b/packages/orchestrator/internal/proxy/proxy_browser_502.html
@@ -10,11 +10,11 @@
     <img src="https://hebbkx1anhila5yf.public.blob.vercel-storage.com/Symbol%20Gradient-Kr5pnWlK3ZhzBcRGf6Am4cNbJvY1Ge.svg" alt="Logo" class="logo">
     <div class="error-header">
         <h1 class="error-title">Closed Port Error</h1>
-        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">{{.sandboxId}}</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">{{.sandboxPort}}</span>.</p>
+        <p class="error-message">The sandbox <span class="highlight" id="sandbox-id">{{.SandboxId}}</span> is running but there&#39s no service running on port <span class="highlight" id="port-number">{{.SandboxPort}}</span>.</p>
     </div>
     <div class="error-details">
-        <span class="sandbox-url">{{.sandboxHost}}</span>
-        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">{{.sandboxPort}}</span></div>
+        <span class="sandbox-url">{{.SandboxHost}}</span>
+        <div class="error-code">Connection refused on port <span class="highlight" id="port-number-code">{{.SandboxPort}}</span></div>
     </div>
     <p class="help-text">Please ensure that your service is properly configured and running on the specified port.</p>
     <a class="debug-link" href="https://e2b.dev/docs/sdk-reference/cli/v1.0.9/sandbox#e2b-sandbox-logs">Check the sandbox logs for more information →</a>

--- a/packages/orchestrator/internal/sandbox/sandbox_linux.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_linux.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -22,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/dns"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/fc"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"

--- a/packages/orchestrator/internal/sandbox/sandbox_linux.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_linux.go
@@ -322,7 +322,7 @@ func NewSandbox(
 
 	cleanup.Add(func() error {
 		dns.Remove(config.SandboxId, ips.HostIP())
-		proxy.RemoveSandbox(config.SandboxId)
+		proxy.RemoveSandbox(config.SandboxId, ips.HostIP())
 
 		return nil
 	})

--- a/packages/orchestrator/internal/sandbox/sandbox_linux.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_linux.go
@@ -87,7 +87,7 @@ func NewSandbox(
 	ctx context.Context,
 	tracer trace.Tracer,
 	dns *dns.DNS,
-	proxy *proxy.SessionProxy,
+	proxy *proxy.SandboxProxy,
 	networkPool *network.Pool,
 	templateCache *template.Cache,
 	config *orchestrator.SandboxConfig,

--- a/packages/orchestrator/internal/sandbox/sandbox_other.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_other.go
@@ -69,13 +69,13 @@ func (s *Sandbox) LoggerMetadata() sbxlogger.SandboxMetadata {
 // Run cleanup functions for the already initialized resources if there is any error or after you are done with the started sandbox.
 func NewSandbox(
 
-// YOU ARE IN SANDBOX_OTHER.GO
-// YOU PROBABLY WANT TO BE IN SANDBOX_LINUX.GO
+	// YOU ARE IN SANDBOX_OTHER.GO
+	// YOU PROBABLY WANT TO BE IN SANDBOX_LINUX.GO
 
 	ctx context.Context,
 	tracer trace.Tracer,
 	dns *dns.DNS,
-	proxy *proxy.SessionProxy,
+	proxy *proxy.SandboxProxy,
 	networkPool *network.Pool,
 	templateCache *template.Cache,
 	config *orchestrator.SandboxConfig,

--- a/packages/orchestrator/internal/sandbox/sandbox_other.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_other.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/dns"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
@@ -69,8 +69,8 @@ func (s *Sandbox) LoggerMetadata() sbxlogger.SandboxMetadata {
 // Run cleanup functions for the already initialized resources if there is any error or after you are done with the started sandbox.
 func NewSandbox(
 
-	// YOU ARE IN SANDBOX_OTHER.GO
-	// YOU PROBABLY WANT TO BE IN SANDBOX_LINUX.GO
+// YOU ARE IN SANDBOX_OTHER.GO
+// YOU PROBABLY WANT TO BE IN SANDBOX_LINUX.GO
 
 	ctx context.Context,
 	tracer trace.Tracer,

--- a/packages/orchestrator/internal/sandbox/sandbox_other.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_other.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -74,6 +75,7 @@ func NewSandbox(
 	ctx context.Context,
 	tracer trace.Tracer,
 	dns *dns.DNS,
+	proxy *proxy.SessionProxy,
 	networkPool *network.Pool,
 	templateCache *template.Cache,
 	config *orchestrator.SandboxConfig,

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"math"
 	"net"
 	"os"
@@ -38,6 +39,7 @@ type server struct {
 	orchestrator.UnimplementedSandboxServiceServer
 	sandboxes       *smap.Map[*sandbox.Sandbox]
 	dns             *dns.DNS
+	proxy           *proxy.SessionProxy
 	tracer          trace.Tracer
 	networkPool     *network.Pool
 	templateCache   *template.Cache
@@ -54,6 +56,7 @@ type Service struct {
 	server   *server
 	grpc     *grpc.Server
 	dns      *dns.DNS
+	proxy    *proxy.SessionProxy
 	port     uint16
 	shutdown struct {
 		once sync.Once
@@ -68,7 +71,7 @@ type Service struct {
 	useClickhouseMetrics string
 }
 
-func New(ctx context.Context, port uint, clientID string) (*Service, error) {
+func New(ctx context.Context, port uint, clientID string, proxy *proxy.SessionProxy) (*Service, error) {
 	if port > math.MaxUint16 {
 		return nil, fmt.Errorf("%d is larger than maximum possible port %d", port, math.MaxInt16)
 	}
@@ -92,6 +95,7 @@ func New(ctx context.Context, port uint, clientID string) (*Service, error) {
 	// BLOCK: initialize services
 	{
 		srv.dns = dns.New()
+		srv.proxy = proxy
 
 		opts := []logging.Option{
 			logging.WithLogOnEvents(logging.StartCall, logging.PayloadReceived, logging.PayloadSent, logging.FinishCall),
@@ -143,6 +147,7 @@ func New(ctx context.Context, port uint, clientID string) (*Service, error) {
 		srv.server = &server{
 			tracer:               otel.Tracer(ServiceName),
 			dns:                  srv.dns,
+			proxy:                srv.proxy,
 			sandboxes:            smap.New[*sandbox.Sandbox](),
 			networkPool:          networkPool,
 			templateCache:        templateCache,

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -39,7 +39,7 @@ type server struct {
 	orchestrator.UnimplementedSandboxServiceServer
 	sandboxes       *smap.Map[*sandbox.Sandbox]
 	dns             *dns.DNS
-	proxy           *proxy.SessionProxy
+	proxy           *proxy.SandboxProxy
 	tracer          trace.Tracer
 	networkPool     *network.Pool
 	templateCache   *template.Cache
@@ -56,7 +56,7 @@ type Service struct {
 	server   *server
 	grpc     *grpc.Server
 	dns      *dns.DNS
-	proxy    *proxy.SessionProxy
+	proxy    *proxy.SandboxProxy
 	port     uint16
 	shutdown struct {
 		once sync.Once
@@ -71,7 +71,7 @@ type Service struct {
 	useClickhouseMetrics string
 }
 
-func New(ctx context.Context, port uint, clientID string, proxy *proxy.SessionProxy) (*Service, error) {
+func New(ctx context.Context, port uint, clientID string, proxy *proxy.SandboxProxy) (*Service, error) {
 	if port > math.MaxUint16 {
 		return nil, fmt.Errorf("%d is larger than maximum possible port %d", port, math.MaxInt16)
 	}

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -183,7 +183,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 
 	// Don't allow connecting to the sandbox anymore.
 	s.dns.Remove(in.SandboxId, sbx.Slot.HostIP())
-	s.proxy.RemoveSandbox(in.SandboxId)
+	s.proxy.RemoveSandbox(in.SandboxId, sbx.Slot.HostIP())
 
 	// Remove the sandbox from the cache to prevent loading it again in API during the time the instance is stopping.
 	// Old comment:

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -49,6 +49,7 @@ func (s *server) Create(ctxConn context.Context, req *orchestrator.SandboxCreate
 		childCtx,
 		s.tracer,
 		s.dns,
+		s.proxy,
 		s.networkPool,
 		s.templateCache,
 		req.Sandbox,
@@ -182,6 +183,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 
 	// Don't allow connecting to the sandbox anymore.
 	s.dns.Remove(in.SandboxId, sbx.Slot.HostIP())
+	s.proxy.RemoveSandbox(in.SandboxId)
 
 	// Remove the sandbox from the cache to prevent loading it again in API during the time the instance is stopping.
 	// Old comment:

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -5,16 +5,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"log"
 	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
 	"syscall"
-	"time"
-
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/consul"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -174,10 +172,8 @@ func main() {
 			}
 		}
 
-		// close session proxy, wait 5 seconds until all connections are closed
-		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer shutdownCtxCancel()
-		defer sessionProxy.Shutdown(shutdownCtx)
+		// close sandbox proxy, this will wait until all sessions are closed
+		defer sessionProxy.Shutdown(context.Background())
 	}()
 
 	wg.Wait()

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"log"
 	"os"
 	"os/signal"
@@ -18,6 +17,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/consul"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/server"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -161,13 +161,12 @@ func main() {
 
 		errChan := make(chan error, 1)
 		go func() {
-			err := sessionProxy.Start()
-			errChan <- err
+			errChan <- sessionProxy.Start()
 		}()
 
 		select {
 		case <-ctx.Done():
-		case <-errChan:
+		case err = <-errChan:
 			if err != nil {
 				zap.L().Error("session proxy failed", zap.Error(err))
 				exitCode.Add(1)

--- a/packages/shared/pkg/meters/main.go
+++ b/packages/shared/pkg/meters/main.go
@@ -16,12 +16,13 @@ const (
 type UpDownCounterType string
 
 const (
-	SandboxCountMeterName                  UpDownCounterType = "api.env.instance.running"
-	BuildCounterMeterName                                    = "api.env.build.running"
-	NewNetworkSlotSPoolCounterMeterName                      = "orchestrator.network.slots_pool.new"
-	ReusedNetworkSlotSPoolCounterMeterName                   = "orchestrator.network.slots_pool.reused"
-	NBDkSlotSReadyPoolCounterMeterName                       = "orchestrator.nbd.slots_pool.read"
-	ActiveConnectionsCounterMeterName                        = "client_proxy.connections.active"
+	SandboxCountMeterName                              UpDownCounterType = "api.env.instance.running"
+	BuildCounterMeterName                                                = "api.env.build.running"
+	NewNetworkSlotSPoolCounterMeterName                                  = "orchestrator.network.slots_pool.new"
+	ReusedNetworkSlotSPoolCounterMeterName                               = "orchestrator.network.slots_pool.reused"
+	NBDkSlotSReadyPoolCounterMeterName                                   = "orchestrator.nbd.slots_pool.read"
+	ActiveConnectionsCounterMeterName                                    = "client_proxy.connections.active"
+	OrchestratorProxyActiveConnectionsCounterMeterName                   = "orchestrator.proxy.connections.active"
 )
 
 var meter = otel.GetMeterProvider().Meter("nomad")

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,11 @@ variable "orchestrator_port" {
   default = 5008
 }
 
+variable "orchestrator_proxy_port" {
+  type    = number
+  default = 5007
+}
+
 variable "template_manager_port" {
   type    = number
   default = 5009


### PR DESCRIPTION
Implements http proxy in orchestrator that replaces current nginx-based session proxy that is using dns server from orchestrator to route traffic.

- Legacy Nginx session-proxy is intact and can still be used as it is, next step will be remove it when traffic migrated
- Orchestrator proxy for now runs on port `5007` allowing smooth deployment
- Support for pretty (for browsers) and json error messages when port in sandbox not listening
- Proxy settings is taken from currently used client-proxy, so should be already battle-tested