### PR TITLE
Remove managed Redis sharding and add replication

### DIFF
--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -62,7 +62,7 @@ resource "google_redis_cluster" "redis_cluster_api" {
   }
 
   region                  = var.gcp_region
-  replica_count           = 2
+  replica_count           = 1
   node_type               = "REDIS_STANDARD_SMALL"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
   authorization_mode      = "AUTH_MODE_DISABLED"

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -70,8 +70,7 @@ resource "google_redis_cluster" "redis_cluster_api" {
   deletion_protection_enabled = true
 
   zone_distribution_config {
-    mode = "SINGLE_ZONE"
-    zone = var.gcp_zone
+    mode = "MULTI_ZONE"
   }
 
   persistence_config {

--- a/terraform/redis/main.tf
+++ b/terraform/redis/main.tf
@@ -55,14 +55,14 @@ resource "google_service_networking_connection" "private_service_connection" {
 
 resource "google_redis_cluster" "redis_cluster_api" {
   name        = "${var.prefix}redis-cluster-api"
-  shard_count = 2
+  shard_count = 1
 
   psc_configs {
     network = "projects/${var.gcp_project_id}/global/networks/${var.network_name}"
   }
 
   region                  = var.gcp_region
-  replica_count           = 1
+  replica_count           = 2
   node_type               = "REDIS_STANDARD_SMALL"
   transit_encryption_mode = "TRANSIT_ENCRYPTION_MODE_DISABLED"
   authorization_mode      = "AUTH_MODE_DISABLED"


### PR DESCRIPTION
Remove sharding for the managed Redis cluster, because we should not need it right now and add replication instead.