### PR TITLE
Use the FC api /entropy endpoint to configure the virtio-rng device

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/client_linux.go
+++ b/packages/orchestrator/internal/sandbox/fc/client_linux.go
@@ -240,11 +240,33 @@ func (c *apiClient) setMachineConfig(
 		Context: ctx,
 		Body:    machineConfig,
 	}
-
 	_, err := c.client.Operations.PutMachineConfiguration(&machineConfigParams)
 	if err != nil {
 		return fmt.Errorf("error setting fc machine config: %w", err)
 	}
+	return nil
+}
+
+// https://github.com/firecracker-microvm/firecracker/blob/main/docs/entropy.md#firecracker-implementation
+func (c *apiClient) setEntropyDevice(ctx context.Context, size int64, oneTimeBurst int64, refillTime int64) error {
+	entropyConfig := operations.PutEntropyDeviceParams{
+		Context: ctx,
+		Body: &models.EntropyDevice{
+			RateLimiter: &models.RateLimiter{
+				Bandwidth: &models.TokenBucket{
+					Size:         &size,
+					OneTimeBurst: &oneTimeBurst,
+					RefillTime:   &refillTime,
+				},
+			},
+		},
+	}
+
+	_, err := c.client.Operations.PutEntropyDevice(&entropyConfig)
+	if err != nil {
+		return fmt.Errorf("error setting fc entropy config: %w", err)
+	}
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -312,6 +312,14 @@ func (p *Process) Create(
 	}
 	telemetry.ReportEvent(childCtx, "set fc machine config")
 
+	err = p.client.setEntropyDevice(childCtx, 1000, 0, 100)
+	if err != nil {
+		fcStopErr := p.Stop()
+
+		return errors.Join(fmt.Errorf("error setting fc entropy config: %w", err), fcStopErr)
+	}
+	telemetry.ReportEvent(childCtx, "set fc entropy config")
+
 	err = p.client.startVM(childCtx)
 	if err != nil {
 		fcStopErr := p.Stop()


### PR DESCRIPTION


this is equivalent to running
```sh
curl --unix-socket $socket_location -i \
    -X PUT 'http://localhost/entropy' \
    -H 'Accept: application/json' \
    -H 'Content-Type: application/json' \
    -d "{
        \"rate_limiter\": {
            \"bandwidth\": {
                \"size\": 1000,
                \"one_time_burst\": 0,
                \"refill_time\": 100
            }
        }
    }"
  ```