### PR TITLE
Don't fail on remaining space eviction

### DIFF
--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -188,7 +188,7 @@ func (s *DiffStore) deleteOldestFromCache() (bool, error) {
 
 		sfSize, err := item.Value().FileSize()
 		if err != nil {
-			zap.L().Error("failed to get size of deleted item from cache", zap.Error(err))
+			zap.L().Warn("failed to get size of deleted item from cache", zap.Error(err))
 			sfSize = fallbackDiffSize
 		}
 

--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -12,6 +12,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const (
+	ToMBShift        = 20
+	fallbackDiffSize = 100 << ToMBShift
+)
+
 const DefaultCachePath = "/orchestrator/build"
 
 type deleteDiff struct {
@@ -183,8 +188,8 @@ func (s *DiffStore) deleteOldestFromCache() (bool, error) {
 
 		sfSize, err := item.Value().FileSize()
 		if err != nil {
-			e = fmt.Errorf("failed to get diff size: %w", err)
-			return false
+			zap.L().Error("failed to get size of deleted item from cache", zap.Error(err))
+			sfSize = fallbackDiffSize
 		}
 
 		s.scheduleDelete(item.Key(), sfSize)


### PR DESCRIPTION
Don't fail if the size get fails on remaining space eviction. The file size is used only as a estimate and doesn't have real meaning for removing the diff from the cache.