### PR TITLE
Automatic deployment improvements

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   deploy:
-    name: Deploy Infra to the staging environment
+    name: Deploy Infra to the ${{ inputs.environment }} environment
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ download-prod-env:
 	@ hcp auth login
 	@ hcp profile init --vault-secrets
 	@ hcp vault-secrets secrets read env_$(ENV) >/dev/null 2>&1 && echo "Environment found, writing to the .env.$(ENV) file" || { echo "Environment $(ENV) does not exist"; exit 1; }
-	@ rm ".env.$(ENV)"
+	@ rm -f ".env.$(ENV)"
 	@ hcp vault-secrets secrets open env_$(ENV) -o ".env.$(ENV)"
 	@ DECODED=$$(cat ".env.$(ENV)" | base64 -d) && echo "$$DECODED" > ".env.$(ENV)"
 

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -54,13 +54,10 @@ job "orchestrator" {
       }
 
       artifact {
-        source      = "gcs::https://www.googleapis.com/storage/v1/${bucket_name}/orchestrator"
-
         %{ if environment == "dev" }
-        // Checksum in only available for dev to increase development speed in prod use rolling updates
-        options {
-          checksum = "md5:${orchestrator_checksum}"
-        }
+        source      = "gcs::https://www.googleapis.com/storage/v1/${bucket_name}/orchestrator?version=${orchestrator_checksum}"
+        %{ else }
+        source      = "gcs::https://www.googleapis.com/storage/v1/${bucket_name}/orchestrator"
         %{ endif }
       }
     }


### PR DESCRIPTION
This PR addresses small nits for the automatic deployment.

It does:
- Replaces Nomad orchestrator checksum for ?version. This is there to allow orchestrator rolling (with new version) without updating the Nomad job in dev environment. It should still retain the functionality of quickly replacing the orchestrator when using make plan && make apply. 
- Updates the GH actions job name to show correct environment
- Fixes bug when removing non existing file in `make download-prod-env`