### PR TITLE
Fix build cache key for snapshots

### DIFF
--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -126,7 +126,7 @@ func (s *DiffStore) startDiskSpaceEviction(threshold float64) {
 		case <-timer.C:
 			dUsed, dTotal, err := diskUsage(s.cachePath)
 			if err != nil {
-				fmt.Printf("[build data cache]: failed to get disk usage: %v\n", err)
+				zap.L().Error("failed to get disk usage", zap.Error(err))
 				timer.Reset(getDelay(false))
 				continue
 			}
@@ -142,7 +142,7 @@ func (s *DiffStore) startDiskSpaceEviction(threshold float64) {
 
 			succ, err := s.deleteOldestFromCache()
 			if err != nil {
-				fmt.Printf("[build data cache]: failed to delete oldest item from cache: %v\n", err)
+				zap.L().Error("failed to delete oldest item from cache", zap.Error(err))
 				timer.Reset(getDelay(false))
 				continue
 			}
@@ -164,7 +164,7 @@ func (s *DiffStore) getPendingDeletesSize() int64 {
 	return pendingSize
 }
 
-// deleteOldestFromCache deletes the oldest item (smallest TTL) from the cache
+// deleteOldestFromCache deletes the oldest item (smallest TTL) from the cache.
 // ttlcache has items in order by TTL
 func (s *DiffStore) deleteOldestFromCache() (bool, error) {
 	success := false

--- a/packages/orchestrator/internal/sandbox/build/diff.go
+++ b/packages/orchestrator/internal/sandbox/build/diff.go
@@ -24,7 +24,7 @@ type Diff interface {
 	io.Closer
 	io.ReaderAt
 	Slice(off, length int64) ([]byte, error)
-	CacheKey() string
+	CacheKey() DiffStoreKey
 	CachePath() (string, error)
 	FileSize() (int64, error)
 	Init(ctx context.Context) error
@@ -52,7 +52,7 @@ func (n *NoDiff) FileSize() (int64, error) {
 	return 0, ErrNoDiff{}
 }
 
-func (n *NoDiff) CacheKey() string {
+func (n *NoDiff) CacheKey() DiffStoreKey {
 	return ""
 }
 

--- a/packages/orchestrator/internal/sandbox/build/local_diff.go
+++ b/packages/orchestrator/internal/sandbox/build/local_diff.go
@@ -13,7 +13,7 @@ import (
 type LocalDiffFile struct {
 	*os.File
 	cachePath string
-	cacheKey  string
+	cacheKey  DiffStoreKey
 }
 
 func NewLocalDiffFile(
@@ -23,7 +23,6 @@ func NewLocalDiffFile(
 ) (*LocalDiffFile, error) {
 	cachePathSuffix := id.Generate()
 
-	cacheKey := fmt.Sprintf("%s/%s", buildId, diffType)
 	cacheFile := fmt.Sprintf("%s-%s-%s", buildId, diffType, cachePathSuffix)
 	cachePath := filepath.Join(basePath, cacheFile)
 
@@ -35,7 +34,7 @@ func NewLocalDiffFile(
 	return &LocalDiffFile{
 		File:      f,
 		cachePath: cachePath,
-		cacheKey:  cacheKey,
+		cacheKey:  GetDiffStoreKey(buildId, diffType),
 	}, nil
 }
 
@@ -69,13 +68,13 @@ func (f *LocalDiffFile) ToDiff(
 type localDiff struct {
 	size      int64
 	blockSize int64
+	cacheKey  DiffStoreKey
 	cachePath string
 	cache     *block.Cache
-	cacheKey  string
 }
 
 func newLocalDiff(
-	cacheKey string,
+	cacheKey DiffStoreKey,
 	cachePath string,
 	size int64,
 	blockSize int64,
@@ -88,9 +87,9 @@ func newLocalDiff(
 	return &localDiff{
 		size:      size,
 		blockSize: blockSize,
+		cacheKey:  cacheKey,
 		cachePath: cachePath,
 		cache:     cache,
-		cacheKey:  cacheKey,
 	}, nil
 }
 
@@ -114,7 +113,7 @@ func (b *localDiff) FileSize() (int64, error) {
 	return b.cache.FileSize()
 }
 
-func (b *localDiff) CacheKey() string {
+func (b *localDiff) CacheKey() DiffStoreKey {
 	return b.cacheKey
 }
 

--- a/packages/orchestrator/internal/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/internal/sandbox/build/storage_diff.go
@@ -19,6 +19,7 @@ func storagePath(buildId string, diffType DiffType) string {
 type StorageDiff struct {
 	chunker     *utils.SetOnce[*block.Chunker]
 	cachePath   string
+	cacheKey    DiffStoreKey
 	storagePath string
 	blockSize   int64
 	bucket      *gcs.BucketHandle
@@ -43,11 +44,12 @@ func newStorageDiff(
 		chunker:     utils.NewSetOnce[*block.Chunker](),
 		blockSize:   blockSize,
 		bucket:      bucket,
+		cacheKey:    GetDiffStoreKey(buildId, diffType),
 	}
 }
 
-func (b *StorageDiff) CacheKey() string {
-	return b.storagePath
+func (b *StorageDiff) CacheKey() DiffStoreKey {
+	return b.cacheKey
 }
 
 func (b *StorageDiff) Init(ctx context.Context) error {


### PR DESCRIPTION
The https://github.com/e2b-dev/infra/pull/253 introduced a bug by using wrong build cache key when creating snapshots. This PR fixes the cache key and adds a bit of refactor to prevent the same bug in the future.

The issue could be simulated using the following steps:
1) start sandbox
2) pause sandbox
3) ...sandbox files are uploading to GCP, but not in the build cache (because of the wrong key)
4) resume sandbox
5) cache miss, trying to download from GCP, but nothing is yet in GCP -> error