### PR TITLE
Remove proxy pool min connection enforcement

### DIFF
--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -22,8 +22,7 @@ const (
 	orchestratorProxyPort = 5007 // orchestrator proxy port
 	maxRetries            = 3
 
-	minOrchestratorProxyConns = 3
-	idleTimeout               = 620 * time.Second
+	idleTimeout = 620 * time.Second
 
 	// We use a constant connection key, because we don't have to separate connection pools
 	// as we need to do when connecting to sandboxes (from orchestrator proxy) to prevent reuse of pool connections
@@ -36,7 +35,6 @@ var dnsClient = dns.Client{}
 func NewClientProxy(port uint) (*reverse_proxy.Proxy, error) {
 	proxy := reverse_proxy.New(
 		port,
-		minOrchestratorProxyConns,
 		idleTimeout,
 		func(r *http.Request) (*pool.Destination, error) {
 			sandboxId, port, err := reverse_proxy.ParseHost(r.Host)

--- a/packages/nomad/client-proxy.hcl
+++ b/packages/nomad/client-proxy.hcl
@@ -77,6 +77,10 @@ job "client-proxy" {
         image        = "${image_name}"
         ports        = ["${port_name}"]
         args         = ["--port", "${port_number}"]
+
+        ulimit {
+          nofile = "262144:262144"
+        }
       }
     }
   }

--- a/packages/nomad/client-proxy.hcl
+++ b/packages/nomad/client-proxy.hcl
@@ -77,10 +77,6 @@ job "client-proxy" {
         image        = "${image_name}"
         ports        = ["${port_name}"]
         args         = ["--port", "${port_number}"]
-
-        ulimit {
-          nofile = "262144:262144"
-        }
       }
     }
   }

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -18,8 +18,7 @@ import (
 )
 
 const (
-	minSandboxConns = 1
-	idleTimeout     = 630 * time.Second
+	idleTimeout = 630 * time.Second
 )
 
 type SandboxProxy struct {
@@ -29,7 +28,6 @@ type SandboxProxy struct {
 func NewSandboxProxy(port uint, sandboxes *smap.Map[*sandbox.Sandbox]) (*SandboxProxy, error) {
 	proxy := reverse_proxy.New(
 		port,
-		minSandboxConns,
 		idleTimeout,
 		func(r *http.Request) (*pool.Destination, error) {
 			sandboxId, port, err := reverse_proxy.ParseHost(r.Host)

--- a/packages/shared/pkg/proxy/proxy.go
+++ b/packages/shared/pkg/proxy/proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/tracking"
 )
 
-const maxClientConns = 8192 // Reasonably big number that is lower than the number of available ports.
+const maxClientConns = 16384 // Reasonably big number that is lower than the number of available ports.
 
 type Proxy struct {
 	http.Server
@@ -21,12 +21,10 @@ type Proxy struct {
 
 func New(
 	port uint,
-	poolSizePerConnectionKey int,
 	idleTimeout time.Duration,
 	getDestination func(r *http.Request) (*pool.Destination, error),
 ) *Proxy {
 	p := pool.New(
-		poolSizePerConnectionKey,
 		maxClientConns,
 		idleTimeout,
 	)

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -116,7 +116,6 @@ func newTestProxy(getDestination func(r *http.Request) (*pool.Destination, error
 	// Set up the proxy server
 	proxy := New(
 		uint(port),
-		1,
 		20*time.Second, // Short idle timeout
 		getDestination,
 	)


### PR DESCRIPTION
Because the HTTP pipelining is disabled, there is not much reason to split pools and enforce minimum connections.
This PR also sets Docker ulimit for the client-proxy via Nomad.