### PR TITLE
Fix the filter in grafana dashboard for orch cache disk

### DIFF
--- a/terraform/grafana/stack/dashboards/main/panels/orchestrator-nodes-disk-cache.json
+++ b/terraform/grafana/stack/dashboards/main/panels/orchestrator-nodes-disk-cache.json
@@ -132,7 +132,7 @@
       },
       "disableTextWrap": false,
       "editorMode": "builder",
-      "expr": "nomad_client_host_disk_available{disk=\"/dev/sdb\"} / 1073741824",
+      "expr": "nomad_client_host_disk_available{disk=\"/dev/sdb\", node_pool=\"default\"} / 1073741824",
       "fullMetaSearch": false,
       "includeNullMetadata": true,
       "instant": false,


### PR DESCRIPTION
Filter out builder nodes