### PR TITLE
Fix gRPC idle status reporting

### DIFF
--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -51,8 +51,15 @@ func (n *Node) Status() api.NodeStatus {
 		return n.status
 	}
 
-	if n.Client.connection.GetState() != connectivity.Ready {
+	switch n.Client.connection.GetState() {
+	case connectivity.Shutdown:
+		return api.NodeStatusUnhealthy
+	case connectivity.TransientFailure:
 		return api.NodeStatusConnecting
+	case connectivity.Connecting:
+		return api.NodeStatusConnecting
+	default:
+		break
 	}
 
 	return n.status

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -53,9 +53,9 @@ func (n *Node) Status() api.NodeStatus {
 
 	switch n.Client.connection.GetState() {
 	case connectivity.Shutdown:
-		return api.NodeStatusUnhealthy
+		fallthrough
 	case connectivity.TransientFailure:
-		return api.NodeStatusConnecting
+		fallthrough
 	case connectivity.Connecting:
 		return api.NodeStatusConnecting
 	default:

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -53,9 +53,9 @@ func (n *Node) Status() api.NodeStatus {
 
 	switch n.Client.connection.GetState() {
 	case connectivity.Shutdown:
-		fallthrough
+		return api.NodeStatusUnhealthy
 	case connectivity.TransientFailure:
-		fallthrough
+		return api.NodeStatusConnecting
 	case connectivity.Connecting:
 		return api.NodeStatusConnecting
 	default:


### PR DESCRIPTION
Fixes status reporting when grpc is in IDLE status. Right now, if the node goes to the IDLE state (no requests for longer time), no new sandboxes could be created and the state doesn't change back.