### PR TITLE
Turn off autoscale if autoscale not allowed

### DIFF
--- a/packages/cluster/client/main.tf
+++ b/packages/cluster/client/main.tf
@@ -1,3 +1,7 @@
+locals {
+  max_replicas = max(var.cluster_size, var.cluster_size_max)
+}
+
 resource "google_compute_health_check" "nomad_check" {
   name                = "${var.cluster_name}-nomad-client-check"
   check_interval_sec  = 15
@@ -23,10 +27,10 @@ resource "google_compute_region_autoscaler" "client" {
   target = google_compute_region_instance_group_manager.client_cluster.id
 
   autoscaling_policy {
-    max_replicas    = max(var.cluster_size, var.cluster_size_max)
+    max_replicas    = max(local.max_replicas, var.cluster_size)
     min_replicas    = var.cluster_size
     cooldown_period = 240
-    mode            = "ONLY_SCALE_OUT"
+    mode            = local.max_replicas != var.cluster_size ? "ONLY_SCALE_OUT" : "OFF"
 
     cpu_utilization {
       target = 0.6

--- a/packages/cluster/client/main.tf
+++ b/packages/cluster/client/main.tf
@@ -30,6 +30,7 @@ resource "google_compute_region_autoscaler" "client" {
     max_replicas    = max(local.max_replicas, var.cluster_size)
     min_replicas    = var.cluster_size
     cooldown_period = 240
+    # Turn off autoscaling when the cluster size is equal to the maximum size.
     mode            = local.max_replicas != var.cluster_size ? "ONLY_SCALE_OUT" : "OFF"
 
     cpu_utilization {


### PR DESCRIPTION
# Description

This should allow rolling updates even for such case and prevent following error:
```
Resizing of autoscaled regional managed instance groups is not allowed. If you want to manually adjust target size remove the autoscaler or set autoscaling policy mode to OFF.
```