### PR TITLE
Disable `SetXForwarded` to prevent servers returning unexpected `content-location`

### DIFF
--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -69,7 +69,7 @@ func newProxyClient(
 				}
 
 				r.SetURL(t.Url)
-				r.SetXForwarded()
+				// We are **not** using SetXForwarded() because servers can sometimes modify the content-location header to be http which might break some customer services.
 				r.Out.Host = r.In.Host
 			},
 			ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {


### PR DESCRIPTION
It seems that the `SetXForwarded` setting of `X-Forwarded-Proto` header for `http` might be affecting user functionality—some services like Expo are returning unexpected `content-location` starting with `http://` then.

We need to check if the `X-Forwarded-Proto` really does this and if so deploy this fix in client-proxy and orchestrators.