### PR TITLE
Increase template waiting state deadline

### DIFF
--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -33,7 +33,7 @@ type TemplateManager struct {
 const (
 	syncInterval             = time.Minute * 1
 	syncTimeout              = time.Minute * 15
-	syncWaitingStateDeadline = time.Minute * 20
+	syncWaitingStateDeadline = time.Minute * 40
 )
 
 func New(ctx context.Context, db *db.DB, buildCache *templatecache.TemplatesBuildCache) (*TemplateManager, error) {


### PR DESCRIPTION
Increase template waiting state deadline to 40 minutes (from 20 minutes) to allow larger (and slower) Docker image builds.