### PR TITLE
make the variables readonly

### DIFF
--- a/packages/cluster-disk-image/setup/install-nomad.sh
+++ b/packages/cluster-disk-image/setup/install-nomad.sh
@@ -31,30 +31,30 @@ function print_usage {
 }
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   >&2 echo -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
+  local -r arg_name="$1"
+  local -r arg_value="$2"
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
@@ -99,12 +99,12 @@ function install_dependencies {
 }
 
 function user_exists {
-  local readonly username="$1"
+  local -r username="$1"
   id "$username" >/dev/null 2>&1
 }
 
 function create_nomad_user {
-  local readonly username="$1"
+  local -r username="$1"
 
   if $(user_exists "$username"); then
     echo "User $username already exists. Will not create again."
@@ -115,8 +115,8 @@ function create_nomad_user {
 }
 
 function create_nomad_install_paths {
-  local readonly path="$1"
-  local readonly username="$2"
+  local -r path="$1"
+  local -r username="$2"
 
   log_info "Creating install dirs for Nomad at $path"
   sudo mkdir -p "$path"
@@ -130,14 +130,14 @@ function create_nomad_install_paths {
 }
 
 function install_binaries {
-  local readonly version="$1"
-  local readonly path="$2"
-  local readonly username="$3"
+  local -r version="$1"
+  local -r path="$2"
+  local -r username="$3"
 
-  local readonly url="https://releases.hashicorp.com/nomad/${version}/nomad_${version}_linux_amd64.zip"
-  local readonly download_path="/tmp/nomad_${version}_linux_amd64.zip"
-  local readonly bin_dir="$path/bin"
-  local readonly nomad_dest_path="$bin_dir/nomad"
+  local -r url="https://releases.hashicorp.com/nomad/${version}/nomad_${version}_linux_amd64.zip"
+  local -r download_path="/tmp/nomad_${version}_linux_amd64.zip"
+  local -r bin_dir="$path/bin"
+  local -r nomad_dest_path="$bin_dir/nomad"
 
   log_info "Downloading Nomad $version from $url to $download_path"
   curl -o "$download_path" "$url"
@@ -148,7 +148,7 @@ function install_binaries {
   sudo chown "$username:$username" "$nomad_dest_path"
   sudo chmod a+x "$nomad_dest_path"
 
-  local readonly symlink_path="$SYSTEM_BIN_DIR/nomad"
+  local -r symlink_path="$SYSTEM_BIN_DIR/nomad"
   if [[ -f "$symlink_path" ]]; then
     log_info "Symlink $symlink_path already exists. Will not add again."
   else

--- a/packages/cluster/scripts/run-api-nomad.sh
+++ b/packages/cluster/scripts/run-api-nomad.sh
@@ -13,37 +13,37 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   echo >&2 -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 # Based on code from: http://stackoverflow.com/a/16623897/483528
 function strip_prefix {
-  local readonly str="$1"
-  local readonly prefix="$2"
+  local -r str="$1"
+  local -r prefix="$2"
   echo "${str#$prefix}"
 }
 
 function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
+  local -r arg_name="$1"
+  local -r arg_value="$2"
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
@@ -54,7 +54,7 @@ function assert_not_empty {
 
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
-  local readonly path="$1"
+  local -r path="$1"
 
   log_info "Looking up Metadata value at $COMPUTE_INSTANCE_METADATA_URL/$path"
   curl --silent --show-error --location --header "$GOOGLE_CLOUD_METADATA_REQUEST_HEADER" "$COMPUTE_INSTANCE_METADATA_URL/$path"
@@ -62,7 +62,7 @@ function get_instance_metadata_value {
 
 # Get the value of the given Custom Metadata Key
 function get_instance_custom_metadata_value {
-  local readonly key="$1"
+  local -r key="$1"
 
   log_info "Looking up Custom Instance Metadata value for key \"$key\""
   get_instance_metadata_value "instance/attributes/$key"
@@ -109,7 +109,7 @@ function get_instance_ip_address {
 }
 
 function assert_is_installed {
-  local readonly name="$1"
+  local -r name="$1"
 
   if [[ ! $(command -v ${name}) ]]; then
     log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
@@ -118,13 +118,13 @@ function assert_is_installed {
 }
 
 function generate_nomad_config {
-  local readonly server="$1"
-  local readonly client="$2"
-  local readonly num_servers="$3"
-  local readonly config_dir="$4"
-  local readonly user="$5"
-  local readonly consul_token="$6"
-  local readonly config_path="$config_dir/$NOMAD_CONFIG_FILE"
+  local -r server="$1"
+  local -r client="$2"
+  local -r num_servers="$3"
+  local -r config_dir="$4"
+  local -r user="$5"
+  local -r consul_token="$6"
+  local -r config_path="$config_dir/$NOMAD_CONFIG_FILE"
 
   local instance_name=""
   local instance_ip_address=""
@@ -205,13 +205,13 @@ EOF
 }
 
 function generate_supervisor_config {
-  local readonly supervisor_config_path="$1"
-  local readonly nomad_config_dir="$2"
-  local readonly nomad_data_dir="$3"
-  local readonly nomad_bin_dir="$4"
-  local readonly nomad_log_dir="$5"
-  local readonly nomad_user="$6"
-  local readonly use_sudo="$7"
+  local -r supervisor_config_path="$1"
+  local -r nomad_config_dir="$2"
+  local -r nomad_data_dir="$3"
+  local -r nomad_bin_dir="$4"
+  local -r nomad_log_dir="$5"
+  local -r nomad_user="$6"
+  local -r use_sudo="$7"
 
   if [[ "$use_sudo" == "true" ]]; then
     log_info "The --use-sudo flag is set, so running Nomad as the root user"
@@ -247,7 +247,7 @@ function bootstrap {
   done
   log_info "Nomad server started."
 
-  local readonly nomad_token="$1"
+  local -r nomad_token="$1"
   log_info "Bootstrapping Nomad"
   echo "$nomad_token" >"/tmp/nomad.token"
   nomad acl bootstrap /tmp/nomad.token
@@ -256,7 +256,7 @@ function bootstrap {
 
 # Based on: http://unix.stackexchange.com/a/7732/215969
 function get_owner_of_path {
-  local readonly path="$1"
+  local -r path="$1"
   ls -ld "$path" | awk '{print $3}'
 }
 

--- a/packages/cluster/scripts/run-build-cluster-nomad.sh
+++ b/packages/cluster/scripts/run-build-cluster-nomad.sh
@@ -13,37 +13,37 @@ readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   echo >&2 -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 # Based on code from: http://stackoverflow.com/a/16623897/483528
 function strip_prefix {
-  local readonly str="$1"
-  local readonly prefix="$2"
+  local -r str="$1"
+  local -r prefix="$2"
   echo "${str#$prefix}"
 }
 
 function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
+  local -r arg_name="$1"
+  local -r arg_value="$2"
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
@@ -54,7 +54,7 @@ function assert_not_empty {
 
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
-  local readonly path="$1"
+  local -r path="$1"
 
   log_info "Looking up Metadata value at $COMPUTE_INSTANCE_METADATA_URL/$path"
   curl --silent --show-error --location --header "$GOOGLE_CLOUD_METADATA_REQUEST_HEADER" "$COMPUTE_INSTANCE_METADATA_URL/$path"
@@ -62,7 +62,7 @@ function get_instance_metadata_value {
 
 # Get the value of the given Custom Metadata Key
 function get_instance_custom_metadata_value {
-  local readonly key="$1"
+  local -r key="$1"
 
   log_info "Looking up Custom Instance Metadata value for key \"$key\""
   get_instance_metadata_value "instance/attributes/$key"
@@ -109,7 +109,7 @@ function get_instance_ip_address {
 }
 
 function assert_is_installed {
-  local readonly name="$1"
+  local -r name="$1"
 
   if [[ ! $(command -v ${name}) ]]; then
     log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
@@ -118,13 +118,13 @@ function assert_is_installed {
 }
 
 function generate_nomad_config {
-  local readonly server="$1"
-  local readonly client="$2"
-  local readonly num_servers="$3"
-  local readonly config_dir="$4"
-  local readonly user="$5"
-  local readonly consul_token="$6"
-  local readonly config_path="$config_dir/$NOMAD_CONFIG_FILE"
+  local -r server="$1"
+  local -r client="$2"
+  local -r num_servers="$3"
+  local -r config_dir="$4"
+  local -r user="$5"
+  local -r consul_token="$6"
+  local -r config_path="$config_dir/$NOMAD_CONFIG_FILE"
 
   local instance_name=""
   local instance_ip_address=""
@@ -213,13 +213,13 @@ EOF
 }
 
 function generate_supervisor_config {
-  local readonly supervisor_config_path="$1"
-  local readonly nomad_config_dir="$2"
-  local readonly nomad_data_dir="$3"
-  local readonly nomad_bin_dir="$4"
-  local readonly nomad_log_dir="$5"
-  local readonly nomad_user="$6"
-  local readonly use_sudo="$7"
+  local -r supervisor_config_path="$1"
+  local -r nomad_config_dir="$2"
+  local -r nomad_data_dir="$3"
+  local -r nomad_bin_dir="$4"
+  local -r nomad_log_dir="$5"
+  local -r nomad_user="$6"
+  local -r use_sudo="$7"
 
   if [[ "$use_sudo" == "true" ]]; then
     log_info "The --use-sudo flag is set, so running Nomad as the root user"
@@ -255,7 +255,7 @@ function bootstrap {
   done
   log_info "Nomad server started."
 
-  local readonly nomad_token="$1"
+  local -r nomad_token="$1"
   log_info "Bootstrapping Nomad"
   echo "$nomad_token" >"/tmp/nomad.token"
   nomad acl bootstrap /tmp/nomad.token
@@ -264,7 +264,7 @@ function bootstrap {
 
 # Based on: http://unix.stackexchange.com/a/7732/215969
 function get_owner_of_path {
-  local readonly path="$1"
+  local -r path="$1"
   ls -ld "$path" | awk '{print $3}'
 }
 

--- a/packages/cluster/scripts/run-nomad.sh
+++ b/packages/cluster/scripts/run-nomad.sh
@@ -44,37 +44,37 @@ function print_usage {
 }
 
 function log {
-  local readonly level="$1"
-  local readonly message="$2"
-  local readonly timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+  local -r level="$1"
+  local -r message="$2"
+  local -r timestamp=$(date +"%Y-%m-%d %H:%M:%S")
   echo >&2 -e "${timestamp} [${level}] [$SCRIPT_NAME] ${message}"
 }
 
 function log_info {
-  local readonly message="$1"
+  local -r message="$1"
   log "INFO" "$message"
 }
 
 function log_warn {
-  local readonly message="$1"
+  local -r message="$1"
   log "WARN" "$message"
 }
 
 function log_error {
-  local readonly message="$1"
+  local -r message="$1"
   log "ERROR" "$message"
 }
 
 # Based on code from: http://stackoverflow.com/a/16623897/483528
 function strip_prefix {
-  local readonly str="$1"
-  local readonly prefix="$2"
+  local -r str="$1"
+  local -r prefix="$2"
   echo "${str#$prefix}"
 }
 
 function assert_not_empty {
-  local readonly arg_name="$1"
-  local readonly arg_value="$2"
+  local -r arg_name="$1"
+  local -r arg_value="$2"
 
   if [[ -z "$arg_value" ]]; then
     log_error "The value for '$arg_name' cannot be empty"
@@ -85,7 +85,7 @@ function assert_not_empty {
 
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
-  local readonly path="$1"
+  local -r path="$1"
 
   log_info "Looking up Metadata value at $COMPUTE_INSTANCE_METADATA_URL/$path"
   curl --silent --show-error --location --header "$GOOGLE_CLOUD_METADATA_REQUEST_HEADER" "$COMPUTE_INSTANCE_METADATA_URL/$path"
@@ -93,7 +93,7 @@ function get_instance_metadata_value {
 
 # Get the value of the given Custom Metadata Key
 function get_instance_custom_metadata_value {
-  local readonly key="$1"
+  local -r key="$1"
 
   log_info "Looking up Custom Instance Metadata value for key \"$key\""
   get_instance_metadata_value "instance/attributes/$key"
@@ -140,7 +140,7 @@ function get_instance_ip_address {
 }
 
 function assert_is_installed {
-  local readonly name="$1"
+  local -r name="$1"
 
   if [[ ! $(command -v ${name}) ]]; then
     log_error "The binary '$name' is required by this script but is not installed or in the system's PATH."
@@ -149,13 +149,13 @@ function assert_is_installed {
 }
 
 function generate_nomad_config {
-  local readonly server="$1"
-  local readonly client="$2"
-  local readonly num_servers="$3"
-  local readonly config_dir="$4"
-  local readonly user="$5"
-  local readonly consul_token="$6"
-  local readonly config_path="$config_dir/$NOMAD_CONFIG_FILE"
+  local -r server="$1"
+  local -r client="$2"
+  local -r num_servers="$3"
+  local -r config_dir="$4"
+  local -r user="$5"
+  local -r consul_token="$6"
+  local -r config_path="$config_dir/$NOMAD_CONFIG_FILE"
 
   local instance_name=""
   local instance_ip_address=""
@@ -266,13 +266,13 @@ EOF
 }
 
 function generate_supervisor_config {
-  local readonly supervisor_config_path="$1"
-  local readonly nomad_config_dir="$2"
-  local readonly nomad_data_dir="$3"
-  local readonly nomad_bin_dir="$4"
-  local readonly nomad_log_dir="$5"
-  local readonly nomad_user="$6"
-  local readonly use_sudo="$7"
+  local -r supervisor_config_path="$1"
+  local -r nomad_config_dir="$2"
+  local -r nomad_data_dir="$3"
+  local -r nomad_bin_dir="$4"
+  local -r nomad_log_dir="$5"
+  local -r nomad_user="$6"
+  local -r use_sudo="$7"
 
   if [[ "$use_sudo" == "true" ]]; then
     log_info "The --use-sudo flag is set, so running Nomad as the root user"
@@ -308,7 +308,7 @@ function bootstrap {
   done
   log_info "Nomad server started."
 
-  local readonly nomad_token="$1"
+  local -r nomad_token="$1"
   log_info "Bootstrapping Nomad"
   echo "$nomad_token" >"/tmp/nomad.token"
   nomad acl bootstrap /tmp/nomad.token
@@ -316,7 +316,7 @@ function bootstrap {
 }
 
 function create_node_pools {
-  local readonly nomad_token="$1"
+  local -r nomad_token="$1"
   log_info "Creating node pools"
   cat > "$config_dir/api_node_pool.hcl"  <<EOF
 node_pool "api" {
@@ -334,7 +334,7 @@ EOF
 
 # Based on: http://unix.stackexchange.com/a/7732/215969
 function get_owner_of_path {
-  local readonly path="$1"
+  local -r path="$1"
   ls -ld "$path" | awk '{print $3}'
 }
 


### PR DESCRIPTION
'local readonly' makes a variable called "readonly" local, which isn't actually what we want to have happen here.

To be clear, my IDE warned me of this (thanks to shellchecks' [SC2316](https://github.com/koalaman/shellcheck/wiki/SC2316) warning). I did throw together a demo to prove that it was correct:

```bash
#!/usr/bin/env bash

function test1() {
    local readonly one=$1
    local readonly two=$2
    one=$two
    echo "test1: that shouldn't have worked"
}

function test2() {
    local -r one=$1
    local -r two=$2
    one=$two    # line 13
    echo "test2: that shouldn't have worked"
}

test1
test2
```

When running bash 5.2.37(1) locally, it results in the following output:

```
$ ./test.sh 
test1: that shouldn't have worked
./test.sh: line 13: one: readonly variable
```

Not particularly important in the places it's being used here, but if it's going to be committed, it may as well work :grin: 

Really interesting work here, I'm enjoying digging through it. Thanks!