### PR TITLE
Fixed template build missing early return

### DIFF
--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -162,7 +162,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 					return
 				}
 
-				logger.Error("Template build finished")
+				logger.Info("Template build finished")
 				return
 			}
 		}


### PR DESCRIPTION
Fixed issue when background sync fires before build is marked as building, takes it and forgotten return statement continues flow into point when process was asking template manager about status of yet non-existing build resulting in failing state instantly.