### PR TITLE
Return sorting to sandbox list

### DIFF
--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -69,6 +69,11 @@ func (a *APIStore) GetSandboxes(c *gin.Context, params api.GetSandboxesParams) {
 
 	sandboxes := getRunningSandboxes(ctx, a.orchestrator, team.ID, metadataFilter)
 
+	// Sort sandboxes by start time descending
+	slices.SortFunc(sandboxes, func(a, b utils.PaginatedSandbox) int {
+		return a.StartedAt.Compare(b.StartedAt)
+	})
+
 	c.JSON(http.StatusOK, sandboxes)
 }
 

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -71,7 +71,8 @@ func (a *APIStore) GetSandboxes(c *gin.Context, params api.GetSandboxesParams) {
 
 	// Sort sandboxes by start time descending
 	slices.SortFunc(sandboxes, func(a, b utils.PaginatedSandbox) int {
-		return a.StartedAt.Compare(b.StartedAt)
+		// SortFunc sorts the list ascending by default, because we want the opposite behavior we switch `a` and `b`
+		return b.StartedAt.Compare(a.StartedAt)
 	})
 
 	c.JSON(http.StatusOK, sandboxes)

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -319,6 +319,17 @@ func TestSandboxListSortedV1(t *testing.T) {
 	assert.Equal(t, http.StatusOK, listResponse.StatusCode())
 	assert.GreaterOrEqual(t, 3, len(*listResponse.JSON200))
 
+	// Verify all sandboxes are in the list
+	contains := 0
+	for _, sbx := range *listResponse.JSON200 {
+		switch sbx.SandboxID {
+		case sbx1.SandboxID, sbx2.SandboxID, sbx3.SandboxID:
+			contains++
+		}
+	}
+
+	assert.Equal(t, 3, contains)
+
 	// Verify the order of the sandboxes
 	for i := 1; i <= len(*listResponse.JSON200); i++ {
 		assert.GreaterOrEqual(t, (*listResponse.JSON200)[i-1].StartedAt.Compare((*listResponse.JSON200)[i].StartedAt), 0)

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -331,7 +331,7 @@ func TestSandboxListSortedV1(t *testing.T) {
 	assert.Equal(t, 3, contains)
 
 	// Verify the order of the sandboxes
-	for i := 1; i <= len(*listResponse.JSON200); i++ {
-		assert.GreaterOrEqual(t, (*listResponse.JSON200)[i-1].StartedAt.Compare((*listResponse.JSON200)[i].StartedAt), 0)
+	for i := 0; i < len(*listResponse.JSON200)-1; i++ {
+		assert.GreaterOrEqual(t, (*listResponse.JSON200)[i].StartedAt.Compare((*listResponse.JSON200)[i+1].StartedAt), 0)
 	}
 }

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -304,3 +304,21 @@ func TestSandboxListWithFilterV1(t *testing.T) {
 	assert.Equal(t, 1, len(*listResponse.JSON200))
 	assert.Equal(t, sbx.SandboxID, (*listResponse.JSON200)[0].SandboxID)
 }
+
+func TestSandboxListSortedV1(t *testing.T) {
+	c := setup.GetAPIClient()
+
+	// Create three sandboxes
+	sbx1 := utils.SetupSandboxWithCleanup(t, c)
+	sbx2 := utils.SetupSandboxWithCleanup(t, c)
+	sbx3 := utils.SetupSandboxWithCleanup(t, c)
+
+	// List with filter
+	listResponse, err := c.GetSandboxesWithResponse(context.Background(), nil, setup.WithAPIKey())
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, listResponse.StatusCode())
+	assert.Equal(t, 3, len(*listResponse.JSON200))
+	assert.Equal(t, sbx1.SandboxID, (*listResponse.JSON200)[2].SandboxID)
+	assert.Equal(t, sbx2.SandboxID, (*listResponse.JSON200)[1].SandboxID)
+	assert.Equal(t, sbx3.SandboxID, (*listResponse.JSON200)[0].SandboxID)
+}

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -317,8 +317,10 @@ func TestSandboxListSortedV1(t *testing.T) {
 	listResponse, err := c.GetSandboxesWithResponse(context.Background(), nil, setup.WithAPIKey())
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, listResponse.StatusCode())
-	assert.Equal(t, 3, len(*listResponse.JSON200))
-	assert.Equal(t, sbx1.SandboxID, (*listResponse.JSON200)[2].SandboxID)
-	assert.Equal(t, sbx2.SandboxID, (*listResponse.JSON200)[1].SandboxID)
-	assert.Equal(t, sbx3.SandboxID, (*listResponse.JSON200)[0].SandboxID)
+	assert.GreaterOrEqual(t, 3, len(*listResponse.JSON200))
+
+	// Verify the order of the sandboxes
+	for i := 1; i <= len(*listResponse.JSON200); i++ {
+		assert.GreaterOrEqual(t, (*listResponse.JSON200)[i-1].StartedAt.Compare((*listResponse.JSON200)[i].StartedAt), 0)
+	}
 }

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -332,6 +332,6 @@ func TestSandboxListSortedV1(t *testing.T) {
 
 	// Verify the order of the sandboxes
 	for i := 0; i < len(*listResponse.JSON200)-1; i++ {
-		assert.GreaterOrEqual(t, (*listResponse.JSON200)[i].StartedAt.Compare((*listResponse.JSON200)[i+1].StartedAt), 0)
+		assert.True(t, (*listResponse.JSON200)[i].StartedAt.After((*listResponse.JSON200)[i+1].StartedAt))
 	}
 }


### PR DESCRIPTION
# Description

Sorting was removed by accident during introduction of the new sandbox list endpoint