### PR TITLE
Sync files explicitly before next operation

### DIFF
--- a/packages/orchestrator/internal/template/build/ext4/tools.go
+++ b/packages/orchestrator/internal/template/build/ext4/tools.go
@@ -140,6 +140,11 @@ func enlargeFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, ad
 	if err != nil {
 		return 0, fmt.Errorf("error truncating rootfs file: %w", err)
 	}
+
+	if err := rootfsFile.Sync(); err != nil {
+		return 0, fmt.Errorf("error syncing rootfs file: %w", err)
+	}
+
 	telemetry.ReportEvent(ctx, "truncated rootfs file to size of build + defaultDiskSizeMB")
 	return rootfsSize, err
 }

--- a/packages/orchestrator/internal/template/build/ext4/tools.go
+++ b/packages/orchestrator/internal/template/build/ext4/tools.go
@@ -141,6 +141,8 @@ func enlargeFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, ad
 		return 0, fmt.Errorf("error truncating rootfs file: %w", err)
 	}
 
+	// Sync the metadata and data to disk.
+	// This is important to ensure that the file is fully written when used by other processes, like FC.
 	if err := rootfsFile.Sync(); err != nil {
 		return 0, fmt.Errorf("error syncing rootfs file: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/memory.go
+++ b/packages/orchestrator/internal/template/build/memory.go
@@ -22,5 +22,10 @@ func NewMemory(memoryBuildDir string, sizeMb int64) (string, error) {
 		return "", fmt.Errorf("error truncating blank memfile: %w", err)
 	}
 
+	err = emptyMemoryFile.Sync()
+	if err != nil {
+		return "", fmt.Errorf("error syncing blank memfile: %w", err)
+	}
+
 	return emptyMemoryFilePath, nil
 }

--- a/packages/orchestrator/internal/template/build/memory.go
+++ b/packages/orchestrator/internal/template/build/memory.go
@@ -17,11 +17,14 @@ func NewMemory(memoryBuildDir string, sizeMb int64) (string, error) {
 		return "", fmt.Errorf("error creating blank memfile: %w", err)
 	}
 	defer emptyMemoryFile.Close()
+
 	err = emptyMemoryFile.Truncate(sizeMb << ToMBShift)
 	if err != nil {
 		return "", fmt.Errorf("error truncating blank memfile: %w", err)
 	}
 
+	// Sync the metadata to disk.
+	// This is important to ensure that the file is fully written when used by other processes, like FC.
 	err = emptyMemoryFile.Sync()
 	if err != nil {
 		return "", fmt.Errorf("error syncing blank memfile: %w", err)

--- a/packages/orchestrator/internal/template/build/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/oci/oci.go
@@ -123,5 +123,9 @@ func ToExt4(ctx context.Context, img v1.Image, rootfsPath string, sizeLimit int6
 		return fmt.Errorf("error converting tar to ext4: %w", err)
 	}
 
+	if err := rootfsFile.Sync(); err != nil {
+		return fmt.Errorf("error syncing rootfs file: %w", err)
+	}
+
 	return nil
 }

--- a/packages/orchestrator/internal/template/build/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/oci/oci.go
@@ -123,6 +123,8 @@ func ToExt4(ctx context.Context, img v1.Image, rootfsPath string, sizeLimit int6
 		return fmt.Errorf("error converting tar to ext4: %w", err)
 	}
 
+	// Sync the metadata and data to disk.
+	// This is important to ensure that the file is fully written when used by other processes, like FC.
 	if err := rootfsFile.Sync(); err != nil {
 		return fmt.Errorf("error syncing rootfs file: %w", err)
 	}


### PR DESCRIPTION
Sync files explicitly before the next operation. Close doesn't sync the file metadata and data to be used by other processes like FC or filesystem changes (https://www.reddit.com/r/golang/comments/6gsjlf/dont_defer_close_on_writable_files/). The synchronization is necessary for e.g. resizing the file filesystem properly.

Should help fix the filesystem integrity checks during template build.