### PR TITLE
Fix nil dereference when checking error while connecting to NDB

### DIFF
--- a/packages/orchestrator/internal/sandbox/nbd/path_direct_linux.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct_linux.go
@@ -152,9 +152,9 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 			sock.Close()
 		}
 		// Release the device back to the pool
-		err = d.devicePool.ReleaseDevice(deviceIndex)
-		if err != nil {
-			zap.L().Error("error opening NBD, error releasing device", zap.Error(err), zap.Uint32("device_index", deviceIndex))
+		releaseErr := d.devicePool.ReleaseDevice(deviceIndex)
+		if releaseErr != nil {
+			zap.L().Error("error opening NBD, error releasing device", zap.Error(releaseErr), zap.Uint32("device_index", deviceIndex))
 		}
 
 		if strings.Contains(err.Error(), "invalid argument") {


### PR DESCRIPTION
# Description

Fixes:
```
goroutine [running]:
github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd.(*DirectPathMount).Open()
	/build/orchestrator/internal/sandbox/nbd/path_direct_linux.go:160
panic: runtime error: invalid memory address or nil pointer dereference
```