### PR TITLE
Orchestrator rolling updates with job definiton

### DIFF
--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -350,7 +350,7 @@ locals {
 
 resource "random_id" "orchestrator_job" {
   keepers = {
-    # Dynamically replace placeholders using a for loop
+    # Use both the orchestrator job (including vars) definition and the latest orchestrator checksum to detect changes
     orchestrator_job = sha256("${local.orchestrator_job_check}-${data.external.orchestrator_checksum.result.hex}")
   }
 

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -316,25 +316,9 @@ data "external" "orchestrator_checksum" {
   }
 }
 
-resource "random_id" "server" {
-  keepers = {
-    # Generate a new id each time we switch to a new AMI id
-    # TODO: Change this to simulate change in orchstrator job
-    orchestrator_job = "12"
-  }
-
-  byte_length = 8
-}
-
-resource "nomad_variable" "example" {
-  path = "nomad/jobs"
-  items = {
-    latest_orchestrator_job = random_id.server.hex
-  }
-}
 
 locals {
-  orchestrator_job = templatefile("${path.module}/orchestrator.hcl", {
+  orchestrator_envs = {
     gcp_zone         = var.gcp_zone
     port             = var.orchestrator_port
     proxy_port       = var.orchestrator_proxy_port
@@ -352,14 +336,43 @@ locals {
     clickhouse_username          = var.clickhouse_username
     clickhouse_password          = var.clickhouse_password
     clickhouse_database          = var.clickhouse_database
-    random_id                    = random_id.server.hex
-  })
+  }
+
+  orchestrator_job_check = templatefile("${path.module}/orchestrator.hcl", merge(
+    local.orchestrator_envs,
+    {
+      latest_orchestrator_job_id = "placeholder",
+    }
+  ))
+}
+
+
+
+resource "random_id" "orchestrator_job" {
+  keepers = {
+    # Dynamically replace placeholders using a for loop
+    orchestrator_job = sha256("${local.orchestrator_job_check}-${data.external.orchestrator_checksum.result.hex}")
+  }
+
+  byte_length = 8
+}
+
+resource "nomad_variable" "orchestrator_hash" {
+  path = "nomad/jobs"
+  items = {
+    latest_orchestrator_job_id = random_id.orchestrator_job.hex
+  }
 }
 
 resource "nomad_job" "orchestrator" {
   deregister_on_id_change = false
 
-  jobspec = local.orchestrator_job
+  jobspec = templatefile("${path.module}/orchestrator.hcl", merge(
+    local.orchestrator_envs,
+    {
+      latest_orchestrator_job_id = random_id.orchestrator_job.hex
+    }
+  ))
 }
 
 data "google_storage_bucket_object" "template_manager" {

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -316,8 +316,24 @@ data "external" "orchestrator_checksum" {
   }
 }
 
-resource "nomad_job" "orchestrator" {
-  jobspec = templatefile("${path.module}/orchestrator.hcl", {
+resource "random_id" "server" {
+  keepers = {
+    # Generate a new id each time we switch to a new AMI id
+    orchestrator_job = "5"
+  }
+
+  byte_length = 8
+}
+
+resource "nomad_variable" "example" {
+  path = "nomad/jobs"
+  items = {
+    latest_orchestrator_job = random_id.server.hex
+  }
+}
+
+locals {
+  orchestrator_job = templatefile("${path.module}/orchestrator.hcl", {
     gcp_zone         = var.gcp_zone
     port             = var.orchestrator_port
     proxy_port       = var.orchestrator_proxy_port
@@ -335,7 +351,14 @@ resource "nomad_job" "orchestrator" {
     clickhouse_username          = var.clickhouse_username
     clickhouse_password          = var.clickhouse_password
     clickhouse_database          = var.clickhouse_database
+    random_id                    = random_id.server.hex
   })
+}
+
+resource "nomad_job" "orchestrator" {
+  deregister_on_id_change = false
+
+  jobspec = local.orchestrator_job
 }
 
 data "google_storage_bucket_object" "template_manager" {

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -319,7 +319,8 @@ data "external" "orchestrator_checksum" {
 resource "random_id" "server" {
   keepers = {
     # Generate a new id each time we switch to a new AMI id
-    orchestrator_job = "5"
+    # TODO: Change this to simulate change in orchstrator job
+    orchestrator_job = "12"
   }
 
   byte_length = 8

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -1,16 +1,8 @@
-job "orchestrator-${random_id}" {
+job "orchestrator-${latest_orchestrator_job_id}" {
   type = "system"
-  datacenters = ["${gcp_zone}"]
+  node_pool = "default"
 
   priority = 90
-
-  // This constraint ensures that only one orchestrator is running at a time,
-  // now that we use differently names jobs.
-  // TODO: We cannot use this on group level, so if we want to run the script check we will need to use colliding port.
-  constraint {
-    distinct_property = "$${node.unique.id}"
-    value             = "1"
-  }
 
   group "client-orchestrator" {
     network {
@@ -55,11 +47,11 @@ job "orchestrator-${random_id}" {
         data = <<EOT
 #!/bin/bash
 
-if [ "{{with nomadVar "nomad/jobs" }}{{ .latest_orchestrator_job }}{{ end }}" != "${random_id}" ]; then
+if [ "{{with nomadVar "nomad/jobs" }}{{ .latest_orchestrator_job_id }}{{ end }}" != "${latest_orchestrator_job_id}" ]; then
   echo "This orchestrator is not the latest version, exiting"
   exit 1
 fi
-        EOT
+EOT
       }
       
       config {

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -6,8 +6,9 @@ job "orchestrator-${random_id}" {
 
   // This constraint ensures that only one orchestrator is running at a time,
   // now that we use differently names jobs.
+  // TODO: We cannot use this on group level, so if we want to run the script check we will need to use colliding port.
   constraint {
-    distinct_property = "orchestrator"
+    distinct_property = "$${node.unique.id}"
     value             = "1"
   }
 

--- a/packages/nomad/orchestrator.hcl
+++ b/packages/nomad/orchestrator.hcl
@@ -1,8 +1,15 @@
-job "orchestrator" {
+job "orchestrator-${random_id}" {
   type = "system"
   datacenters = ["${gcp_zone}"]
 
   priority = 90
+
+  // This constraint ensures that only one orchestrator is running at a time,
+  // now that we use differently names jobs.
+  constraint {
+    distinct_property = "orchestrator"
+    value             = "1"
+  }
 
   group "client-orchestrator" {
     network {
@@ -30,8 +37,41 @@ job "orchestrator" {
       port = "${proxy_port}"
     }
 
+    task "check-placement" {
+      driver = "raw_exec"
+
+      lifecycle {
+        hook = "prestart"
+        sidecar = false
+      }
+
+      restart {
+        attempts = 0
+      }
+
+      template {
+        destination = "local/check-placement.sh"
+        data = <<EOT
+#!/bin/bash
+
+if [ "{{with nomadVar "nomad/jobs" }}{{ .latest_orchestrator_job }}{{ end }}" != "${random_id}" ]; then
+  echo "This orchestrator is not the latest version, exiting"
+  exit 1
+fi
+        EOT
+      }
+      
+      config {
+        command = "local/check-placement.sh"
+      }
+    }
+
     task "start" {
       driver = "raw_exec"
+
+      restart {
+        attempts = 0
+      }
 
       env {
         NODE_ID                      = "$${node.unique.id}"


### PR DESCRIPTION
# Description

- This will allow us to update orchestrator job definition without causing downtime
- Also it improves observability how many orchestrators are running for the current version

## How it works

We generate new unique id if either job definition, secret or orchestrator binary changed
We use this ID to generate a new job, which has the new job definition
We save the ID to nomad as a variable and theres's a `prestart` check, which compares the ID of the job with the latest ID (the one saved in nomad), if they don't match the orchestrator is not started

This means there will be multiple jobs for orchestrator, but new orchestrator will start only for the latest job