### PR TITLE
Wait for services healthcheck instead of sleep

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -53,8 +53,8 @@ runs:
         mkdir -p ~/logs
         
         # Start orchestrator
-        ./scripts/start_service.sh "Orchestrator" packages/orchestrator run-debug ~/logs/orchestrator.log http://localhost:5008/health
+        bash ./scripts/start-service.sh "Orchestrator" packages/orchestrator run-debug ~/logs/orchestrator.log http://localhost:5008/health
         
         # Start API
-        ./scripts/start_service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
+        bash ./scripts/start-service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
       shell: bash

--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -51,14 +51,10 @@ runs:
         echo "SUPABASE_JWT_SECRETS=${SUPABASE_JWT_SECRETS}" >> .env.test
         
         mkdir -p ~/logs
-
-        make -C packages/orchestrator run-debug 2>&1 | tee ~/logs/orchestrator.log &
-        ORCH_PID=$!
-        sleep 30
-        if ps -p $ORCH_PID > /dev/null; then echo "Orchestrator started, starting API now..."; else exit 1; fi
-
-        make -C packages/api run 2>&1 | tee ~/logs/api.log &
-        API_PID=$!
-        sleep 30
-        if ps -p $API_PID > /dev/null; then echo "API service started"; else exit 1; fi
+        
+        # Start orchestrator
+        ./scripts/start_service.sh "Orchestrator" packages/orchestrator run-debug ~/logs/orchestrator.log http://localhost:5008/health
+        
+        # Start API
+        ./scripts/start_service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
       shell: bash

--- a/packages/orchestrator/internal/server/healthcheck.go
+++ b/packages/orchestrator/internal/server/healthcheck.go
@@ -138,7 +138,11 @@ func (h *Healthcheck) healthHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	if h.status == Unhealthy {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/scripts/start-service.sh
+++ b/scripts/start-service.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Default timeout, override with STARTUP_TIMEOUT env
+TIMEOUT=${STARTUP_TIMEOUT:-30}
+
+if [ "$#" -ne 5 ]; then
+    echo "Usage: $0 <name> <make_path> <make_command> <log_file> <health_url>"
+    exit 1
+fi
+
+NAME="$1"
+MAKE_PATH="$2"
+MAKE_COMMAND="$3"
+LOG_FILE="$4"
+HEALTH_URL="$5"
+
+echo "Starting $NAME..."
+make -C "$MAKE_PATH" "$MAKE_COMMAND" 2>&1 | tee "$LOG_FILE" &
+
+echo "Waiting for $NAME to become healthy at $HEALTH_URL (timeout: $TIMEOUT seconds)..."
+for ((i = 0; i < TIMEOUT; i++)); do
+    if curl -s -o /dev/null -w "%{http_code}" "$HEALTH_URL" | grep -q 200; then
+        echo "$NAME is healthy and running."
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "$NAME failed to become healthy in time."
+exit 1


### PR DESCRIPTION
Await healthy services in the integration tests based on healthcheck (/health endpoint) and not just sleeping fixed amount of seconds. This also speeds up the tests total time.