### PR TITLE
Handle retry error in correct scope

### DIFF
--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -361,7 +361,9 @@ func Test_isErrorRetryable(t *testing.T) {
 		{
 			name: "should return false if error is not retryable",
 			args: args{
-				err: terminalError,
+				err: terminalError{
+					err: errors.New("some other error"),
+				},
 			},
 			want: false,
 		},


### PR DESCRIPTION
Before, when template manager was killed, the outer loop would continue to retry because the retry.Stop error was not returned in the proper scope. 

This change moves that logic to the proper scope so that we don't continue to retry when we reach a terminal state. 

tested by deploying to local cluster, running a build and killing template-manager job. 

logs: 
```

2025-03-24 14:29:49.803 | Setting template build status |  
-- | -- | --
  |   | 2025-03-24 14:29:49.695 | Template build info found in cache |  
  |   | 2025-03-24 14:29:49.456 | Polling timed out |  
  |   | 2025-03-24 14:29:49.456 | got terminal error when polling build status |  
  |   | 2025-03-24 14:29:49.455 | error when calling setStatus |  
  |   | 2025-03-24 14:29:49.455 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:48.730 | Template build info found in cache |  
  |   | 2025-03-24 14:29:48.384 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:47.755 | Template build info found in cache |  
  |   | 2025-03-24 14:29:47.638 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:46.949 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:46.793 | Template build info found in cache |  
  |   | 2025-03-24 14:29:45.854 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:45.819 | Template build info found in cache |  
  |   | 2025-03-24 14:29:45.183 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:44.852 | Template build info found in cache |  
  |   | 2025-03-24 14:29:44.549 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:43.861 | Template build info found in cache |  
  |   | 2025-03-24 14:29:43.593 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:42.917 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:42.903 | Template build info found in cache |  
  |   | 2025-03-24 14:29:42.424 | terminal error when polling build status |  
  |   | 2025-03-24 14:29:42.397 | Checking template build status |  
  |   | 2025-03-24 14:29:42.397 | Polling build status
```

`Setting template build status` sets builds status to failed and loop exits