### PR TITLE
Allow orchestrator deployment updates without restarting running deployments

### DIFF
--- a/packages/nomad/orchestrator.sh
+++ b/packages/nomad/orchestrator.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export NODE_ID=$NODE_ID
+export CONSUL_TOKEN="${consul_acl_token}"
+export OTEL_TRACING_PRINT="${otel_tracing_print}"
+export LOGS_COLLECTOR_ADDRESS="${logs_collector_address}"
+export LOGS_COLLECTOR_PUBLIC_IP="${logs_collector_public_ip}"
+export ENVIRONMENT="${environment}"
+export TEMPLATE_BUCKET_NAME="${template_bucket_name}"
+export OTEL_COLLECTOR_GRPC_ENDPOINT="${otel_collector_grpc_endpoint}"
+export CLICKHOUSE_CONNECTION_STRING="${clickhouse_connection_string}"
+export CLICKHOUSE_USERNAME="${clickhouse_username}"
+export CLICKHOUSE_PASSWORD="${clickhouse_password}"
+export CLICKHOUSE_DATABASE="${clickhouse_database}"
+
+# We should allow versioning for the orchestrator this way.
+# Alternatively validate the checksum.
+# Also let's copy the binary to local dir to avoid problems.
+/fc-envd/orchestrator --port ${port}

--- a/packages/nomad/orchestrator.sh
+++ b/packages/nomad/orchestrator.sh
@@ -13,7 +13,7 @@ export CLICKHOUSE_USERNAME="${clickhouse_username}"
 export CLICKHOUSE_PASSWORD="${clickhouse_password}"
 export CLICKHOUSE_DATABASE="${clickhouse_database}"
 
-# We should allow versioning for the orchestrator this way.
-# Alternatively validate the checksum.
-# Also let's copy the binary to local dir to avoid problems.
+# TODO: We should allow versioning for the orchestrator here or at least make the download more robust/explicit—we are using the fuse mount for envd here.
+# We can also validate the checksum here.
+# TODO: Also let's copy the binary to local dir to avoid problems.
 /fc-envd/orchestrator --port ${port}


### PR DESCRIPTION
This PR outlines how the orchestrator job updates could work, if we need to "opportunistically" deploy orchestrator job/envs changes.

It moves the changing parts of the job to a separate script while providing this script via Nomad variable—as opposed to a normal variable. We are able to control the lifecycle of Nomad variable if we use it in a template stanza and set the behavior for changes to "noop" if the change should not restart tasks.
Later, we can try the signal/script change behavior to trigger the orchestrator reload.

This change moves the logic (artifact download, setting envs, starting orchestrator) to a separate script, but I did not find any other way to achieve the functionality we wanted.

Before this is ready, we need to at least:
- [ ] Make the orchestrator (previously in artifact stanza) downloading/version check more robust
- [ ] Test in all situations
- [ ] Have a clear path on how we will move from the current system to this one
- [ ] Check if we should pass a port variable via the job's env stanza, to prevent a situation where a port change in the job changes just services (not reloading allocation), but the ports in the allocations are not changed. It is possible that the service/port var change would trigger a whole job reload nevertheless.