### PR TITLE
Fix RPC server duration metric

### DIFF
--- a/packages/nomad/otel-collector.hcl
+++ b/packages/nomad/otel-collector.hcl
@@ -122,7 +122,7 @@ processors:
           - "orchestrator.*"
           - "api.*"
           - "client_proxy.*"
-          - "rpc_server_duration"
+          - "rpc.server.duration.*"
   metricstransform:
     transforms:
       - include: "nomad_client_host_cpu_idle"


### PR DESCRIPTION
Fixes rpc server duration metric logging. For some reason it doesn't work with `_`, but it works with any char (`.`), so I'm using that.