### PR TITLE
Fix bug for outer retry will eat  inner retry.stop error and continue instead of stopping bug for template manager api polling logic

### DIFF
--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -187,6 +187,7 @@ func (c *PollBuildStatus) setStatus() error {
 	if err != nil && errors.Is(err, context.DeadlineExceeded) {
 		return errors.Wrap(err, "context deadline exceeded")
 	} else if err != nil { // retry only on context deadline exceeded
+		c.logger.Error("terminal error when polling build status", zap.Error(err))
 		return terminalError
 	}
 

--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -176,6 +176,8 @@ func (c *PollBuildStatus) poll() {
 	}
 }
 
+// terminalError is a terminal error that should not be retried
+// set like this so that we can check for it using errors.Is
 var terminalError = retry.Stop(errors.WithStack(errors.New("terminal error")))
 
 func (c *PollBuildStatus) setStatus() error {

--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -42,7 +42,7 @@ func (f fakeTemplateManagerClient) SetFinished(ctx context.Context, templateID s
 	return f.setFinishedError
 }
 
-func TestPollBuildStatus_getSetStatusFn(t *testing.T) {
+func TestPollBuildStatus_setStatus(t *testing.T) {
 	type fields struct {
 		statusClient testStatusClient
 		buildID      uuid.UUID
@@ -299,4 +299,94 @@ type fakeBuildStatusSetter struct {
 
 func (f *fakeBuildStatusSetter) setBuildStatus() error {
 	return f.setBuildStatusError
+}
+
+func TestPollBuildStatus_setStatusReturnsCorrectErrorType(t *testing.T) {
+	// TemplateBuildStatus returns context deadline exceeded, return a normal (retryable) error
+	// otherwise return a non-retryable error
+	type testCase struct {
+		name         string
+		isRetryable  bool
+		statusClient *fakeStatusClient
+	}
+
+	tests := []testCase{
+		{
+			name:        "should return retryable error if context deadline exceeded",
+			isRetryable: true,
+			statusClient: &fakeStatusClient{
+				err: context.DeadlineExceeded,
+			},
+		},
+		{
+			name:        "should return non-retryable error if error is not context deadline exceeded",
+			isRetryable: false,
+			statusClient: &fakeStatusClient{
+				err: errors.New("some other error"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		c := &PollBuildStatus{
+			statusClient: tt.statusClient,
+			logger:       zap.NewNop(),
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.setStatus()
+			// compare error types
+			retryable := isErrorRetryable(err)
+			if retryable != tt.isRetryable {
+				t.Errorf("Expected retryable error %v, got %v", tt.isRetryable, retryable)
+			}
+		})
+	}
+}
+
+func Test_isErrorRetryable(t *testing.T) {
+	type args struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "should return true if normal error",
+			args: args{
+				err: errors.New("some other error"),
+			},
+			want: true,
+		},
+		{
+			name: "should return false if error is not retryable",
+			args: args{
+				err: terminalError,
+			},
+			want: false,
+		},
+
+		{
+			name: "should return true if error is nil",
+			args: args{
+				err: nil,
+			},
+			want: true,
+		},
+		// context deadline exceeded
+		{
+			name: "should return true if error is context deadline exceeded",
+			args: args{
+				err: context.DeadlineExceeded,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isErrorRetryable(tt.args.err); got != tt.want {
+				t.Errorf("isErrorRetryable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -365,14 +365,6 @@ func Test_isErrorRetryable(t *testing.T) {
 			},
 			want: false,
 		},
-
-		{
-			name: "should return true if error is nil",
-			args: args{
-				err: nil,
-			},
-			want: true,
-		},
 		// context deadline exceeded
 		{
 			name: "should return true if error is context deadline exceeded",


### PR DESCRIPTION
the inner polling loop behaves like this 
```
	if err != nil && strings.Contains(err.Error(), "context deadline exceeded") {
		return errors.Wrap(err, "context deadline exceeded")
	} else if err != nil { // retry only on context deadline exceeded
		return retry.Stop(errors.Wrap(err, "error when polling build status"))
	}
```
which the outer polling loop receives like this 
```
	err := retrier.Run(c.setStatus)
	if err != nil {
		return errors.Wrap(err, "error when polling build status")
	}
```

which would result in polling for errors that should be stopped from the inner loop from the outer loop. This changes adds a check for terminal errors to bubble up the callstack and stop the outer loop from the inner loop and tests for this behavior