### PR TITLE
Fix blocking sandbox logger

### DIFF
--- a/packages/shared/pkg/logger/exporter.go
+++ b/packages/shared/pkg/logger/exporter.go
@@ -30,23 +30,6 @@ func NewHTTPWriter(ctx context.Context, endpoint string) zapcore.WriteSyncer {
 	}
 }
 
-func NewBufferedHTTPWriter(ctx context.Context, endpoint string) zapcore.WriteSyncer {
-	httpWriter := &zapcore.BufferedWriteSyncer{
-		WS:            NewHTTPWriter(ctx, endpoint),
-		Size:          256 * 1024, // 256 kB
-		FlushInterval: 5 * time.Second,
-	}
-
-	go func() {
-		<-ctx.Done()
-		if err := httpWriter.Stop(); err != nil {
-			fmt.Printf("Error stopping HTTP writer: %v\n", err)
-		}
-	}()
-
-	return httpWriter
-}
-
 func (h *HTTPWriter) Write(source []byte) (n int, err error) {
 	h.wg.Add(1)
 

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -27,7 +27,7 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 	if !config.IsInternal && config.CollectorAddress != "" {
 		// Add Vector exporter to the core
 		vectorEncoder := zapcore.NewJSONEncoder(GetSandboxEncoderConfig())
-		httpWriter := logger.NewBufferedHTTPWriter(ctx, config.CollectorAddress)
+		httpWriter := logger.NewHTTPWriter(ctx, config.CollectorAddress)
 		core = zapcore.NewCore(
 			vectorEncoder,
 			httpWriter,


### PR DESCRIPTION
This PR removed the `BufferedWriteSyncer` and replaces it with simple `HTTPExporter` directly.

**Bug description**
Previous implementation using `BufferedWriteSyncer` caused the logging to be blocked. This is because `BufferedWriteSyncer` locks `write` when doing `flush`, and `flush` calls `Sync`, effectively awaiting all HTTPRequests synchronously on write.

Also, as we're sending log message one by one anyway, this buffering was causing delayed spam on the logs collector instead of sending messages gradually.
