### PR TITLE
Mitigate and debug block bitmap differences

### DIFF
--- a/packages/orchestrator/internal/template/build/ext4/tools.go
+++ b/packages/orchestrator/internal/template/build/ext4/tools.go
@@ -82,9 +82,9 @@ func GetFreeSpace(ctx context.Context, tracer trace.Tracer, rootfsPath string, b
 
 func CheckIntegrity(rootfsPath string, fix bool) (string, error) {
 	logMetadata(rootfsPath)
-	args := "-nf"
+	args := "-nfv"
 	if fix {
-		args = "-pf"
+		args = "-pfv"
 	}
 	cmd := exec.Command("e2fsck", args, rootfsPath)
 	out, err := cmd.CombinedOutput()

--- a/packages/orchestrator/internal/template/build/template_builder.go
+++ b/packages/orchestrator/internal/template/build/template_builder.go
@@ -483,10 +483,20 @@ func (b *TemplateBuilder) enlargeDiskAfterProvisioning(
 			zap.String("result", ext4Check),
 			zap.Error(err),
 		)
-		return fmt.Errorf("error checking final enlarge filesystem integrity: %w", err)
+
+		// Occasionally there is Block bitmap differences. For this reason, we retry with fix.
+		ext4Check, err := ext4.CheckIntegrity(rootfsPath, true)
+		zap.L().Error("final enlarge filesystem ext4 integrity - retry with fix",
+			zap.String("result", ext4Check),
+			zap.Error(err),
+		)
+		if err != nil {
+			return fmt.Errorf("error checking final enlarge filesystem integrity: %w", err)
+		}
+	} else {
+		zap.L().Debug("final enlarge filesystem ext4 integrity",
+			zap.String("result", ext4Check),
+		)
 	}
-	zap.L().Debug("final enlarge filesystem ext4 integrity",
-		zap.String("result", ext4Check),
-	)
 	return nil
 }


### PR DESCRIPTION
Mitigate and debug block bitmap differences happening occasionally after enlarging a template filesystem.


```
result=e2fsck 1.46.5 (30-Dec-2021)
Pass 1: Checking inodes, blocks, and sizes
Pass 2: Checking directory structure
Pass 3: Checking directory connectivity
Pass 4: Checking reference counts
Pass 5: Checking group summary information
Block bitmap differences:  +131074
Fix? no


/tmp/templates/.../rootfs.ext4.build: ********** WARNING: Filesystem still has errors **********

/tmp/templates/.../rootfs.ext4.build: 6110/24304 files (0.1% non-contiguous), 82406/213041 blocks
```