### PR TITLE
Improve list tests - Add unique metadata per test

### DIFF
--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -2,12 +2,14 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/tests/integration/internal/api"
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
 	"github.com/e2b-dev/infra/tests/integration/internal/utils"
@@ -51,7 +53,7 @@ func TestSandboxListWithFilter(t *testing.T) {
 	_ = utils.SetupSandboxWithCleanup(t, c)
 
 	// sandbox with custom metadata
-	sbx := utils.SetupSandboxWithCleanupWithTimeout(t, c, 30, &api.SandboxMetadata{"favouriteColor": "blue"})
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithTimeout(30), utils.WithMetadata(api.SandboxMetadata{"favouriteColor": "blue"}))
 
 	metadataString := "favouriteColor=blue"
 
@@ -68,10 +70,11 @@ func TestSandboxListWithFilter(t *testing.T) {
 func TestSandboxListRunning(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	// Create a sandbox
-	sbx := utils.SetupSandboxWithCleanup(t, c)
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
 
-	metadataString := "sandboxType=test"
+	// Create a sandbox
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 
 	// List running sandboxes
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
@@ -96,13 +99,14 @@ func TestSandboxListRunning(t *testing.T) {
 func TestSandboxListPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+
 	// Create and pause a sandbox
-	sbx := utils.SetupSandboxWithCleanup(t, c)
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandboxID := sbx.SandboxID
 
 	pauseSandbox(t, c, sandboxID)
-
-	metadataString := "sandboxType=test"
 
 	// List paused sandboxes
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
@@ -128,16 +132,18 @@ func TestSandboxListPaused(t *testing.T) {
 func TestSandboxListPaginationRunning(t *testing.T) {
 	c := setup.GetAPIClient()
 
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+
 	// Create two sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c)
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox1ID := sbx1.SandboxID
 
-	sbx2 := utils.SetupSandboxWithCleanup(t, c)
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox2ID := sbx2.SandboxID
 
 	// Test pagination with limit
 	var limit int32 = 1
-	metadataString := "sandboxType=test"
 
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
 		Limit:    &limit,
@@ -173,18 +179,20 @@ func TestSandboxListPaginationRunning(t *testing.T) {
 func TestSandboxListPaginationPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+
 	// Create two paused sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c)
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox1ID := sbx1.SandboxID
 	pauseSandbox(t, c, sandbox1ID)
 
-	sbx2 := utils.SetupSandboxWithCleanup(t, c)
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox2ID := sbx2.SandboxID
 	pauseSandbox(t, c, sandbox2ID)
 
 	// Test pagination with limit
 	var limit int32 = 1
-	metadataString := "sandboxType=test"
 
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
 		Limit:    &limit,
@@ -220,11 +228,14 @@ func TestSandboxListPaginationPaused(t *testing.T) {
 func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+
 	// Create two sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c)
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox1ID := sbx1.SandboxID
 
-	sbx2 := utils.SetupSandboxWithCleanup(t, c)
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox2ID := sbx2.SandboxID
 
 	// Pause the second sandbox
@@ -232,7 +243,6 @@ func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 
 	// Test pagination with limit
 	var limit int32 = 1
-	metadataString := "sandboxType=test"
 
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
 		Limit:    &limit,
@@ -269,10 +279,11 @@ func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 func TestSandboxListRunningV1(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	// Create a sandbox
-	sbx := utils.SetupSandboxWithCleanup(t, c)
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
 
-	metadataString := "sandboxType=test"
+	// Create a sandbox
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 
 	// List running sandboxes
 	listResponse, err := c.GetSandboxesWithResponse(context.Background(), &api.GetSandboxesParams{
@@ -297,9 +308,10 @@ func TestSandboxListRunningV1(t *testing.T) {
 func TestSandboxListWithFilterV1(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	sbx := utils.SetupSandboxWithCleanup(t, c)
+	uniqueString := id.Generate()
+	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
 
-	metadataString := "sandboxType=test"
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 
 	// List with filter
 	listResponse, err := c.GetSandboxesWithResponse(context.Background(), &api.GetSandboxesParams{

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -52,10 +52,12 @@ func TestSandboxListWithFilter(t *testing.T) {
 	// standard sandbox
 	_ = utils.SetupSandboxWithCleanup(t, c)
 
-	// sandbox with custom metadata
-	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithTimeout(30), utils.WithMetadata(api.SandboxMetadata{"favouriteColor": "blue"}))
+	metadataKey := "favouriteColor"
+	metadataValue := "blue"
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	metadataString := "favouriteColor=blue"
+	// sandbox with custom metadata
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 
 	// List with filter
 	listResponse, err := c.GetV2SandboxesWithResponse(context.Background(), &api.GetV2SandboxesParams{
@@ -99,11 +101,11 @@ func TestSandboxListRunning(t *testing.T) {
 func TestSandboxListPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	// Create and pause a sandbox
-	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 	sandboxID := sbx.SandboxID
 
 	pauseSandbox(t, c, sandboxID)
@@ -132,14 +134,14 @@ func TestSandboxListPaused(t *testing.T) {
 func TestSandboxListPaginationRunning(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	// Create two sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 	sandbox1ID := sbx1.SandboxID
 
-	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 	sandbox2ID := sbx2.SandboxID
 
 	// Test pagination with limit
@@ -179,15 +181,15 @@ func TestSandboxListPaginationRunning(t *testing.T) {
 func TestSandboxListPaginationPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	// Create two paused sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 	sandbox1ID := sbx1.SandboxID
 	pauseSandbox(t, c, sandbox1ID)
 
-	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 	sandbox2ID := sbx2.SandboxID
 	pauseSandbox(t, c, sandbox2ID)
 
@@ -228,14 +230,14 @@ func TestSandboxListPaginationPaused(t *testing.T) {
 func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	// Create two sandboxes
-	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx1 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
+	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
+
 	sandbox1ID := sbx1.SandboxID
-
-	sbx2 := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
 	sandbox2ID := sbx2.SandboxID
 
 	// Pause the second sandbox
@@ -279,11 +281,11 @@ func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 func TestSandboxListRunningV1(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	// Create a sandbox
-	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 
 	// List running sandboxes
 	listResponse, err := c.GetSandboxesWithResponse(context.Background(), &api.GetSandboxesParams{
@@ -308,10 +310,11 @@ func TestSandboxListRunningV1(t *testing.T) {
 func TestSandboxListWithFilterV1(t *testing.T) {
 	c := setup.GetAPIClient()
 
-	uniqueString := id.Generate()
-	metadataString := fmt.Sprintf("sandboxType=%s", uniqueString)
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
 
-	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{"sandboxType": uniqueString}))
+	sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
 
 	// List with filter
 	listResponse, err := c.GetSandboxesWithResponse(context.Background(), &api.GetSandboxesParams{

--- a/tests/integration/internal/tests/envd/process_test.go
+++ b/tests/integration/internal/tests/envd/process_test.go
@@ -19,7 +19,7 @@ func TestCommandKillNextApp(t *testing.T) {
 	defer cancel()
 
 	client := setup.GetAPIClient()
-	sbx := utils.SetupSandboxWithCleanupWithTimeout(t, client, 300, nil)
+	sbx := utils.SetupSandboxWithCleanup(t, client, utils.WithTimeout(300))
 
 	envdClient := setup.GetEnvdClient(t, ctx)
 
@@ -125,7 +125,7 @@ func TestCommandKillWithAnd(t *testing.T) {
 	defer cancel()
 
 	client := setup.GetAPIClient()
-	sbx := utils.SetupSandboxWithCleanupWithTimeout(t, client, 300, nil)
+	sbx := utils.SetupSandboxWithCleanup(t, client, utils.WithTimeout(300))
 
 	envdClient := setup.GetEnvdClient(t, ctx)
 

--- a/tests/integration/internal/utils/sandbox.go
+++ b/tests/integration/internal/utils/sandbox.go
@@ -12,35 +12,50 @@ import (
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
 )
 
-// SetupSandboxWithCleanupWithTimeout creates a new sandbox with specific timeout and returns its data
-func SetupSandboxWithCleanupWithTimeout(t *testing.T, c *api.ClientWithResponses, sbxTimeout int32, sbxMetadata *api.SandboxMetadata) *api.Sandbox {
+type SandboxConfig struct {
+	metadata api.SandboxMetadata
+	timeout  int32
+}
+
+type SandboxOption func(config SandboxConfig)
+
+func WithMetadata(metadata api.SandboxMetadata) SandboxOption {
+	return func(config SandboxConfig) {
+		for key, value := range metadata {
+			config.metadata[key] = value
+		}
+	}
+}
+
+func WithTimeout(timeout int32) SandboxOption {
+	return func(config SandboxConfig) {
+		config.timeout = timeout
+	}
+}
+
+// SetupSandboxWithCleanup creates a new sandbox and returns its data
+func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses, options ...SandboxOption) *api.Sandbox {
 	t.Helper()
 
 	// t.Context() doesn't work with go vet, so we use our own context
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
-	defaultMetadata := api.SandboxMetadata{
-		"sandboxType": "test",
+	config := SandboxConfig{
+		timeout: 30, // default timeout
+		metadata: api.SandboxMetadata{
+			"sandboxType": "test",
+		},
 	}
 
-	var metadata *api.SandboxMetadata
-	if sbxMetadata != nil {
-		metadataOverride := defaultMetadata
-
-		for k, v := range *sbxMetadata {
-			metadataOverride[k] = v
-		}
-
-		metadata = &metadataOverride
-	} else {
-		metadata = &defaultMetadata
+	for _, option := range options {
+		option(config)
 	}
 
 	createSandboxResponse, err := c.PostSandboxesWithResponse(ctx, api.NewSandbox{
 		TemplateID: setup.SandboxTemplateID,
-		Timeout:    &sbxTimeout,
-		Metadata:   metadata,
+		Timeout:    &config.timeout,
+		Metadata:   &config.metadata,
 	}, setup.WithAPIKey())
 
 	assert.NoError(t, err)
@@ -55,11 +70,6 @@ func SetupSandboxWithCleanupWithTimeout(t *testing.T, c *api.ClientWithResponses
 	})
 
 	return createSandboxResponse.JSON201
-}
-
-// SetupSandboxWithCleanup creates a new sandbox and returns its data
-func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses) *api.Sandbox {
-	return SetupSandboxWithCleanupWithTimeout(t, c, 30, nil)
 }
 
 // TeardownSandbox kills the sandbox with the given ID

--- a/tests/integration/internal/utils/sandbox.go
+++ b/tests/integration/internal/utils/sandbox.go
@@ -17,10 +17,10 @@ type SandboxConfig struct {
 	timeout  int32
 }
 
-type SandboxOption func(config SandboxConfig)
+type SandboxOption func(config *SandboxConfig)
 
 func WithMetadata(metadata api.SandboxMetadata) SandboxOption {
-	return func(config SandboxConfig) {
+	return func(config *SandboxConfig) {
 		for key, value := range metadata {
 			config.metadata[key] = value
 		}
@@ -28,7 +28,7 @@ func WithMetadata(metadata api.SandboxMetadata) SandboxOption {
 }
 
 func WithTimeout(timeout int32) SandboxOption {
-	return func(config SandboxConfig) {
+	return func(config *SandboxConfig) {
 		config.timeout = timeout
 	}
 }
@@ -49,7 +49,7 @@ func SetupSandboxWithCleanup(t *testing.T, c *api.ClientWithResponses, options .
 	}
 
 	for _, option := range options {
-		option(config)
+		option(&config)
 	}
 
 	createSandboxResponse, err := c.PostSandboxesWithResponse(ctx, api.NewSandbox{


### PR DESCRIPTION
# Description

To prevent cross-contamination during multiple tests, ensure the use of distinct metadata.