### PR TITLE
Disabled keep alive on client proxy cache

### DIFF
--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -251,7 +251,7 @@ func run() int {
 		IdleConnTimeout:       620 * time.Second, // Matches keepalive_timeout
 		TLSHandshakeTimeout:   10 * time.Second,  // Similar to client_header_timeout
 		ResponseHeaderTimeout: 24 * time.Hour,    // Matches proxy_read_timeout
-		DisableKeepAlives:     false,             // Allow keep-alives
+		DisableKeepAlives:     true,              // Disable keep-alive, not supported
 	}
 
 	server.Handler = http.HandlerFunc(proxyHandler(transport))


### PR DESCRIPTION
Client cache is currently targetting nginx sandbox cache that has already disabled keep alive, same with new not yet used orchestrator cache that is also configure without keep alive.

This should fix expectations of client proxy to communicate with already closed connections, because keep alive is disabled in both nginx-based session and orchestrator proxies.