### PR TITLE
Orchestrators network namespaces safe-acquire

### DIFF
--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -115,7 +115,7 @@ func buildTemplate(parentCtx context.Context, kernelVersion, fcVersion, template
 		}
 	}()
 
-	networkPool, err := network.NewPool(ctx, 8, 8, clientID)
+	networkPool, err := network.NewPool(ctx, 8, 8, clientID, tracer)
 	if err != nil {
 		return fmt.Errorf("could not create network pool: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -73,7 +73,7 @@ func NewPool(ctx context.Context, newSlotsPoolSize, reusedSlotsPoolSize int, cli
 }
 
 func (p *Pool) createNetworkSlot() (*Slot, error) {
-	ips, err := p.slotStorage.Acquire()
+	ips, err := p.slotStorage.Acquire(p.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/meters"
@@ -29,7 +30,7 @@ type Pool struct {
 	slotStorage Storage
 }
 
-func NewPool(ctx context.Context, newSlotsPoolSize, reusedSlotsPoolSize int, clientID string) (*Pool, error) {
+func NewPool(ctx context.Context, newSlotsPoolSize, reusedSlotsPoolSize int, clientID string, tracer trace.Tracer) (*Pool, error) {
 	newSlots := make(chan Slot, newSlotsPoolSize-1)
 	reusedSlots := make(chan Slot, reusedSlotsPoolSize)
 
@@ -43,7 +44,7 @@ func NewPool(ctx context.Context, newSlotsPoolSize, reusedSlotsPoolSize int, cli
 		return nil, fmt.Errorf("failed to create reused slot counter: %w", err)
 	}
 
-	slotStorage, err := NewStorage(slotsSize, clientID)
+	slotStorage, err := NewStorage(slotsSize, clientID, tracer)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create slot storage: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -1,6 +1,6 @@
 package network
 
-import "github.com/e2b-dev/infra/packages/shared/pkg/env"
+import "go.opentelemetry.io/otel/trace"
 
 type Storage interface {
 	Acquire() (*Slot, error)
@@ -8,10 +8,6 @@ type Storage interface {
 }
 
 // NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
-func NewStorage(slotsSize int, clientID string) (Storage, error) {
-	if env.IsLocal() {
-		return NewStorageMemory(slotsSize)
-	} else {
-		return NewStorageKV(slotsSize, clientID)
-	}
+func NewStorage(slotsSize int, clientID string, tracer trace.Tracer) (Storage, error) {
+	return NewStorageLocal(slotsSize, tracer)
 }

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -1,13 +1,15 @@
 package network
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
 type Storage interface {
-	Acquire() (*Slot, error)
+	Acquire(ctx context.Context) (*Slot, error)
 	Release(*Slot) error
 }
 

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -1,6 +1,10 @@
 package network
 
-import "go.opentelemetry.io/otel/trace"
+import (
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+)
 
 type Storage interface {
 	Acquire() (*Slot, error)
@@ -9,5 +13,9 @@ type Storage interface {
 
 // NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
 func NewStorage(slotsSize int, clientID string, tracer trace.Tracer) (Storage, error) {
-	return NewStorageLocal(slotsSize, tracer)
+	if env.IsDevelopment() {
+		return NewStorageLocal(slotsSize, tracer)
+	}
+
+	return NewStorageKV(slotsSize, clientID)
 }

--- a/packages/orchestrator/internal/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_kv.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -47,7 +48,7 @@ func newConsulClient(token string) (*consulApi.Client, error) {
 	return consulClient, nil
 }
 
-func (s *StorageKV) Acquire() (*Slot, error) {
+func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 	kv := s.consulClient.KV()
 
 	var slot *Slot

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -58,11 +58,11 @@ func (s *StorageLocal) Acquire() (*Slot, error) {
 	// we skip the first slot because it's the host slot
 	slotIdx := 1
 
-	select {
-	case <-acquireTimeoutCtx.Done():
-		return nil, fmt.Errorf("failed to acquire IP slot: timeout")
-	default:
-		for {
+	for {
+		select {
+		case <-acquireTimeoutCtx.Done():
+			return nil, fmt.Errorf("failed to acquire IP slot: timeout")
+		default:
 			if len(s.acquiredNs) >= s.slotsSize {
 				return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
 			}

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -45,12 +45,12 @@ func NewStorageLocal(slotsSize int, tracer trace.Tracer) (*StorageLocal, error) 
 	}, nil
 }
 
-func (s *StorageLocal) Acquire() (*Slot, error) {
-	acquireTimeoutCtx, acquireCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
-	defer acquireCancel()
-
-	_, span := s.tracer.Start(acquireTimeoutCtx, "network-namespace-acquire")
+func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
+	spanCtx, span := s.tracer.Start(ctx, "network-namespace-acquire")
 	defer span.End()
+
+	acquireTimeoutCtx, acquireCancel := context.WithTimeout(spanCtx, time.Millisecond*500)
+	defer acquireCancel()
 
 	s.acquiredNsMu.Lock()
 	defer s.acquiredNsMu.Unlock()

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -46,7 +46,7 @@ func NewStorageLocal(slotsSize int, tracer trace.Tracer) (*StorageLocal, error) 
 }
 
 func (s *StorageLocal) Acquire() (*Slot, error) {
-	acquireTimeoutCtx, acquireCancel := context.WithTimeout(context.Background(), time.Second*5)
+	acquireTimeoutCtx, acquireCancel := context.WithTimeout(context.Background(), time.Millisecond*500)
 	defer acquireCancel()
 
 	_, span := s.tracer.Start(acquireTimeoutCtx, "network-namespace-acquire")

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -88,8 +88,8 @@ func (s *StorageLocal) Acquire() (*Slot, error) {
 				return nil, fmt.Errorf("error checking if namespace is available: %v", err)
 			}
 
-			// todo: maybe we should append it into foreign namespaces?
 			if !available {
+				s.foreignNs[slotName] = struct{}{}
 				zap.L().Debug("Skipping slot because not available", zap.String("slot", slotName))
 				continue
 			}

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -1,0 +1,161 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type StorageLocal struct {
+	slotsSize    int
+	foreignNs    map[string]struct{}
+	acquiredNs   map[string]struct{}
+	acquiredNsMu sync.Mutex
+}
+
+const netNamespacesDir = "/var/run/netns"
+
+func NewStorageLocal(slotsSize int) (*StorageLocal, error) {
+	// get namespaces that we want to always skip
+	foreignNs, err := getForeignNamespaces()
+	if err != nil {
+		return nil, fmt.Errorf("error getting already used namespaces: %v", err)
+	}
+
+	foreignNsMap := make(map[string]struct{})
+	for _, ns := range foreignNs {
+		foreignNsMap[ns] = struct{}{}
+		zap.L().Info(fmt.Sprintf("Found foreign namespace: %s", ns))
+	}
+
+	return &StorageLocal{
+		foreignNs:    foreignNsMap,
+		slotsSize:    slotsSize,
+		acquiredNs:   make(map[string]struct{}, slotsSize),
+		acquiredNsMu: sync.Mutex{},
+	}, nil
+}
+
+func (s *StorageLocal) Acquire() (*Slot, error) {
+	s.acquiredNsMu.Lock()
+	defer s.acquiredNsMu.Unlock()
+
+	acquireTimeoutCtx, acquireCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer acquireCancel()
+
+	// we skip the first slot because it's the host slot
+	slotIdx := 1
+
+	select {
+	case <-acquireTimeoutCtx.Done():
+		return nil, fmt.Errorf("failed to acquire IP slot: timeout")
+	default:
+		for {
+			if len(s.acquiredNs) >= s.slotsSize {
+				return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
+			}
+
+			slotIdx++
+			slotName := getSlotName(slotIdx)
+
+			// skip the slot if it's already in use by foreign program
+			if _, found := s.foreignNs[slotName]; found {
+				zap.L().Debug("Skipping slot because already use by foreign program", zap.String("slot", slotName))
+				continue
+			}
+
+			// skip the slot if it's already acquired
+			if _, found := s.acquiredNs[slotName]; found {
+				zap.L().Debug("Skipping slot because already acquired", zap.String("slot", slotName))
+				continue
+			}
+
+			// check if the slot can be acquired
+			available, err := isNamespaceAvailable(slotName)
+			if err != nil {
+				return nil, fmt.Errorf("error checking if namespace is available: %v", err)
+			}
+
+			// todo: maybe we should append it into foreign namespaces?
+			if !available {
+				zap.L().Debug("Skipping slot because not available", zap.String("slot", slotName))
+				continue
+			}
+
+			s.acquiredNs[slotName] = struct{}{}
+			slotKey := getMemoryKey(slotIdx)
+
+			return NewSlot(slotKey, slotIdx), nil
+		}
+	}
+}
+
+func (s *StorageLocal) Release(ips *Slot) error {
+	s.acquiredNsMu.Lock()
+	defer s.acquiredNsMu.Unlock()
+
+	slotName := getSlotName(ips.Idx)
+	delete(s.acquiredNs, slotName)
+
+	return nil
+}
+
+func isNamespaceAvailable(name string) (bool, error) {
+	nsPath := filepath.Join(netNamespacesDir, name)
+	_, err := os.Stat(nsPath)
+
+	if os.IsNotExist(err) {
+		// Namespace does not exist, so it's available
+		return true, nil
+	} else if err != nil {
+		// Some other error
+		return false, err
+	}
+
+	// File exists so namespace is in use.
+	return false, nil
+}
+
+func getForeignNamespaces() ([]string, error) {
+	var ns []string
+
+	files, err := os.ReadDir(netNamespacesDir)
+	if err != nil {
+		// Folder does not exist, so we can assume no namespaces are in use
+		if os.IsNotExist(err) {
+			return ns, nil
+		}
+
+		return nil, fmt.Errorf("error reading netns directory: %v", err)
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		name := file.Name()
+		if name == "host" {
+			continue
+		}
+
+		ns = append(ns, name)
+	}
+
+	return ns, nil
+}
+
+func getSlotName(slotIdx int) string {
+	slotIdxStr := strconv.Itoa(slotIdx)
+	return fmt.Sprintf("ns-%s", slotIdxStr)
+}
+
+func getMemoryKey(slotIdx int) string {
+	return strconv.Itoa(slotIdx)
+}

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -63,7 +63,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 		case <-acquireTimeoutCtx.Done():
 			return nil, fmt.Errorf("failed to acquire IP slot: timeout")
 		default:
-			if len(s.acquiredNs) >= s.slotsSize {
+			if len(s.acquiredNs) > s.slotsSize {
 				return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
 			}
 
@@ -95,7 +95,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 			}
 
 			s.acquiredNs[slotName] = struct{}{}
-			slotKey := getMemoryKey(slotIdx)
+			slotKey := getLocalKey(slotIdx)
 
 			return NewSlot(slotKey, slotIdx), nil
 		}
@@ -162,6 +162,6 @@ func getSlotName(slotIdx int) string {
 	return fmt.Sprintf("ns-%s", slotIdxStr)
 }
 
-func getMemoryKey(slotIdx int) string {
+func getLocalKey(slotIdx int) string {
 	return strconv.Itoa(slotIdx)
 }

--- a/packages/orchestrator/internal/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_memory.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -19,7 +20,7 @@ func NewStorageMemory(slotsSize int) (*StorageMemory, error) {
 	}, nil
 }
 
-func (s *StorageMemory) Acquire() (*Slot, error) {
+func (s *StorageMemory) Acquire(_ context.Context) (*Slot, error) {
 	s.freeSlotsMu.Lock()
 	defer s.freeSlotsMu.Unlock()
 

--- a/packages/orchestrator/internal/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_memory.go
@@ -3,6 +3,7 @@ package network
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 )
 
@@ -44,4 +45,8 @@ func (s *StorageMemory) Release(ips *Slot) error {
 	s.freeSlots[ips.Idx] = false
 
 	return nil
+}
+
+func getMemoryKey(slotIdx int) string {
+	return strconv.Itoa(slotIdx)
 }

--- a/packages/orchestrator/internal/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_memory.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"strconv"
 	"sync"
 )
 
@@ -44,8 +43,4 @@ func (s *StorageMemory) Release(ips *Slot) error {
 	s.freeSlots[ips.Idx] = false
 
 	return nil
-}
-
-func getMemoryKey(slotIdx int) string {
-	return strconv.Itoa(slotIdx)
 }

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -117,7 +117,6 @@ func run(port, proxyPort uint) (success bool) {
 	}
 
 	serviceName := service.GetServiceName(services)
-
 	serviceError := make(chan error)
 	defer close(serviceError)
 
@@ -202,7 +201,9 @@ func run(port, proxyPort uint) (success bool) {
 		zap.L().Fatal("failed to create sandbox proxy", zap.Error(err))
 	}
 
-	networkPool, err := network.NewPool(ctx, network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, clientID)
+	tracer := otel.Tracer(serviceName)
+
+	networkPool, err := network.NewPool(ctx, network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, clientID, tracer)
 	if err != nil {
 		zap.L().Fatal("failed to create network pool", zap.Error(err))
 	}
@@ -215,7 +216,6 @@ func run(port, proxyPort uint) (success bool) {
 	serviceInfo := service.NewInfoContainer(clientID, version, commitSHA)
 
 	grpcSrv := grpcserver.New(serviceInfo)
-	tracer := otel.Tracer(serviceName)
 
 	_, err = server.New(ctx, grpcSrv, networkPool, devicePool, tracer, serviceInfo, sandboxProxy, sandboxes)
 	if err != nil {


### PR DESCRIPTION
- Local-only implementation of network namespaces acquire that is safe to run on not clean environments.
- During startup checks all already create namespaces and adds them into foreign "block list" to skip them.
- When available namespace is found it will test if its really not existing (was not created during program lifetime).


Notes:
- Acquire is infinite loop with context timeout set to 5 seconds. We should lower it, will check that.
- When acquire function will find empty namespaces but then its marked as available maybe we should also put it into map and fast-skip it later.