### PR TITLE
Better error for blocked teams

### DIFF
--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -93,7 +93,7 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, input *openap
 
 		var forbiddenError *db.TeamForbiddenError
 		if errors.As(validationError.Err, &forbiddenError) {
-			return validationError.Err
+			return fmt.Errorf("Forbidden: %w", validationError.Err)
 		}
 
 		return fmt.Errorf("%s\n%s (%w)", a.errorMessage, validationError.ClientMsg, validationError.Err)

--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -14,9 +13,11 @@ import (
 	"github.com/google/uuid"
 	middleware "github.com/oapi-codegen/gin-middleware"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
+	"github.com/e2b-dev/infra/packages/shared/pkg/db"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -74,11 +75,6 @@ func (a *commonAuthenticator[T]) getHeaderKeysFromRequest(req *http.Request) (st
 
 // Authenticate uses the specified validator to ensure an API key is valid.
 func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, input *openapi3filter.AuthenticationInput) error {
-	// Our security scheme is named ApiKeyAuth, ensure this is the case
-	if input.SecuritySchemeName != a.securitySchemeName {
-		return fmt.Errorf("security scheme %s != '%s'", a.securitySchemeName, input.SecuritySchemeName)
-	}
-
 	// Now, we need to get the API key from the request
 	headerKey, err := a.getHeaderKeysFromRequest(input.RequestValidationInput.Request)
 	if err != nil {
@@ -92,10 +88,15 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, input *openap
 	// If the API key is valid, we will get a result back
 	result, validationError := a.validationFunction(ctx, headerKey)
 	if validationError != nil {
-		log.Printf("validation error %v", validationError.Err)
+		zap.L().Info("validation error", zap.Error(validationError.Err))
 		telemetry.ReportError(ctx, fmt.Errorf("%s %w", a.errorMessage, validationError.Err))
 
-		return fmt.Errorf(a.errorMessage)
+		var forbiddenError *db.TeamForbiddenError
+		if errors.As(validationError.Err, &forbiddenError) {
+			return validationError.Err
+		}
+
+		return fmt.Errorf("%s\n%s (%w)", a.errorMessage, validationError.ClientMsg, validationError.Err)
 	}
 
 	telemetry.ReportEvent(ctx, "api key validated")

--- a/packages/api/internal/cache/auth/cache.go
+++ b/packages/api/internal/cache/auth/cache.go
@@ -2,6 +2,7 @@ package autchcache
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -52,7 +53,7 @@ func (c *TeamAuthCache) GetOrSet(ctx context.Context, key string, dataCallback D
 	if item == nil {
 		team, tier, err = dataCallback(ctx, key)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("error while getting the team: %w", err)
 		}
 
 		templateInfo = &TeamInfo{team: team, tier: tier, lastRefresh: time.Now()}

--- a/packages/api/internal/cache/auth/cache.go
+++ b/packages/api/internal/cache/auth/cache.go
@@ -2,7 +2,6 @@ package autchcache
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -53,7 +52,7 @@ func (c *TeamAuthCache) GetOrSet(ctx context.Context, key string, dataCallback D
 	if item == nil {
 		team, tier, err = dataCallback(ctx, key)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to get the team from db for a key: %w", err)
+			return nil, nil, err
 		}
 
 		templateInfo = &TeamInfo{team: team, tier: tier, lastRefresh: time.Now()}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -387,7 +387,7 @@ func (a *APIStore) GetTeamFromSupabaseToken(ctx context.Context, teamID string) 
 	if errors.Is(err, &db.TeamForbiddenError{}) {
 		return authcache.AuthTeamInfo{}, &api.APIError{
 			Err:       fmt.Errorf("failed getting team: %w", err),
-			ClientMsg: err.Error(),
+			ClientMsg: fmt.Sprintf("Forbidden: %s", err.Error()),
 			Code:      http.StatusUnauthorized,
 		}
 	}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -269,6 +269,15 @@ func (a *APIStore) GetTeamFromAPIKey(ctx context.Context, apiKey string) (authca
 		return a.db.GetTeamAuth(ctx, key)
 	})
 	if err != nil {
+		var usageErr *db.TeamForbiddenError
+		if errors.As(err, &usageErr) {
+			return authcache.AuthTeamInfo{}, &api.APIError{
+				Err:       err,
+				ClientMsg: err.Error(),
+				Code:      http.StatusForbidden,
+			}
+		}
+
 		return authcache.AuthTeamInfo{}, &api.APIError{
 			Err:       fmt.Errorf("failed to get the team from db for an api key: %w", err),
 			ClientMsg: "Cannot get the team for the given API key",
@@ -375,10 +384,10 @@ func (a *APIStore) GetTeamFromSupabaseToken(ctx context.Context, teamID string) 
 	team, tier, err := a.authCache.GetOrSet(ctx, teamID, func(ctx context.Context, key string) (*models.Team, *models.Tier, error) {
 		return a.db.GetTeamByIDAndUserIDAuth(ctx, teamID, userID)
 	})
-	if errors.Is(err, &db.TeamUsageError{}) {
+	if errors.Is(err, &db.TeamForbiddenError{}) {
 		return authcache.AuthTeamInfo{}, &api.APIError{
 			Err:       fmt.Errorf("failed getting team: %w", err),
-			ClientMsg: "Team is blocked",
+			ClientMsg: err.Error(),
 			Code:      http.StatusUnauthorized,
 		}
 	}

--- a/packages/shared/pkg/db/apiKeys.go
+++ b/packages/shared/pkg/db/apiKeys.go
@@ -11,25 +11,25 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/models/teamapikey"
 )
 
-type TeamUsageError struct {
+type TeamForbiddenError struct {
 	message string
 }
 
-func (e *TeamUsageError) Error() string {
+func (e *TeamForbiddenError) Error() string {
 	return e.message
 }
 
 func validateTeamUsage(team *models.Team) error {
 	if team.IsBanned {
-		return &TeamUsageError{message: "team is banned"}
+		return &TeamForbiddenError{message: "team is banned"}
 	}
 
 	if team.IsBlocked {
 		if team.BlockedReason == nil {
-			return &TeamUsageError{message: "team was blocked"}
+			return &TeamForbiddenError{message: "team was blocked"}
 		}
 
-		return &TeamUsageError{message: fmt.Sprintf("team was blocked, reason: %s", *team.BlockedReason)}
+		return &TeamForbiddenError{message: fmt.Sprintf("team was blocked, reason: %s", *team.BlockedReason)}
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Return better error when team is blocked or banned.

```
{
  "code": 403,
  "message": "Forbidden: team was blocked, reason: didn't use e2b enough"
}
```

instead of

```
{
  "code": 401,
  "message": "Invalid API key, please visit https://e2b.dev/docs/quickstart/api-key for more information."
}
```