### PR TITLE
Fix link for missing API Key

### DIFF
--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -141,7 +141,7 @@ func CreateAuthenticationFunc(
 			},
 			validationFunction: teamValidationFunction,
 			contextKey:         TeamContextKey,
-			errorMessage:       "Invalid API key, please visit https://e2b.dev/docs?reason=sdk-missing-api-key to get your API key.",
+			errorMessage:       "Invalid API key, please visit https://e2b.dev/docs/quickstart/api-key for more information.",
 		},
 		&commonAuthenticator[uuid.UUID]{
 			securitySchemeName: "AccessTokenAuth",


### PR DESCRIPTION
# Description

Current URL is broken, change it to [new one](https://e2b.dev/docs/quickstart/api-key)