### PR TITLE
Fix error message type for validation

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -137,7 +137,11 @@ func NewGinServer(ctx context.Context, logger *zap.Logger, apiStore *handlers.AP
 	)
 
 	// We now register our store above as the handler for the interface
-	api.RegisterHandlers(r, apiStore)
+	api.RegisterHandlersWithOptions(r, apiStore, api.GinServerOptions{
+		ErrorHandler: func(c *gin.Context, err error, statusCode int) {
+			utils.ErrorHandler(c, err.Error(), statusCode)
+		},
+	})
 
 	r.MaxMultipartMemory = maxMultipartMemory
 


### PR DESCRIPTION
# Description

E.g. for incorrectly passing parameter multiple times (exploded) instead of only separated by comma, we are returning following response
```json
 {"msg":"Invalid format for parameter state: parameter 'state' is not exploded, but is specified multiple times"}
```

But SDK expects the error to have field `message`.

After passing our error handler, we return following error
```json
{"code":400,"message":"validation error: Invalid format for parameter state: parameter 'state' is not exploded, but is specified multiple times"}
```

This was causing for some validation errors to be logged as:
```
SandboxError: 400: [object Object]
```
 in JS SDK.