### PR TITLE
Add index for build status

### DIFF
--- a/packages/db/migrations/20250506112836_builds_status_index.sql
+++ b/packages/db/migrations/20250506112836_builds_status_index.sql
@@ -1,0 +1,9 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+-- The index creation takes a lot of time
+CREATE INDEX CONCURRENTLY idx_env_builds_status
+    ON public.env_builds(status)
+    TABLESPACE pg_default;
+
+-- +goose Down
+DROP INDEX CONCURRENTLY public.idx_env_builds_status;

--- a/packages/db/migrations/20250506112836_builds_status_index.sql
+++ b/packages/db/migrations/20250506112836_builds_status_index.sql
@@ -1,9 +1,7 @@
 -- +goose NO TRANSACTION
 -- +goose Up
 -- The index creation takes a lot of time
-CREATE INDEX CONCURRENTLY idx_env_builds_status
-    ON public.env_builds(status)
-    TABLESPACE pg_default;
+CREATE INDEX CONCURRENTLY idx_env_builds_status ON public.env_builds(status);
 
 -- +goose Down
 DROP INDEX CONCURRENTLY public.idx_env_builds_status;


### PR DESCRIPTION
# Description

As we save snapshots to sandbox builds, there's a growing number of rows in the table, which makes some queries slow (e.g., listing all running builds). Adding an index on status will help with this.