### PR TITLE
Fix migrations for newer Supabase versions

### DIFF
--- a/packages/db/migrations/20000101000000_auth.sql
+++ b/packages/db/migrations/20000101000000_auth.sql
@@ -36,13 +36,24 @@ DO $$
 $$;
 
 
--- Create "users" table
-CREATE TABLE IF NOT EXISTS "auth"."users"
-(
-    "id"                   uuid              NOT NULL DEFAULT gen_random_uuid(),
-    "email"                text              NOT NULL,
-    PRIMARY KEY ("id")
-);
+-- Check if the table exists before trying to create it
+DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'auth'
+              AND table_name = 'users'
+        ) THEN
+            EXECUTE '
+        CREATE TABLE auth.users (
+            id uuid NOT NULL DEFAULT gen_random_uuid(),
+            email text NOT NULL,
+            PRIMARY KEY (id)
+        );';
+        END IF;
+    END;
+$$;
 
 -- +goose StatementEnd
 

--- a/packages/db/migrations/20000101000000_auth.sql
+++ b/packages/db/migrations/20000101000000_auth.sql
@@ -36,6 +36,9 @@ DO $$
 $$;
 
 
+-- Grant execute on auth.uid() to postgres role
+GRANT EXECUTE ON FUNCTION auth.uid() TO postgres;
+
 -- Check if the table exists before trying to create it
 DO $$
     BEGIN

--- a/packages/db/migrations/20231124185944_create_schemas_and_tables.sql
+++ b/packages/db/migrations/20231124185944_create_schemas_and_tables.sql
@@ -2,7 +2,6 @@
 -- +goose StatementBegin
 
 -- Add new schema named "auth"
-CREATE SCHEMA IF NOT EXISTS "auth";
 CREATE SCHEMA IF NOT EXISTS "extensions";
 
 -- Create "tiers" table
@@ -84,14 +83,6 @@ CREATE TABLE IF NOT EXISTS "public"."team_api_keys"
     CONSTRAINT "team_api_keys_teams_team_api_keys" FOREIGN KEY ("team_id") REFERENCES "public"."teams" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
 );
 ALTER TABLE "public"."team_api_keys" ENABLE ROW LEVEL SECURITY;
-
--- Create "users" table
-CREATE TABLE IF NOT EXISTS "auth"."users"
-(
-    "id"    uuid                   NOT NULL DEFAULT gen_random_uuid(),
-    "email" character varying(255) NOT NULL,
-    PRIMARY KEY ("id")
-);
 
 -- Create "access_tokens" table
 CREATE TABLE IF NOT EXISTS "public"."access_tokens"


### PR DESCRIPTION
# Description

Supabase now doesn't allow to create anything in `auth` schema, so you can't even run `CREATE IF NOT EXISTS`. This should do the same. Also removed duplicated `auth.users` table creation (if not exists)