### PR TITLE
Specify the clock source as kvm-clock

### DIFF
--- a/packages/orchestrator/internal/template/build/snapshot_linux.go
+++ b/packages/orchestrator/internal/template/build/snapshot_linux.go
@@ -290,7 +290,7 @@ func (s *Snapshot) configureFC(ctx context.Context, tracer trace.Tracer) error {
 
 	// IPv4 configuration - format: [local_ip]::[gateway_ip]:[netmask]:hostname:iface:dhcp_option:[dns]
 	ipv4 := fmt.Sprintf("%s::%s:%s:instance:%s:off:%s", fcAddr, fcTapAddress, fcMaskLong, fcIfaceID, fcDNS)
-	kernelArgs := fmt.Sprintf("quiet loglevel=1 ip=%s ipv6.disable=0 ipv6.autoconf=1 reboot=k panic=1 pci=off nomodules i8042.nokbd i8042.noaux random.trust_cpu=on", ipv4)
+	kernelArgs := fmt.Sprintf("quiet loglevel=1 ip=%s ipv6.disable=0 ipv6.autoconf=1 reboot=k panic=1 pci=off nomodules i8042.nokbd i8042.noaux random.trust_cpu=on clocksource=kvm-clock", ipv4)
 	kernelImagePath := storage.KernelMountedPath
 	bootSourceConfig := operations.PutGuestBootSourceParams{
 		Context: childCtx,


### PR DESCRIPTION
<img width="781" alt="image" src="https://github.com/user-attachments/assets/6a6e838f-ec13-4a8b-a6c6-377dac8e6c24" />
When the virtual machine is resumed, the time is the time before the snapshot is created. The reason is the time drift of the TSC clock source in the virtualization scenario. It takes about 3 seconds for the chronyd service to synchronize the system time to the accurate time. Using the kvm-clock clock source can solve this problem.
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/e6cac043-d633-4c30-abbc-3e20e008a22d" />
