### PR TITLE
Build and use envd for integration tests

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -25,4 +25,5 @@ runs:
         make -C packages/template-manager build-debug
         make -C packages/orchestrator build-debug
         make -C packages/api build-debug
+        make -C packages/envd build-debug
       shell: bash

--- a/.github/actions/host-init/init-client.sh
+++ b/.github/actions/host-init/init-client.sh
@@ -74,8 +74,11 @@ mkdir -p /fc-vm
 # Download envd buckets
 envd_dir="/fc-envd"
 mkdir -p $envd_dir
-gcloud storage cp gs://e2b-prod-public-builds/envd "${envd_dir}/."
+
+# Provide fresh envd binary and old one from our archive
+cp packages/envd/bin/debug/envd "${envd_dir}/."
 gcloud storage cp gs://e2b-prod-public-builds/envd-v0.0.1 "${envd_dir}/."
+
 chmod -R 755 $envd_dir
 ls -lh $envd_dir
 du -h "${envd_dir}/envd"


### PR DESCRIPTION
Currently there is copy paste of already build envd from our public bucket, 
but in case we want to test changes in envd itself we should
build it ourself in every integrations tests run.