### PR TITLE
Pass Envd access token for metrics endpoint

### DIFF
--- a/packages/orchestrator/internal/sandbox/metrics.go
+++ b/packages/orchestrator/internal/sandbox/metrics.go
@@ -36,6 +36,10 @@ func (s *Sandbox) GetMetrics(ctx context.Context) (SandboxMetrics, error) {
 		return SandboxMetrics{}, err
 	}
 
+	if s.Metadata.Config.EnvdAccessToken != nil {
+		request.Header.Set("X-Access-Token", *s.Metadata.Config.EnvdAccessToken)
+	}
+
 	response, err := httpClient.Do(request)
 	if err != nil {
 		return SandboxMetrics{}, err


### PR DESCRIPTION
# Description

If the sandbox is secured the access token is required even for metrics endpoint