### PR TITLE
Fix GoLint deprecations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,8 @@ linters-settings:
     confidence: 0
   stylecheck:
     checks: [all, -ST1000, -ST1020]
+  usetesting:
+    os-setenv: true
 
 linters:
   enable:
@@ -67,12 +69,11 @@ linters:
     - importas
     - reassign
     - tagalign
-    - tenv
     - predeclared
-    - interfacer
     - unconvert
     - unparam
     - usestdlibvars
+    - usetesting
     - wastedassign
     - wsl
     - gofmt


### PR DESCRIPTION
Fixes the following deprecations:

The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.
The linter 'tenv' is deprecated (since v1.64.0) due to: Duplicate feature in another linter. Replaced by usetesting.