### PR TITLE
Increase the initial huge pages ratio

### DIFF
--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -209,7 +209,7 @@ echo "- Huge page size: $hugepage_size_in_mib MiB"
 hugepages=$(($hugepages_ram / $hugepage_size_in_mib))
 
 # This percentage will be permanently allocated for huge pages and in monitoring it will be shown as used.
-base_hugepages_percentage=20
+base_hugepages_percentage=50
 base_hugepages=$(($hugepages * $base_hugepages_percentage / 100))
 base_hugepages=$(remove_decimal $base_hugepages)
 echo "- Allocating $base_hugepages huge pages ($base_hugepages_percentage%) for base usage"


### PR DESCRIPTION
# Description

If we use too much memory, the orchestrator node might not be able to allocate huge pages anymore because the memory is too fragmented.