### PR TITLE
Add kill process test

### DIFF
--- a/packages/template-manager/cmd/build-template/main.go
+++ b/packages/template-manager/cmd/build-template/main.go
@@ -61,9 +61,9 @@ func Build(ctx context.Context, kernelVersion, fcVersion, templateID, buildID st
 			true,
 		),
 		VCpuCount:       2,
-		MemoryMB:        256,
+		MemoryMB:        1024,
 		StartCmd:        "",
-		DiskSizeMB:      512,
+		DiskSizeMB:      1024,
 		BuildLogsWriter: &buf,
 	}
 

--- a/tests/integration/internal/setup/constants.go
+++ b/tests/integration/internal/setup/constants.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	apiTimeout = 120 * time.Second
+	apiTimeout  = 120 * time.Second
+	envdTimeout = 600 * time.Second
 )
 
 var (

--- a/tests/integration/internal/setup/envd_client.go
+++ b/tests/integration/internal/setup/envd_client.go
@@ -25,7 +25,7 @@ func GetEnvdClient(tb testing.TB, _ context.Context) *EnvdClient {
 	tb.Helper()
 
 	hc := http.Client{
-		Timeout: apiTimeout,
+		Timeout: envdTimeout,
 	}
 
 	httpC, err := api.NewClientWithResponses(EnvdProxy, api.WithHTTPClient(&hc))

--- a/tests/integration/internal/tests/envd/process_test.go
+++ b/tests/integration/internal/tests/envd/process_test.go
@@ -1,0 +1,117 @@
+package envd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/tests/integration/internal/envd/process"
+	"github.com/e2b-dev/infra/tests/integration/internal/setup"
+	"github.com/e2b-dev/infra/tests/integration/internal/utils"
+)
+
+func TestCommandKillNextApp(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := setup.GetAPIClient()
+	sbx := utils.SetupSandboxWithCleanup(t, client)
+
+	envdClient := setup.GetEnvdClient(t, ctx)
+
+	// Step 1: Run `npx create-next-app`
+	createAppReq := connect.NewRequest(&process.StartRequest{
+		Process: &process.ProcessConfig{
+			Cmd: "npx",
+			Args: []string{
+				"create-next-app@latest", "nextapp", "--yes",
+			},
+		},
+	})
+	setup.SetSandboxHeader(createAppReq.Header(), sbx.SandboxID, sbx.ClientID)
+	setup.SetUserHeader(createAppReq.Header(), "user")
+	createAppStream, err := envdClient.ProcessClient.Start(ctx, createAppReq)
+	require.NoError(t, err)
+	defer createAppStream.Close()
+
+	for createAppStream.Receive() {
+		t.Log("create:", createAppStream.Msg())
+	}
+	require.NoError(t, createAppStream.Err())
+
+	// Step 2: Run `npm run dev` in background
+	cwd := "~/nextapp"
+	runDevReq := connect.NewRequest(&process.StartRequest{
+		Process: &process.ProcessConfig{
+			Cmd:  "npm",
+			Args: []string{"run", "dev"},
+			Cwd:  &cwd,
+		},
+	})
+	setup.SetSandboxHeader(runDevReq.Header(), sbx.SandboxID, sbx.ClientID)
+	setup.SetUserHeader(runDevReq.Header(), "user")
+	runDevStream, err := envdClient.ProcessClient.Start(ctx, runDevReq)
+	require.NoError(t, err)
+	defer runDevStream.Close()
+
+	// Read dev output
+	receiveDone := make(chan error, 1)
+	go func() {
+		defer close(receiveDone)
+		for runDevStream.Receive() {
+			t.Log("dev:", runDevStream.Msg())
+		}
+		receiveDone <- runDevStream.Err()
+	}()
+
+	defer func() {
+		select {
+		case <-ctx.Done():
+			t.Logf("Context done while receiving dev logs: %v", ctx.Err())
+			_ = runDevStream.Close()
+		case err := <-receiveDone:
+			require.NoError(t, err, "streaming ended with error")
+		}
+	}()
+
+	// Step 3: Wait for next dev to start and list processes
+	time.Sleep(10 * time.Second)
+
+	listReq := connect.NewRequest(&process.ListRequest{})
+	setup.SetSandboxHeader(listReq.Header(), sbx.SandboxID, sbx.ClientID)
+	setup.SetUserHeader(listReq.Header(), "user")
+	listResp, err := envdClient.ProcessClient.List(ctx, listReq)
+	require.NoError(t, err)
+
+	assert.Len(t, listResp.Msg.Processes, 1, "Expected one process (next dev) running")
+
+	// Step 4: Kill all processes
+	for _, proc := range listResp.Msg.Processes {
+		t.Logf("killing process PID=%d CMD=%s", proc.Pid, proc.Config.Cmd)
+		killReq := connect.NewRequest(&process.SendSignalRequest{
+			Signal: process.Signal_SIGNAL_SIGKILL,
+			Process: &process.ProcessSelector{
+				Selector: &process.ProcessSelector_Pid{
+					Pid: proc.Pid,
+				},
+			},
+		})
+		setup.SetSandboxHeader(killReq.Header(), sbx.SandboxID, sbx.ClientID)
+		setup.SetUserHeader(killReq.Header(), "user")
+		_, err := envdClient.ProcessClient.SendSignal(ctx, killReq)
+		assert.NoError(t, err)
+	}
+
+	// Step 5: Final process list
+	finalListResp, err := envdClient.ProcessClient.List(ctx, listReq)
+	require.NoError(t, err)
+
+	assert.Len(t, finalListResp.Msg.Processes, 0, "Expected no processes running")
+	for _, proc := range finalListResp.Msg.Processes {
+		t.Errorf("remaining process: PID=%d CMD=%s", proc.Pid, proc.Config.Cmd)
+	}
+}

--- a/tests/integration/internal/tests/envd/process_test.go
+++ b/tests/integration/internal/tests/envd/process_test.go
@@ -19,7 +19,7 @@ func TestCommandKillNextApp(t *testing.T) {
 	defer cancel()
 
 	client := setup.GetAPIClient()
-	sbx := utils.SetupSandboxWithCleanup(t, client)
+	sbx := utils.SetupSandboxWithCleanupWithTimeout(t, client, 300)
 
 	envdClient := setup.GetEnvdClient(t, ctx)
 
@@ -121,7 +121,7 @@ func TestCommandKillWithAnd(t *testing.T) {
 	defer cancel()
 
 	client := setup.GetAPIClient()
-	sbx := utils.SetupSandboxWithCleanup(t, client)
+	sbx := utils.SetupSandboxWithCleanupWithTimeout(t, client, 300)
 
 	envdClient := setup.GetEnvdClient(t, ctx)
 

--- a/tests/integration/internal/utils/sandbox.go
+++ b/tests/integration/internal/utils/sandbox.go
@@ -19,7 +19,7 @@ func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses) *api.Sand
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	sbxTimeout := int32(30)
+	sbxTimeout := int32(60)
 	createSandboxResponse, err := c.PostSandboxesWithResponse(ctx, api.NewSandbox{
 		TemplateID: setup.SandboxTemplateID,
 		Timeout:    &sbxTimeout,

--- a/tests/integration/internal/utils/sandbox.go
+++ b/tests/integration/internal/utils/sandbox.go
@@ -11,15 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// SetupSandboxWithCleanup creates a new sandbox and returns its data
-func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses) *api.Sandbox {
+// SetupSandboxWithCleanupWithTimeout creates a new sandbox with specific timeout and returns its data
+func SetupSandboxWithCleanupWithTimeout(t *testing.T, c *api.ClientWithResponses, sbxTimeout int32) *api.Sandbox {
 	t.Helper()
 
 	// t.Context() doesn't work with go vet, so we use our own context
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	sbxTimeout := int32(60)
 	createSandboxResponse, err := c.PostSandboxesWithResponse(ctx, api.NewSandbox{
 		TemplateID: setup.SandboxTemplateID,
 		Timeout:    &sbxTimeout,
@@ -40,6 +39,11 @@ func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses) *api.Sand
 	})
 
 	return createSandboxResponse.JSON201
+}
+
+// SetupSandboxWithCleanup creates a new sandbox and returns its data
+func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses) *api.Sandbox {
+	return SetupSandboxWithCleanupWithTimeout(t, c, 30)
 }
 
 // TeardownSandbox kills the sandbox with the given ID


### PR DESCRIPTION
Add test for killing NextJs process, and command `first && second`, and listing the running processes right after kill. 

Note: I needed to increase the memory and disk size for the base (built in integration tests) template, as well as sandbox and http client timeouts, to be able to handle these tests.

Prevents regression for https://github.com/e2b-dev/infra/pull/472