### PR TITLE
Fix max memory default migration

### DIFF
--- a/packages/db/migrations/20250513111201_tier_fix_max_memory.sql
+++ b/packages/db/migrations/20250513111201_tier_fix_max_memory.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE tiers
+    ALTER COLUMN "max_ram_mb" SET DEFAULT '8192'::bigint;
+UPDATE tiers SET "max_ram_mb" = 8192 WHERE "max_ram_mb" = 8096;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE tiers
+    ALTER COLUMN "max_ram_mb" SET DEFAULT '8096'::bigint;
+-- +goose StatementEnd


### PR DESCRIPTION
# Description

Set to 8096 instead of 8192, bad math