### PR TITLE
Fix race conditon between process cancellation and pipe closing

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -119,7 +119,7 @@ func New(
 	var outWg sync.WaitGroup
 
 	// Create a context for waiting for and cancelling output pipes.
-	// Cancellation if the process via timeout will propagate and cancel this context too.
+	// Cancellation of the process via timeout will propagate and cancel this context too.
 	outCtx, outCancel := context.WithCancel(ctx)
 
 	h := &Handler{

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -44,8 +44,10 @@ type Handler struct {
 	cmd *exec.Cmd
 	tty *os.File
 
-	ctx    context.Context
 	cancel context.CancelFunc
+
+	outCtx    context.Context
+	outCancel context.CancelFunc
 
 	stdin io.WriteCloser
 
@@ -116,6 +118,22 @@ func New(
 
 	var outWg sync.WaitGroup
 
+	// Create a context for waiting for and cancelling output pipes.
+	// Cancellation if the process via timeout will propagate and cancel this context too.
+	outCtx, outCancel := context.WithCancel(ctx)
+
+	h := &Handler{
+		Config:    req.GetProcess(),
+		cmd:       cmd,
+		Tag:       req.Tag,
+		DataEvent: outMultiplex,
+		cancel:    cancel,
+		outCtx:    outCtx,
+		outCancel: outCancel,
+		EndEvent:  NewMultiplexedChannel[rpc.ProcessEvent_End](0),
+		logger:    logger,
+	}
+
 	if req.GetPty() != nil {
 		// The pty should ideally start only in the Start method, but the package does not support that and we would have to code it manually.
 		// The output of the pty should correctly be passed though.
@@ -158,129 +176,113 @@ func New(
 			}
 		}()
 
-		return &Handler{
-			Config:    req.GetProcess(),
-			cmd:       cmd,
-			tty:       tty,
-			Tag:       req.Tag,
-			DataEvent: outMultiplex,
-			ctx:       ctx,
-			cancel:    cancel,
-			EndEvent:  NewMultiplexedChannel[rpc.ProcessEvent_End](0),
-			logger:    logger,
-		}, nil
-	}
+		h.tty = tty
+	} else {
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stdout pipe for command '%s': %w", cmd, err))
+		}
 
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stdin pipe for command '%s': %w", cmd, err))
-	}
+		outWg.Add(1)
+		go func() {
+			defer outWg.Done()
+			stdoutLogs := make(chan []byte, outputBufferSize)
+			defer close(stdoutLogs)
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stdout pipe for command '%s': %w", cmd, err))
-	}
+			stdoutLogger := logger.With().Str("event_type", "stdout").Logger()
 
-	outWg.Add(1)
-	go func() {
-		defer outWg.Done()
-		stdoutLogs := make(chan []byte, outputBufferSize)
-		defer close(stdoutLogs)
+			go logs.LogBufferedDataEvents(stdoutLogs, &stdoutLogger, "data")
 
-		stdoutLogger := logger.With().Str("event_type", "stdout").Logger()
+			for {
+				buf := make([]byte, stdChunkSize)
 
-		go logs.LogBufferedDataEvents(stdoutLogs, &stdoutLogger, "data")
+				n, readErr := stdout.Read(buf)
 
-		for {
-			buf := make([]byte, stdChunkSize)
-
-			n, readErr := stdout.Read(buf)
-
-			if n > 0 {
-				outMultiplex.Source <- rpc.ProcessEvent_Data{
-					Data: &rpc.ProcessEvent_DataEvent{
-						Output: &rpc.ProcessEvent_DataEvent_Stdout{
-							Stdout: buf[:n],
+				if n > 0 {
+					outMultiplex.Source <- rpc.ProcessEvent_Data{
+						Data: &rpc.ProcessEvent_DataEvent{
+							Output: &rpc.ProcessEvent_DataEvent_Stdout{
+								Stdout: buf[:n],
+							},
 						},
-					},
+					}
+
+					stdoutLogs <- buf[:n]
 				}
 
-				stdoutLogs <- buf[:n]
-			}
-
-			if errors.Is(readErr, io.EOF) {
-				break
-			}
-
-			if readErr != nil {
-				fmt.Fprintf(os.Stderr, "error reading from stdout: %s\n", readErr)
-
-				break
-			}
-		}
-	}()
-
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stderr pipe for command '%s': %w", cmd, err))
-	}
-
-	outWg.Add(1)
-	go func() {
-		defer outWg.Done()
-		stderrLogs := make(chan []byte, outputBufferSize)
-		defer close(stderrLogs)
-
-		stderrLogger := logger.With().Str("event_type", "stderr").Logger()
-
-		go logs.LogBufferedDataEvents(stderrLogs, &stderrLogger, "data")
-
-		for {
-			buf := make([]byte, stdChunkSize)
-
-			n, readErr := stderr.Read(buf)
-
-			if n > 0 {
-				outMultiplex.Source <- rpc.ProcessEvent_Data{
-					Data: &rpc.ProcessEvent_DataEvent{
-						Output: &rpc.ProcessEvent_DataEvent_Stderr{
-							Stderr: buf[:n],
-						},
-					},
+				if errors.Is(readErr, io.EOF) {
+					break
 				}
 
-				stderrLogs <- buf[:n]
-			}
+				if readErr != nil {
+					fmt.Fprintf(os.Stderr, "error reading from stdout: %s\n", readErr)
 
-			if errors.Is(readErr, io.EOF) {
-				break
+					break
+				}
 			}
+		}()
 
-			if readErr != nil {
-				fmt.Fprintf(os.Stderr, "error reading from stderr: %s\n", readErr)
-
-				break
-			}
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stderr pipe for command '%s': %w", cmd, err))
 		}
-	}()
+
+		outWg.Add(1)
+		go func() {
+			defer outWg.Done()
+			stderrLogs := make(chan []byte, outputBufferSize)
+			defer close(stderrLogs)
+
+			stderrLogger := logger.With().Str("event_type", "stderr").Logger()
+
+			go logs.LogBufferedDataEvents(stderrLogs, &stderrLogger, "data")
+
+			for {
+				buf := make([]byte, stdChunkSize)
+
+				n, readErr := stderr.Read(buf)
+
+				if n > 0 {
+					outMultiplex.Source <- rpc.ProcessEvent_Data{
+						Data: &rpc.ProcessEvent_DataEvent{
+							Output: &rpc.ProcessEvent_DataEvent_Stderr{
+								Stderr: buf[:n],
+							},
+						},
+					}
+
+					stderrLogs <- buf[:n]
+				}
+
+				if errors.Is(readErr, io.EOF) {
+					break
+				}
+
+				if readErr != nil {
+					fmt.Fprintf(os.Stderr, "error reading from stderr: %s\n", readErr)
+
+					break
+				}
+			}
+		}()
+
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating stdin pipe for command '%s': %w", cmd, err))
+		}
+
+		h.stdin = stdin
+	}
 
 	go func() {
 		outWg.Wait()
+
 		close(outMultiplex.Source)
-		cancel()
+
+		outCancel()
 	}()
 
-	return &Handler{
-		Config:    req.GetProcess(),
-		cmd:       cmd,
-		stdin:     stdin,
-		Tag:       req.Tag,
-		DataEvent: outMultiplex,
-		ctx:       ctx,
-		cancel:    cancel,
-		EndEvent:  NewMultiplexedChannel[rpc.ProcessEvent_End](0),
-		logger:    logger,
-	}, nil
+	return h, nil
 }
 
 func (p *Handler) SendSignal(signal syscall.Signal) error {
@@ -289,7 +291,7 @@ func (p *Handler) SendSignal(signal syscall.Signal) error {
 	}
 
 	if signal == syscall.SIGKILL || signal == syscall.SIGTERM {
-		p.cancel()
+		p.outCancel()
 	}
 
 	return p.cmd.Process.Signal(signal)
@@ -354,7 +356,8 @@ func (p *Handler) Start() (uint32, error) {
 }
 
 func (p *Handler) Wait() {
-	<-p.ctx.Done()
+	// Wait for the output pipes to be closed or cancelled.
+	<-p.outCtx.Done()
 
 	err := p.cmd.Wait()
 
@@ -385,4 +388,8 @@ func (p *Handler) Wait() {
 		Str("event_type", "process_end").
 		Interface("process_result", endEvent).
 		Send()
+
+	// Ensure the process cancel is called to cleanup resources.
+	// As it is called after end event and Wait, it should not affect command execution or returned events.
+	p.cancel()
 }

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -86,6 +86,9 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 
 	proc, err := handler.New(procCtx, u, req.Msg, &handlerL, s.envs, cancelProc)
 	if err != nil {
+		// Ensure the process cancel is called to cleanup resources.
+		cancelProc()
+
 		return err
 	}
 

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -78,8 +78,8 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 	}
 
 	// Create a new context with a timeout if provided.
-	// We do not want the command to  be killed if the request context is cancelled
-	procCtx, cancelProc := context.WithCancel(context.Background())
+	// We do not want the command to be killed if the request context is cancelled
+	procCtx, cancelProc := context.Background(), func() {}
 	if timeout > 0 { // zero timeout means no timeout
 		procCtx, cancelProc = context.WithTimeout(procCtx, timeout)
 	}


### PR DESCRIPTION
- Cleanup handler initialization
- Fix output context cancellation—prevent race condition with the whole process context
- Ensure the process cancel is not overriding what signal is propagated when forwarding signals to the process