### PR TITLE
Remove the extra message appended to the error coming from backend

### DIFF
--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -103,9 +103,7 @@ func newProxyClient(
 					}
 				}
 
-				zap.L().Error("sandbox error handler called", zap.Error(err))
-
-				http.Error(w, "Failed to route request to sandbox", http.StatusBadGateway)
+				zap.L().Warn("sandbox error handler called", zap.Error(err))
 
 				return
 			},


### PR DESCRIPTION
# Description

There's extra string added to the error coming from orchestrator proxy
Also I don't think should be altering errors coming from sandboxes

JSON:
```json
{
  "sandboxId":"iskokv1sjax752ysoylqj",
  "message":"The sandbox is running but port is not open",
  "port":3000,
  "code":502
}Failed to route request to sandbox\n'
```

HTML:
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/24024f7a-7cd0-42a6-b763-9b9e8c3d6cd2" />

