### PR TITLE
Update Makefile - properly handle error codes in plan part

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ update-prod-env:
 .PHONY: plan
 plan:
 	@ printf "Planning Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
-	$(TF) fmt -recursive
-	$(tf_vars) $(TF) plan -out=.tfplan.$(ENV) -compact-warnings -detailed-exitcode; \
+	@ $(TF) fmt -recursive
+	@ $(tf_vars) $(TF) plan -out=.tfplan.$(ENV) -compact-warnings -detailed-exitcode; \
 	status=$$?; \
 	if [ $$status -eq 0 ]; then \
 		echo "No changes."; \


### PR DESCRIPTION
The terraform exits correctly with error code 2, which means there are actually changes. That is ok, no need to for Makefile to end with error code as well. This is what we want (I believe). 

```
# make plan
To perform exactly these actions, run the following command to apply:
    terraform apply ".tfplan.prod"
make: *** [Makefile:84: plan] Error 2
```

vs

```
# make plan
To perform exactly these actions, run the following command to apply:
    terraform apply ".tfplan.prod"
Changes detected.
```