### PR TITLE
Fix build failed status handling

### DIFF
--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -158,7 +158,7 @@ func (c *PollBuildStatus) poll(ctx context.Context) {
 		case <-ticker.C:
 			c.logger.Info("Checking template build status")
 
-			err, completeStatus := c.checkBuildStatus(ctx)
+			err, buildCompleted := c.checkBuildStatus(ctx)
 			if err != nil {
 				c.logger.Error("Build status polling received unrecoverable error", zap.Error(err))
 
@@ -171,7 +171,7 @@ func (c *PollBuildStatus) poll(ctx context.Context) {
 
 			// build status can return empty error when build is still in progress
 			// this will cause fast return to avoid pooling when build is already finished
-			if completeStatus {
+			if buildCompleted {
 				return
 			}
 		}
@@ -266,12 +266,12 @@ func (c *PollBuildStatus) checkBuildStatus(ctx context.Context) (error, bool) {
 
 	c.logger.Debug("dispatching based on status", zap.Any("status", c.status))
 
-	err, completeStatus := c.dispatchBasedOnStatus(ctx, c.status)
+	err, buildCompleted := c.dispatchBasedOnStatus(ctx, c.status)
 	if err != nil {
 		return errors.Wrap(err, "error when dispatching build status"), false
 	}
 
-	return nil, completeStatus
+	return nil, buildCompleted
 }
 
 func (tm *TemplateManager) removeFromProcessingQueue(buildID uuid.UUID) {

--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -145,11 +145,11 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 		status *template_manager.TemplateBuildStatusResponse
 	}
 	tests := []struct {
-		name             string
-		fields           fields
-		args             args
-		wantSuccessState bool
-		wantErr          bool
+		name              string
+		fields            fields
+		args              args
+		wantCompleteState bool
+		wantErr           bool
 	}{
 		{
 			name: "should return error if status is nil",
@@ -159,8 +159,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 			args: args{
 				status: nil,
 			},
-			wantSuccessState: false,
-			wantErr:          true,
+			wantCompleteState: false,
+			wantErr:           true,
 		},
 		{
 			name: "should handle failed status",
@@ -174,8 +174,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					Status: template_manager.TemplateBuildState_Failed,
 				},
 			},
-			wantSuccessState: false,
-			wantErr:          true,
+			wantCompleteState: false,
+			wantErr:           true,
 		},
 		{
 			name: "should handle completed status with nil metadata",
@@ -187,8 +187,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					Status: template_manager.TemplateBuildState_Completed,
 				},
 			},
-			wantSuccessState: false,
-			wantErr:          true,
+			wantCompleteState: false,
+			wantErr:           true,
 		},
 		{
 			name: "should handle completed status successfully",
@@ -206,8 +206,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					},
 				},
 			},
-			wantSuccessState: false,
-			wantErr:          true,
+			wantCompleteState: false,
+			wantErr:           true,
 		},
 		{
 			name: "should not send to done channel for building status",
@@ -219,8 +219,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					Status: template_manager.TemplateBuildState_Building,
 				},
 			},
-			wantSuccessState: false,
-			wantErr:          false,
+			wantCompleteState: false,
+			wantErr:           false,
 		},
 		// should not get error when no error setting status
 		{
@@ -233,8 +233,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					Status: template_manager.TemplateBuildState_Building,
 				},
 			},
-			wantErr:          false,
-			wantSuccessState: false,
+			wantErr:           false,
+			wantCompleteState: false,
 		},
 		// should not get error when no error setting finished
 		{
@@ -251,8 +251,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					},
 				},
 			},
-			wantErr:          false,
-			wantSuccessState: true,
+			wantErr:           false,
+			wantCompleteState: true,
 		},
 		// should error when nil metadata
 		{
@@ -265,8 +265,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 					Status: template_manager.TemplateBuildState_Completed,
 				},
 			},
-			wantErr:          true,
-			wantSuccessState: false,
+			wantErr:           true,
+			wantCompleteState: false,
 		},
 		// should not error when status is failure
 		{
@@ -280,8 +280,8 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 				},
 			},
 
-			wantErr:          false,
-			wantSuccessState: false,
+			wantErr:           false,
+			wantCompleteState: true,
 		},
 	}
 	for _, tt := range tests {
@@ -291,7 +291,7 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 				logger:                zap.NewNop(),
 			}
 
-			err, success := c.dispatchBasedOnStatus(context.TODO(), tt.args.status)
+			err, completed := c.dispatchBasedOnStatus(context.TODO(), tt.args.status)
 			if tt.wantErr {
 				if err == nil {
 					t.Errorf("Expected error, got no error")
@@ -302,13 +302,13 @@ func TestPollBuildStatus_dispatchBasedOnStatus(t *testing.T) {
 				}
 			}
 
-			if tt.wantSuccessState {
-				if !success {
-					t.Errorf("Expected success, got failure")
+			if tt.wantCompleteState {
+				if !completed {
+					t.Errorf("Expected completed, got failure")
 				}
 			} else {
-				if success {
-					t.Errorf("Expected failure, got success")
+				if completed {
+					t.Errorf("Expected failure, got completed")
 				}
 			}
 		})


### PR DESCRIPTION
Fix build status handling when the build is in failed status, but completed. Right now if the build is in the failed state, the status is repeatedly requested until it times out.