### PR TITLE
Fix missing "goose" during deployment when running `make migrate` 

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.work'
+          cache: false
+
       - name: Setup environment
         uses: ./.github/actions/deploy-setup
         with:


### PR DESCRIPTION
# Description

After installing goose, it still can't be found, because gopath isn't set. Setting up go before fixes the issue