### PR TITLE
API: Request to node status will send status change to the orchestrator

### DIFF
--- a/packages/api/internal/handlers/admin.go
+++ b/packages/api/internal/handlers/admin.go
@@ -53,7 +53,7 @@ func (a *APIStore) PostNodesNodeID(c *gin.Context, nodeId api.NodeID) {
 		return
 	}
 
-	err = node.SendStatusChange(ctx, nodeId, body.Status)
+	err = node.SendStatusChange(ctx, body.Status)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when sending status change: %s", err))
 

--- a/packages/api/internal/handlers/admin.go
+++ b/packages/api/internal/handlers/admin.go
@@ -53,7 +53,14 @@ func (a *APIStore) PostNodesNodeID(c *gin.Context, nodeId api.NodeID) {
 		return
 	}
 
-	node.SetStatus(body.Status)
+	err = node.SendStatusChange(ctx, nodeId, body.Status)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when sending status change: %s", err))
+
+		errMsg := fmt.Errorf("error when sending status change: %w", err)
+		telemetry.ReportCriticalError(ctx, errMsg)
+		return
+	}
 
 	c.Status(http.StatusNoContent)
 }

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -41,8 +41,8 @@ var (
 	}
 
 	ApiNodeToOrchestratorStateMapper = map[api.NodeStatus]orchestratorinfo.ServiceInfoStatus{
-		api.NodeStatusReady: orchestratorinfo.ServiceInfoStatus_OrchestratorHealthy,
-		api.NodeStatusDraining: orchestratorinfo.ServiceInfoStatus_OrchestratorDraining,
+		api.NodeStatusReady:     orchestratorinfo.ServiceInfoStatus_OrchestratorHealthy,
+		api.NodeStatusDraining:  orchestratorinfo.ServiceInfoStatus_OrchestratorDraining,
 		api.NodeStatusUnhealthy: orchestratorinfo.ServiceInfoStatus_OrchestratorUnhealthy,
 	}
 )

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -18,7 +18,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/node"
 	e2bgrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc"
-	orchestrator "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	orchestratorinfo "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
 	e2bhealth "github.com/e2b-dev/infra/packages/shared/pkg/health"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
@@ -32,6 +32,20 @@ type GRPCClient struct {
 
 	connection e2bgrpc.ClientConnInterface
 }
+
+var (
+	OrchestratorToApiNodeStateMapper = map[orchestratorinfo.ServiceInfoStatus]api.NodeStatus{
+		orchestratorinfo.ServiceInfoStatus_OrchestratorHealthy:   api.NodeStatusReady,
+		orchestratorinfo.ServiceInfoStatus_OrchestratorDraining:  api.NodeStatusDraining,
+		orchestratorinfo.ServiceInfoStatus_OrchestratorUnhealthy: api.NodeStatusUnhealthy,
+	}
+
+	ApiNodeToOrchestratorStateMapper = map[api.NodeStatus]orchestratorinfo.ServiceInfoStatus{
+		api.NodeStatusReady: orchestratorinfo.ServiceInfoStatus_OrchestratorHealthy,
+		api.NodeStatusDraining: orchestratorinfo.ServiceInfoStatus_OrchestratorDraining,
+		api.NodeStatusUnhealthy: orchestratorinfo.ServiceInfoStatus_OrchestratorUnhealthy,
+	}
+)
 
 func NewClient(host string) (*GRPCClient, error) {
 	conn, err := e2bgrpc.GetConnection(host, false, grpc.WithStatsHandler(otelgrpc.NewClientHandler()), grpc.WithBlock(), grpc.WithTimeout(time.Second))
@@ -84,7 +98,12 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 	if err != nil {
 		zap.L().Error("Failed to get node info", zap.Error(err))
 	} else {
-		nodeStatus = o.getNodeStatusConverted(nodeInfo.ServiceStatus)
+		nodeStatus, ok = OrchestratorToApiNodeStateMapper[nodeInfo.ServiceStatus]
+		if !ok {
+			zap.L().Error("Unknown service info status", zap.Any("status", nodeInfo.ServiceStatus), zap.String("node_id", node.ID))
+			nodeStatus = api.NodeStatusUnhealthy
+		}
+
 		nodeVersion = nodeInfo.ServiceVersion
 	}
 
@@ -110,20 +129,6 @@ func (o *Orchestrator) GetClient(nodeID string) (*GRPCClient, error) {
 	}
 
 	return n.Client, nil
-}
-
-func (o *Orchestrator) getNodeStatusConverted(s orchestratorinfo.ServiceInfoStatus) api.NodeStatus {
-	switch s {
-	case orchestratorinfo.ServiceInfoStatus_OrchestratorHealthy:
-		return api.NodeStatusReady
-	case orchestratorinfo.ServiceInfoStatus_OrchestratorDraining:
-		return api.NodeStatusDraining
-	case orchestratorinfo.ServiceInfoStatus_OrchestratorUnhealthy:
-		return api.NodeStatusUnhealthy
-	default:
-		zap.L().Error("Unknown service info status", zap.Any("status", s))
-		return api.NodeStatusUnhealthy
-	}
 }
 
 func (o *Orchestrator) getNodeHealth(node *node.NodeInfo) (bool, error) {

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -76,10 +76,10 @@ func (n *Node) setStatus(status api.NodeStatus) {
 	}
 }
 
-func (n *Node) SendStatusChange(ctx context.Context, nodeId string, s api.NodeStatus) error {
+func (n *Node) SendStatusChange(ctx context.Context, s api.NodeStatus) error {
 	nodeStatus, ok := ApiNodeToOrchestratorStateMapper[s]
 	if !ok {
-		zap.L().Error("Unknown service info status", zap.Any("status", s), zap.String("node_id", nodeId))
+		zap.L().Error("Unknown service info status", zap.Any("status", s), zap.String("node_id", n.Info.ID))
 		return fmt.Errorf("unknown service info status: %s", s)
 	}
 


### PR DESCRIPTION
- currently there was just per-api health status adjustment
- this new thing now requests status change on orchestrator itself and waits for propagation via node sync