### PR TITLE
Connect clickhouse client to clickhouse deployment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -171,10 +171,10 @@ module "nomad" {
   otel_tracing_print      = var.otel_tracing_print
 
   # Clickhouse
-  clickhouse_connection_string = var.clickhouse_connection_string
-  clickhouse_username          = var.clickhouse_username
+  clickhouse_connection_string = "clickhouse.service.consul:9000"
+  clickhouse_username          = "clickhouse"
   clickhouse_password          = module.init.clickhouse_password_secret_data
-  clickhouse_database          = var.clickhouse_database
+  clickhouse_database          = "default"
 
   # API
   api_machine_count                         = var.api_cluster_size

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -424,7 +424,7 @@ resource "nomad_job" "clickhouse" {
     gcs_folder          = "clickhouse-data"
     hmac_key            = google_storage_hmac_key.clickhouse_hmac_key.access_id
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
-    username            = "clickhouse"
+    username            = var.clickhouse_username 
     password_sha256_hex = sha256(var.clickhouse_password)
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -226,23 +226,3 @@ variable "template_bucket_name" {
   type        = string
   description = "The name of the FC template bucket"
 }
-
-variable "clickhouse_connection_string" {
-  type        = string
-  description = "The connection string for the ClickHouse database"
-}
-
-variable "clickhouse_username" {
-  type        = string
-  description = "The username for the ClickHouse database"
-}
-
-variable "clickhouse_password" {
-  type        = string
-  description = "The password for the ClickHouse database"
-}
-
-variable "clickhouse_database" {
-  type        = string
-  description = "The database for the ClickHouse database"
-}


### PR DESCRIPTION
Clickhouse needs some environment variables to be set in order to connect to the database. We need to set them but they are static and not secret. The password is also generated by terraform. This removes the top level variables so that the programmer does not have to include configuration to deploy clickhouse