### PR TITLE
Use tags to distinguish between servers

### DIFF
--- a/packages/nomad/clickhouse.hcl
+++ b/packages/nomad/clickhouse.hcl
@@ -34,9 +34,9 @@ job "clickhouse" {
     }
 
     service {
-      name = "clickhouse-server-${i + 1}"
+      name = "clickhouse"
       port = "clickhouse-server"
-      tags = ["tcp"]
+      tags = ["server-${i + 1}"]
 
       check {
         type     = "http"
@@ -64,7 +64,7 @@ job "clickhouse" {
         }
 
         extra_hosts = [
-          "clickhouse-server-${i + 1}.service.consul:127.0.0.1",
+          "server-${i + 1}.clickhouse.service.consul:127.0.0.1",
         ]
 
         volumes = [
@@ -134,6 +134,7 @@ job "clickhouse" {
             </s3>
         </policies>
     </storage_configuration>
+
     <remote_servers replace="true">
       <cluster>
         <!-- a secret for servers to use to communicate to each other  -->
@@ -141,7 +142,7 @@ job "clickhouse" {
         %{ for j in range("${server_count}") }
         <shard>
           <replica>
-            <host>clickhouse-server-${j + 1}.service.consul</host>
+            <host>server-${j + 1}.clickhouse.service.consul</host>
             <port>${clickhouse_server_port}</port>
             <user>${username}</user>
             <password>${password}</password>

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -61,7 +61,7 @@ resource "nomad_job" "api" {
     redis_url                      = "redis://redis.service.consul:${var.redis_port.port}"
     redis_cluster_url              = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "${data.google_secret_manager_secret_version.redis_url.secret_data}:${var.redis_port.port}" : ""
     dns_port_number                = var.api_dns_port_number
-    clickhouse_connection_string   = "clickhouse-server-1.service.consul:9000" # TODO: This will be replaced by load balancer address in following PRs
+    clickhouse_connection_string   = "clickhouse.service.consul:9000"
     clickhouse_username            = var.clickhouse_username
     clickhouse_password            = random_password.clickhouse_password.result
     clickhouse_database            = var.clickhouse_database
@@ -333,7 +333,7 @@ locals {
     otel_tracing_print           = var.otel_tracing_print
     template_bucket_name         = var.template_bucket_name
     otel_collector_grpc_endpoint = "localhost:4317"
-    clickhouse_connection_string = "clickhouse-server-1.service.consul:9000" # TODO: This will be replaced by load balancer address in following PRs
+    clickhouse_connection_string = "clickhouse.service.consul:9000"
     clickhouse_username          = var.clickhouse_username
     clickhouse_password          = random_password.clickhouse_password.result
     clickhouse_database          = var.clickhouse_database


### PR DESCRIPTION
# Description

Allows to reference `clickhouse` as `clickhouse.service.consul` or if you need specific node (needed for clickhouse internally) as `server-n.clickhouse.service.consul`