### PR TITLE
Fix using AWS storage backend for orchestrator

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	awsOperationTimeout = 5 * time.Second
-	awsWriteTimeout     = 14 * time.Second
-	awsReadTimeout      = 10 * time.Second
+	awsWriteTimeout     = 30 * time.Second
+	awsReadTimeout      = 15 * time.Second
 )
 
 type AWSBucketStorageProvider struct {

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -170,7 +170,7 @@ func (a *AWSBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, 
 
 	defer resp.Body.Close()
 
-	return resp.Body.Read(buff)
+	return io.ReadFull(resp.Body, buff)
 }
 
 func (a *AWSBucketStorageObjectProvider) Size() (int64, error) {

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -90,7 +90,8 @@ func (a *AWSBucketStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
 
 	resp, err := a.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &a.bucketName, Key: &a.path})
 	if err != nil {
-		if errors.Is(err, &types.NoSuchKey{}) {
+		var nsk *types.NoSuchKey
+		if errors.As(err, &nsk) {
 			return 0, ErrorObjectNotExist
 		}
 
@@ -159,7 +160,8 @@ func (a *AWSBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, 
 	readRange := aws.String(fmt.Sprintf("bytes=%d-%d", off, off+int64(len(buff))-1))
 	resp, err := a.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &a.bucketName, Key: &a.path, Range: readRange})
 	if err != nil {
-		if errors.Is(err, &types.NoSuchKey{}) {
+		var nsk *types.NoSuchKey
+		if errors.As(err, &nsk) {
 			return 0, ErrorObjectNotExist
 		}
 


### PR DESCRIPTION
Current implementation of AWS storage backend is not working for writing and reading template builds.
There was issue during catching error for no such key (is expected when we have template without headers).
Use of `io.ReadFull` to make sure we will read full buffer.