### PR TITLE
Prevent usage of weak JWT secrets

### DIFF
--- a/packages/api/internal/handlers/store_test.go
+++ b/packages/api/internal/handlers/store_test.go
@@ -32,6 +32,7 @@ func TestGetJWTClaims(t *testing.T) {
 
 	token1 := signToken(t, secret1, "1")
 	token2 := signToken(t, secret2, "2")
+	tokenEmpty := signToken(t, "", "3")
 
 	t.Run("valid token for first secret", func(t *testing.T) {
 		claims, err := getJWTClaims([]string{secret1, secret2}, token1)
@@ -53,6 +54,12 @@ func TestGetJWTClaims(t *testing.T) {
 
 	t.Run("no secrets", func(t *testing.T) {
 		claims, err := getJWTClaims([]string{}, token1)
+		assert.Error(t, err)
+		assert.Nil(t, claims)
+	})
+
+	t.Run("empty secret", func(t *testing.T) {
+		claims, err := getJWTClaims([]string{""}, tokenEmpty)
 		assert.Error(t, err)
 		assert.Nil(t, claims)
 	})

--- a/packages/api/internal/handlers/store_test.go
+++ b/packages/api/internal/handlers/store_test.go
@@ -27,8 +27,8 @@ func signToken(t *testing.T, secret string, subject string) string {
 }
 
 func TestGetJWTClaims(t *testing.T) {
-	secret1 := "testsecret1"
-	secret2 := "testsecret2"
+	secret1 := "testsecret1testsecret1"
+	secret2 := "testsecret2testsecret2"
 
 	token1 := signToken(t, secret1, "1")
 	token2 := signToken(t, secret2, "2")


### PR DESCRIPTION
If there is a JWT secret that is shorter than 16 characters, it will be ignored. This is to prevent weak JWT secrets, as well as empty JWT secrets.