### PR TITLE
Disable stacktraces for external loggers

### DIFF
--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -19,6 +19,8 @@ type LoggerConfig struct {
 	IsInternal bool
 	// IsDebug enables debug level logging, otherwise zap.InfoLevel level is used.
 	IsDebug bool
+	// DisableStacktrace disables stacktraces for the logger.
+	DisableStacktrace bool
 
 	// InitialFields fields that are added to every log entry.
 	InitialFields []zap.Field
@@ -36,8 +38,8 @@ func NewLogger(ctx context.Context, loggerConfig LoggerConfig) (*zap.Logger, err
 
 	config := zap.Config{
 		Level:             level,
-		DisableStacktrace: false,
-		// Taks stacktraces more liberally
+		DisableStacktrace: loggerConfig.DisableStacktrace,
+		// Takes stacktraces more liberally
 		Development:   true,
 		Sampling:      nil,
 		Encoding:      "json",

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -14,6 +14,7 @@ type SandboxLoggerConfig struct {
 	// The service name is added to every log entry.
 	ServiceName string
 	// IsInternal differentiates between our (internal) logs, and user accessible (external) logs.
+	// For external logger, we also disable stacktraces
 	IsInternal       bool
 	CollectorAddress string
 }
@@ -36,9 +37,10 @@ func NewLogger(ctx context.Context, config SandboxLoggerConfig) *zap.Logger {
 	}
 
 	lg, err := logger.NewLogger(ctx, logger.LoggerConfig{
-		ServiceName: config.ServiceName,
-		IsInternal:  config.IsInternal,
-		IsDebug:     true,
+		ServiceName:       config.ServiceName,
+		IsInternal:        config.IsInternal,
+		IsDebug:           true,
+		DisableStacktrace: !config.IsInternal,
 		InitialFields: []zap.Field{
 			zap.String("logger", config.ServiceName),
 		},


### PR DESCRIPTION
# Description

Disables stacktraces for external logger. It isn't very useful to the users and also unreadable in CLI