### PR TITLE
Log a warning in envd indicating that the sandbox exceeded the threshold cpu/memory

### DIFF
--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	Version = "0.2.0"
+	Version = "0.2.1"
 
 	commitSHA string
 


### PR DESCRIPTION
This would happen upon getting metrics at set interval already set in orchestrator checks. 
