### PR TITLE
Fix nodes sync race condition

### DIFF
--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -13,9 +13,9 @@ import (
 )
 
 // TODO: this should be removed once we have a better way to handle node sync
-// Don't sync instances that were started in the grace period on node sync
-// This is to prevent add/remove instances that are still being started
-const syncSandboxGracePeriod = 10 * time.Second
+// Don't remove instances that were started in the grace period on node sync
+// This is to prevent remove instances that are still being started
+const syncSandboxRemoveGracePeriod = 10 * time.Second
 
 func getMaxAllowedTTL(now time.Time, startTime time.Time, duration, maxInstanceLength time.Duration) time.Duration {
 	timeLeft := maxInstanceLength - now.Sub(startTime)
@@ -68,7 +68,7 @@ func (c *InstanceCache) Sync(ctx context.Context, instances []*InstanceInfo, nod
 		if item.Instance.ClientID != nodeID {
 			continue
 		}
-		if time.Since(item.StartTime) <= syncSandboxGracePeriod {
+		if time.Since(item.StartTime) <= syncSandboxRemoveGracePeriod {
 			continue
 		}
 		_, found := instanceMap[item.Instance.SandboxID]
@@ -79,9 +79,6 @@ func (c *InstanceCache) Sync(ctx context.Context, instances []*InstanceInfo, nod
 
 	// Add instances that are not in the cache with the default TTL
 	for _, instance := range instances {
-		if time.Since(instance.StartTime) <= syncSandboxGracePeriod {
-			continue
-		}
 		if c.Exists(instance.Instance.SandboxID) {
 			continue
 		}


### PR DESCRIPTION
Fixes a race condition, where the sandbox could be starting, but not yet returned from the orchestrator, causing immediate eviction and sandbox stop. This will result into 502 (sandbox not running/timeout) for the user.

All sandboxes that are started won't be synchronized from the orchestrator in a 10 second period. This is not optimal fix, but should be ok for now until we resolve the issue in general.