### PR TITLE
Add metrics for pause and resume endpoints

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -68,7 +68,12 @@ func NewGinServer(ctx context.Context, logger *zap.Logger, apiStore *handlers.AP
 			"/templates/:templateID/builds/:buildID/logs",
 			"/templates/:templateID/builds/:buildID/status",
 		),
-		customMiddleware.IncludeRoutes(metricsMiddleware.Middleware(serviceName), "/sandboxes"),
+		customMiddleware.IncludeRoutes(
+			metricsMiddleware.Middleware(serviceName),
+			"/sandboxes",
+			"/sandboxes/:sandboxID/pause",
+			"/sandboxes/:sandboxID/resume",
+		),
 		customMiddleware.ExcludeRoutes(ginzap.Ginzap(logger, time.RFC3339Nano, true),
 			"/health",
 			"/sandboxes/:sandboxID/refreshes",

--- a/packages/nomad/otel-collector.hcl
+++ b/packages/nomad/otel-collector.hcl
@@ -108,6 +108,7 @@ processors:
       include:
         match_type: regexp
         # Exclude metrics that start with `http`, `go`, `rpc`, or `nomad` but aren't `nomad.client`
+        # Include info about grpc server endpoint durations - used for monitoring request times
         metric_names:
           - "nomad_client_host_cpu_idle"
           - "nomad_client_host_disk_available"
@@ -121,6 +122,7 @@ processors:
           - "orchestrator.*"
           - "api.*"
           - "client_proxy.*"
+          - "rpc_server_duration"
   metricstransform:
     transforms:
       - include: "nomad_client_host_cpu_idle"


### PR DESCRIPTION
Adds metrics for pause and resume in the API, and for all grpc methods in the orchestrator.