### PR TITLE
Improve graph for pause error traces

### DIFF
--- a/terraform/grafana/stack/panels/sandbox-pause-errors-old.json
+++ b/terraform/grafana/stack/panels/sandbox-pause-errors-old.json
@@ -157,12 +157,13 @@
       ],
       "limit": 1000,
       "metricsQueryType": "range",
-      "queryType": "traceqlSearch",
+      "query": "{name=\"sandbox-pause\" && resource.service.name=\"orchestrator\" && status=error }",
+      "queryType": "traceql",
       "refId": "A",
       "spss": 1,
       "tableType": "spans"
     }
   ],
-  "title": "PAUSE ERRORS Sandbox time",
+  "title": "PAUSE ERRORS Sandbox time (trace \"sandbox-pause\")",
   "type": "timeseries"
 }

--- a/terraform/grafana/stack/panels/sandbox-pause-latency-old.json
+++ b/terraform/grafana/stack/panels/sandbox-pause-latency-old.json
@@ -132,7 +132,7 @@
       ],
       "limit": 1000,
       "metricsQueryType": "range",
-      "query": "{name=\"sandbox-pause\" && resource.service.name=\"orchestrator\" }",
+      "query": "{name=\"sandbox-pause\" && resource.service.name=\"orchestrator\" && status!=error }",
       "queryType": "traceql",
       "refId": "A",
       "spss": 1,


### PR DESCRIPTION
Changes source of pause error traces from the HTTP to the orchestrator ones in the chart