### PR TITLE
Improve traces logging for cleanup

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -72,6 +72,7 @@ func NewGinServer(ctx context.Context, logger *zap.Logger, apiStore *handlers.AP
 		customMiddleware.IncludeRoutes(
 			metricsMiddleware.Middleware(serviceName),
 			"/sandboxes",
+			"/sandboxes/:sandboxID",
 			"/sandboxes/:sandboxID/pause",
 			"/sandboxes/:sandboxID/resume",
 		),

--- a/packages/orchestrator/cmd/mock-sandbox/mock.go
+++ b/packages/orchestrator/cmd/mock-sandbox/mock.go
@@ -163,7 +163,7 @@ func mockSandbox(
 		"true",
 	)
 	defer func() {
-		cleanupErr := cleanup.Run()
+		cleanupErr := cleanup.Run(ctx)
 		if cleanupErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to cleanup sandbox: %v\n", cleanupErr)
 		}
@@ -181,7 +181,7 @@ func mockSandbox(
 
 	time.Sleep(keepAlive)
 
-	err = sbx.Stop()
+	err = sbx.Stop(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to stop sandbox: %v\n", err)
 

--- a/packages/orchestrator/cmd/mock-snapshot/mock.go
+++ b/packages/orchestrator/cmd/mock-snapshot/mock.go
@@ -169,7 +169,7 @@ func mockSnapshot(
 		"true",
 	)
 	defer func() {
-		cleanupErr := cleanup.Run()
+		cleanupErr := cleanup.Run(ctx)
 		if cleanupErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to cleanup sandbox: %v\n", cleanupErr)
 		}
@@ -275,7 +275,7 @@ func mockSnapshot(
 		"true",
 	)
 	defer func() {
-		cleanupErr := cleanup2.Run()
+		cleanupErr := cleanup2.Run(ctx)
 		if cleanupErr != nil {
 			fmt.Fprintf(os.Stderr, "failed to cleanup sandbox: %v\n", cleanupErr)
 		}

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct_linux.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct_linux.go
@@ -12,12 +12,15 @@ import (
 	"time"
 
 	"github.com/Merovius/nbd/nbdnl"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
 type DirectPathMount struct {
+	tracer      trace.Tracer
 	Backend     block.Device
 	ctx         context.Context
 	dispatcher  *Dispatch
@@ -28,10 +31,11 @@ type DirectPathMount struct {
 	devicePool  *DevicePool
 }
 
-func NewDirectPathMount(b block.Device, devicePool *DevicePool) *DirectPathMount {
+func NewDirectPathMount(tracer trace.Tracer, b block.Device, devicePool *DevicePool) *DirectPathMount {
 	ctx, cancelfn := context.WithCancel(context.Background())
 
 	return &DirectPathMount{
+		tracer:     tracer,
 		Backend:    b,
 		ctx:        ctx,
 		cancelfn:   cancelfn,
@@ -131,34 +135,42 @@ func (d *DirectPathMount) Open(ctx context.Context) (uint32, error) {
 	return d.deviceIndex, nil
 }
 
-func (d *DirectPathMount) Close() error {
+func (d *DirectPathMount) Close(ctx context.Context) error {
+	childCtx, childSpan := d.tracer.Start(ctx, "direct-path-mount-close")
+	defer childSpan.End()
+
 	// First cancel the context, which will stop waiting on pending readAt/writeAt...
+	telemetry.ReportEvent(childCtx, "canceling context")
 	d.cancelfn()
 
 	// Now wait for any pending responses to be sent
+	telemetry.ReportEvent(childCtx, "waiting for pending responses")
 	if d.dispatcher != nil {
 		d.dispatcher.Wait()
 	}
 
 	// Now ask to disconnect
+	telemetry.ReportEvent(childCtx, "disconnecting NBD")
 	err := nbdnl.Disconnect(d.deviceIndex)
 	if err != nil {
 		return err
 	}
 
 	// Close all the socket pairs...
+	telemetry.ReportEvent(childCtx, "closing socket pairs")
 	err = d.conn.Close()
 	if err != nil {
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
-	defer cancel()
 	// Wait until it's completely disconnected...
+	telemetry.ReportEvent(childCtx, "waiting for complete disconnection")
+	ctxTimeout, cancel := context.WithTimeout(childCtx, 4*time.Second)
+	defer cancel()
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-ctxTimeout.Done():
+			return ctxTimeout.Err()
 		default:
 		}
 

--- a/packages/orchestrator/internal/sandbox/sandbox_linux.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_linux.go
@@ -126,7 +126,10 @@ func NewSandbox(
 		return nil, cleanup, fmt.Errorf("failed to get network slot: %w", err)
 	}
 
-	cleanup.Add(func() error {
+	cleanup.Add(func(ctx context.Context) error {
+		_, span := tracer.Start(ctx, "network-slot-clean")
+		defer span.End()
+
 		returnErr := networkPool.Return(ips)
 		if returnErr != nil {
 			return fmt.Errorf("failed to return network slot: %w", returnErr)
@@ -138,7 +141,7 @@ func NewSandbox(
 
 	sandboxFiles := t.Files().NewSandboxFiles(config.SandboxId)
 
-	cleanup.Add(func() error {
+	cleanup.Add(func(ctx context.Context) error {
 		filesErr := cleanupFiles(sandboxFiles)
 		if filesErr != nil {
 			return fmt.Errorf("failed to cleanup files: %w", filesErr)
@@ -156,6 +159,7 @@ func NewSandbox(
 	}
 
 	rootfsOverlay, err := rootfs.NewCowDevice(
+		tracer,
 		readonlyRootfs,
 		sandboxFiles.SandboxCacheRootfsPath(),
 		sandboxFiles.RootfsBlockSize(),
@@ -165,8 +169,11 @@ func NewSandbox(
 		return nil, cleanup, fmt.Errorf("failed to create overlay file: %w", err)
 	}
 
-	cleanup.Add(func() error {
-		rootfsOverlay.Close()
+	cleanup.Add(func(ctx context.Context) error {
+		childCtx, span := tracer.Start(ctx, "rootfs-overlay-close")
+		defer span.End()
+
+		rootfsOverlay.Close(childCtx)
 
 		return nil
 	})
@@ -194,7 +201,10 @@ func NewSandbox(
 		return nil, cleanup, fmt.Errorf("failed to start uffd: %w", uffdStartErr)
 	}
 
-	cleanup.Add(func() error {
+	cleanup.Add(func(ctx context.Context) error {
+		_, span := tracer.Start(ctx, "uffd-stop")
+		defer span.End()
+
 		stopErr := fcUffd.Stop()
 		if stopErr != nil {
 			return fmt.Errorf("failed to stop uffd: %w", stopErr)
@@ -271,7 +281,10 @@ func NewSandbox(
 	// By default, the sandbox should be healthy, if the status change we report it.
 	sbx.healthy.Store(true)
 
-	cleanup.AddPriority(func() error {
+	cleanup.AddPriority(func(ctx context.Context) error {
+		_, span := tracer.Start(ctx, "fc-uffd-stop")
+		defer span.End()
+
 		var errs []error
 
 		fcStopErr := fcHandle.Stop()
@@ -319,7 +332,10 @@ func NewSandbox(
 
 	telemetry.ReportEvent(childCtx, "added DNS record", attribute.String("ip", ips.HostIP()), attribute.String("hostname", config.SandboxId))
 
-	cleanup.Add(func() error {
+	cleanup.Add(func(ctx context.Context) error {
+		_, span := tracer.Start(ctx, "dns-proxy-remove")
+		defer span.End()
+
 		dns.Remove(config.SandboxId, ips.HostIP())
 		proxy.RemoveSandbox(config.SandboxId, ips.HostIP())
 
@@ -331,23 +347,23 @@ func NewSandbox(
 	return sbx, cleanup, nil
 }
 
-func (s *Sandbox) Wait() error {
+func (s *Sandbox) Wait(ctx context.Context) error {
 	select {
 	case fcErr := <-s.process.Exit:
-		stopErr := s.Stop()
+		stopErr := s.Stop(ctx)
 		uffdErr := <-s.uffdExit
 
 		return errors.Join(fcErr, stopErr, uffdErr)
 	case uffdErr := <-s.uffdExit:
-		stopErr := s.Stop()
+		stopErr := s.Stop(ctx)
 		fcErr := <-s.process.Exit
 
 		return errors.Join(uffdErr, stopErr, fcErr)
 	}
 }
 
-func (s *Sandbox) Stop() error {
-	err := s.cleanup.Run()
+func (s *Sandbox) Stop(ctx context.Context) error {
+	err := s.cleanup.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to stop sandbox: %w", err)
 	}


### PR DESCRIPTION
Adds traces (by passing context) for sandbox cleanup. This is to here help debug pause taking long time. 

This PR also adds monitoring of /sandboxes/:sandboxID for monitoring "kill" execution time.