### PR TITLE
Lower Loki chunk retention and ttls

### DIFF
--- a/packages/nomad/loki.hcl
+++ b/packages/nomad/loki.hcl
@@ -92,7 +92,7 @@ chunk_store_config:
   chunk_cache_config:
     embedded_cache:
       enabled: true
-      max_size_mb: 512
+      max_size_mb: 2048
       ttl: 30m
 
 query_range:
@@ -103,7 +103,7 @@ query_range:
     cache:
       embedded_cache:
         enabled: true
-        max_size_mb: 512
+        max_size_mb: 2048
         ttl: 30m
 
 ingester_client:
@@ -112,7 +112,7 @@ ingester_client:
     max_send_msg_size: 104857600  # 100 Mb
 
 ingester:
-  chunk_idle_period: 1m
+  chunk_idle_period: 10m
   chunk_encoding: snappy
   max_chunk_age: 15m
   chunk_target_size: 1048576  # 1MB
@@ -147,6 +147,7 @@ limits_config:
   per_stream_rate_limit: "80MB"
   per_stream_rate_limit_burst: "240MB"
   max_streams_per_user: 0
+  split_queries_by_interval: 30m
   max_global_streams_per_user: 0
   unordered_writes: true
   reject_old_samples_max_age: 168h

--- a/packages/nomad/loki.hcl
+++ b/packages/nomad/loki.hcl
@@ -85,7 +85,7 @@ storage_config:
   tsdb_shipper:
     active_index_directory: /loki/tsdb-shipper-active
     cache_location: /loki/tsdb-shipper-cache
-    cache_ttl: 24h
+    cache_ttl: 1h
     shared_store: gcs
 
 chunk_store_config:
@@ -93,18 +93,18 @@ chunk_store_config:
     embedded_cache:
       enabled: true
       max_size_mb: 512
-      ttl: 1h
+      ttl: 30m
 
 query_range:
   align_queries_with_step: true
   cache_results: true
-  max_retries: 5
+  max_retries: 2
   results_cache:
     cache:
       embedded_cache:
         enabled: true
-        max_size_mb: 256
-        ttl: 1h
+        max_size_mb: 512
+        ttl: 30m
 
 ingester_client:
   grpc_client_config:
@@ -112,11 +112,13 @@ ingester_client:
     max_send_msg_size: 104857600  # 100 Mb
 
 ingester:
-  chunk_idle_period: 30m
+  chunk_idle_period: 1m
   chunk_encoding: snappy
+  max_chunk_age: 15m
   chunk_target_size: 1048576  # 1MB
   wal:
     dir: /loki/wal
+    enabled: false
     flush_on_shutdown: true
 
 schema_config:


### PR DESCRIPTION
From the Loki Grafana it seems that part of the memory problems with the current Loki setup is because of the number of retained chunks. These can be failed chunks in several cases though, so I think we first need to find stable Loki configuration.
The next step would be adding scaling/moving the data to other DB (clickhouse?).


We also disabled `wal` which normally helps with replaying the previous unprocessed traffic, but with our job placement it does not make sense now.