### PR TITLE
Update self-host.md to account for new jwt auth mechanism

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -63,6 +63,8 @@ Check if you can use config for terraform state management
 9. Secrets are created and stored in GCP Secrets Manager. Once created, that is the source of truth--you will need to update values there to make changes. Create a secret value for the following secrets:
   - e2b-cloudflare-api-token
       > Get Cloudflare API Token: go to the [Cloudflare dashboard](https://dash.cloudflare.com/) -> Manage Account -> Account API Tokens -> Create Token -> Edit Zone DNS -> in "Zone Resources" select your domain and generate the token
+  - e2b-supabase-jwt-secrets (optional / required to self-host the [E2B dashboard](https://github.com/e2b-dev/dashboard))
+      > Get Supabase JWT Secret: go to the [Supabase dashboard](https://supabase.com/dashboard) -> Select your Project -> Project Settings -> Data API -> JWT Settings
   - e2b-grafana-api-key (optional) - read more in [grafana README](./terraform/grafana/README.md)
   - Posthog API keys for monitoring (optional)
 10. Run `make plan-without-jobs` and then `make apply`


### PR DESCRIPTION
In favor of the new google secret for supabase jwt authentication headers on the api, we should update our self hosting guides and let users know that the google secret is required for dashboard hosting.

RFC: In my opinion we should keep the impact of this as minimal as possible, as long as we are not fully committed to this authentication approach. Since the dashboard self-hosting guide refers to this repository for self-hosting the infrastructure first, and to keep the impact minimal, i would suggest only mentioning the setup for this here. 

Thoughts?