### PR TITLE
Fix race condition in the template manager

### DIFF
--- a/packages/api/internal/handlers/template_start_build.go
+++ b/packages/api/internal/handlers/template_start_build.go
@@ -146,10 +146,9 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 		zap.L().Error("build failed", zap.Error(buildErr))
 		telemetry.ReportCriticalError(ctx, buildErr)
 
-		a.templateBuildsCache.SetStatus(buildUUID, envbuild.StatusFailed)
-		dbErr := a.db.EnvBuildSetStatus(ctx, templateID, buildUUID, envbuild.StatusFailed)
-		if dbErr != nil {
-			telemetry.ReportCriticalError(ctx, fmt.Errorf("error when setting build status: %w", dbErr))
+		err = a.templateManager.SetStatus(ctx, templateID, buildUUID, envbuild.StatusFailed)
+		if err != nil {
+			telemetry.ReportCriticalError(ctx, fmt.Errorf("error when setting build status: %w", err))
 		}
 
 		return
@@ -157,11 +156,11 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 
 	// status building must be set after build is triggered because then
 	// it's possible build status job will be triggered before build cache on template manager is created and build will fail
-	a.templateBuildsCache.SetStatus(buildUUID, envbuild.StatusBuilding)
-	err = a.db.EnvBuildSetStatus(ctx, templateID, buildUUID, envbuild.StatusBuilding)
+	err = a.templateManager.SetStatus(ctx, templateID, buildUUID, envbuild.StatusBuilding)
 	if err != nil {
-		err = fmt.Errorf("error when setting build status: %w", err)
-		telemetry.ReportCriticalError(ctx, err)
+		telemetry.ReportCriticalError(ctx, fmt.Errorf("error when setting build status: %w", err))
+
+		return
 	}
 
 	telemetry.ReportEvent(ctx, "created new environment", attribute.String("env.id", templateID))


### PR DESCRIPTION
# Description

If database call takes long enough it's possible to finish build successfully and if you immediately try to spawn a sandbox with this template, it's possible it will return 404, because it isn't propagated in DB yet  