### PR TITLE
Use google.com instead of e2b.dev to test internet connectivity

### DIFF
--- a/tests/periodic-test/internet-works.ts
+++ b/tests/periodic-test/internet-works.ts
@@ -16,7 +16,7 @@ try {
   sandbox = await Sandbox.create()
   console.log('Sandbox created with ID:', sandbox.sandboxId)
 
-  const out = await sandbox.commands.run('wget https://e2b.dev', {
+  const out = await sandbox.commands.run('wget https://google.com', {
     requestTimeoutMs: 10000,
   })
   console.log('wget output', out.stderr)


### PR DESCRIPTION
We can change the endpoint we are checking so we are not reporting sandbox * [e2b.dev](http://e2b.dev/) availability this way? :D