### PR TITLE
Limit public access to our VM ports

### DIFF
--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -543,19 +543,20 @@ resource "google_compute_firewall" "internal_remote_connection_firewall_ingress"
 
   priority = 900
 
-  direction     = "INGRESS"
-  target_tags   = [var.cluster_tag_name]
-  source_ranges = var.environment == "dev" ? ["0.0.0.0/0"] : ["10.128.0.0/9"]
+  direction   = "INGRESS"
+  target_tags = [var.cluster_tag_name]
+  # https://googlecloudplatform.github.io/iap-desktop/setup-iap/
+  source_ranges = var.environment == "dev" ? ["0.0.0.0/0"] : ["35.235.240.0/20"]
 }
 
 resource "google_compute_firewall" "remote_connection_firewall_ingress" {
   name    = "${var.prefix}${var.cluster_tag_name}-remote-connection-firewall-ingress"
   network = var.network_name
 
-    deny {
-      protocol = "tcp"
-      ports    = ["22", "3389"]
-    }
+  deny {
+    protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
 
 
 

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -532,17 +532,31 @@ resource "google_compute_firewall" "client_proxy_firewall_ingress" {
 }
 
 
+resource "google_compute_firewall" "internal_remote_connection_firewall_ingress" {
+  name    = "${var.prefix}${var.cluster_tag_name}-internal-remote-connection-firewall-ingress"
+  network = var.network_name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
+
+  priority = 0
+
+  direction     = "INGRESS"
+  target_tags   = [var.cluster_tag_name]
+  source_ranges = var.environment == "dev" ? ["0.0.0.0/0"] : ["10.128.0.0/9"]
+}
+
 resource "google_compute_firewall" "remote_connection_firewall_ingress" {
   name    = "${var.prefix}${var.cluster_tag_name}-remote-connection-firewall-ingress"
   network = var.network_name
 
-  dynamic "deny" {
-    for_each = var.environment != "dev" ? toset(["22", "3389"]) : toset(["3389"])
-    content {
+    deny {
       protocol = "tcp"
-      ports    = [deny.value]
+      ports    = ["22", "3389"]
     }
-  }
+
 
 
   priority = 0

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -532,6 +532,27 @@ resource "google_compute_firewall" "client_proxy_firewall_ingress" {
 }
 
 
+resource "google_compute_firewall" "remote_connection_firewall_ingress" {
+  name    = "${var.prefix}${var.cluster_tag_name}-remote-connection-firewall-ingress"
+  network = var.network_name
+
+  dynamic "deny" {
+    for_each = var.environment != "dev" ? toset(["22", "3389"]) : toset(["3389"])
+    content {
+      protocol = "tcp"
+      ports    = [deny.value]
+    }
+  }
+
+
+  priority = 0
+
+  direction     = "INGRESS"
+  target_tags   = [var.cluster_tag_name]
+  source_ranges = ["0.0.0.0/0"]
+}
+
+
 resource "google_compute_firewall" "orch_firewall_egress" {
   name    = "${var.prefix}${var.cluster_tag_name}-firewall-egress"
   network = var.network_name

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -541,7 +541,7 @@ resource "google_compute_firewall" "internal_remote_connection_firewall_ingress"
     ports    = ["22", "3389"]
   }
 
-  priority = 0
+  priority = 900
 
   direction     = "INGRESS"
   target_tags   = [var.cluster_tag_name]
@@ -559,7 +559,7 @@ resource "google_compute_firewall" "remote_connection_firewall_ingress" {
 
 
 
-  priority = 0
+  priority = 1000
 
   direction     = "INGRESS"
   target_tags   = [var.cluster_tag_name]


### PR DESCRIPTION
# Description

- Client proxy health endpoint is the only service with different port for health check
- You can still SSH via GCP console, but you can't connect directly from command line (you would need to add your personal IP)

**Allow**:
- For internal IPs for 22 and 3389 (remote desktop access) - prio 900 (all ips if dev)

**Deny**: 
- All access for 22 and 3389 (remote desktop access) - prio 1000
- Access for not needed ports 