### PR TITLE
Allow only plan the deployment

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -15,6 +15,11 @@ on:
         description: 'Target environment for deployment, e.g. staging'
         required: true
         type: string
+      plan_only:
+        description: 'Only plan the infrastructure changes without applying them'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-${{ inputs.environment }}
@@ -45,11 +50,16 @@ jobs:
           make copy-public-builds
 
       - name: Migrate database
+        if: ${{ inputs.plan_only != 'true' }}
         run: |
           make migrate
 
-      - name: Deploy infrastructure
+      - name: Plan infrastructure
         run: |
           make plan-without-jobs
+
+      - name: Apply infrastructure
+        if: ${{ inputs.plan_only != 'true' }}
+        run: |
           make apply
         

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -50,7 +50,7 @@ jobs:
           make copy-public-builds
 
       - name: Migrate database
-        if: inputs.plan_only != 'true'
+        if: inputs.plan_only == 'false'
         run: |
           make migrate
 
@@ -59,7 +59,7 @@ jobs:
           make plan-without-jobs
 
       - name: Apply infrastructure
-        if: inputs.plan_only != 'true'
+        if: inputs.plan_only == 'false'
         run: |
           make apply
         

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -50,7 +50,7 @@ jobs:
           make copy-public-builds
 
       - name: Migrate database
-        if: ${{ inputs.plan_only != 'true' }}
+        if: inputs.plan_only != true
         run: |
           make migrate
 
@@ -59,7 +59,7 @@ jobs:
           make plan-without-jobs
 
       - name: Apply infrastructure
-        if: ${{ inputs.plan_only != 'true' }}
+        if: inputs.plan_only != true
         run: |
           make apply
         

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -18,8 +18,8 @@ on:
       plan_only:
         description: 'Only plan the infrastructure changes without applying them'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
 
 concurrency:
   group: deploy-${{ inputs.environment }}
@@ -50,7 +50,7 @@ jobs:
           make copy-public-builds
 
       - name: Migrate database
-        if: inputs.plan_only != true
+        if: inputs.plan_only != 'true'
         run: |
           make migrate
 
@@ -59,7 +59,7 @@ jobs:
           make plan-without-jobs
 
       - name: Apply infrastructure
-        if: inputs.plan_only != true
+        if: inputs.plan_only != 'true'
         run: |
           make apply
         

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -63,7 +63,7 @@ jobs:
               make plan-only-jobs/$job_name
 
               # Apply only if plan_only is not true
-              if [ "${{ inputs.plan_only }}" != "true" ]; then
+              if [ "${{ inputs.plan_only }}" == "false" ]; then
                 make apply
               else
                 echo "Skipping apply, plan_only is true"

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -18,6 +18,11 @@ on:
         description: 'Name of the jobs to deploy, e.g. api, template-manager, separated by ;'
         required: true
         type: string
+      plan_only:
+        description: 'Only plan the changes without applying them'
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-${{ inputs.environment }}
@@ -56,7 +61,13 @@ jobs:
             if [ -n "$job_name" ]; then
               echo "::group::Deploying job: $job_name"
               make plan-only-jobs/$job_name
-              make apply
+
+              # Apply only if plan_only is not true
+              if [ "${{ inputs.plan_only }}" != "true" ]; then
+                make apply
+              else
+                echo "Skipping apply, plan_only is true"
+              fi
               echo "::endgroup::"
             fi
           done

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -21,8 +21,8 @@ on:
       plan_only:
         description: 'Only plan the changes without applying them'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: "false"
 
 concurrency:
   group: deploy-${{ inputs.environment }}


### PR DESCRIPTION
Add input to only plan the terraform configuration, not actually applying it. This is to verify that the plan is correct.