### PR TITLE
Use native exponential buckets for histograms

### DIFF
--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-create-errors.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-create-errors.json
@@ -121,7 +121,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"400\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"400\"}[$__interval])\n))",
       "format": "time_series",
       "instant": false,
       "interval": "60s",
@@ -135,7 +135,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"500\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"500\"}[$__interval])\n))",
       "hide": false,
       "instant": false,
       "interval": "60",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-create-latency-long-term.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-create-latency-long-term.json
@@ -225,7 +225,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+            "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
             "hide": false,
             "instant": false,
             "legendFormat": "50th Percentile",
@@ -238,7 +238,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "95th Percentile",
@@ -251,7 +251,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "99th Percentile",
@@ -264,7 +264,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "Maximum",
@@ -277,7 +277,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])\n",
+            "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])\n",
             "hide": true,
             "instant": false,
             "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-create-latency.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-create-latency.json
@@ -231,7 +231,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
       "hide": false,
       "instant": false,
       "legendFormat": "50th Percentile",
@@ -244,7 +244,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "95th Percentile",
@@ -257,7 +257,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "99th Percentile",
@@ -270,7 +270,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "Maximum",
@@ -283,7 +283,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])\n",
+      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes\", http_status_code=\"200\"}[$__rate_interval])\n",
       "hide": true,
       "instant": false,
       "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-errors.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-errors.json
@@ -121,7 +121,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"400\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"400\"}[$__interval])\n))",
       "format": "time_series",
       "instant": false,
       "interval": "60s",
@@ -135,7 +135,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"500\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"500\"}[$__interval])\n))",
       "hide": false,
       "instant": false,
       "interval": "60",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-latency-long-term.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-latency-long-term.json
@@ -225,7 +225,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+            "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
             "hide": false,
             "instant": false,
             "legendFormat": "50th Percentile",
@@ -238,7 +238,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "95th Percentile",
@@ -251,7 +251,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "99th Percentile",
@@ -264,7 +264,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+            "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
             "hide": false,
             "instant": false,
             "legendFormat": "Maximum",
@@ -277,7 +277,7 @@
                 "uid": "grafanacloud-prom"
             },
             "editorMode": "code",
-            "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])\n",
+            "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])\n",
             "hide": true,
             "instant": false,
             "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-latency.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-kill-latency.json
@@ -231,7 +231,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
       "hide": false,
       "instant": false,
       "legendFormat": "50th Percentile",
@@ -244,7 +244,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "95th Percentile",
@@ -257,7 +257,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "99th Percentile",
@@ -270,7 +270,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "Maximum",
@@ -283,7 +283,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])\n",
+      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"DELETE\", http_route=\"/sandboxes/:sandboxID\", http_status_code=\"200\"}[$__rate_interval])\n",
       "hide": true,
       "instant": false,
       "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-errors-orchestrator.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-errors-orchestrator.json
@@ -121,7 +121,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "sum by (rpc_grpc_status_code) (\n  increase(rpc_server_duration_milliseconds_count{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code!=\"0\"}[$__interval])\n)",
+      "expr": "histogram_count(sum by (rpc_grpc_status_code) (\n  increase(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code!=\"0\"}[$__interval])\n))",
       "format": "time_series",
       "instant": false,
       "interval": "60s",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-errors.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-errors.json
@@ -121,7 +121,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"400\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"400\"}[$__interval])\n))",
       "format": "time_series",
       "instant": false,
       "interval": "60s",
@@ -135,7 +135,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"500\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"500\"}[$__interval])\n))",
       "hide": false,
       "instant": false,
       "interval": "60",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-latency-orchestrator.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-latency-orchestrator.json
@@ -232,7 +232,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(rpc_server_duration_milliseconds_bucket{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "50th Percentile",
@@ -245,7 +245,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(rpc_server_duration_milliseconds_bucket{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "95th Percentile",
@@ -258,7 +258,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(rpc_server_duration_milliseconds_bucket{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "99th Percentile",
@@ -271,7 +271,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(rpc_server_duration_milliseconds_bucket{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "Maximum",
@@ -284,7 +284,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# Total requests\nidelta(rpc_server_duration_milliseconds_bucket{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])\n",
+      "expr": "# Total requests\nidelta(rpc_server_duration_milliseconds{job=\"orchestrator\", rpc_method=\"Pause\", rpc_grpc_status_code=\"0\"}[$__rate_interval])\n",
       "hide": true,
       "instant": false,
       "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-latency.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-pause-latency.json
@@ -232,7 +232,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
       "hide": false,
       "instant": false,
       "legendFormat": "50th Percentile",
@@ -245,7 +245,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "95th Percentile",
@@ -258,7 +258,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "99th Percentile",
@@ -271,7 +271,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "Maximum",
@@ -284,7 +284,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])\n",
+      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/pause\", http_status_code=\"200\"}[$__rate_interval])\n",
       "hide": true,
       "instant": false,
       "legendFormat": "2xx",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-resume-errors.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-resume-errors.json
@@ -121,7 +121,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"400\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 4xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"400\"}[$__interval])\n))",
       "format": "time_series",
       "instant": false,
       "interval": "60s",
@@ -135,7 +135,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nsum (\n    increase(orchestration_api_http_server_duration_milliseconds_count{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"500\"}[$__interval])\n)",
+      "expr": "# 9. HTTP 5xx Error Count (Exact counts per interval)\nhistogram_count(sum (\n    increase(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"500\"}[$__interval])\n))",
       "hide": false,
       "instant": false,
       "interval": "60",

--- a/terraform/grafana/stack/dashboards/main/panels/sandbox-resume-latency.json
+++ b/terraform/grafana/stack/dashboards/main/panels/sandbox-resume-latency.json
@@ -232,7 +232,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
+      "expr": "# 3. 50th Percentile (Median) Response Time\nhistogram_quantile(0.5, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))\n",
       "hide": false,
       "instant": false,
       "legendFormat": "50th Percentile",
@@ -245,7 +245,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 5. 95th Percentile Response Time\nhistogram_quantile(0.95, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "95th Percentile",
@@ -258,7 +258,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. 99th Percentile Response Time \nhistogram_quantile(0.99, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "99th Percentile",
@@ -271,7 +271,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
+      "expr": "# 6. Maximum Percentile Response Time \nhistogram_quantile(1, sum(rate(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])) by (handler, method, le))",
       "hide": false,
       "instant": false,
       "legendFormat": "Maximum",
@@ -284,7 +284,7 @@
         "uid": "grafanacloud-prom"
       },
       "editorMode": "code",
-      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds_bucket{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])\n",
+      "expr": "# Total requests\nidelta(orchestration_api_http_server_duration_milliseconds{http_method=\"POST\", http_route=\"/sandboxes/:sandboxID/resume\", http_status_code=\"200\"}[$__rate_interval])\n",
       "hide": true,
       "instant": false,
       "legendFormat": "2xx",


### PR DESCRIPTION
Use native exponential buckets for histograms.

More information about native exponential buckets:
https://grafana.com/blog/2025/05/06/prometheus-native-histograms-in-grafana-cloud-more-precise-easier-to-use-and-better-compatibility

As this PR changes the usage to native buckets and updates Grafana panels, old data won't be shown anymore.