### PR TITLE
Create new build id for each integrations test run

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -22,6 +22,7 @@ runs:
     - name: Build Packages
       run: |
         make -C tests/integration build-debug
+        make -C packages/db build-debug
         make -C packages/template-manager build-debug
         make -C packages/orchestrator build-debug
         make -C packages/api build-debug

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -25,6 +25,7 @@ runs:
         export DOCKER_IMAGE_PATH="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_DOCKER_REPOSITORY_NAME}/${TEMPLATE_ID}"
         echo "Docker image template path: ${DOCKER_IMAGE_PATH}"
         
+        gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
         docker pull "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317"
         docker tag "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317" "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
         docker push "${DOCKER_IMAGE_PATH}:${BUILD_ID}"

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -28,6 +28,7 @@ runs:
         gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
         docker pull "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317"
         docker tag "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317" "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
+        docker push "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
         
         make -C packages/template-manager build-template \
           TEMPLATE_ID=${TEMPLATE_ID} \

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -14,11 +14,18 @@ runs:
         # Not used, but required to be defined
         GOOGLE_SERVICE_ACCOUNT_BASE64: "required-but-not-needed"
       run: |
-        # Generate a unique build ID for the template for this run
+        # Generate an unique build ID for the template for this run
         export BUILD_ID=$(uuidgen)
+        echo "This build unique ID: ${BUILD_ID}"
         
         echo "TESTS_SANDBOX_TEMPLATE_ID=${TEMPLATE_ID}" >> .env.test
         echo "TESTS_SANDBOX_BUILD_ID=${BUILD_ID}" >> .env.test
+        
+        # Manually reupload Docker image from common build ID
+        export DOCKER_IMAGE_PATH=${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_DOCKER_REPOSITORY_NAME}/${TEMPLATE_ID}
+        docker pull ${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317
+        docker tag ${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317 ${DOCKER_IMAGE_PATH}:${BUILD_ID}
+        docker push ${DOCKER_IMAGE_PATH}:${BUILD_ID}
         
         make -C packages/template-manager build-template \
           TEMPLATE_ID=${TEMPLATE_ID} \

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -22,10 +22,12 @@ runs:
         echo "TESTS_SANDBOX_BUILD_ID=${BUILD_ID}" >> .env.test
         
         # Manually reupload Docker image from common build ID
-        export DOCKER_IMAGE_PATH=${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_DOCKER_REPOSITORY_NAME}/${TEMPLATE_ID}
-        docker pull ${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317
-        docker tag ${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317 ${DOCKER_IMAGE_PATH}:${BUILD_ID}
-        docker push ${DOCKER_IMAGE_PATH}:${BUILD_ID}
+        export DOCKER_IMAGE_PATH="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT_ID}/${GCP_DOCKER_REPOSITORY_NAME}/${TEMPLATE_ID}"
+        echo "Docker image template path: ${DOCKER_IMAGE_PATH}"
+        
+        docker pull "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317"
+        docker tag "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317" "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
+        docker push "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
         
         make -C packages/template-manager build-template \
           TEMPLATE_ID=${TEMPLATE_ID} \

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -28,7 +28,6 @@ runs:
         gcloud auth configure-docker "${GCP_REGION}-docker.pkg.dev" --quiet
         docker pull "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317"
         docker tag "${DOCKER_IMAGE_PATH}:98130b63-ca75-431d-956a-9d829d14d317" "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
-        docker push "${DOCKER_IMAGE_PATH}:${BUILD_ID}"
         
         make -C packages/template-manager build-template \
           TEMPLATE_ID=${TEMPLATE_ID} \

--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -7,7 +7,6 @@ runs:
     - name: Build Sandbox Template
       env:
         TEMPLATE_ID: "2j6ly824owf4awgai1xo"
-        BUILD_ID: "98130b63-ca75-431d-956a-9d829d14d317"
         KERNEL_VERSION: "vmlinux-6.1.102"
         FIRECRACKER_VERSION: "v1.10.1_1fcdaec"
         # Rootfs Docker image repository
@@ -15,6 +14,9 @@ runs:
         # Not used, but required to be defined
         GOOGLE_SERVICE_ACCOUNT_BASE64: "required-but-not-needed"
       run: |
+        # Generate a unique build ID for the template for this run
+        export BUILD_ID=$(uuidgen)
+        
         echo "TESTS_SANDBOX_TEMPLATE_ID=${TEMPLATE_ID}" >> .env.test
         echo "TESTS_SANDBOX_BUILD_ID=${BUILD_ID}" >> .env.test
         

--- a/.github/actions/host-init/action.yml
+++ b/.github/actions/host-init/action.yml
@@ -25,6 +25,7 @@ runs:
         printenv > .env.test
         
         echo "GCP_REGION=${GCP_REGION}" >> $GITHUB_ENV
+        echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> $GITHUB_ENV
       shell: bash
 
     - name: Set up Docker

--- a/packages/db/Makefile
+++ b/packages/db/Makefile
@@ -20,7 +20,7 @@ init:
 .PHONY: build-debug
 build-debug:
 	go mod download
-	go vet ./internal/...
+	go vet ./...
 
 .PHONE: create-migration
 create-migration: goose-init

--- a/packages/db/Makefile
+++ b/packages/db/Makefile
@@ -17,6 +17,11 @@ init:
 	brew install sqlc
 	@echo "Done"
 
+.PHONY: build-debug
+build-debug:
+	go mod download
+	go vet ./internal/...
+
 .PHONE: create-migration
 create-migration: goose-init
 ifeq ($(origin NAME), undefined)

--- a/tests/integration/internal/main_test.go
+++ b/tests/integration/internal/main_test.go
@@ -3,12 +3,14 @@ package internal
 import (
 	"context"
 	"log"
+	"net/http"
 	"testing"
 
 	"github.com/e2b-dev/infra/tests/integration/internal/api"
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
 	"github.com/e2b-dev/infra/tests/integration/internal/utils"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,7 @@ func TestCacheTemplate(t *testing.T) {
 		Timeout:    &sbxTimeout,
 	}, setup.WithAPIKey())
 	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, sbx.StatusCode())
 
 	t.Cleanup(func() {
 		if sbx == nil {


### PR DESCRIPTION
Fixes integrations tests failing by creating a new build id each tests run to not interfere with other integration test runs.