### PR TITLE
Return a correct status code for resume conflict

### DIFF
--- a/packages/api/internal/cache/instance/reservation_test.go
+++ b/packages/api/internal/cache/instance/reservation_test.go
@@ -1,0 +1,70 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sandboxID = "test-sandbox-id"
+)
+
+var teamID = uuid.New()
+
+func newInstanceCache() (*InstanceCache, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cache := NewCache(ctx, nil, nil, nil)
+	return cache, cancel
+}
+
+func TestReservation(t *testing.T) {
+	cache, cancel := newInstanceCache()
+	defer cancel()
+
+	exceeded, _, err := cache.Reserve(sandboxID, teamID, 1)
+	assert.NoError(t, err)
+	assert.False(t, exceeded)
+}
+
+func TestReservation_Exceeded(t *testing.T) {
+	cache, cancel := newInstanceCache()
+	defer cancel()
+
+	exceeded, _, err := cache.Reserve(sandboxID, teamID, 0)
+	assert.NoError(t, err)
+	assert.True(t, exceeded)
+}
+
+func TestReservation_SameSandbox(t *testing.T) {
+	cache, cancel := newInstanceCache()
+	defer cancel()
+
+	exceeded, _, err := cache.Reserve(sandboxID, teamID, 10)
+	assert.NoError(t, err)
+	assert.False(t, exceeded)
+
+	exceeded, _, err = cache.Reserve(sandboxID, teamID, 10)
+	require.Error(t, err)
+	assert.False(t, exceeded)
+
+	var errAlreadyBeingStarted *ErrAlreadyBeingStarted
+	assert.ErrorAs(t, err, &errAlreadyBeingStarted)
+}
+
+func TestReservation_Release(t *testing.T) {
+	cache, cancel := newInstanceCache()
+	defer cancel()
+
+	exceeded, release, err := cache.Reserve(sandboxID, teamID, 1)
+	assert.NoError(t, err)
+	assert.False(t, exceeded)
+	release()
+
+	exceeded, _, err = cache.Reserve(sandboxID, teamID, 1)
+	assert.NoError(t, err)
+	assert.False(t, exceeded)
+}

--- a/packages/api/internal/cache/instance/reservation_test.go
+++ b/packages/api/internal/cache/instance/reservation_test.go
@@ -25,46 +25,39 @@ func TestReservation(t *testing.T) {
 	cache, cancel := newInstanceCache()
 	defer cancel()
 
-	exceeded, _, err := cache.Reserve(sandboxID, teamID, 1)
+	_, err := cache.Reserve(sandboxID, teamID, 1)
 	assert.NoError(t, err)
-	assert.False(t, exceeded)
 }
 
 func TestReservation_Exceeded(t *testing.T) {
 	cache, cancel := newInstanceCache()
 	defer cancel()
 
-	exceeded, _, err := cache.Reserve(sandboxID, teamID, 0)
-	assert.NoError(t, err)
-	assert.True(t, exceeded)
+	_, err := cache.Reserve(sandboxID, teamID, 0)
+	assert.Error(t, err)
+	assert.IsType(t, &ErrSandboxLimitExceeded{}, err)
 }
 
 func TestReservation_SameSandbox(t *testing.T) {
 	cache, cancel := newInstanceCache()
 	defer cancel()
 
-	exceeded, _, err := cache.Reserve(sandboxID, teamID, 10)
+	_, err := cache.Reserve(sandboxID, teamID, 10)
 	assert.NoError(t, err)
-	assert.False(t, exceeded)
 
-	exceeded, _, err = cache.Reserve(sandboxID, teamID, 10)
+	_, err = cache.Reserve(sandboxID, teamID, 10)
 	require.Error(t, err)
-	assert.False(t, exceeded)
-
-	var errAlreadyBeingStarted *ErrAlreadyBeingStarted
-	assert.ErrorAs(t, err, &errAlreadyBeingStarted)
+	assert.IsType(t, &ErrAlreadyBeingStarted{}, err)
 }
 
 func TestReservation_Release(t *testing.T) {
 	cache, cancel := newInstanceCache()
 	defer cancel()
 
-	exceeded, release, err := cache.Reserve(sandboxID, teamID, 1)
+	release, err := cache.Reserve(sandboxID, teamID, 1)
 	assert.NoError(t, err)
-	assert.False(t, exceeded)
 	release()
 
-	exceeded, _, err = cache.Reserve(sandboxID, teamID, 1)
+	_, err = cache.Reserve(sandboxID, teamID, 1)
 	assert.NoError(t, err)
-	assert.False(t, exceeded)
 }


### PR DESCRIPTION
# Description

If you tried to resume a sandbox while it's already resuming it failed and returned 429 incorrectly. Now it returns 409 