### PR TITLE
Fix process kill tests

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -43,7 +43,11 @@ test/%:
 	export TESTS_SUPABASE_TOKEN=$(TESTS_SUPABASE_TOKEN); \
 	export TESTS_SANDBOX_TEAM_ID=$(TESTS_SANDBOX_TEAM_ID); \
 	go test -v ./internal/main_test.go -count=1 && \
-	go tool gotestsum --rerun-fails=2 --packages="./internal/tests/$(notdir $@)/..." --format standard-verbose --junitfile=test-results.xml -- -count=1
+	TEST_PATH="./internal/tests/$(subst test/,,$@)"; \
+	case "$${TEST_PATH}" in \
+		*.go) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 ;; \
+		*) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 ;; \
+	esac
 
 .PHONY: connect-orchestrator
 connect-orchestrator:


### PR DESCRIPTION
The process kill signal doesn't await the process exit. Therefore, we need to:
1. Connect to the process
2. Run kill signal
3. Wait for process exit
4. (List of running processes)

Fixes https://github.com/e2b-dev/infra/actions/runs/15257884800/job/42909742405