### PR TITLE
Fix bug when template has multiple builds

### DIFF
--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/db"
+	"github.com/e2b-dev/infra/packages/shared/pkg/models/envbuild"
 )
 
 type SeedData struct {
@@ -106,7 +108,7 @@ func seed(db *db.DB, data SeedData) error {
 		SetID(data.BuildID).
 		SetEnvID(data.EnvID).
 		SetDockerfile("FROM e2bdev/base:latest").
-		SetStatus("uploaded").
+		SetStatus(envbuild.StatusUploaded).
 		SetVcpu(2).
 		SetRAMMB(512).
 		SetFreeDiskSizeMB(512).
@@ -114,6 +116,25 @@ func seed(db *db.DB, data SeedData) error {
 		SetKernelVersion("vmlinux-6.1.102").
 		SetFirecrackerVersion("v1.10.1_1fcdaec").
 		SetEnvdVersion("0.1.5").
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create env build: %w", err)
+	}
+
+	// Create an older build, so we have multiple builds
+	_, err = db.Client.EnvBuild.Create().
+		SetID(uuid.New()).
+		SetEnvID(data.EnvID).
+		SetDockerfile("FROM e2bdev/base:latest").
+		SetStatus(envbuild.StatusUploaded).
+		SetVcpu(2).
+		SetRAMMB(512).
+		SetFreeDiskSizeMB(512).
+		SetTotalDiskSizeMB(1982).
+		SetKernelVersion("vmlinux-6.1.102").
+		SetFirecrackerVersion("v1.10.1_1fcdaec").
+		SetEnvdVersion("0.1.5").
+		SetCreatedAt(time.Now().Add(-time.Hour)).
 		Save(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create env build: %w", err)

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -104,40 +104,41 @@ func seed(db *db.DB, data SeedData) error {
 		return fmt.Errorf("failed to create env: %w", err)
 	}
 
-	_, err = db.Client.EnvBuild.Create().
-		SetID(data.BuildID).
-		SetEnvID(data.EnvID).
-		SetDockerfile("FROM e2bdev/base:latest").
-		SetStatus(envbuild.StatusUploaded).
-		SetVcpu(2).
-		SetRAMMB(512).
-		SetFreeDiskSizeMB(512).
-		SetTotalDiskSizeMB(1982).
-		SetKernelVersion("vmlinux-6.1.102").
-		SetFirecrackerVersion("v1.10.1_1fcdaec").
-		SetEnvdVersion("0.1.5").
-		Save(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create env build: %w", err)
+	type buildData struct {
+		id        uuid.UUID
+		createdAt *time.Time
 	}
 
-	// Create an older build, so we have multiple builds
-	_, err = db.Client.EnvBuild.Create().
-		SetID(uuid.New()).
-		SetEnvID(data.EnvID).
-		SetDockerfile("FROM e2bdev/base:latest").
-		SetStatus(envbuild.StatusUploaded).
-		SetVcpu(2).
-		SetRAMMB(512).
-		SetFreeDiskSizeMB(512).
-		SetTotalDiskSizeMB(1982).
-		SetKernelVersion("vmlinux-6.1.102").
-		SetFirecrackerVersion("v1.10.1_1fcdaec").
-		SetEnvdVersion("0.1.5").
-		SetCreatedAt(time.Now().Add(-time.Hour)).
-		Save(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create env build: %w", err)
+	oldBuildTime := time.Now().Add(-time.Hour)
+	builds := []buildData{
+		{
+			id:        data.BuildID,
+			createdAt: nil,
+		},
+		// An older build, so we have multiple builds
+		{
+			id:        uuid.New(),
+			createdAt: &oldBuildTime,
+		},
+	}
+
+	for _, build := range builds {
+		_, err = db.Client.EnvBuild.Create().
+			SetID(build.id).
+			SetEnvID(data.EnvID).
+			SetDockerfile("FROM e2bdev/base:latest").
+			SetStatus(envbuild.StatusUploaded).
+			SetVcpu(2).
+			SetRAMMB(512).
+			SetFreeDiskSizeMB(512).
+			SetTotalDiskSizeMB(1982).
+			SetKernelVersion("vmlinux-6.1.102").
+			SetFirecrackerVersion("v1.10.1_1fcdaec").
+			SetEnvdVersion("0.1.5").
+			SetNillableCreatedAt(build.createdAt).Save(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to create env build: %w", err)
+		}
 	}
 
 	_, err = db.Client.EnvAlias.Create().


### PR DESCRIPTION
# Description

`.Only()` overrides `Limit`, so it will change `Limit` to 2 and then raise an error if there's more builds present  