### PR TITLE
Retry integration tests on fail

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,19 +26,19 @@ jobs:
         uses: ./.github/actions/start-services
 
       - name: Run Integration Tests
+        uses: nick-fields/retry@v3
         env:
           TESTS_API_SERVER_URL: "http://localhost:3000"
           TESTS_ORCHESTRATOR_HOST: "localhost:5008"
-        run: |
-          # Monitor logs of the services
-          ls -l ~/logs
-          tail -f ~/logs/orchestrator.log -n 0 &
-          tail -f ~/logs/api.log -n 0 &
-
-      - uses: nick-fields/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           retry_on: error
-          # Run the integration tests
-          command: make test-integration
+          command: |
+            # Monitor logs of the services
+            ls -l ~/logs
+            tail -f ~/logs/orchestrator.log -n 0 &
+            tail -f ~/logs/api.log -n 0 &
+            
+            # Run the integration tests
+            make test-integration

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,5 +35,10 @@ jobs:
           tail -f ~/logs/orchestrator.log -n 0 &
           tail -f ~/logs/api.log -n 0 &
 
+      - uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_on: error
           # Run the integration tests
-          make test-integration
+          command: make test-integration


### PR DESCRIPTION
Retry integration tests on fail (3 times max) to prevent flakiness with the EOF error