### PR TITLE
Fix missing property in filessystem stat

### DIFF
--- a/packages/envd/internal/services/filesystem/stat.go
+++ b/packages/envd/internal/services/filesystem/stat.go
@@ -36,6 +36,7 @@ func (Service) Stat(ctx context.Context, req *connect.Request[rpc.StatRequest]) 
 			Entry: &rpc.EntryInfo{
 				Name: fileInfo.Name(),
 				Type: getEntryType(fileInfo),
+				Path: path,
 			},
 		},
 	), nil


### PR DESCRIPTION
# Description

Fixes missing property `Path` when calling `Stat`