### PR TITLE
Fix error message in proxies

### DIFF
--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -61,8 +61,9 @@ type htmlTemplateData struct {
 }
 
 type jsonTemplateData struct {
-	Error     string `json:"error"`
+	Message   string `json:"message"`
 	SandboxId string `json:"sandboxId"`
+	Code      int    `json:"code"`
 }
 
 func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http.Request) {
@@ -318,7 +319,7 @@ func buildHtmlNotFoundError(sandboxId string, host string) ([]byte, error) {
 
 func buildJsonNotFoundError(sandboxId string) ([]byte, error) {
 	response := jsonTemplateData{
-		Error:     "Sandbox not found",
+		Message:   "Sandbox not found",
 		SandboxId: sandboxId,
 	}
 

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -122,7 +122,7 @@ func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http
 						w.WriteHeader(http.StatusInternalServerError)
 						return
 					}
-					w.WriteHeader(http.StatusNotFound)
+					w.WriteHeader(http.StatusBadGateway)
 					w.Header().Add("Content-Type", "text/html")
 					w.Write(res)
 					return
@@ -133,7 +133,7 @@ func proxyHandler(transport *http.Transport) func(w http.ResponseWriter, r *http
 						w.WriteHeader(http.StatusInternalServerError)
 						return
 					}
-					w.WriteHeader(http.StatusNotFound)
+					w.WriteHeader(http.StatusBadGateway)
 					w.Header().Add("Content-Type", "application/json")
 					w.Write(res)
 					return

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -34,7 +34,7 @@ type htmlTemplateData struct {
 }
 
 type jsonTemplateData struct {
-	Error     string `json:"error"`
+	Message   string `json:"message"`
 	SandboxId string `json:"sandboxId"`
 	Port      uint64 `json:"port"`
 }
@@ -183,7 +183,7 @@ func (p *SandboxProxy) buildHtmlClosedPortError(sandboxId string, host string, p
 
 func (p *SandboxProxy) buildJsonClosedPortError(sandboxId string, port uint64) []byte {
 	response := jsonTemplateData{
-		Error:     "The sandbox is running but port is not open",
+		Message:   "The sandbox is running but port is not open",
 		SandboxId: sandboxId,
 		Port:      port,
 	}


### PR DESCRIPTION
# Description

In SDK we expect error with field `message` not `error`:  https://github.com/e2b-dev/E2B/blob/main/packages/js-sdk/src/envd/api.ts#L28