### PR TITLE
Fix periodic tests start cmd

### DIFF
--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -52,7 +52,7 @@ const buildStatus = await streamCommandOutput('npx', [
     '--name',
     templateName,
     '--cmd',
-    'echo "start cmd debug" && sleep 10 && echo "done starting command debug"',
+    '\'echo "start cmd debug" && sleep 10 && echo "done starting command debug"\'',
 ]);
 
 if (buildStatus.status.code !== 0) {


### PR DESCRIPTION
Fix periodic tests start cmd by escaping the argument