### PR TITLE
Use nodeID to prevent mismatch

### DIFF
--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -64,7 +64,7 @@ func (o *Orchestrator) getSandboxes(ctx context.Context, node *nNode.NodeInfo) (
 					SandboxID:  config.SandboxId,
 					TemplateID: config.TemplateId,
 					Alias:      config.Alias,
-					ClientID:   sbx.ClientId,
+					ClientID:   node.ID, // TODO: this is a fix, because the orchestrator returns incorrect node ID
 				},
 				&teamID,
 				&buildID,

--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -64,7 +64,7 @@ func (o *Orchestrator) getSandboxes(ctx context.Context, node *nNode.NodeInfo) (
 					SandboxID:  config.SandboxId,
 					TemplateID: config.TemplateId,
 					Alias:      config.Alias,
-					ClientID:   node.ID, // TODO: this is a fix, because the orchestrator returns incorrect node ID
+					ClientID:   node.ID, // to prevent mismatch use the node ID which we use for the request
 				},
 				&teamID,
 				&buildID,


### PR DESCRIPTION
# Description

To prevent a mismatch between the node ID in the API and the one reported from the orchestrator, always use the one from which we expect the response.