### PR TITLE
Fix envd start with Docker installed

### DIFF
--- a/packages/orchestrator/internal/template/build/provision.sh
+++ b/packages/orchestrator/internal/template/build/provision.sh
@@ -82,6 +82,9 @@ echo "Don't wait for ttyS0 (serial console kernel logs)"
 # This is required when the Firecracker kernel args has specified console=ttyS0
 systemctl mask serial-getty@ttyS0.service
 
+echo "Disable network online wait"
+systemctl mask systemd-networkd-wait-online.service
+
 # Clean machine-id from Docker
 rm -rf /etc/machine-id
 

--- a/packages/orchestrator/internal/template/build/rootfs.go
+++ b/packages/orchestrator/internal/template/build/rootfs.go
@@ -170,8 +170,13 @@ ExecStart=-/sbin/agetty --noissue --autologin root %I 115200,38400,9600 vt102
 
 	hostname := "e2b.local"
 
-	hosts := fmt.Sprintf(`127.0.0.1   localhost
-127.0.1.1   %s
+	hosts := fmt.Sprintf(`127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::	ip6-localnet
+ff00::	ip6-mcastprefix
+ff02::1	ip6-allnodes
+ff02::2	ip6-allrouters
+127.0.1.1	%s
 `, hostname)
 
 	e2bFile := fmt.Sprintf(`ENV_ID=%s

--- a/packages/orchestrator/internal/template/build/rootfs.go
+++ b/packages/orchestrator/internal/template/build/rootfs.go
@@ -146,6 +146,7 @@ func additionalOCILayers(
 	memoryLimit := int(math.Min(float64(config.MemoryMB)/2, 512))
 	envdService := fmt.Sprintf(`[Unit]
 Description=Env Daemon Service
+After=multi-user.target
 
 [Service]
 Type=simple

--- a/packages/orchestrator/internal/template/build/rootfs.go
+++ b/packages/orchestrator/internal/template/build/rootfs.go
@@ -146,7 +146,6 @@ func additionalOCILayers(
 	memoryLimit := int(math.Min(float64(config.MemoryMB)/2, 512))
 	envdService := fmt.Sprintf(`[Unit]
 Description=Env Daemon Service
-After=multi-user.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Fixes envd init with Docker installed. This configures localhost ipv6 and disables `systemd-networkd-wait-online.service`.

The issue was manifesting by getting stuck on systemd await for `systemd-networkd-wait-online.service`.