### PR TITLE
Use separate status for snapshots

### DIFF
--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -30,7 +30,7 @@ type TemplateManager struct {
 	buildCache *templatecache.TemplatesBuildCache
 }
 
-var (
+const (
 	syncInterval             = time.Minute * 1
 	syncTimeout              = time.Minute * 15
 	syncWaitingStateDeadline = time.Minute * 20

--- a/packages/shared/pkg/db/snapshot.go
+++ b/packages/shared/pkg/db/snapshot.go
@@ -111,7 +111,7 @@ func (db *DB) NewSnapshotBuild(
 		SetKernelVersion(snapshotConfig.KernelVersion).
 		SetFirecrackerVersion(snapshotConfig.FirecrackerVersion).
 		SetEnvdVersion(snapshotConfig.EnvdVersion).
-		SetStatus(envbuild.StatusBuilding).
+		SetStatus(envbuild.StatusSnapshotting).
 		SetTotalDiskSizeMB(snapshotConfig.TotalDiskSizeMB).
 		Save(ctx)
 	if err != nil {

--- a/packages/shared/pkg/models/envbuild/envbuild.go
+++ b/packages/shared/pkg/models/envbuild/envbuild.go
@@ -104,11 +104,12 @@ const DefaultStatus = StatusWaiting
 
 // Status values.
 const (
-	StatusWaiting  Status = "waiting"
-	StatusBuilding Status = "building"
-	StatusFailed   Status = "failed"
-	StatusSuccess  Status = "success"
-	StatusUploaded Status = "uploaded"
+	StatusWaiting      Status = "waiting"
+	StatusBuilding     Status = "building"
+	StatusSnapshotting Status = "snapshotting"
+	StatusFailed       Status = "failed"
+	StatusSuccess      Status = "success"
+	StatusUploaded     Status = "uploaded"
 )
 
 func (s Status) String() string {
@@ -118,7 +119,7 @@ func (s Status) String() string {
 // StatusValidator is a validator for the "status" field enum values. It is called by the builders before save.
 func StatusValidator(s Status) error {
 	switch s {
-	case StatusWaiting, StatusBuilding, StatusFailed, StatusSuccess, StatusUploaded:
+	case StatusWaiting, StatusBuilding, StatusSnapshotting, StatusFailed, StatusSuccess, StatusUploaded:
 		return nil
 	default:
 		return fmt.Errorf("envbuild: invalid enum value for status field: %q", s)

--- a/packages/shared/pkg/models/migrate/schema.go
+++ b/packages/shared/pkg/models/migrate/schema.go
@@ -91,7 +91,7 @@ var (
 		{Name: "created_at", Type: field.TypeTime, Default: "CURRENT_TIMESTAMP"},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "finished_at", Type: field.TypeTime, Nullable: true},
-		{Name: "status", Type: field.TypeEnum, Enums: []string{"waiting", "building", "failed", "success", "uploaded"}, Default: "waiting", SchemaType: map[string]string{"postgres": "text"}},
+		{Name: "status", Type: field.TypeEnum, Enums: []string{"waiting", "building", "snapshotting", "failed", "success", "uploaded"}, Default: "waiting", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "dockerfile", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "start_cmd", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "vcpu", Type: field.TypeInt64},

--- a/packages/shared/pkg/schema/build.go
+++ b/packages/shared/pkg/schema/build.go
@@ -32,7 +32,7 @@ func (EnvBuild) Fields() []ent.Field {
 		field.Time("updated_at").Default(time.Now),
 		field.Time("finished_at").Optional().Nillable(),
 		field.String("env_id").SchemaType(map[string]string{dialect.Postgres: "text"}).Optional().Nillable(),
-		field.Enum("status").Values("waiting", "building", "failed", "success", "uploaded").Default("waiting").SchemaType(map[string]string{dialect.Postgres: "text"}),
+		field.Enum("status").Values("waiting", "building", "snapshotting", "failed", "success", "uploaded").Default("waiting").SchemaType(map[string]string{dialect.Postgres: "text"}),
 		field.String("dockerfile").SchemaType(map[string]string{dialect.Postgres: "text"}).Optional().Nillable(),
 		field.String("start_cmd").SchemaType(map[string]string{dialect.Postgres: "text"}).Optional().Nillable(),
 		field.Int64("vcpu"),


### PR DESCRIPTION
# Description

There is a race condition with template manager checking old builds, which can mark the snapshot as failed