### PR TITLE
add keeper to clickhouse for fault tolerance and availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ tf_vars := TF_VAR_client_machine_type=$(CLIENT_MACHINE_TYPE) \
 	TF_VAR_template_bucket_location=$(TEMPLATE_BUCKET_LOCATION) \
 	TF_VAR_clickhouse_connection_string=$(CLICKHOUSE_CONNECTION_STRING) \
 	TF_VAR_clickhouse_username=$(CLICKHOUSE_USERNAME) \
-	TF_VAR_clickhouse_database=$(CLICKHOUSE_DATABASE) 
+	TF_VAR_clickhouse_database=$(CLICKHOUSE_DATABASE) \
+	TF_VAR_clickhouse_enabled=$(CLICKHOUSE_ENABLED)
 
 # Login for Packer and Docker (uses gcloud user creds)
 # Login for Terraform (uses application default creds)

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ module "nomad" {
   clickhouse_username          = "clickhouse"
   clickhouse_password          = module.init.clickhouse_password_secret_data
   clickhouse_database          = "default"
-
+  clickhouse_enabled           = var.clickhouse_enabled
   # API
   api_machine_count                         = var.api_cluster_size
   logs_proxy_address                        = "http://${module.cluster.logs_proxy_ip}"

--- a/packages/cluster/main.tf
+++ b/packages/cluster/main.tf
@@ -154,6 +154,29 @@ module "client_cluster" {
   depends_on = [google_storage_bucket_object.setup_config_objects["scripts/run-nomad.sh"], google_storage_bucket_object.setup_config_objects["scripts/run-consul.sh"]]
 }
 
+# Add Filestore instance for NFS
+resource "google_filestore_instance" "api_nfs" {
+  name     = "${var.prefix}-api-nfs"
+  tier     = "BASIC_HDD"
+  location = var.gcp_zone
+
+  file_shares {
+    name        = "api_share"
+    capacity_gb = 1024
+    nfs_export_options {
+      ip_ranges   = ["10.0.0.0/8"] # VPC network range - adjust as needed
+      access_mode = "READ_WRITE"
+      squash_mode = "NO_ROOT_SQUASH"
+    }
+  }
+
+  networks {
+    network = var.network_name
+    modes   = ["MODE_IPV4"]
+  }
+}
+
+
 module "api_cluster" {
   source = "./api-cluster"
 
@@ -172,6 +195,10 @@ module "api_cluster" {
     RUN_NOMAD_FILE_HASH          = local.file_hash["scripts/run-api-nomad.sh"]
     CONSUL_GOSSIP_ENCRYPTION_KEY = google_secret_manager_secret_version.consul_gossip_encryption_key.secret_data
     CONSUL_DNS_REQUEST_TOKEN     = google_secret_manager_secret_version.consul_dns_request_token.secret_data
+
+    NFS_IP         = google_filestore_instance.api_nfs.networks[0].ip_addresses[0]
+    NFS_SHARE      = "/api_share"
+    NFS_MOUNT_PATH = "/mnt/nfs"
   })
 
   environment = var.environment

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -136,11 +136,6 @@ function generate_nomad_config {
   instance_region=$(get_instance_region)
   zone=$(get_instance_zone)
 
-  # Create a directory for ClickHouse data if it doesn't exist
-  # since this config is dependent on the volume being present
-  clickhouse_data_dir="/mnt/nfs/clickhouse/data"
-  mkdir -p "$clickhouse_data_dir/clickhouse-server"
-  mkdir -p "$clickhouse_data_dir/clickhouse-keeper"
 
   log_info "Creating default Nomad config file in $config_path"
   cat >"$config_path" <<EOF
@@ -160,15 +155,7 @@ leave_on_terminate = true
 
 client {
 
-  host_volume "clickhouse-server" {
-    path      = "$clickhouse_data_dir/clickhouse-server"
-    read_only = false
-  }
 
-  host_volume "clickhouse-keeper" {
-    path      = "$clickhouse_data_dir/clickhouse-keeper"
-    read_only = false
-  }
   
   enabled = true
   node_pool = "api"

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -299,7 +299,11 @@ function run {
     shift
   done
 
-
+  export ARCH_CNI=$([ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)
+  export CNI_PLUGIN_VERSION=v1.6.2
+  curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH_CNI}-${CNI_PLUGIN_VERSION}".tgz &&
+    sudo mkdir -p /opt/cni/bin &&
+    sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 
   use_sudo="true"
 

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -136,6 +136,11 @@ function generate_nomad_config {
   instance_region=$(get_instance_region)
   zone=$(get_instance_zone)
 
+  # Create a directory for ClickHouse data if it doesn't exist
+  # since this config is dependent on the volume being present
+  clickhouse_data_dir="/mnt/nfs/clickhouse/data"
+  mkdir -p "$clickhouse_data_dir/clickhouse-server"
+  mkdir -p "$clickhouse_data_dir/clickhouse-keeper"
 
   log_info "Creating default Nomad config file in $config_path"
   cat >"$config_path" <<EOF
@@ -155,7 +160,15 @@ leave_on_terminate = true
 
 client {
 
+  host_volume "clickhouse-server" {
+    path      = "$clickhouse_data_dir/clickhouse-server"
+    read_only = false
+  }
 
+  host_volume "clickhouse-keeper" {
+    path      = "$clickhouse_data_dir/clickhouse-keeper"
+    read_only = false
+  }
   
   enabled = true
   node_pool = "api"

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -139,7 +139,8 @@ function generate_nomad_config {
   # Create a directory for ClickHouse data if it doesn't exist
   # since this config is dependent on the volume being present
   clickhouse_data_dir="/mnt/nfs/clickhouse/data"
-  mkdir -p "$clickhouse_data_dir"
+  mkdir -p "$clickhouse_data_dir/clickhouse-server"
+  mkdir -p "$clickhouse_data_dir/clickhouse-keeper"
 
   log_info "Creating default Nomad config file in $config_path"
   cat >"$config_path" <<EOF
@@ -159,8 +160,13 @@ leave_on_terminate = true
 
 client {
 
-  host_volume "clickhouse" {
-    path      = "$clickhouse_data_dir"
+  host_volume "clickhouse-server" {
+    path      = "$clickhouse_data_dir/clickhouse-server"
+    read_only = false
+  }
+
+  host_volume "clickhouse-keeper" {
+    path      = "$clickhouse_data_dir/clickhouse-keeper"
     read_only = false
   }
   

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -136,6 +136,10 @@ function generate_nomad_config {
   instance_region=$(get_instance_region)
   zone=$(get_instance_zone)
 
+  # Create a directory for ClickHouse data if it doesn't exist
+  # since this config is dependent on the volume being present
+  clickhouse_data_dir="/mnt/nfs/clickhouse/data"
+  mkdir -p "$clickhouse_data_dir"
 
   log_info "Creating default Nomad config file in $config_path"
   cat >"$config_path" <<EOF
@@ -154,6 +158,12 @@ leave_on_interrupt = true
 leave_on_terminate = true
 
 client {
+
+  host_volume "clickhouse" {
+    path      = "$clickhouse_data_dir"
+    read_only = false
+  }
+  
   enabled = true
   node_pool = "api"
   meta {

--- a/packages/cluster/scripts/start-api.sh
+++ b/packages/cluster/scripts/start-api.sh
@@ -6,7 +6,6 @@
 
 set -euo pipefail
 
-
 # Set timestamp format
 PS4='[\D{%Y-%m-%d %H:%M:%S}] '
 # Enable command tracing
@@ -30,8 +29,7 @@ mkdir -p "${NFS_MOUNT_PATH}"
 mount -t nfs -o rw,hard,intr "${NFS_IP}:${NFS_SHARE}" "${NFS_MOUNT_PATH}"
 
 # Add to fstab for persistence
-echo "${NFS_IP}:${NFS_SHARE} ${NFS_MOUNT_PATH} nfs defaults,_netdev 0 0" >> /etc/fstab
-
+echo "${NFS_IP}:${NFS_SHARE} ${NFS_MOUNT_PATH} nfs defaults,_netdev 0 0" >>/etc/fstab
 
 sudo tee -a /etc/sysctl.conf <<EOF
 # Increase the maximum number of socket connections
@@ -64,7 +62,6 @@ cat <<EOF >/root/docker/config.json
 }
 EOF
 
-
 mkdir -p /etc/systemd/resolved.conf.d/
 touch /etc/systemd/resolved.conf.d/consul.conf
 cat <<EOF >/etc/systemd/resolved.conf.d/consul.conf
@@ -73,6 +70,14 @@ DNS=127.0.0.1:8600
 DNSSEC=false
 Domains=~consul
 EOF
+
+touch /etc/systemd/resolved.conf.d/docker.conf
+cat <<EOF >/etc/systemd/resolved.conf.d/docker.conf
+[Resolve]
+DNSStubListener=yes
+DNSStubListenerExtra=172.17.0.1
+EOF
+
 systemctl restart systemd-resolved
 
 # These variables are passed in via Terraform template interpolation

--- a/packages/cluster/scripts/start-api.sh
+++ b/packages/cluster/scripts/start-api.sh
@@ -19,6 +19,21 @@ exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&
 ulimit -n 1048576
 export GOMAXPROCS='nproc'
 
+# Install NFS client
+apt-get update
+apt-get install -y nfs-common
+
+
+# Create mount directory
+mkdir -p "${NFS_MOUNT_PATH}"
+
+# Mount NFS share
+mount -t nfs -o rw,hard,intr "${NFS_IP}:${NFS_SHARE}" "${NFS_MOUNT_PATH}"
+
+# Add to fstab for persistence
+echo "${NFS_IP}:${NFS_SHARE} ${NFS_MOUNT_PATH} nfs defaults,_netdev 0 0" >> /etc/fstab
+
+
 sudo tee -a /etc/sysctl.conf <<EOF
 # Increase the maximum number of socket connections
 net.core.somaxconn = 65535

--- a/packages/cluster/scripts/start-api.sh
+++ b/packages/cluster/scripts/start-api.sh
@@ -23,7 +23,6 @@ export GOMAXPROCS='nproc'
 apt-get update
 apt-get install -y nfs-common
 
-
 # Create mount directory
 mkdir -p "${NFS_MOUNT_PATH}"
 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -144,10 +144,10 @@ job "clickhouse" {
                     <host>clickhouse-1</host>
                     <port>9000</port>
                 </replica>
-                <replica>
-                    <host>clickhouse-2</host>
-                    <port>9000</port>
-                </replica>
+                # <replica>
+                #     <host>clickhouse-2</host>
+                #     <port>9000</port>
+                # </replica>
             </shard>
         </cluster_1>
     </remote_servers>

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -51,6 +51,13 @@ job "clickhouse" {
       ]
     }
 
+
+    volume "clickhouse" {
+      type      = "host"
+      read_only = false
+      source    = "clickhouse"
+    }
+
     task "clickhouse-server" {
       driver = "docker"
 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -1,3 +1,4 @@
+
 job "clickhouse" {
   datacenters = ["${zone}"]
   type        = "service"
@@ -301,15 +302,15 @@ EOF
 <?xml version="1.0"?>
 <clickhouse>
     <users>
-        <bar>
-            <password>password</password>
+        <${username}>
+            <password_sha256_hex>${password_sha256_hex}</password_sha256_hex>
             <networks>
                 <ip>::/0</ip>
             </networks>
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>
-        </bar>
+        </${user}>
     </users>
 </clickhouse>
 EOF

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -3,129 +3,220 @@ job "clickhouse" {
   type        = "service"
   node_pool   = "api"
 
-
-  group "clickhouse" {
-
-    update {
-      max_parallel     = 2
-      min_healthy_time = "30s"
-      healthy_deadline = "4m"
-
-      auto_revert = true
-    }
-
+  %{ for i in range("${keeper_count}") }
+  group "keeper-${i + 1}" {
     count = 1
 
+    update {
+      max_parallel = 0
+    }
+
     network {
+      mode = "bridge"
+
+      dns {
+        servers = ["172.17.0.1", "8.8.8.8", "8.8.4.4", "169.254.169.254"]
+      }
+
+      port "keeper" {
+        static = ${9181 + i}
+        to = ${9181 + i}
+      }
+
+      port "raft" {
+        static = ${9234 + i}
+        to = ${9234 + i}
+      }
+    }
+
+    service {
+      name = "clickhouse-keeper-${i + 1}"
+      port = "keeper"
+    }
+
+    service {
+      name = "clickhouse-keeper-raft-${i + 1}"
+      port = "raft"
+    }
+
+    task "clickhouse-keeper" {
+      driver = "docker"
+
+      config {
+        image = "clickhouse/clickhouse-server:25.3"
+        ports = ["keeper", "raft"]
+
+        extra_hosts = [
+          "clickhouse-keeper-${i + 1}.service.consul:127.0.0.1",
+          "clickhouse-keeper-raft-${i + 1}.service.consul:127.0.0.1",
+        ]
+
+        volumes = [
+          "/mnt/nfs/clickhouse/data/clickhouse-keeper-${i + 1}:/var/lib/clickhouse",
+          "local/keeper.xml:/etc/clickhouse-server/config.d/keeper_config.xml",
+        ]
+      }
+
+      resources {
+        cpu    = 400
+        memory = 512
+      }
+
+      template {
+        destination = "local/keeper.xml"
+        data        = <<EOF
+<?xml version="1.0"?>
+<clickhouse>
+
+    <logger>
+        <console>1</console>
+        <level>information</level>
+    </logger>
+
+    <keeper_server>
+        <log_storage_disk>log_s3</log_storage_disk>
+        <latest_log_storage_disk>log_local</latest_log_storage_disk>
+
+        <snapshot_storage_disk>snapshot_s3</snapshot_storage_disk>
+        <latest_snapshot_storage_disk>snapshot_s3</latest_snapshot_storage_disk>
+
+        <state_storage_disk>state_s3</state_storage_disk>
+        <latest_state_storage_disk>state_s3</latest_state_storage_disk>
+
+        <tcp_port>${9181 + i}</tcp_port>
+        <server_id>${i + 1}</server_id>
+
+         <raft_configuration>
+         %{ for j in range("${keeper_count}") }
+            <server>
+                <id>${j + 1}</id>
+                <hostname>clickhouse-keeper-raft-${j + 1}.service.consul</hostname>
+                <port>${9234 + j}</port>
+            </server>
+            %{ endfor }
+        </raft_configuration>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+        </coordination_settings>
+    </keeper_server>
+
+    <storage_configuration>
+        <disks>
+            <log_local>
+                <type>local</type>
+                <path>/var/lib/clickhouse/coordination/logs/</path>
+            </log_local>
+            <log_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/keeper-${i + 1}/logs/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </log_s3>
+            <snapshot_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/keeper-${i + 1}/snapshots/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </snapshot_s3>
+            <state_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/keeper-${i + 1}/state/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </state_s3>
+        </disks>
+    </storage_configuration>
+</clickhouse> 
+EOF
+      }
+    }
+  }
+  %{ endfor }
+
+
+%{ for i in range("${server_count}") }
+  group "server-${i + 1}" {
+    count = 1
+
+    update {
+      max_parallel = 0
+    }
+
+    network {
+      mode = "bridge"
+
+      dns {
+        servers = ["172.17.0.1", "8.8.8.8", "8.8.4.4", "169.254.169.254"]
+      }
+
+      port "http" {
+        static = ${8123 + i}
+        to = ${8123 + i}
+      }
+
       port "clickhouse" {
-        to     = 9000
-        static = 9000
+        static = ${9000 + i}
+        to = ${9000 + i}
       }
 
-      port "clickhouse_http" {
-        static = 8123
-        to     = 8123
-      }
-
-      port "clickhouse-keeper" {
-        static = 9181
-        to     = 9181
-      }
-
-      port "clickhouse-keeper-raft" {
-        static = 9234
-        to     = 9234
+      port "interserver" {
+        static = ${9009 + i}
+        to = ${9009 + i}
       }
     }
 
     service {
-      name = "clickhouse"
+      name = "clickhouse-http-${i + 1}"
+      port = "http"
+    }
+
+    service {
+      name = "clickhouse-${i + 1}"
       port = "clickhouse"
-
-      check {
-        type     = "http"
-        path     = "/ping"
-        port     = "clickhouse_http"
-        interval = "10s"
-        timeout  = "5s"
-      }
-
-      tags = [
-        "traefik.enable=true",
-        "traefik.http.routers.clickhouse.rule=Host(`clickhouse.service.consul`)",
-      ]
     }
 
     service {
-      name = "clickhouse-keeper"
-      port = "clickhouse-keeper"
-
-      check {
-        type     = "tcp"
-        interval = "10s"
-        timeout  = "5s"
-      }
+      name = "clickhouse-interserver-${i + 1}"
+      port = "interserver"
     }
-
-    service {
-      name = "clickhouse-keeper-raft"
-      port = "clickhouse-keeper-raft"
-
-      check {
-        type     = "tcp"
-        interval = "10s"
-        timeout  = "5s"
-      }
-    }
-
-    volume "clickhouse-server" {
-      type      = "host"
-      read_only = false
-      source    = "clickhouse-server"
-    }
-
-    volume "clickhouse-keeper" {
-      type      = "host"
-      read_only = false
-      source    = "clickhouse-keeper"
-    }
-
-
 
     task "clickhouse-server" {
       driver = "docker"
 
-      volume_mount {
-        volume      = "clickhouse-server"
-        destination = "/var/lib/clickhouse"
-        read_only   = false
-      }
-
-      kill_timeout = "120s"
-
-      resources {
-        cpu    = 500
-        memory = 2048
-      }
-
       config {
-        image = "clickhouse/clickhouse-server:${clickhouse_version}"
-        ports = ["clickhouse", "clickhouse_http"]
+        image = "clickhouse/clickhouse-server:25.3"
+        ports = ["http", "clickhouse", "interserver"]
+
+        extra_hosts = [
+          "clickhouse-http-${i + 1}.service.consul:127.0.0.1",
+          "clickhouse-${i + 1}.service.consul:127.0.0.1",
+          "clickhouse-interserver-${i + 1}.service.consul:127.0.0.1",
+        ]
+
+        volumes = [
+          "/mnt/nfs/clickhouse/data/clickhouse-server-${i + 1}:/var/lib/clickhouse",
+          "local/config.xml:/etc/clickhouse-server/config.d/config.xml",
+          "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
+          "local/macros.xml:/etc/clickhouse-server/config.d/macros.xml",
+        ]
 
         ulimit {
           nofile = "262144:262144"
         }
+      }
 
-
-        volumes = [
-          "local/config.xml:/etc/clickhouse-server/config.d/gcs.xml",
-          # disabled while testing but will pass password to orchestrator in the future
-          "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
-          "local/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
-        ]
+      resources {
+        cpu    = 500
+        memory = 1024
       }
 
       template {
+        destination = "local/config.xml"
         data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
@@ -133,7 +224,6 @@ job "clickhouse" {
      # see https://github.com/ClickHouse/ClickHouse/pull/77515 for more details
     <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
     <shutdown_wait_unfinished_queries>1</shutdown_wait_unfinished_queries>
-
 
     <logger>
         <console>1</console>
@@ -148,25 +238,25 @@ job "clickhouse" {
         <path>/var/lib/clickhouse/task_queue/ddl</path>
     </distributed_ddl>
 
-        <default_replica_path>/var/lib/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>
-
-
-
+    <default_replica_path>/var/lib/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>
 
     <zookeeper>
+        %{ for j in range("${keeper_count}") }
         <node>
-            <host>{{ env "NOMAD_IP_clickhouse_keeper" }}</host>
-            <port>9181</port>
+            <host>clickhouse-keeper-${j + 1}.service.consul</host>
+            <port>${9181 + j}</port>
         </node>
+        %{ endfor }
     </zookeeper>
     <storage_configuration>
-        <disks>
+         <disks>
             <s3>
-                <support_batch_delete>false</support_batch_delete>
                 <type>s3</type>
-                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/</endpoint>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/server-${i + 1}/</endpoint>
                 <access_key_id>${hmac_key}</access_key_id>
                 <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+                # <metadata_type>plain_rewritable</metadata_type>
             </s3>
         </disks>
            <policies>
@@ -184,152 +274,61 @@ job "clickhouse" {
         <secret>mysecretphrase</secret>
             <shard>
                 <internal_replication>true</internal_replication>
+                %{ for j in range("${server_count}") }
                 <replica>
-                    <host>{{ env "NOMAD_IP_clickhouse" }}</host>
-                    <port>9000</port>
+                    <host>clickhouse-${j + 1}.service.consul</host>
+                    <port>${9000 + j}</port>
                 </replica>
+                %{ endfor }
             </shard>
         </cluster>
     </remote_servers>
+
     <listen_host>0.0.0.0</listen_host>
-    <interserver_http_port>9010</interserver_http_port>
-    <interserver_http_host>{{ env "NOMAD_IP_clickhouse" }}</interserver_http_host>
+
+    <http_port>${8123 + i}</http_port>
+    <tcp_port>${9000 + i}</tcp_port>
+
+    <interserver_http_host>clickhouse-interserver-${i + 1}.service.consul</interserver_http_host>
+    <interserver_http_port>${9009 + i}</interserver_http_port>
 </clickhouse>
 EOF
-        destination = "local/config.xml"
       }
 
       template {
+        destination = "local/users.xml"
         data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
     <users>
-        <${username}>
-            <password_sha256_hex>${password_sha256_hex}</password_sha256_hex>
+        <bar>
+            <password>password</password>
             <networks>
                 <ip>::/0</ip>
             </networks>
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>
-        </${username}>
+        </bar>
     </users>
 </clickhouse>
 EOF
-        destination = "local/users.xml"
       }
 
       template {
+        destination = "local/macros.xml"
         data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
     <macros>
         <cluster>cluster</cluster>
         <shard>01</shard>
-        <replica>01</replica>
+        <replica>0${i + 1}</replica>
     </macros>
 </clickhouse> 
 EOF
-        destination = "local/macros.xml"
-      }
-    }
-
-
-    task "clickhouse-keeper" {
-      driver = "docker"
-
-      volume_mount {
-        volume      = "clickhouse-keeper"
-        destination = "/var/lib/clickhouse"
-        read_only   = false
-      }
-
-      resources {
-        cpu    = 500
-        memory = 2048
-      }
-
-      config {
-        image = "clickhouse/clickhouse-server:latest"
-
-        ports = ["clickhouse-keeper", "clickhouse-keeper-raft"]
-
-        volumes = [
-          "local/keeper.xml:/etc/clickhouse-server/config.d/keeper.xml",
-        ]
-      }
-
-      template {
-        data        = <<EOF
-<?xml version="1.0"?>
-<clickhouse>
-
-    <logger>
-        <console>1</console>
-         <level>information</level>
-    </logger>
-
-
-   <keeper_server>
-        <log_storage_disk>log_s3</log_storage_disk>
-        <latest_log_storage_disk>log_local</latest_log_storage_disk>
-
-        <snapshot_storage_disk>snapshot_s3</snapshot_storage_disk>
-        <latest_snapshot_storage_disk>snapshot_s3</latest_snapshot_storage_disk>
-
-        <state_storage_disk>state_s3</state_storage_disk>
-        <latest_state_storage_disk>state_s3</latest_state_storage_disk>
-
-        <tcp_port>9181</tcp_port>
-        <server_id>1</server_id>
-
-         <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>{{ env "NOMAD_IP_clickhouse_keeper" }}</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-        </coordination_settings>
-    </keeper_server>
-
-    <storage_configuration>
-        <disks>
-            <log_local>
-                <type>local</type>
-                <path>/var/lib/clickhouse/coordination/logs/</path>
-            </log_local>
-            <log_s3>
-                <type>s3</type>
-                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/logs/</endpoint>
-                <access_key_id>${hmac_key}</access_key_id>
-                <secret_access_key>${hmac_secret}</secret_access_key>
-                <support_batch_delete>false</support_batch_delete>
-            </log_s3>
-            <snapshot_s3>
-                <type>s3</type>
-                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/snapshots/</endpoint>
-                <access_key_id>${hmac_key}</access_key_id>
-                <secret_access_key>${hmac_secret}</secret_access_key>
-                <support_batch_delete>false</support_batch_delete>
-            </snapshot_s3>
-            <state_s3>
-                <type>s3</type>
-                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/state/</endpoint>
-                <access_key_id>${hmac_key}</access_key_id>
-                <secret_access_key>${hmac_secret}</secret_access_key>
-                <support_batch_delete>false</support_batch_delete>
-            </state_s3>
-        </disks>
-    </storage_configuration>
-</clickhouse> 
-EOF
-        destination = "local/keeper.xml"
       }
     }
   }
+%{ endfor }
 } 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -175,7 +175,7 @@ job "clickhouse" {
             <shard>
                 <internal_replication>true</internal_replication>
                 <replica>
-                    <host>clickhouse-1</host>
+                    <host>{{ env "NOMAD_IP_clickhouse" }}</host>
                     <port>9000</port>
                 </replica>
 
@@ -184,7 +184,7 @@ job "clickhouse" {
     </remote_servers>
     <listen_host>0.0.0.0</listen_host>
     <interserver_http_port>9010</interserver_http_port>
-    <interserver_http_host>clickhouse-1</interserver_http_host>
+    <interserver_http_host>{{ env "NOMAD_IP_clickhouse" }}</interserver_http_host>
 </clickhouse>
 EOF
         destination = "local/config.xml"

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -121,6 +121,7 @@ job "clickhouse" {
           "local/config.xml:/etc/clickhouse-server/config.d/gcs.xml",
           # disabled while testing but will pass password to orchestrator in the future
           "local/users.xml:/etc/clickhouse-server/users.d/users.xml",
+          "local/macros.xml:/etc/clickhouse-server/config.d/macros.xml"
         ]
       }
 
@@ -142,6 +143,13 @@ job "clickhouse" {
     <replicated_merge_tree>
         <storage_policy>s3</storage_policy>
     </replicated_merge_tree>
+
+    <distributed_ddl>
+        <path>/var/lib/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+
+        <default_replica_path>/var/lib/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>
+
 
 
 
@@ -171,8 +179,8 @@ job "clickhouse" {
             </s3>
         </policies>
     </storage_configuration>
-        <remote_servers replace="true">
-        <cluster_1>
+    <remote_servers replace="true">
+      <cluster>
         <secret>mysecretphrase</secret>
             <shard>
                 <internal_replication>true</internal_replication>
@@ -180,9 +188,8 @@ job "clickhouse" {
                     <host>{{ env "NOMAD_IP_clickhouse" }}</host>
                     <port>9000</port>
                 </replica>
-
             </shard>
-        </cluster_1>
+        </cluster>
     </remote_servers>
     <listen_host>0.0.0.0</listen_host>
     <interserver_http_port>9010</interserver_http_port>
@@ -217,7 +224,7 @@ EOF
 <?xml version="1.0"?>
 <clickhouse>
     <macros>
-        <cluster>my_cluster</cluster>
+        <cluster>cluster</cluster>
         <shard>01</shard>
         <replica>01</replica>
     </macros>
@@ -294,7 +301,7 @@ EOF
         <disks>
             <log_local>
                 <type>local</type>
-                <path>/tmp/lib/clickhouse/coordination/logs/</path>
+                <path>/var/lib/clickhouse/coordination/logs/</path>
             </log_local>
             <log_s3>
                 <type>s3</type>

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -56,6 +56,27 @@ job "clickhouse" {
       ]
     }
 
+    service {
+      name = "clickhouse-keeper"
+      port = "clickhouse-keeper"
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
+
+    service {
+      name = "clickhouse-keeper-raft"
+      port = "clickhouse-keeper-raft"
+
+      check {
+        type     = "tcp"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
 
     volume "clickhouse" {
       type      = "host"
@@ -116,7 +137,7 @@ job "clickhouse" {
 
     <zookeeper>
         <node>
-            <host>clickhouse-keeper</host>
+            <host>clickhouse-keeper.service.consul</host>
             <port>9181</port>
         </node>
     </zookeeper>
@@ -149,10 +170,7 @@ job "clickhouse" {
                     <host>clickhouse-1</host>
                     <port>9000</port>
                 </replica>
-                # <replica>
-                #     <host>clickhouse-2</host>
-                #     <port>9000</port>
-                # </replica>
+
             </shard>
         </cluster_1>
     </remote_servers>
@@ -211,7 +229,7 @@ EOF
       config {
         image = "clickhouse/clickhouse-server:latest"
 
-        ports = ["clickhouse-keeper"]
+        ports = ["clickhouse-keeper", "clickhouse-keeper-raft"]
 
         volumes = [
           "local/keeper.xml:/etc/clickhouse-server/config.d/keeper.xml",
@@ -245,7 +263,7 @@ EOF
          <raft_configuration>
             <server>
                 <id>1</id>
-                <hostname>clickhouse.service.consul</hostname>
+                <hostname>clickhouse-keeper.service.consul</hostname>
                 <port>9234</port>
             </server>
         </raft_configuration>

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -31,6 +31,11 @@ job "clickhouse" {
         static = 9181
         to     = 9181
       }
+
+      port "clickhouse-keeper-raft" {
+        static = 9234
+        to     = 9234
+      }
     }
 
     service {
@@ -217,7 +222,6 @@ EOF
         data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
-    <path>/clickhouse/data</path>
 
     <logger>
         <console>1</console>
@@ -241,7 +245,7 @@ EOF
          <raft_configuration>
             <server>
                 <id>1</id>
-                <hostname>clickhouse-keeper</hostname>
+                <hostname>clickhouse.service.consul</hostname>
                 <port>9234</port>
             </server>
         </raft_configuration>

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -310,7 +310,7 @@ EOF
             <profile>default</profile>
             <quota>default</quota>
             <access_management>1</access_management>
-        </${user}>
+        </${username}>
     </users>
 </clickhouse>
 EOF

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -78,10 +78,16 @@ job "clickhouse" {
       }
     }
 
-    volume "clickhouse" {
+    volume "clickhouse-server" {
       type      = "host"
       read_only = false
-      source    = "clickhouse"
+      source    = "clickhouse-server"
+    }
+
+    volume "clickhouse-keeper" {
+      type      = "host"
+      read_only = false
+      source    = "clickhouse-keeper"
     }
 
 
@@ -90,7 +96,7 @@ job "clickhouse" {
       driver = "docker"
 
       volume_mount {
-        volume      = "clickhouse"
+        volume      = "clickhouse-server"
         destination = "/var/lib/clickhouse"
         read_only   = false
       }
@@ -126,9 +132,7 @@ job "clickhouse" {
      # see https://github.com/ClickHouse/ClickHouse/pull/77515 for more details
     <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
     <shutdown_wait_unfinished_queries>1</shutdown_wait_unfinished_queries>
-    <path>/clickhouse/data</path>
 
-    <default_replica_path>/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>
 
     <logger>
         <console>1</console>
@@ -139,9 +143,7 @@ job "clickhouse" {
         <storage_policy>s3</storage_policy>
     </replicated_merge_tree>
 
-    <distributed_ddl>
-        <path>/clickhouse/task_queue/ddl</path>
-    </distributed_ddl>
+
 
     <zookeeper>
         <node>
@@ -230,7 +232,7 @@ EOF
       driver = "docker"
 
       volume_mount {
-        volume      = "clickhouse"
+        volume      = "clickhouse-keeper"
         destination = "/var/lib/clickhouse"
         read_only   = false
       }

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -286,4 +286,5 @@ EOF
         destination = "local/keeper.xml"
       }
     }
-  } 
+  }
+} 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -1,7 +1,7 @@
 job "clickhouse" {
   datacenters = ["${zone}"]
   type        = "service"
-  node_pool = "api"
+  node_pool   = "api"
 
 
   group "clickhouse" {
@@ -18,13 +18,18 @@ job "clickhouse" {
 
     network {
       port "clickhouse" {
-        to = 9000
+        to     = 9000
         static = 9000
       }
-      
+
       port "clickhouse_http" {
         static = 8123
-        to = 8123
+        to     = 8123
+      }
+
+      port "clickhouse-keeper" {
+        static = 9181
+        to     = 9181
       }
     }
 
@@ -73,47 +78,82 @@ job "clickhouse" {
       }
 
       template {
-        data = <<EOF
+        data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
      # this is undocumented but needed to enable waiting for for shutdown for a custom amount of time 
      # see https://github.com/ClickHouse/ClickHouse/pull/77515 for more details
     <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
     <shutdown_wait_unfinished_queries>1</shutdown_wait_unfinished_queries>
+    <path>/clickhouse/data</path>
+
+    <default_replica_path>/clickhouse/tables/{shard}/{database}/{table}</default_replica_path>
+
+    <logger>
+        <console>1</console>
+         <level>information</level>
+    </logger>
+
+    <replicated_merge_tree>
+        <storage_policy>s3</storage_policy>
+    </replicated_merge_tree>
+
+    <distributed_ddl>
+        <path>/clickhouse/task_queue/ddl</path>
+    </distributed_ddl>
+
+    <zookeeper>
+        <node>
+            <host>clickhouse-keeper</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
     <storage_configuration>
         <disks>
-            <gcs>
+            <s3>
                 <support_batch_delete>false</support_batch_delete>
                 <type>s3</type>
                 <endpoint>https://storage.googleapis.com/${gcs_bucket}/${gcs_folder}/</endpoint>
                 <access_key_id>${hmac_key}</access_key_id>
                 <secret_access_key>${hmac_secret}</secret_access_key>
-                <metadata_path>/var/lib/clickhouse/disks/gcs/</metadata_path>
-            </gcs>
-            <gcs_cache>
-                <type>cache</type>
-                <disk>gcs</disk>
-                <path>/var/lib/clickhouse/disks/gcs_cache/</path>
-                <max_size>1Gi</max_size>
-            </gcs_cache>
+            </s3>
         </disks>
-        <policies>
-            <gcs_main>
+           <policies>
+            <s3>
                 <volumes>
                     <main>
-                        <disk>gcs_cache</disk>
+                        <disk>s3</disk>
                     </main>
                 </volumes>
-            </gcs_main>
+            </s3>
         </policies>
     </storage_configuration>
+        <remote_servers replace="true">
+        <cluster_1>
+        <secret>mysecretphrase</secret>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>clickhouse-1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>clickhouse-2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </cluster_1>
+    </remote_servers>
+    <listen_host>0.0.0.0</listen_host>
+    <interserver_http_port>9010</interserver_http_port>
+    <interserver_http_host>clickhouse-1</interserver_http_host>
 </clickhouse>
 EOF
         destination = "local/config.xml"
       }
 
       template {
-        data = <<EOF
+        data        = <<EOF
 <?xml version="1.0"?>
 <clickhouse>
     <users>
@@ -132,6 +172,111 @@ EOF
         destination = "local/users.xml"
       }
 
+      template {
+        data        = <<EOF
+<?xml version="1.0"?>
+<clickhouse>
+    <macros>
+        <cluster>my_cluster</cluster>
+        <shard>01</shard>
+        <replica>01</replica>
+    </macros>
+</clickhouse> 
+EOF
+        destination = "local/macros.xml"
+      }
     }
-  }
-} 
+
+
+    task "clickhouse-keeper" {
+      driver = "docker"
+
+      resources {
+        cpu    = 500
+        memory = 2048
+      }
+
+      config {
+        image = "clickhouse/clickhouse-server:latest"
+
+        ports = ["clickhouse-keeper"]
+
+        volumes = [
+          "local/keeper.xml:/etc/clickhouse-server/config.d/keeper.xml",
+        ]
+      }
+
+      template {
+        data        = <<EOF
+<?xml version="1.0"?>
+<clickhouse>
+    <path>/clickhouse/data</path>
+
+    <logger>
+        <console>1</console>
+         <level>information</level>
+    </logger>
+
+
+   <keeper_server>
+        <log_storage_disk>log_s3</log_storage_disk>
+        <latest_log_storage_disk>log_local</latest_log_storage_disk>
+
+        <snapshot_storage_disk>snapshot_s3</snapshot_storage_disk>
+        <latest_snapshot_storage_disk>snapshot_s3</latest_snapshot_storage_disk>
+
+        <state_storage_disk>state_s3</state_storage_disk>
+        <latest_state_storage_disk>state_s3</latest_state_storage_disk>
+
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+
+         <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>clickhouse-keeper</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+        </coordination_settings>
+    </keeper_server>
+
+    <storage_configuration>
+        <disks>
+            <log_local>
+                <type>local</type>
+                <path>/tmp/lib/clickhouse/coordination/logs/</path>
+            </log_local>
+            <log_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/logs/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </log_s3>
+            <snapshot_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/snapshots/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </snapshot_s3>
+            <state_s3>
+                <type>s3</type>
+                <endpoint>https://storage.googleapis.com/${gcs_bucket}/clickhouse-data/keeper/state/</endpoint>
+                <access_key_id>${hmac_key}</access_key_id>
+                <secret_access_key>${hmac_secret}</secret_access_key>
+                <support_batch_delete>false</support_batch_delete>
+            </state_s3>
+        </disks>
+    </storage_configuration>
+</clickhouse> 
+EOF
+        destination = "local/keeper.xml"
+      }
+    }
+  } 

--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -84,8 +84,16 @@ job "clickhouse" {
       source    = "clickhouse"
     }
 
+
+
     task "clickhouse-server" {
       driver = "docker"
+
+      volume_mount {
+        volume      = "clickhouse"
+        destination = "/var/lib/clickhouse"
+        read_only   = false
+      }
 
       kill_timeout = "120s"
 
@@ -137,7 +145,7 @@ job "clickhouse" {
 
     <zookeeper>
         <node>
-            <host>clickhouse-keeper.service.consul</host>
+            <host>{{ env "NOMAD_IP_clickhouse_keeper" }}</host>
             <port>9181</port>
         </node>
     </zookeeper>
@@ -221,6 +229,12 @@ EOF
     task "clickhouse-keeper" {
       driver = "docker"
 
+      volume_mount {
+        volume      = "clickhouse"
+        destination = "/var/lib/clickhouse"
+        read_only   = false
+      }
+
       resources {
         cpu    = 500
         memory = 2048
@@ -263,7 +277,7 @@ EOF
          <raft_configuration>
             <server>
                 <id>1</id>
-                <hostname>clickhouse-keeper.service.consul</hostname>
+                <hostname>{{ env "NOMAD_IP_clickhouse_keeper" }}</hostname>
                 <port>9234</port>
             </server>
         </raft_configuration>

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -428,6 +428,8 @@ resource "nomad_job" "clickhouse" {
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
     username            = var.clickhouse_username
     password_sha256_hex = sha256(var.clickhouse_password)
+    // This should not be changed
+    keeper_count = 3
+    server_count = 2
   })
 }
-

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -419,6 +419,7 @@ resource "google_storage_hmac_key" "clickhouse_hmac_key" {
 
 # Add this with your other Nomad jobs
 resource "nomad_job" "clickhouse" {
+  count = var.clickhouse_enabled ? 1 : 0
   jobspec = templatefile("${path.module}/clickhouse.hcl", {
     zone                = var.gcp_zone
     clickhouse_version  = "25.1.5.31" # Or make this a variable

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -428,8 +428,7 @@ resource "nomad_job" "clickhouse" {
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
     username            = var.clickhouse_username
     password_sha256_hex = sha256(var.clickhouse_password)
-    // This should not be changed
-    keeper_count = 3
+    keeper_count = 1
     server_count = 2
   })
 }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -428,7 +428,7 @@ resource "nomad_job" "clickhouse" {
     hmac_secret         = google_storage_hmac_key.clickhouse_hmac_key.secret
     username            = var.clickhouse_username
     password_sha256_hex = sha256(var.clickhouse_password)
-    keeper_count = 1
-    server_count = 2
+    keeper_count        = 1
+    server_count        = 2
   })
 }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -401,8 +401,8 @@ resource "google_storage_bucket" "clickhouse_bucket" {
 
 // create service account for bucket
 resource "google_service_account" "clickhouse_service_account" {
-  account_id   = "${var.prefix}clickhouse-service-account"
-  display_name = "${var.prefix}clickhouse-service-account"
+  account_id   = "${var.prefix}clickhouse"
+  display_name = "${var.prefix}clickhouse"
 }
 
 # attach service account to bucket 

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -227,3 +227,8 @@ variable "clickhouse_password" {
 variable "clickhouse_database" {
   type = string
 }
+
+variable "clickhouse_enabled" {
+  type    = bool
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -231,3 +231,8 @@ variable "template_bucket_name" {
   type        = string
   description = "The name of the FC template bucket"
 }
+
+variable "clickhouse_enabled" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
This pull request includes significant changes to the infrastructure and configuration of the API cluster, particularly focusing on the integration of NFS storage and the deployment of ClickHouse. The most important changes include the addition of a Filestore instance, updates to the API cluster environment variables, and modifications to the Nomad configuration scripts.

### Infrastructure Enhancements:
* Added a Filestore instance for NFS in `packages/cluster/main.tf` to provide shared storage for the API cluster.
* Updated environment variables in `packages/cluster/main.tf` to include NFS-related settings, such as `NFS_IP`, `NFS_SHARE`, and `NFS_MOUNT_PATH`.

### Configuration Updates:
* Modified `packages/cluster/scripts/run-api-nomad.sh` to create directories for ClickHouse data and configure host volumes for ClickHouse server and keeper. [[1]](diffhunk://#diff-d26b132d85970e632a7e5e9bf041c62cb8d20b7bc8ff164deb8ac5188e59412dR139-R143) [[2]](diffhunk://#diff-d26b132d85970e632a7e5e9bf041c62cb8d20b7bc8ff164deb8ac5188e59412dR162-R172)
* Added NFS client installation and NFS share mounting steps in `packages/cluster/scripts/start-api.sh` to ensure the NFS storage is properly mounted on the API instances.

### ClickHouse Deployment:
* add feature flag to clickhouse deployment to not confuse our users
* Introduced a new Nomad job configuration for ClickHouse in `packages/nomad/clickhouse.hcl`, including settings for both ClickHouse servers and keepers, with detailed configurations for storage, logging, and replication. [[1]](diffhunk://#diff-70fdcd05684c7d2e46c882c06fbf8a95ea1c14315311614af6d9946eef495a7bR1-R300) [[2]](diffhunk://#diff-70fdcd05684c7d2e46c882c06fbf8a95ea1c14315311614af6d9946eef495a7bL132-R334)
* Updated `packages/nomad/main.tf` to include parameters for the number of ClickHouse keepers and servers.