### PR TITLE
Create config DB if not exists in migrator

### DIFF
--- a/packages/shared/pkg/chdb/migrations/0001_create_metrics_table.down.sql
+++ b/packages/shared/pkg/chdb/migrations/0001_create_metrics_table.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS metrics;
+DROP TABLE IF EXISTS default.metrics;

--- a/packages/shared/pkg/chdb/migrations/0001_create_metrics_table.up.sql
+++ b/packages/shared/pkg/chdb/migrations/0001_create_metrics_table.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS metrics (
+CREATE TABLE IF NOT EXISTS default.metrics (
 	timestamp DateTime('UTC'),
 	sandbox_id String,
 	team_id String,

--- a/packages/shared/pkg/chdb/migrator.go
+++ b/packages/shared/pkg/chdb/migrator.go
@@ -86,6 +86,13 @@ func NewMigrator(config ClickHouseConfig) (*ClickhouseMigrator, error) {
 		},
 	})
 
+	_, err = db.Exec(fmt.Sprintf(`
+		CREATE DATABASE IF NOT EXISTS %s;
+	`, config.Database))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create `%s` database: %w", config.Database, err)
+	}
+
 	_, err = db.Exec(`
 		CREATE TABLE IF NOT EXISTS schema_migrations (
 			version    Int64,

--- a/packages/shared/pkg/chdb/migrator.go
+++ b/packages/shared/pkg/chdb/migrator.go
@@ -93,15 +93,15 @@ func NewMigrator(config ClickHouseConfig) (*ClickhouseMigrator, error) {
 		return nil, fmt.Errorf("failed to create `%s` database: %w", config.Database, err)
 	}
 
-	_, err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS schema_migrations (
+	_, err = db.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s.schema_migrations (
 			version    Int64,
 			dirty      UInt8,
 			sequence   UInt64
 		)
 		ENGINE = ReplicatedMergeTree
 		ORDER BY tuple();
-	`)
+	`, config.Database))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create schema_migrations table: %w", err)
 	}


### PR DESCRIPTION
* explicitly specify db name in migration files
* create config DB is not exist upon starting migrator