### PR TITLE
Delete diff files after template build

### DIFF
--- a/packages/orchestrator/internal/sandbox/sandbox_linux.go
+++ b/packages/orchestrator/internal/sandbox/sandbox_linux.go
@@ -568,6 +568,24 @@ type Snapshot struct {
 	Snapfile          *template.LocalFileLink
 }
 
+func (s *Snapshot) Close(_ context.Context) error {
+	var errs []error
+
+	if err := s.MemfileDiff.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close memfile diff: %w", err))
+	}
+
+	if err := s.RootfsDiff.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close rootfs diff: %w", err))
+	}
+
+	if err := s.Snapfile.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("failed to close snapfile: %w", err))
+	}
+
+	return errors.Join(errs...)
+}
+
 func pauseProcessMemory(
 	ctx context.Context,
 	tracer trace.Tracer,

--- a/packages/orchestrator/internal/sandbox/template/local_template.go
+++ b/packages/orchestrator/internal/sandbox/template/local_template.go
@@ -41,5 +41,15 @@ func (t *LocalTemplate) Rootfs() (block.ReadonlyDevice, error) {
 }
 
 func (t *LocalTemplate) Snapfile() (File, error) {
-	return nil, &NotImplementedError{Msg: "snapfile not implemented for local template"}
+	return &NoopSnapfile{}, nil
+}
+
+type NoopSnapfile struct{}
+
+func (n *NoopSnapfile) Close() error {
+	return nil
+}
+
+func (n *NoopSnapfile) Path() string {
+	return "/dev/null"
 }

--- a/packages/orchestrator/internal/sandbox/template/template.go
+++ b/packages/orchestrator/internal/sandbox/template/template.go
@@ -9,14 +9,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-type NotImplementedError struct {
-	Msg string
-}
-
-func (e NotImplementedError) Error() string {
-	return fmt.Sprintf("not implemented: %s", e.Msg)
-}
-
 type Template interface {
 	Files() *storage.TemplateCacheFiles
 	Memfile() (block.ReadonlyDevice, error)
@@ -44,12 +36,7 @@ func closeTemplate(t Template) (e error) {
 
 	snapfile, err := t.Snapfile()
 	if err != nil {
-		var ni *NotImplementedError
-		if errors.As(err, &ni) {
-			// ignore
-		} else {
-			e = errors.Join(e, err)
-		}
+		e = errors.Join(e, err)
 	} else {
 		closable = append(closable, snapfile)
 	}


### PR DESCRIPTION
Delete diff files after template build. This is not done in orchestrator as we want to reuse the artifacts from pause for resume.