### PR TITLE
Fix dns configuration override

### DIFF
--- a/packages/orchestrator/internal/template/build/provision.sh
+++ b/packages/orchestrator/internal/template/build/provision.sh
@@ -94,6 +94,9 @@ rm -rf /etc/machine-id
 echo "Linking systemd to init"
 ln -sf /lib/systemd/systemd /usr/sbin/init
 
+echo "Unlocking immutable configuration"
+chattr -i /etc/resolv.conf
+
 echo "Finished provisioning script"
 
 # Delete itself

--- a/packages/orchestrator/internal/template/build/provision.sh
+++ b/packages/orchestrator/internal/template/build/provision.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 echo "Starting provisioning script"
 
+echo "Making configuration immutable"
+chattr +i /etc/resolv.conf
+
 # Install required packages if not already installed
 PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp"
 echo "Checking presence of the following packages: $PACKAGES"


### PR DESCRIPTION
Fix possible DNS configuration override when installing systemd on certain systems. Manifesting by not working DNS server and being replaced by a symlink.

The fix is done by making the /etc/resolv.conf immutable while running provisioning script.