### PR TITLE
Add more info to the unknown envd errors

### DIFF
--- a/packages/envd/internal/services/filesystem/watch.go
+++ b/packages/envd/internal/services/filesystem/watch.go
@@ -75,7 +75,7 @@ func (s Service) watchHandler(ctx context.Context, req *connect.Request[rpc.Watc
 				},
 			})
 			if streamErr != nil {
-				return connect.NewError(connect.CodeUnknown, streamErr)
+				return connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr))
 			}
 		case <-ctx.Done():
 			return ctx.Err()
@@ -140,7 +140,7 @@ func (s Service) watchHandler(ctx context.Context, req *connect.Request[rpc.Watc
 					Msg("Streaming filesystem event")
 
 				if streamErr != nil {
-					return connect.NewError(connect.CodeUnknown, streamErr)
+					return connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending filesystem event: %w", streamErr))
 				}
 
 				resetKeepalive()

--- a/packages/envd/internal/services/process/connect.go
+++ b/packages/envd/internal/services/process/connect.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/logs"
 	"github.com/e2b-dev/infra/packages/envd/internal/permissions"
@@ -42,7 +43,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 		},
 	})
 	if streamErr != nil {
-		return connect.NewError(connect.CodeUnknown, streamErr)
+		return connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending start event: %w", streamErr))
 	}
 
 	go func() {
@@ -63,7 +64,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 					},
 				})
 				if streamErr != nil {
-					cancel(connect.NewError(connect.CodeUnknown, streamErr))
+					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr)))
 
 					return
 				}
@@ -82,7 +83,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 					},
 				})
 				if streamErr != nil {
-					cancel(connect.NewError(connect.CodeUnknown, streamErr))
+					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending data event: %w", streamErr)))
 
 					return
 				}
@@ -109,7 +110,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 				},
 			})
 			if streamErr != nil {
-				cancel(connect.NewError(connect.CodeUnknown, streamErr))
+				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
 
 				return
 			}

--- a/packages/envd/internal/services/process/input.go
+++ b/packages/envd/internal/services/process/input.go
@@ -85,7 +85,7 @@ func (s *Service) streamInputHandler(ctx context.Context, stream *connect.Client
 
 	err := stream.Err()
 	if err != nil {
-		return nil, connect.NewError(connect.CodeUnknown, err)
+		return nil, connect.NewError(connect.CodeUnknown, fmt.Errorf("error streaming input: %w", err))
 	}
 
 	return connect.NewResponse(&rpc.StreamInputResponse{}), nil

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -3,6 +3,7 @@ package process
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os/user"
 	"strconv"
@@ -123,7 +124,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				},
 			})
 			if streamErr != nil {
-				cancel(connect.NewError(connect.CodeUnknown, streamErr))
+				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending start event: %w", streamErr)))
 
 				return
 			}
@@ -144,7 +145,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 					},
 				})
 				if streamErr != nil {
-					cancel(connect.NewError(connect.CodeUnknown, streamErr))
+					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr)))
 					return
 				}
 			case <-ctx.Done():
@@ -161,7 +162,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 					},
 				})
 				if streamErr != nil {
-					cancel(connect.NewError(connect.CodeUnknown, streamErr))
+					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending data event: %w", streamErr)))
 					return
 				}
 
@@ -187,7 +188,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				},
 			})
 			if streamErr != nil {
-				cancel(connect.NewError(connect.CodeUnknown, streamErr))
+				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
 
 				return
 			}


### PR DESCRIPTION
We pass most of the envd unknown errors without wrapping the message which can be confusing on client as we cannot be sure where the error originated—on client/server and at what part of the envd request handling.