### PR TITLE
Don't fail build on missing logs

### DIFF
--- a/packages/api/internal/handlers/template_build_status.go
+++ b/packages/api/internal/handlers/template_build_status.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/db"
-
 	"github.com/grafana/loki/pkg/loghttp"
 	"github.com/grafana/loki/pkg/logproto"
 	"go.uber.org/zap"
@@ -19,6 +17,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/auth"
+	"github.com/e2b-dev/infra/packages/shared/pkg/db"
 	"github.com/e2b-dev/infra/packages/shared/pkg/models"
 	"github.com/e2b-dev/infra/packages/shared/pkg/models/envbuild"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"


### PR DESCRIPTION
# Description

If loki crashes, it shouldn't fail build, especially if the build is still running in the background.