### PR TITLE
Increase Nextjs test start wait

### DIFF
--- a/tests/integration/internal/tests/envd/process_test.go
+++ b/tests/integration/internal/tests/envd/process_test.go
@@ -83,7 +83,7 @@ func TestCommandKillNextApp(t *testing.T) {
 	}()
 
 	// Wait for the next dev to start and list processes
-	time.Sleep(10 * time.Second)
+	time.Sleep(30 * time.Second)
 
 	listReq := connect.NewRequest(&process.ListRequest{})
 	setup.SetSandboxHeader(listReq.Header(), sbx.SandboxID)


### PR DESCRIPTION
Increase Nextjs test start wait from 10 to 30 seconds.

process_test.go:70: dev: event:{data:{stdout:" ✓ Ready in 1148ms\n"}}
(https://github.com/e2b-dev/infra/actions/runs/15257884800/job/42909742405)