### PR TITLE
Reconfigure API timeouts

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -45,9 +45,9 @@ const (
 	maxMultipartMemory = 1 << 27 // 128 MiB
 	maxUploadLimit     = 1 << 28 // 256 MiB
 
-	maxReadHeaderTimeout = 60 * time.Second
-	maxReadTimeout       = 75 * time.Second
-	maxWriteTimeout      = 75 * time.Second
+	maxReadTimeout  = 75 * time.Second
+	maxWriteTimeout = 75 * time.Second
+	idleTimeout     = 620 * time.Second
 
 	defaultPort = 80
 )
@@ -171,12 +171,14 @@ func NewGinServer(ctx context.Context, logger *zap.Logger, apiStore *handlers.AP
 	r.MaxMultipartMemory = maxMultipartMemory
 
 	s := &http.Server{
-		Handler:           r,
-		Addr:              fmt.Sprintf("0.0.0.0:%d", port),
-		ReadHeaderTimeout: maxReadHeaderTimeout,
-		ReadTimeout:       maxReadTimeout,
-		WriteTimeout:      maxWriteTimeout,
-		BaseContext:       func(net.Listener) context.Context { return ctx },
+		Handler: r,
+		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
+		// Configure timeouts to be greater than the proxy timeouts.
+		// https://github.com/golang/go/issues/47007
+		ReadTimeout:  maxReadTimeout,
+		WriteTimeout: maxWriteTimeout,
+		IdleTimeout:  idleTimeout,
+		BaseContext:  func(net.Listener) context.Context { return ctx },
 	}
 
 	return s

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -176,7 +176,6 @@ func NewGinServer(ctx context.Context, logger *zap.Logger, apiStore *handlers.AP
 		Handler: r,
 		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
 		// Configure timeouts to be greater than the proxy timeouts.
-		// https://github.com/golang/go/issues/47007
 		ReadTimeout:  maxReadTimeout,
 		WriteTimeout: maxWriteTimeout,
 		IdleTimeout:  idleTimeout,

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -47,7 +47,9 @@ const (
 
 	maxReadTimeout  = 75 * time.Second
 	maxWriteTimeout = 75 * time.Second
-	idleTimeout     = 620 * time.Second
+	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
+	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
+	idleTimeout = 620 * time.Second
 
 	defaultPort = 80
 )

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -26,7 +26,7 @@ const (
 	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
 	// Also it's a good practice to set it to a value higher than the idle timeout of the backend service
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
-	idleTimeout = 620 * time.Second
+	idleTimeout = 610 * time.Second
 
 	// We use a constant connection key, because we don't have to separate connection pools
 	// as we need to do when connecting to sandboxes (from orchestrator proxy) to prevent reuse of pool connections

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -23,7 +23,10 @@ const (
 	maxRetries            = 3
 
 	minOrchestratorProxyConns = 3
-	idleTimeout               = 620 * time.Second
+	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
+	// Also it's a good practice to set it to a value higher than the idle timeout of the backend service
+	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
+	idleTimeout = 620 * time.Second
 
 	// We use a constant connection key, because we don't have to separate connection pools
 	// as we need to do when connecting to sandboxes (from orchestrator proxy) to prevent reuse of pool connections

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -310,8 +310,9 @@ resource "google_compute_url_map" "orch_map" {
 
 ### IPv4 block ###
 resource "google_compute_target_https_proxy" "default" {
-  name    = "${var.prefix}https-proxy"
-  url_map = google_compute_url_map.orch_map.self_link
+  name                        = "${var.prefix}https-proxy"
+  url_map                     = google_compute_url_map.orch_map.self_link
+  http_keep_alive_timeout_sec = 540
 
   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.certificate_map.id}"
 }

--- a/packages/cluster/network/main.tf
+++ b/packages/cluster/network/main.tf
@@ -310,9 +310,8 @@ resource "google_compute_url_map" "orch_map" {
 
 ### IPv4 block ###
 resource "google_compute_target_https_proxy" "default" {
-  name                        = "${var.prefix}https-proxy"
-  url_map                     = google_compute_url_map.orch_map.self_link
-  http_keep_alive_timeout_sec = 540
+  name    = "${var.prefix}https-proxy"
+  url_map = google_compute_url_map.orch_map.self_link
 
   certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.certificate_map.id}"
 }

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -19,7 +19,10 @@ import (
 
 const (
 	minSandboxConns = 1
-	idleTimeout     = 630 * time.Second
+	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
+	// Also it's a good practice to set it to higher values as you progress in the stack
+	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
+	idleTimeout = 630 * time.Second
 )
 
 func NewSandboxProxy(port uint, sandboxes *smap.Map[*sandbox.Sandbox]) (*reverse_proxy.Proxy, error) {

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -22,7 +22,7 @@ const (
 	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
 	// Also it's a good practice to set it to higher values as you progress in the stack
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
-	idleTimeout = 630 * time.Second
+	idleTimeout = 620 * time.Second
 )
 
 func NewSandboxProxy(port uint, sandboxes *smap.Map[*sandbox.Sandbox]) (*reverse_proxy.Proxy, error) {

--- a/packages/shared/pkg/proxy/proxy.go
+++ b/packages/shared/pkg/proxy/proxy.go
@@ -37,9 +37,9 @@ func New(
 			Addr:         fmt.Sprintf(":%d", port),
 			ReadTimeout:  0,
 			WriteTimeout: 0,
-			// Downstream idle > upstream idle,
-			// otherwise a new downstream connection can try to reuse an upstream connection
-			// which is already in state `CLOSE_WAIT` resulting in error
+			// Downstream (client side) idle > upstream (server side) idle
+			// otherwise a new connection between downstream idle and upstream idle
+			// will try to reuse an upstream connection which is in `CLOSE_WAIT` state resulting in error
 			IdleTimeout:       idleTimeout + idleTimeoutBufferUpstreamDownstream,
 			ReadHeaderTimeout: 0,
 			Handler:           handler(p, getDestination),

--- a/packages/shared/pkg/proxy/proxy.go
+++ b/packages/shared/pkg/proxy/proxy.go
@@ -38,8 +38,8 @@ func New(
 			ReadTimeout:  0,
 			WriteTimeout: 0,
 			// Downstream idle > upstream idle,
-			// otherwise a new downstream connection can try to reuse an open upstream connection
-			// and reuse TCP connection which is already closed
+			// otherwise a new downstream connection can try to reuse an upstream connection
+			// which is already in state `CLOSE_WAIT` resulting in error
 			IdleTimeout:       idleTimeout + idleTimeoutBufferUpstreamDownstream,
 			ReadHeaderTimeout: 0,
 			Handler:           handler(p, getDestination),


### PR DESCRIPTION
The read header timeout lower than the backend timeout and the idle timeout lower than the LB idle timeout can be causing connection problems.


- https://github.com/golang/go/issues/47007
- https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#troubleshoot_general_connectivity_issues