### PR TITLE
Shutdown logic for template manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -223,8 +223,9 @@ module "nomad" {
   fc_env_pipeline_bucket_name = module.buckets.fc_env_pipeline_bucket_name
 
   # Template manager
-  template_manager_port = var.template_manager_port
-  template_bucket_name  = module.buckets.fc_template_bucket_name
+  template_manager_port          = var.template_manager_port
+  template_bucket_name           = module.buckets.fc_template_bucket_name
+  template_manager_machine_count = var.build_cluster_size
 
   # Redis
   redis_port = var.redis_port

--- a/packages/api/internal/template-manager/client.go
+++ b/packages/api/internal/template-manager/client.go
@@ -62,10 +62,10 @@ func (a *GRPCClient) healthCheckSync(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			reqCtx, reqCtxCancel := context.WithTimeout(ctx, 2*time.Second)
+			reqCtx, reqCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+			healthStatus, err := a.Client.HealthStatus(reqCtx, nil)
 			reqCtxCancel()
 
-			healthStatus, err := a.Client.HealthStatus(reqCtx, nil)
 			healthCheckAt := time.Now()
 			a.lastHealthCheckAt = &healthCheckAt
 

--- a/packages/api/internal/template-manager/client.go
+++ b/packages/api/internal/template-manager/client.go
@@ -63,9 +63,11 @@ func (a *GRPCClient) healthCheckSync(ctx context.Context) {
 			return
 		case <-ticker.C:
 			reqCtx, reqCtxCancel := context.WithTimeout(ctx, 2*time.Second)
+			reqCtxCancel()
+
 			healthStatus, err := a.Client.HealthStatus(reqCtx, nil)
 			healthCheckAt := time.Now()
-			reqCtxCancel()
+			a.lastHealthCheckAt = &healthCheckAt
 
 			if err != nil {
 				zap.L().Error("failed to get health status of template manager", zap.Error(err))

--- a/packages/api/internal/template-manager/client.go
+++ b/packages/api/internal/template-manager/client.go
@@ -62,12 +62,10 @@ func (a *GRPCClient) healthCheckSync(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			reqCtx, reqCtxCancel := context.WithTimeout(ctx, 5*time.Second)
+			reqCtx, reqCtxCancel := context.WithTimeout(ctx, 2*time.Second)
 			healthStatus, err := a.Client.HealthStatus(reqCtx, nil)
-			reqCtxCancel()
-
 			healthCheckAt := time.Now()
-			a.lastHealthCheckAt = &healthCheckAt
+			reqCtxCancel()
 
 			if err != nil {
 				zap.L().Error("failed to get health status of template manager", zap.Error(err))
@@ -86,9 +84,6 @@ func (a *GRPCClient) healthCheckSync(ctx context.Context) {
 }
 
 func (a *GRPCClient) Close() error {
-	// signal to background health check to stop
-	close(a.healthSyncStop)
-
 	err := a.connection.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close connection: %w", err)

--- a/packages/api/internal/template-manager/client.go
+++ b/packages/api/internal/template-manager/client.go
@@ -86,6 +86,9 @@ func (a *GRPCClient) healthCheckSync(ctx context.Context) {
 }
 
 func (a *GRPCClient) Close() error {
+	// signal to background health check to stop
+	close(a.healthSyncStop)
+
 	err := a.connection.Close()
 	if err != nil {
 		return fmt.Errorf("failed to close connection: %w", err)

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -357,27 +357,25 @@ data "external" "template_manager" {
 }
 
 resource "nomad_job" "template_manager" {
-  jobspec = file("${path.module}/template-manager.hcl")
+  jobspec = templatefile("${path.module}/template-manager.hcl", {
+    update_stanza = var.template_manager_machine_count > 1
 
-  hcl2 {
-    vars = {
-      gcp_project = var.gcp_project_id
-      gcp_region  = var.gcp_region
-      gcp_zone    = var.gcp_zone
-      port        = var.template_manager_port
-      environment = var.environment
+    gcp_project = var.gcp_project_id
+    gcp_region  = var.gcp_region
+    gcp_zone    = var.gcp_zone
+    port        = var.template_manager_port
+    environment = var.environment
 
-      api_secret                   = var.api_secret
-      bucket_name                  = var.fc_env_pipeline_bucket_name
-      docker_registry              = var.custom_envs_repository_name
-      google_service_account_key   = var.google_service_account_key
-      template_manager_checksum    = data.external.template_manager.result.hex
-      otel_tracing_print           = var.otel_tracing_print
-      template_bucket_name         = var.template_bucket_name
-      otel_collector_grpc_endpoint = "localhost:4317"
-      logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
-    }
-  }
+    api_secret                   = var.api_secret
+    bucket_name                  = var.fc_env_pipeline_bucket_name
+    docker_registry              = var.custom_envs_repository_name
+    google_service_account_key   = var.google_service_account_key
+    template_manager_checksum    = data.external.template_manager.result.hex
+    otel_tracing_print           = var.otel_tracing_print
+    template_bucket_name         = var.template_bucket_name
+    otel_collector_grpc_endpoint = "localhost:4317"
+    logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
+  })
 }
 resource "nomad_job" "loki" {
   jobspec = templatefile("${path.module}/loki.hcl", {

--- a/packages/nomad/template-manager.hcl
+++ b/packages/nomad/template-manager.hcl
@@ -5,7 +5,9 @@ job "template-manager" {
 
 %{ if update_stanza }
   update {
-     progress_deadline = "20m"
+      auto_promote      = true # Whether to promote the canary if the rest of the group is not healthy
+      canary            = 1 # Allows to spawn new version of the service before killing the old one
+      progress_deadline = "20m" # Deadline for the update to be completed
   }
 %{ endif }
 

--- a/packages/nomad/template-manager.hcl
+++ b/packages/nomad/template-manager.hcl
@@ -3,6 +3,12 @@ job "template-manager" {
   node_pool  = "build"
   priority = 70
 
+%{ if update_stanza }
+  update {
+     progress_deadline = "20m"
+  }
+%{ endif }
+
   group "template-manager" {
     network {
       port "template-manager" {
@@ -28,9 +34,8 @@ job "template-manager" {
       driver = "raw_exec"
 
 %{ if update_stanza }
-      # If we need more than 10m we will need to update the max_kill_timeout in nomad
       # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
-      kill_timeout = "10m"
+      kill_timeout      = "20m"
 %{ endif }
       kill_signal  = "SIGTERM"
 

--- a/packages/nomad/template-manager.hcl
+++ b/packages/nomad/template-manager.hcl
@@ -28,7 +28,7 @@ job "template-manager" {
       driver = "raw_exec"
 
 %{ if update_stanza }
-      # If we need more than 30s we will need to update the max_kill_timeout in nomad
+      # If we need more than 10m we will need to update the max_kill_timeout in nomad
       # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
       kill_timeout = "10m"
 %{ endif }

--- a/packages/nomad/template-manager.hcl
+++ b/packages/nomad/template-manager.hcl
@@ -1,85 +1,18 @@
-variable "gcp_zone" {
-  type    = string
-}
-
-variable "gcp_project" {
-  type    = string
-}
-
-variable "gcp_region" {
-  type    = string
-}
-
-variable "port" {
-  type    = number
-  default = 5009
-}
-
-variable "docker_registry" {
-  type    = string
-  default = ""
-}
-
-variable "api_secret" {
-  type    = string
-  default = ""
-}
-
-variable "otel_tracing_print" {
-  type    = string
-  default = ""
-}
-
-variable "environment" {
-  type    = string
-  default = ""
-}
-
-variable "template_manager_checksum" {
-  type    = string
-  default = ""
-}
-
-variable "google_service_account_key" {
-  type    = string
-  default = ""
-}
-
-variable "bucket_name" {
-  type    = string
-  default = ""
-}
-
-variable "template_bucket_name" {
-  type    = string
-  default = ""
-}
-
-variable "otel_collector_grpc_endpoint" {
-  type    = string
-  default = ""
-}
-
-variable "logs_collector_address" {
-  type    = string
-  default = ""
-}
-
 job "template-manager" {
-  datacenters = [var.gcp_zone]
+  datacenters = ["${gcp_zone}"]
   node_pool  = "build"
   priority = 70
 
   group "template-manager" {
     network {
       port "template-manager" {
-        static = var.port
+        static = "${port}"
       }
     }
 
     service {
       name = "template-manager"
-      port = var.port
+      port = "${port}"
 
       check {
         type         = "grpc"
@@ -87,12 +20,19 @@ job "template-manager" {
         interval     = "20s"
         timeout      = "5s"
         grpc_use_tls = false
-        port         = var.port
+        port         = "${port}"
       }
     }
 
     task "start" {
       driver = "raw_exec"
+
+%{ if update_stanza }
+      # If we need more than 30s we will need to update the max_kill_timeout in nomad
+      # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
+      kill_timeout = "10m"
+%{ endif }
+      kill_signal  = "SIGTERM"
 
       resources {
         memory     = 1024
@@ -100,27 +40,27 @@ job "template-manager" {
       }
 
       env {
-        GOOGLE_SERVICE_ACCOUNT_BASE64 = var.google_service_account_key
-        GCP_PROJECT_ID                = var.gcp_project
-        GCP_REGION                    = var.gcp_region
-        GCP_DOCKER_REPOSITORY_NAME    = var.docker_registry
-        API_SECRET                    = var.api_secret
-        OTEL_TRACING_PRINT            = var.otel_tracing_print
-        ENVIRONMENT                   = var.environment
-        TEMPLATE_BUCKET_NAME          = var.template_bucket_name
-        OTEL_COLLECTOR_GRPC_ENDPOINT  = var.otel_collector_grpc_endpoint
-        LOGS_COLLECTOR_ADDRESS        = var.logs_collector_address
+        GOOGLE_SERVICE_ACCOUNT_BASE64 = "${google_service_account_key}"
+        GCP_PROJECT_ID                = "${gcp_project}"
+        GCP_REGION                    = "${gcp_region}"
+        GCP_DOCKER_REPOSITORY_NAME    = "${docker_registry}"
+        API_SECRET                    = "${api_secret}"
+        OTEL_TRACING_PRINT            = "${otel_tracing_print}"
+        ENVIRONMENT                   = "${environment}"
+        TEMPLATE_BUCKET_NAME          = "${template_bucket_name}"
+        OTEL_COLLECTOR_GRPC_ENDPOINT  = "${otel_collector_grpc_endpoint}"
+        LOGS_COLLECTOR_ADDRESS        = "${logs_collector_address}"
       }
 
       config {
         command = "/bin/bash"
-        args    = ["-c", " chmod +x local/template-manager && local/template-manager --port ${var.port}"]
+        args    = ["-c", " chmod +x local/template-manager && local/template-manager --port ${port}"]
       }
 
       artifact {
-        source      = "gcs::https://www.googleapis.com/storage/v1/${var.bucket_name}/template-manager"
+        source      = "gcs::https://www.googleapis.com/storage/v1/${bucket_name}/template-manager"
         options {
-            checksum    = "md5:${var.template_manager_checksum}"
+            checksum    = "md5:${template_manager_checksum}"
         }
       }
     }

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -104,7 +104,6 @@ variable "session_proxy_port" {
   })
 }
 
-
 variable "client_proxy_docker_image_digest" {
   type = string
 }
@@ -200,6 +199,10 @@ variable "client_machine_type" {
 
 # Template manager
 variable "template_manager_port" {
+  type = number
+}
+
+variable "template_manager_machine_count" {
   type = number
 }
 

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -32,7 +32,7 @@ const (
 
 var commitSHA string
 
-func main() {
+func run() int32 {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -180,5 +180,9 @@ func main() {
 
 	wg.Wait()
 
-	os.Exit(int(exitCode.Load()))
+	return exitCode.Load()
+}
+
+func main() {
+	os.Exit(int(run()))
 }

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -47,7 +47,7 @@ type ServerStore struct {
 	wg               *sync.WaitGroup // wait group for running builds
 }
 
-func New(logger *zap.Logger, buildLogger *zap.Logger) (*grpc.Server, *ServerStore) {
+func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
 	ctx := context.Background()
 	logger.Info("Initializing template manager")
 

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -3,34 +3,31 @@ package server
 import (
 	"context"
 	"errors"
-	"sync"
-	"time"
-
-	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
 	"github.com/docker/docker/client"
+	e2bgrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc"
+	l "github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/template-manager/internal/constants"
 	docker "github.com/fsouza/go-dockerclient"
-
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/selector"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
-	e2bgrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc"
+	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	l "github.com/e2b-dev/infra/packages/shared/pkg/logger"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/build"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/cache"
-	"github.com/e2b-dev/infra/packages/template-manager/internal/constants"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/template"
+	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
 type ServerStore struct {
@@ -49,6 +46,7 @@ type ServerStore struct {
 
 func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
 	ctx := context.Background()
+
 	logger.Info("Initializing template manager")
 
 	opts := []logging.Option{
@@ -57,7 +55,7 @@ func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
 		logging.WithFieldsFromContext(logging.ExtractFields),
 	}
 
-	s := grpc.NewServer(
+	server := grpc.NewServer(
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             5 * time.Second, // Minimum time between pings from client
 			PermitWithoutStream: true,            // Allow pings even when no active streams
@@ -103,30 +101,34 @@ func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
 		templateStorage:  templateStorage,
 		healthStatus:     templatemanager.HealthState_Healthy,
 		wg:               &sync.WaitGroup{},
+		server:           server,
 	}
 
-	templatemanager.RegisterTemplateServiceServer(s, store)
-	grpc_health_v1.RegisterHealthServer(s, health.NewServer())
+	templatemanager.RegisterTemplateServiceServer(server, store)
+	grpc_health_v1.RegisterHealthServer(server, health.NewServer())
 
-	return s, store
+	return server, store
 }
 
 func (s *ServerStore) Close(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
-		return errors.New("context cancelled during server graceful shutdown")
+		return errors.New("context canceled during server graceful shutdown")
 	default:
 		// no new jobs should be started
+		zap.L().Info("marking service as draining")
 		s.healthStatus = templatemanager.HealthState_Draining
 		if !env.IsLocal() {
 			time.Sleep(5 * time.Second)
 		}
 
 		// wait for all builds to finish
+		zap.L().Info("waiting for all jobs to finish")
 		s.wg.Wait()
 
 		if !env.IsLocal() {
 			// give some time so all connected services can check build status
+			zap.L().Info("waiting before shutting down server")
 			time.Sleep(15 * time.Second)
 		}
 

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -14,12 +14,12 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc/keepalive"
+	"sync"
+	"time"
 
 	artifactregistry "cloud.google.com/go/artifactregistry/apiv1"
-	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
-	l "github.com/e2b-dev/infra/packages/shared/pkg/logger"
-
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/build"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/cache"
 	"github.com/e2b-dev/infra/packages/template-manager/internal/template"

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -44,7 +44,7 @@ type ServerStore struct {
 	wg               *sync.WaitGroup // wait group for running builds
 }
 
-func New(logger *zap.Logger, buildLogger *zap.Logger) *grpc.Server {
+func New(logger *zap.Logger, buildLogger *zap.Logger) (*grpc.Server, *ServerStore) {
 	ctx := context.Background()
 
 	logger.Info("Initializing template manager")

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"sync"
 	"time"
 

--- a/packages/template-manager/internal/server/main.go
+++ b/packages/template-manager/internal/server/main.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"sync"
 	"time"
 


### PR DESCRIPTION
Adds safe shutdown for template manager that waits for all jobs to be finished. Adds kill timeout for template manager service in nomad.

Currently depends on https://github.com/e2b-dev/infra/pull/508 to remove cherry picks from this PR.