### PR TITLE
Print envd logs on integration test envd init fail

### DIFF
--- a/tests/integration/internal/setup/envd_client.go
+++ b/tests/integration/internal/setup/envd_client.go
@@ -72,7 +72,7 @@ func SetAccessTokenHeader(header http.Header, accessToken string) {
 }
 
 func SetUserHeader(header http.Header, user string) {
-	userString := fmt.Sprintf("user:%s", user)
+	userString := fmt.Sprintf("%s:", user)
 	userBase64 := base64.StdEncoding.EncodeToString([]byte(userString))
 	basic := fmt.Sprintf("Basic %s", userBase64)
 	header.Set("Authorization", basic)

--- a/tests/integration/internal/tests/envd/auth_test.go
+++ b/tests/integration/internal/tests/envd/auth_test.go
@@ -185,12 +185,12 @@ func sandboxEnvdInitCall(t *testing.T, ctx context.Context, req envdInitCall) {
 func getSandboxLogs(ctx context.Context, client *setup.EnvdClient, sbx *api.PostSandboxesResponse) (string, error) {
 	req := connect.NewRequest(&process.StartRequest{
 		Process: &process.ProcessConfig{
-			Cmd:  "sudo",
-			Args: []string{"journalctl", "-u", "envd"},
+			Cmd:  "journalctl",
+			Args: []string{"-u", "envd"},
 		},
 	})
 	setup.SetSandboxHeader(req.Header(), sbx.JSON201.SandboxID, sbx.JSON201.ClientID)
-	setup.SetUserHeader(req.Header(), "user")
+	setup.SetUserHeader(req.Header(), "root")
 	stream, err := client.ProcessClient.Start(
 		ctx,
 		req,

--- a/tests/integration/internal/tests/envd/auth_test.go
+++ b/tests/integration/internal/tests/envd/auth_test.go
@@ -2,7 +2,9 @@ package envd
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -12,6 +14,7 @@ import (
 	"github.com/e2b-dev/infra/tests/integration/internal/api"
 	envdapi "github.com/e2b-dev/infra/tests/integration/internal/envd/api"
 	"github.com/e2b-dev/infra/tests/integration/internal/envd/filesystem"
+	"github.com/e2b-dev/infra/tests/integration/internal/envd/process"
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
 )
 
@@ -168,4 +171,50 @@ func sandboxEnvdInitCall(t *testing.T, ctx context.Context, req envdInitCall) {
 	}
 
 	assert.Equal(t, req.expectedResHttpStatus, res.StatusCode())
+
+	if res.StatusCode() == http.StatusBadGateway {
+		logs, err := getSandboxLogs(ctx, req.client, req.sbx)
+		if err != nil {
+			t.Logf("Failed to get logs from sandbox %s: %s", req.sbx.JSON201.SandboxID, err)
+		} else {
+			t.Logf("Sandbox logs for the failed (502) request to sandbox %s:\n%s", req.sbx.JSON201.SandboxID, logs)
+		}
+	}
+}
+
+func getSandboxLogs(ctx context.Context, client *setup.EnvdClient, sbx *api.PostSandboxesResponse) (string, error) {
+	req := connect.NewRequest(&process.StartRequest{
+		Process: &process.ProcessConfig{
+			Cmd:  "sudo",
+			Args: []string{"journalctl", "-u", "envd"},
+		},
+	})
+	setup.SetSandboxHeader(req.Header(), sbx.JSON201.SandboxID, sbx.JSON201.ClientID)
+	setup.SetUserHeader(req.Header(), "user")
+	stream, err := client.ProcessClient.Start(
+		ctx,
+		req,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to get logs from sandbox: %w", err)
+	}
+
+	defer stream.Close()
+
+	out := []string{}
+
+	for stream.Receive() {
+		msg := stream.Msg()
+
+		if msg.Event.GetData() != nil {
+			switch data := msg.Event.GetData().GetOutput().(type) {
+			case *process.ProcessEvent_DataEvent_Stdout:
+				out = append(out, string(data.Stdout))
+			case *process.ProcessEvent_DataEvent_Stderr:
+				out = append(out, string(data.Stderr))
+			}
+		}
+	}
+
+	return strings.Join(out, ""), nil
 }


### PR DESCRIPTION
If the envd init request in integration tests fail we get and print the envd logs so we can inspect what happened.