### PR TITLE
Fix require no error on pause sandbox

### DIFF
--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -18,7 +18,7 @@ import (
 func pauseSandbox(t *testing.T, c *api.ClientWithResponses, sandboxID string) {
 	pauseSandboxResponse, err := c.PostSandboxesSandboxIDPauseWithResponse(context.Background(), sandboxID, setup.WithAPIKey())
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, http.StatusNoContent, pauseSandboxResponse.StatusCode())
 }
 


### PR DESCRIPTION
# Describe

If there's an error in pause, the response will be null resulting in panic