### PR TITLE
Adds sandbox startedAt to snapshot

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -2638,7 +2638,6 @@ github.com/e2b-dev/fsnotify v0.0.0-20241202191622-2cae6c99fd56 h1:mzTVxfzZjgu+yX
 github.com/e2b-dev/fsnotify v0.0.0-20241202191622-2cae6c99fd56/go.mod h1:49MToyZ6q0q2rwa5A77Gdh9p3gqmoID22vEJeAYyNDs=
 github.com/e2b-dev/fsnotify v0.0.0-20241216144736-0d773a6a878f h1:lDK0AOq8wIL0kP00qo5SEkw8rFEbNoT7q034oBfUcxk=
 github.com/e2b-dev/fsnotify v0.0.0-20241216144736-0d773a6a878f/go.mod h1:49MToyZ6q0q2rwa5A77Gdh9p3gqmoID22vEJeAYyNDs=
-github.com/e2b-dev/fsnotify v0.0.0-20241216145137-2fe5d32bcb51/go.mod h1:49MToyZ6q0q2rwa5A77Gdh9p3gqmoID22vEJeAYyNDs=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.3.0 h1:RRL0nge+cWGlxXbUzJ7yMcq6w2XBEr19dCN6HECGaT0=
 github.com/eapache/go-resiliency v1.3.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
@@ -2928,6 +2927,7 @@ github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0L
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
 github.com/golang/glog v1.2.2/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
@@ -3874,7 +3874,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
-github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=

--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -35,6 +35,7 @@ func (o *Orchestrator) PauseInstance(
 	snapshotConfig := &db.SnapshotInfo{
 		BaseTemplateID:     sbx.Instance.TemplateID,
 		SandboxID:          sbx.Instance.SandboxID,
+		SandboxStartedAt:   sbx.StartTime,
 		VCPU:               sbx.VCpu,
 		RAMMB:              sbx.RamMB,
 		TotalDiskSizeMB:    sbx.TotalDiskSizeMB,

--- a/packages/shared/pkg/db/snapshot.go
+++ b/packages/shared/pkg/db/snapshot.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -15,6 +16,7 @@ import (
 
 type SnapshotInfo struct {
 	SandboxID          string
+	SandboxStartedAt   time.Time
 	BaseTemplateID     string
 	VCPU               int64
 	RAMMB              int64
@@ -78,6 +80,7 @@ func (db *DB) NewSnapshotBuild(
 			SetBaseEnvID(snapshotConfig.BaseTemplateID).
 			SetEnv(e).
 			SetMetadata(snapshotConfig.Metadata).
+			SetSandboxStartedAt(snapshotConfig.SandboxStartedAt).
 			Save(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create snapshot '%s': %w", snapshotConfig.SandboxID, err)
@@ -89,6 +92,7 @@ func (db *DB) NewSnapshotBuild(
 			Snapshot.
 			UpdateOne(s).
 			SetMetadata(snapshotConfig.Metadata).
+			SetSandboxStartedAt(snapshotConfig.SandboxStartedAt).
 			Save(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update snapshot '%s': %w", snapshotConfig.SandboxID, err)

--- a/packages/shared/pkg/models/migrate/schema.go
+++ b/packages/shared/pkg/models/migrate/schema.go
@@ -120,6 +120,7 @@ var (
 		{Name: "base_env_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "sandbox_id", Type: field.TypeString, Unique: true, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "metadata", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "sandbox_started_at", Type: field.TypeTime},
 		{Name: "env_id", Type: field.TypeString, SchemaType: map[string]string{"postgres": "text"}},
 	}
 	// SnapshotsTable holds the schema information for the "snapshots" table.
@@ -130,7 +131,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "snapshots_envs_snapshots",
-				Columns:    []*schema.Column{SnapshotsColumns[5]},
+				Columns:    []*schema.Column{SnapshotsColumns[6]},
 				RefColumns: []*schema.Column{EnvsColumns[0]},
 				OnDelete:   schema.Cascade,
 			},

--- a/packages/shared/pkg/models/mutation.go
+++ b/packages/shared/pkg/models/mutation.go
@@ -3476,19 +3476,20 @@ func (m *EnvBuildMutation) ResetEdge(name string) error {
 // SnapshotMutation represents an operation that mutates the Snapshot nodes in the graph.
 type SnapshotMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *uuid.UUID
-	created_at    *time.Time
-	base_env_id   *string
-	sandbox_id    *string
-	metadata      *map[string]string
-	clearedFields map[string]struct{}
-	env           *string
-	clearedenv    bool
-	done          bool
-	oldValue      func(context.Context) (*Snapshot, error)
-	predicates    []predicate.Snapshot
+	op                 Op
+	typ                string
+	id                 *uuid.UUID
+	created_at         *time.Time
+	base_env_id        *string
+	sandbox_id         *string
+	metadata           *map[string]string
+	sandbox_started_at *time.Time
+	clearedFields      map[string]struct{}
+	env                *string
+	clearedenv         bool
+	done               bool
+	oldValue           func(context.Context) (*Snapshot, error)
+	predicates         []predicate.Snapshot
 }
 
 var _ ent.Mutation = (*SnapshotMutation)(nil)
@@ -3775,6 +3776,42 @@ func (m *SnapshotMutation) ResetMetadata() {
 	m.metadata = nil
 }
 
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (m *SnapshotMutation) SetSandboxStartedAt(t time.Time) {
+	m.sandbox_started_at = &t
+}
+
+// SandboxStartedAt returns the value of the "sandbox_started_at" field in the mutation.
+func (m *SnapshotMutation) SandboxStartedAt() (r time.Time, exists bool) {
+	v := m.sandbox_started_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldSandboxStartedAt returns the old "sandbox_started_at" field's value of the Snapshot entity.
+// If the Snapshot object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *SnapshotMutation) OldSandboxStartedAt(ctx context.Context) (v time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldSandboxStartedAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldSandboxStartedAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldSandboxStartedAt: %w", err)
+	}
+	return oldValue.SandboxStartedAt, nil
+}
+
+// ResetSandboxStartedAt resets all changes to the "sandbox_started_at" field.
+func (m *SnapshotMutation) ResetSandboxStartedAt() {
+	m.sandbox_started_at = nil
+}
+
 // ClearEnv clears the "env" edge to the Env entity.
 func (m *SnapshotMutation) ClearEnv() {
 	m.clearedenv = true
@@ -3836,7 +3873,7 @@ func (m *SnapshotMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *SnapshotMutation) Fields() []string {
-	fields := make([]string, 0, 5)
+	fields := make([]string, 0, 6)
 	if m.created_at != nil {
 		fields = append(fields, snapshot.FieldCreatedAt)
 	}
@@ -3851,6 +3888,9 @@ func (m *SnapshotMutation) Fields() []string {
 	}
 	if m.metadata != nil {
 		fields = append(fields, snapshot.FieldMetadata)
+	}
+	if m.sandbox_started_at != nil {
+		fields = append(fields, snapshot.FieldSandboxStartedAt)
 	}
 	return fields
 }
@@ -3870,6 +3910,8 @@ func (m *SnapshotMutation) Field(name string) (ent.Value, bool) {
 		return m.SandboxID()
 	case snapshot.FieldMetadata:
 		return m.Metadata()
+	case snapshot.FieldSandboxStartedAt:
+		return m.SandboxStartedAt()
 	}
 	return nil, false
 }
@@ -3889,6 +3931,8 @@ func (m *SnapshotMutation) OldField(ctx context.Context, name string) (ent.Value
 		return m.OldSandboxID(ctx)
 	case snapshot.FieldMetadata:
 		return m.OldMetadata(ctx)
+	case snapshot.FieldSandboxStartedAt:
+		return m.OldSandboxStartedAt(ctx)
 	}
 	return nil, fmt.Errorf("unknown Snapshot field %s", name)
 }
@@ -3932,6 +3976,13 @@ func (m *SnapshotMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetMetadata(v)
+		return nil
+	case snapshot.FieldSandboxStartedAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetSandboxStartedAt(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Snapshot field %s", name)
@@ -3996,6 +4047,9 @@ func (m *SnapshotMutation) ResetField(name string) error {
 		return nil
 	case snapshot.FieldMetadata:
 		m.ResetMetadata()
+		return nil
+	case snapshot.FieldSandboxStartedAt:
+		m.ResetSandboxStartedAt()
 		return nil
 	}
 	return fmt.Errorf("unknown Snapshot field %s", name)

--- a/packages/shared/pkg/models/snapshot/snapshot.go
+++ b/packages/shared/pkg/models/snapshot/snapshot.go
@@ -24,6 +24,8 @@ const (
 	FieldSandboxID = "sandbox_id"
 	// FieldMetadata holds the string denoting the metadata field in the database.
 	FieldMetadata = "metadata"
+	// FieldSandboxStartedAt holds the string denoting the sandbox_started_at field in the database.
+	FieldSandboxStartedAt = "sandbox_started_at"
 	// EdgeEnv holds the string denoting the env edge name in mutations.
 	EdgeEnv = "env"
 	// Table holds the table name of the snapshot in the database.
@@ -45,6 +47,7 @@ var Columns = []string{
 	FieldEnvID,
 	FieldSandboxID,
 	FieldMetadata,
+	FieldSandboxStartedAt,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).
@@ -88,6 +91,11 @@ func ByEnvID(opts ...sql.OrderTermOption) OrderOption {
 // BySandboxID orders the results by the sandbox_id field.
 func BySandboxID(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldSandboxID, opts...).ToFunc()
+}
+
+// BySandboxStartedAt orders the results by the sandbox_started_at field.
+func BySandboxStartedAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldSandboxStartedAt, opts...).ToFunc()
 }
 
 // ByEnvField orders the results by env field.

--- a/packages/shared/pkg/models/snapshot/where.go
+++ b/packages/shared/pkg/models/snapshot/where.go
@@ -77,6 +77,11 @@ func SandboxID(v string) predicate.Snapshot {
 	return predicate.Snapshot(sql.FieldEQ(FieldSandboxID, v))
 }
 
+// SandboxStartedAt applies equality check predicate on the "sandbox_started_at" field. It's identical to SandboxStartedAtEQ.
+func SandboxStartedAt(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldEQ(FieldSandboxStartedAt, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Snapshot {
 	return predicate.Snapshot(sql.FieldEQ(FieldCreatedAt, v))
@@ -310,6 +315,46 @@ func SandboxIDEqualFold(v string) predicate.Snapshot {
 // SandboxIDContainsFold applies the ContainsFold predicate on the "sandbox_id" field.
 func SandboxIDContainsFold(v string) predicate.Snapshot {
 	return predicate.Snapshot(sql.FieldContainsFold(FieldSandboxID, v))
+}
+
+// SandboxStartedAtEQ applies the EQ predicate on the "sandbox_started_at" field.
+func SandboxStartedAtEQ(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldEQ(FieldSandboxStartedAt, v))
+}
+
+// SandboxStartedAtNEQ applies the NEQ predicate on the "sandbox_started_at" field.
+func SandboxStartedAtNEQ(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldNEQ(FieldSandboxStartedAt, v))
+}
+
+// SandboxStartedAtIn applies the In predicate on the "sandbox_started_at" field.
+func SandboxStartedAtIn(vs ...time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldIn(FieldSandboxStartedAt, vs...))
+}
+
+// SandboxStartedAtNotIn applies the NotIn predicate on the "sandbox_started_at" field.
+func SandboxStartedAtNotIn(vs ...time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldNotIn(FieldSandboxStartedAt, vs...))
+}
+
+// SandboxStartedAtGT applies the GT predicate on the "sandbox_started_at" field.
+func SandboxStartedAtGT(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldGT(FieldSandboxStartedAt, v))
+}
+
+// SandboxStartedAtGTE applies the GTE predicate on the "sandbox_started_at" field.
+func SandboxStartedAtGTE(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldGTE(FieldSandboxStartedAt, v))
+}
+
+// SandboxStartedAtLT applies the LT predicate on the "sandbox_started_at" field.
+func SandboxStartedAtLT(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldLT(FieldSandboxStartedAt, v))
+}
+
+// SandboxStartedAtLTE applies the LTE predicate on the "sandbox_started_at" field.
+func SandboxStartedAtLTE(v time.Time) predicate.Snapshot {
+	return predicate.Snapshot(sql.FieldLTE(FieldSandboxStartedAt, v))
 }
 
 // HasEnv applies the HasEdge predicate on the "env" edge.

--- a/packages/shared/pkg/models/snapshot_create.go
+++ b/packages/shared/pkg/models/snapshot_create.go
@@ -63,6 +63,12 @@ func (sc *SnapshotCreate) SetMetadata(m map[string]string) *SnapshotCreate {
 	return sc
 }
 
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (sc *SnapshotCreate) SetSandboxStartedAt(t time.Time) *SnapshotCreate {
+	sc.mutation.SetSandboxStartedAt(t)
+	return sc
+}
+
 // SetID sets the "id" field.
 func (sc *SnapshotCreate) SetID(u uuid.UUID) *SnapshotCreate {
 	sc.mutation.SetID(u)
@@ -132,6 +138,9 @@ func (sc *SnapshotCreate) check() error {
 	if _, ok := sc.mutation.Metadata(); !ok {
 		return &ValidationError{Name: "metadata", err: errors.New(`models: missing required field "Snapshot.metadata"`)}
 	}
+	if _, ok := sc.mutation.SandboxStartedAt(); !ok {
+		return &ValidationError{Name: "sandbox_started_at", err: errors.New(`models: missing required field "Snapshot.sandbox_started_at"`)}
+	}
 	if _, ok := sc.mutation.EnvID(); !ok {
 		return &ValidationError{Name: "env", err: errors.New(`models: missing required edge "Snapshot.env"`)}
 	}
@@ -187,6 +196,10 @@ func (sc *SnapshotCreate) createSpec() (*Snapshot, *sqlgraph.CreateSpec) {
 	if value, ok := sc.mutation.Metadata(); ok {
 		_spec.SetField(snapshot.FieldMetadata, field.TypeJSON, value)
 		_node.Metadata = value
+	}
+	if value, ok := sc.mutation.SandboxStartedAt(); ok {
+		_spec.SetField(snapshot.FieldSandboxStartedAt, field.TypeTime, value)
+		_node.SandboxStartedAt = value
 	}
 	if nodes := sc.mutation.EnvIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -306,6 +319,18 @@ func (u *SnapshotUpsert) UpdateMetadata() *SnapshotUpsert {
 	return u
 }
 
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (u *SnapshotUpsert) SetSandboxStartedAt(v time.Time) *SnapshotUpsert {
+	u.Set(snapshot.FieldSandboxStartedAt, v)
+	return u
+}
+
+// UpdateSandboxStartedAt sets the "sandbox_started_at" field to the value that was provided on create.
+func (u *SnapshotUpsert) UpdateSandboxStartedAt() *SnapshotUpsert {
+	u.SetExcluded(snapshot.FieldSandboxStartedAt)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create except the ID field.
 // Using this option is equivalent to using:
 //
@@ -410,6 +435,20 @@ func (u *SnapshotUpsertOne) SetMetadata(v map[string]string) *SnapshotUpsertOne 
 func (u *SnapshotUpsertOne) UpdateMetadata() *SnapshotUpsertOne {
 	return u.Update(func(s *SnapshotUpsert) {
 		s.UpdateMetadata()
+	})
+}
+
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (u *SnapshotUpsertOne) SetSandboxStartedAt(v time.Time) *SnapshotUpsertOne {
+	return u.Update(func(s *SnapshotUpsert) {
+		s.SetSandboxStartedAt(v)
+	})
+}
+
+// UpdateSandboxStartedAt sets the "sandbox_started_at" field to the value that was provided on create.
+func (u *SnapshotUpsertOne) UpdateSandboxStartedAt() *SnapshotUpsertOne {
+	return u.Update(func(s *SnapshotUpsert) {
+		s.UpdateSandboxStartedAt()
 	})
 }
 
@@ -684,6 +723,20 @@ func (u *SnapshotUpsertBulk) SetMetadata(v map[string]string) *SnapshotUpsertBul
 func (u *SnapshotUpsertBulk) UpdateMetadata() *SnapshotUpsertBulk {
 	return u.Update(func(s *SnapshotUpsert) {
 		s.UpdateMetadata()
+	})
+}
+
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (u *SnapshotUpsertBulk) SetSandboxStartedAt(v time.Time) *SnapshotUpsertBulk {
+	return u.Update(func(s *SnapshotUpsert) {
+		s.SetSandboxStartedAt(v)
+	})
+}
+
+// UpdateSandboxStartedAt sets the "sandbox_started_at" field to the value that was provided on create.
+func (u *SnapshotUpsertBulk) UpdateSandboxStartedAt() *SnapshotUpsertBulk {
+	return u.Update(func(s *SnapshotUpsert) {
+		s.UpdateSandboxStartedAt()
 	})
 }
 

--- a/packages/shared/pkg/models/snapshot_update.go
+++ b/packages/shared/pkg/models/snapshot_update.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
@@ -75,6 +76,20 @@ func (su *SnapshotUpdate) SetNillableSandboxID(s *string) *SnapshotUpdate {
 // SetMetadata sets the "metadata" field.
 func (su *SnapshotUpdate) SetMetadata(m map[string]string) *SnapshotUpdate {
 	su.mutation.SetMetadata(m)
+	return su
+}
+
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (su *SnapshotUpdate) SetSandboxStartedAt(t time.Time) *SnapshotUpdate {
+	su.mutation.SetSandboxStartedAt(t)
+	return su
+}
+
+// SetNillableSandboxStartedAt sets the "sandbox_started_at" field if the given value is not nil.
+func (su *SnapshotUpdate) SetNillableSandboxStartedAt(t *time.Time) *SnapshotUpdate {
+	if t != nil {
+		su.SetSandboxStartedAt(*t)
+	}
 	return su
 }
 
@@ -155,6 +170,9 @@ func (su *SnapshotUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := su.mutation.Metadata(); ok {
 		_spec.SetField(snapshot.FieldMetadata, field.TypeJSON, value)
+	}
+	if value, ok := su.mutation.SandboxStartedAt(); ok {
+		_spec.SetField(snapshot.FieldSandboxStartedAt, field.TypeTime, value)
 	}
 	if su.mutation.EnvCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -256,6 +274,20 @@ func (suo *SnapshotUpdateOne) SetNillableSandboxID(s *string) *SnapshotUpdateOne
 // SetMetadata sets the "metadata" field.
 func (suo *SnapshotUpdateOne) SetMetadata(m map[string]string) *SnapshotUpdateOne {
 	suo.mutation.SetMetadata(m)
+	return suo
+}
+
+// SetSandboxStartedAt sets the "sandbox_started_at" field.
+func (suo *SnapshotUpdateOne) SetSandboxStartedAt(t time.Time) *SnapshotUpdateOne {
+	suo.mutation.SetSandboxStartedAt(t)
+	return suo
+}
+
+// SetNillableSandboxStartedAt sets the "sandbox_started_at" field if the given value is not nil.
+func (suo *SnapshotUpdateOne) SetNillableSandboxStartedAt(t *time.Time) *SnapshotUpdateOne {
+	if t != nil {
+		suo.SetSandboxStartedAt(*t)
+	}
 	return suo
 }
 
@@ -366,6 +398,9 @@ func (suo *SnapshotUpdateOne) sqlSave(ctx context.Context) (_node *Snapshot, err
 	}
 	if value, ok := suo.mutation.Metadata(); ok {
 		_spec.SetField(snapshot.FieldMetadata, field.TypeJSON, value)
+	}
+	if value, ok := suo.mutation.SandboxStartedAt(); ok {
+		_spec.SetField(snapshot.FieldSandboxStartedAt, field.TypeTime, value)
 	}
 	if suo.mutation.EnvCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/packages/shared/pkg/schema/snapshots.go
+++ b/packages/shared/pkg/schema/snapshots.go
@@ -26,6 +26,7 @@ func (Snapshot) Fields() []ent.Field {
 		field.String("env_id").SchemaType(map[string]string{dialect.Postgres: "text"}),
 		field.String("sandbox_id").Unique().SchemaType(map[string]string{dialect.Postgres: "text"}),
 		field.JSON("metadata", map[string]string{}).SchemaType(map[string]string{dialect.Postgres: "jsonb"}),
+		field.Time("sandbox_started_at"),
 	}
 }
 


### PR DESCRIPTION
Added sandbox startedAt to snapshot

- would require db migration
- you'd need to pull sandbox logs from billing to set when they were started

more info:
https://e2b-team.slack.com/archives/C07VCHSF9NK/p1739207493629409