### PR TITLE
Improve lifecycle cache unit test flakiness

### DIFF
--- a/packages/api/internal/cache/instance/lifecycle_cache_test.go
+++ b/packages/api/internal/cache/instance/lifecycle_cache_test.go
@@ -185,6 +185,10 @@ func TestLifecycleCacheHasEvicting(t *testing.T) {
 
 	// Wait for eviction to complete
 	<-evictCalled
+	// Wait for the eviction process (remove from an evicting map) to complete,
+	// this delay is waiting just for code runtime.
+	// Not ideal, but should be enough for most of the time
+	time.Sleep(50 * time.Millisecond)
 
 	assert.False(t, cache.Has("test", true))
 	assert.False(t, cache.Has("test", false))


### PR DESCRIPTION
Improves flakiness of a `TestLifecycleCacheHasEvicting` unit test where the channel might have ended sooner than the evicting map deletion 