### PR TITLE
Extend provisioning timeout to 5 minutes

### DIFF
--- a/packages/orchestrator/internal/template/build/template_builder.go
+++ b/packages/orchestrator/internal/template/build/template_builder.go
@@ -48,7 +48,7 @@ const (
 	templatesDirectory = "/tmp/templates"
 
 	sbxTimeout           = time.Hour
-	provisionTimeout     = 1 * time.Minute
+	provisionTimeout     = 5 * time.Minute
 	configurationTimeout = 5 * time.Minute
 	waitTimeForStartCmd  = 20 * time.Second
 	waitEnvdTimeout      = 60 * time.Second


### PR DESCRIPTION
Extend provisioning timeout to 5 minutes. This is to help the global ubuntu apt outage ([Reddit](https://www.reddit.com/r/Ubuntu/comments/1kxyig1/anyone_know_what_is_going_on_with_ubuntu_archives/?sort=new))