### PR TITLE
Use var instead of random_password since we moved that resource

### DIFF
--- a/packages/api/main.tf
+++ b/packages/api/main.tf
@@ -82,7 +82,7 @@ resource "google_secret_manager_secret_version" "api_secret_value" {
 }
 
 resource "google_secret_manager_secret" "clickhouse_password" {
-  secret_id = "${var.prefix}clickhouse-password"
+  secret_id = "${var.prefix}clickhouse-db-password"
 
   replication {
     auto {}

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -420,6 +420,6 @@ resource "nomad_job" "clickhouse" {
     hmac_key            = google_storage_hmac_key.clickhouse_hmac_key.access_id
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
     username            = "clickhouse"
-    password_sha256_hex = sha256(random_password.clickhouse_password.result)
+    password_sha256_hex = sha256(var.clickhouse_password)
   })
 }


### PR DESCRIPTION
if you run make plan on main you will get an error
```
var.clickhouse_password
  The password for the ClickHouse database

  Enter a value: f

╷
│ Error: Reference to undeclared resource
│ 
│   on packages/nomad/main.tf line 423, in resource "nomad_job" "clickhouse":
│  423:     password_sha256_hex = sha256(random_password.clickhouse_password.result)
│ 
│ A managed resource "random_password" "clickhouse_password" has not been declared in module.nomad.
╵
make: *** [Makefile:58: plan] Error 1
➜  infra git:(fix-clickhouse-bug)     
```

but this changes fixes

```
  infra git:(fix-clickhouse-bug) make apply                                                                                                                                                          ~/infra
Applying Terraform for env: dev

./scripts/confirm.sh dev
TF_VAR_client_machine_type=n1-standard-16 TF_VAR_client_cluster_size=1 TF_VAR_client_cluster_auto_scaling_max=1 TF_VAR_api_machine_type=e2-standard-4 TF_VAR_api_cluster_size=2 TF_VAR_build_machine_type=n1-standard-8 TF_VAR_build_cluster_size=1 TF_VAR_server_machine_type=e2-standard-2 TF_VAR_server_cluster_size=3 TF_VAR_gcp_project_id=e2b-staging-wendt-robert TF_VAR_gcp_region=us-central1 TF_VAR_gcp_zone=us-central1-a TF_VAR_domain_name=e2b-robert.dev TF_VAR_additional_domains= TF_VAR_prefix="e2b-"  TF_VAR_terraform_state_bucket=e2b-dev-cluster TF_VAR_otel_tracing_print=false TF_VAR_environment=staging TF_VAR_template_bucket_name= TF_VAR_template_bucket_location=us-central1 TF_VAR_clickhouse_connection_string='clickhouse.service.consul:9000' TF_VAR_clickhouse_username='clickhouse' TF_VAR_clickhouse_database='default'  \
terraform apply \
-auto-approve \
-input=false \
-compact-warnings \
-parallelism=20 \
.tfplan.dev
module.api.google_secret_manager_secret.clickhouse_password: Creating...
module.api.google_secret_manager_secret.clickhouse_password: Creation complete after 0s [id=projects/e2b-staging-wendt-robert/secrets/e2b-clickhouse-db-password]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
➜  infra git:(fix-clickhouse-bug)                      
```