### PR TITLE
Use chown of chmod for user home dir to fix permission and ownership issues

### DIFF
--- a/tests/integration/internal/tests/envd/filesystem_test.go
+++ b/tests/integration/internal/tests/envd/filesystem_test.go
@@ -67,14 +67,17 @@ func TestFilePermissions(t *testing.T) {
 	sbx := createSandbox(t, setup.WithAPIKey())
 
 	envdClient := setup.GetEnvdClient(t, ctx)
+	req := connect.NewRequest(&process.StartRequest{
+		Process: &process.ProcessConfig{
+			Cmd:  "ls",
+			Args: []string{"-la", "/home/user"},
+		},
+	})
+	setup.SetSandboxHeader(req.Header(), sbx.JSON201.SandboxID, sbx.JSON201.ClientID)
+	setup.SetUserHeader(req.Header(), "user")
 	stream, err := envdClient.ProcessClient.Start(
 		ctx,
-		connect.NewRequest(&process.StartRequest{
-			Process: &process.ProcessConfig{
-				Cmd:  "ls",
-				Args: []string{"-la", "/home/user"},
-			},
-		}),
+		req,
 	)
 
 	assert.NoError(t, err)


### PR DESCRIPTION
if a user includes the following line in their  Dockerfile 

```
RUN chmod 666 -R /home/user/app
```

these  permissions are overwritten by the following line later in our provision.sh script 
```
chmod 777 -R /home/user
```

This change prevents this from happening while retaining user ownership of files copied into that directory using a flow similar to the following 

```
FROM python:3.12-slim 

RUN mkdir -p /home/user 

COPY startup.sh /home/user/startup.sh

```

