### PR TITLE
Refactor Supabase JWT secret handling in Nomad and API modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,7 @@ module "nomad" {
   api_secret                                = module.api.api_secret
   custom_envs_repository_name               = module.api.custom_envs_repository_name
   postgres_connection_string_secret_name    = module.api.postgres_connection_string_secret_name
-  supabase_jwt_secrets_secret_name          = module.api.supabase_jwt_secrets_secret_name
+  supabase_jwt_secrets_secret_data          = module.api.supabase_jwt_secrets_secret_data
   posthog_api_key_secret_name               = module.api.posthog_api_key_secret_name
   analytics_collector_host_secret_name      = module.init.analytics_collector_host_secret_name
   analytics_collector_api_token_secret_name = module.init.analytics_collector_api_token_secret_name

--- a/packages/api/outputs.tf
+++ b/packages/api/outputs.tf
@@ -10,8 +10,8 @@ output "postgres_connection_string_secret_name" {
   value = google_secret_manager_secret.postgres_connection_string.name
 }
 
-output "supabase_jwt_secrets_secret_name" {
-  value = google_secret_manager_secret.supabase_jwt_secrets.name
+output "supabase_jwt_secrets_secret_data" {
+  value = google_secret_manager_secret_version.supabase_jwt_secrets.secret_data
 }
 
 output "posthog_api_key_secret_name" {

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -3,9 +3,6 @@ data "google_secret_manager_secret_version" "postgres_connection_string" {
   secret = var.postgres_connection_string_secret_name
 }
 
-data "google_secret_manager_secret_version" "supabase_jwt_secrets" {
-  secret = var.supabase_jwt_secrets_secret_name
-}
 
 data "google_secret_manager_secret_version" "posthog_api_key" {
   secret = var.posthog_api_key_secret_name
@@ -39,7 +36,7 @@ resource "nomad_job" "api" {
     port_number                   = var.api_port.port
     api_docker_image              = var.api_docker_image_digest
     postgres_connection_string    = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
-    supabase_jwt_secrets          = data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data
+    supabase_jwt_secrets          = var.supabase_jwt_secrets_secret_data
     posthog_api_key               = data.google_secret_manager_secret_version.posthog_api_key.secret_data
     environment                   = var.environment
     analytics_collector_host      = data.google_secret_manager_secret_version.analytics_collector_host.secret_data
@@ -424,7 +421,7 @@ resource "nomad_job" "clickhouse" {
     gcs_folder          = "clickhouse-data"
     hmac_key            = google_storage_hmac_key.clickhouse_hmac_key.access_id
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
-    username            = var.clickhouse_username 
+    username            = var.clickhouse_username
     password_sha256_hex = sha256(var.clickhouse_password)
   })
 }

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -88,7 +88,7 @@ variable "postgres_connection_string_secret_name" {
   type = string
 }
 
-variable "supabase_jwt_secrets_secret_name" {
+variable "supabase_jwt_secrets_secret_data" {
   type = string
 }
 


### PR DESCRIPTION
using data to access secrets creates data races, instead lets plumb the data through to avoid that