### PR TITLE
Pass env vars from the Docker image to the start and ready commands

### DIFF
--- a/packages/orchestrator/internal/template/build/build.go
+++ b/packages/orchestrator/internal/template/build/build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"text/template"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/trace"
 
@@ -30,37 +31,37 @@ func Build(
 	artifactRegistry artifactsregistry.ArtifactsRegistry,
 	templateBuildDir string,
 	rootfsPath string,
-) (r *block.Local, m *block.Local, e error) {
+) (r *block.Local, m *block.Local, c v1.Config, e error) {
 	childCtx, childSpan := tracer.Start(ctx, "template-build")
 	defer childSpan.End()
 
 	// Create a rootfs file
 	rtfs := NewRootfs(artifactRegistry, templateConfig)
-	err := rtfs.createExt4Filesystem(childCtx, tracer, postProcessor, rootfsPath)
+	config, err := rtfs.createExt4Filesystem(childCtx, tracer, postProcessor, rootfsPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating rootfs for template '%s' during build '%s': %w", templateConfig.TemplateId, templateConfig.BuildId, err)
+		return nil, nil, v1.Config{}, fmt.Errorf("error creating rootfs for template '%s' during build '%s': %w", templateConfig.TemplateId, templateConfig.BuildId, err)
 	}
 
 	buildIDParsed, err := uuid.Parse(templateConfig.BuildId)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse build id: %w", err)
+		return nil, nil, v1.Config{}, fmt.Errorf("failed to parse build id: %w", err)
 	}
 
 	rootfs, err := block.NewLocal(rootfsPath, templateConfig.RootfsBlockSize(), buildIDParsed)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading rootfs blocks: %w", err)
+		return nil, nil, v1.Config{}, fmt.Errorf("error reading rootfs blocks: %w", err)
 	}
 
 	// Create empty memfile
 	memfilePath, err := NewMemory(templateBuildDir, templateConfig.MemoryMB)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating memfile: %w", err)
+		return nil, nil, v1.Config{}, fmt.Errorf("error creating memfile: %w", err)
 	}
 
 	memfile, err := block.NewLocal(memfilePath, templateConfig.MemfilePageSize(), buildIDParsed)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error creating memfile blocks: %w", err)
+		return nil, nil, v1.Config{}, fmt.Errorf("error creating memfile blocks: %w", err)
 	}
 
-	return rootfs, memfile, nil
+	return rootfs, memfile, config, nil
 }

--- a/packages/orchestrator/internal/template/build/command.go
+++ b/packages/orchestrator/internal/template/build/command.go
@@ -26,6 +26,7 @@ func (b *TemplateBuilder) runCommand(
 	command string,
 	runAsUser string,
 	cwd *string,
+	envVars map[string]string,
 ) error {
 	return b.runCommandWithConfirmation(
 		ctx,
@@ -35,6 +36,7 @@ func (b *TemplateBuilder) runCommand(
 		command,
 		runAsUser,
 		cwd,
+		envVars,
 		// No confirmation needed for this command
 		make(chan struct{}),
 	)
@@ -48,6 +50,7 @@ func (b *TemplateBuilder) runCommandWithConfirmation(
 	command string,
 	runAsUser string,
 	cwd *string,
+	envVars map[string]string,
 	confirmCh chan<- struct{},
 ) error {
 	runCmdReq := connect.NewRequest(&process.StartRequest{
@@ -57,6 +60,7 @@ func (b *TemplateBuilder) runCommandWithConfirmation(
 			Args: []string{
 				"-l", "-c", command,
 			},
+			Envs: envVars,
 		},
 	})
 

--- a/packages/orchestrator/internal/template/build/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/oci/oci.go
@@ -87,3 +87,22 @@ func ToExt4(ctx context.Context, img v1.Image, rootfsPath string, sizeLimit int6
 
 	return nil
 }
+
+func ParseEnvs(envs []string) map[string]string {
+	envMap := make(map[string]string, len(envs))
+	for _, env := range envs {
+		if strings.TrimSpace(env) == "" {
+			continue
+		}
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		if key != "" && value != "" {
+			envMap[key] = value
+		}
+	}
+	return envMap
+}

--- a/packages/orchestrator/internal/template/build/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/oci/oci.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim/ext4/tar2ext4"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"go.opentelemetry.io/otel/trace"
 
@@ -17,11 +17,11 @@ import (
 
 const ToMBShift = 20
 
-func GetImage(ctx context.Context, tracer trace.Tracer, artifactRegistry artifactsregistry.ArtifactsRegistry, templateId string, buildId string) (v1.Image, error) {
+func GetImage(ctx context.Context, tracer trace.Tracer, artifactRegistry artifactsregistry.ArtifactsRegistry, templateId string, buildId string) (containerregistry.Image, error) {
 	childCtx, childSpan := tracer.Start(ctx, "pull-docker-image")
 	defer childSpan.End()
 
-	platform := v1.Platform{
+	platform := containerregistry.Platform{
 		OS:           "linux",
 		Architecture: "amd64",
 	}
@@ -35,7 +35,7 @@ func GetImage(ctx context.Context, tracer trace.Tracer, artifactRegistry artifac
 	return img, nil
 }
 
-func GetImageSize(img v1.Image) (int64, error) {
+func GetImageSize(img containerregistry.Image) (int64, error) {
 	imageSize := int64(0)
 
 	layers, err := img.Layers()
@@ -54,7 +54,7 @@ func GetImageSize(img v1.Image) (int64, error) {
 	return imageSize, nil
 }
 
-func ToExt4(ctx context.Context, img v1.Image, rootfsPath string, sizeLimit int64) error {
+func ToExt4(ctx context.Context, img containerregistry.Image, rootfsPath string, sizeLimit int64) error {
 	r := mutate.Extract(img)
 	defer r.Close()
 

--- a/packages/orchestrator/internal/template/build/ready_command.go
+++ b/packages/orchestrator/internal/template/build/ready_command.go
@@ -21,6 +21,7 @@ func (b *TemplateBuilder) runReadyCommand(
 	postProcessor *writer.PostProcessor,
 	template *TemplateConfig,
 	sandboxID string,
+	envVars map[string]string,
 ) error {
 	ctx, span := b.tracer.Start(ctx, "run-ready-command")
 	defer span.End()
@@ -47,6 +48,7 @@ func (b *TemplateBuilder) runReadyCommand(
 			template.ReadyCmd,
 			"root",
 			&cwd,
+			envVars,
 		)
 
 		if err == nil {

--- a/packages/orchestrator/internal/template/build/rootfs.go
+++ b/packages/orchestrator/internal/template/build/rootfs.go
@@ -9,7 +9,7 @@ import (
 	"os"
 
 	"github.com/dustin/go-humanize"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -66,7 +66,7 @@ func NewRootfs(artifactRegistry artifactsregistry.ArtifactsRegistry, template *T
 	}
 }
 
-func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, postProcessor *writer.PostProcessor, rootfsPath string) (c v1.Config, e error) {
+func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, postProcessor *writer.PostProcessor, rootfsPath string) (c containerregistry.Config, e error) {
 	childCtx, childSpan := tracer.Start(ctx, "create-ext4-file")
 	defer childSpan.End()
 
@@ -80,30 +80,30 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 
 	img, err := oci.GetImage(childCtx, tracer, r.artifactRegistry, r.template.TemplateId, r.template.BuildId)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error requesting docker image: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error requesting docker image: %w", err)
 	}
 
 	imageSize, err := oci.GetImageSize(img)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error getting image size: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error getting image size: %w", err)
 	}
 	postProcessor.WriteMsg(fmt.Sprintf("Docker image size: %s", humanize.Bytes(uint64(imageSize))))
 
 	postProcessor.WriteMsg("Setting up system files")
 	layers, err := additionalOCILayers(childCtx, r.template)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error populating filesystem: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error populating filesystem: %w", err)
 	}
 	img, err = mutate.AppendLayers(img, layers...)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error appending layers: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error appending layers: %w", err)
 	}
 	telemetry.ReportEvent(childCtx, "set up filesystem")
 
 	postProcessor.WriteMsg("Creating file system and pulling Docker image")
 	err = oci.ToExt4(ctx, img, rootfsPath, maxRootfsSize)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
 	}
 	telemetry.ReportEvent(childCtx, "created rootfs ext4 file")
 
@@ -111,13 +111,13 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 	// Make rootfs writable, be default it's readonly
 	err = ext4.MakeWritable(ctx, tracer, rootfsPath)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error making rootfs file writable: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error making rootfs file writable: %w", err)
 	}
 
 	// Resize rootfs
 	rootfsFinalSize, err := ext4.Enlarge(ctx, tracer, rootfsPath, r.template.DiskSizeMB<<ToMBShift)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error enlarging rootfs: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error enlarging rootfs: %w", err)
 	}
 	r.template.rootfsSize = rootfsFinalSize
 
@@ -128,12 +128,12 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 		zap.Error(err),
 	)
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error checking ext4 filesystem integrity: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error checking ext4 filesystem integrity: %w", err)
 	}
 
 	config, err := img.ConfigFile()
 	if err != nil {
-		return v1.Config{}, fmt.Errorf("error getting image config file: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error getting image config file: %w", err)
 	}
 
 	return config.Config, nil
@@ -142,7 +142,7 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 func additionalOCILayers(
 	ctx context.Context,
 	config *TemplateConfig,
-) ([]v1.Layer, error) {
+) ([]containerregistry.Layer, error) {
 	var scriptDef bytes.Buffer
 	err := ProvisionScriptTemplate.Execute(&scriptDef, struct {
 		ResultPath string
@@ -270,7 +270,7 @@ echo "System Init"`), 0o777},
 		return nil, fmt.Errorf("error creating layer from symlinks: %w", err)
 	}
 
-	return []v1.Layer{
+	return []containerregistry.Layer{
 		filesLayer,
 		symlinkLayer,
 	}, nil

--- a/packages/orchestrator/internal/template/build/rootfs.go
+++ b/packages/orchestrator/internal/template/build/rootfs.go
@@ -66,7 +66,7 @@ func NewRootfs(artifactRegistry artifactsregistry.ArtifactsRegistry, template *T
 	}
 }
 
-func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, postProcessor *writer.PostProcessor, rootfsPath string) (e error) {
+func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, postProcessor *writer.PostProcessor, rootfsPath string) (c v1.Config, e error) {
 	childCtx, childSpan := tracer.Start(ctx, "create-ext4-file")
 	defer childSpan.End()
 
@@ -80,30 +80,30 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 
 	img, err := oci.GetImage(childCtx, tracer, r.artifactRegistry, r.template.TemplateId, r.template.BuildId)
 	if err != nil {
-		return fmt.Errorf("error requesting docker image: %w", err)
+		return v1.Config{}, fmt.Errorf("error requesting docker image: %w", err)
 	}
 
 	imageSize, err := oci.GetImageSize(img)
 	if err != nil {
-		return fmt.Errorf("error getting image size: %w", err)
+		return v1.Config{}, fmt.Errorf("error getting image size: %w", err)
 	}
 	postProcessor.WriteMsg(fmt.Sprintf("Docker image size: %s", humanize.Bytes(uint64(imageSize))))
 
 	postProcessor.WriteMsg("Setting up system files")
 	layers, err := additionalOCILayers(childCtx, r.template)
 	if err != nil {
-		return fmt.Errorf("error populating filesystem: %w", err)
+		return v1.Config{}, fmt.Errorf("error populating filesystem: %w", err)
 	}
 	img, err = mutate.AppendLayers(img, layers...)
 	if err != nil {
-		return fmt.Errorf("error appending layers: %w", err)
+		return v1.Config{}, fmt.Errorf("error appending layers: %w", err)
 	}
 	telemetry.ReportEvent(childCtx, "set up filesystem")
 
 	postProcessor.WriteMsg("Creating file system and pulling Docker image")
 	err = oci.ToExt4(ctx, img, rootfsPath, maxRootfsSize)
 	if err != nil {
-		return fmt.Errorf("error creating ext4 filesystem: %w", err)
+		return v1.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
 	}
 	telemetry.ReportEvent(childCtx, "created rootfs ext4 file")
 
@@ -111,13 +111,13 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 	// Make rootfs writable, be default it's readonly
 	err = ext4.MakeWritable(ctx, tracer, rootfsPath)
 	if err != nil {
-		return fmt.Errorf("error making rootfs file writable: %w", err)
+		return v1.Config{}, fmt.Errorf("error making rootfs file writable: %w", err)
 	}
 
 	// Resize rootfs
 	rootfsFinalSize, err := ext4.Enlarge(ctx, tracer, rootfsPath, r.template.DiskSizeMB<<ToMBShift)
 	if err != nil {
-		return fmt.Errorf("error enlarging rootfs: %w", err)
+		return v1.Config{}, fmt.Errorf("error enlarging rootfs: %w", err)
 	}
 	r.template.rootfsSize = rootfsFinalSize
 
@@ -128,10 +128,15 @@ func (r *Rootfs) createExt4Filesystem(ctx context.Context, tracer trace.Tracer, 
 		zap.Error(err),
 	)
 	if err != nil {
-		return fmt.Errorf("error checking ext4 filesystem integrity: %w", err)
+		return v1.Config{}, fmt.Errorf("error checking ext4 filesystem integrity: %w", err)
 	}
 
-	return nil
+	config, err := img.ConfigFile()
+	if err != nil {
+		return v1.Config{}, fmt.Errorf("error getting image config file: %w", err)
+	}
+
+	return config.Config, nil
 }
 
 func additionalOCILayers(

--- a/packages/orchestrator/internal/template/build/tar.go
+++ b/packages/orchestrator/internal/template/build/tar.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sort"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 )
 
@@ -17,7 +17,7 @@ type layerFile struct {
 
 // LayerFile creates a layer from a single file map. These layers are reproducible and consistent.
 // A filemap is a path -> file content map representing a file system.
-func LayerFile(filemap map[string]layerFile) (v1.Layer, error) {
+func LayerFile(filemap map[string]layerFile) (containerregistry.Layer, error) {
 	b := &bytes.Buffer{}
 	w := tar.NewWriter(b)
 
@@ -51,7 +51,7 @@ func LayerFile(filemap map[string]layerFile) (v1.Layer, error) {
 }
 
 // LayerSymlink creates a layer from a single symlink map. These layers are reproducible and consistent.
-func LayerSymlink(symlinks map[string]string) (v1.Layer, error) {
+func LayerSymlink(symlinks map[string]string) (containerregistry.Layer, error) {
 	b := &bytes.Buffer{}
 	w := tar.NewWriter(b)
 

--- a/packages/orchestrator/internal/template/build/template_builder.go
+++ b/packages/orchestrator/internal/template/build/template_builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
 	templatelocal "github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/ext4"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/oci"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/writer"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/template"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
@@ -137,7 +138,7 @@ func (b *TemplateBuilder) Build(ctx context.Context, template *TemplateConfig) (
 	// Created here to be able to pass it to CreateSandbox for populating COW cache
 	rootfsPath := filepath.Join(templateBuildDir, rootfsBuildFileName)
 
-	rootfs, memfile, err := Build(
+	rootfs, memfile, buildConfig, err := Build(
 		ctx,
 		b.tracer,
 		template,
@@ -250,10 +251,14 @@ func (b *TemplateBuilder) Build(ctx context.Context, template *TemplateConfig) (
 		scriptDef.String(),
 		"root",
 		nil,
+		map[string]string{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error running configuration script: %w", err)
 	}
+
+	// Env variables for the start command and ready command
+	envVars := oci.ParseEnvs(buildConfig.Env)
 
 	// Start command
 	commandsCtx, commandsCancel := context.WithCancel(ctx)
@@ -273,6 +278,7 @@ func (b *TemplateBuilder) Build(ctx context.Context, template *TemplateConfig) (
 				template.StartCmd,
 				"root",
 				&cwd,
+				envVars,
 				startCmdConfirm,
 			)
 			// If the ctx is canceled, the ready command succeeded and no start command await is necessary.
@@ -295,6 +301,7 @@ func (b *TemplateBuilder) Build(ctx context.Context, template *TemplateConfig) (
 		postProcessor,
 		template,
 		sbx.Metadata.Config.SandboxId,
+		envVars,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error running ready command: %w", err)

--- a/packages/shared/pkg/artifacts-registry/registry.go
+++ b/packages/shared/pkg/artifacts-registry/registry.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
@@ -29,7 +29,7 @@ var (
 
 type ArtifactsRegistry interface {
 	GetTag(ctx context.Context, templateId string, buildId string) (string, error)
-	GetImage(ctx context.Context, templateId string, buildId string, platform v1.Platform) (v1.Image, error)
+	GetImage(ctx context.Context, templateId string, buildId string, platform containerregistry.Platform) (containerregistry.Image, error)
 	Delete(ctx context.Context, templateId string, buildId string) error
 }
 

--- a/packages/shared/pkg/artifacts-registry/registry_aws.go
+++ b/packages/shared/pkg/artifacts-registry/registry_aws.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
@@ -80,7 +80,7 @@ func (g *AWSArtifactsRegistry) GetTag(ctx context.Context, templateId string, bu
 	return fmt.Sprintf("%s:%s", *res.Repositories[0].RepositoryUri, buildId), nil
 }
 
-func (g *AWSArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform v1.Platform) (v1.Image, error) {
+func (g *AWSArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform containerregistry.Platform) (containerregistry.Image, error) {
 	imageUrl, err := g.GetTag(ctx, templateId, buildId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image URL: %w", err)

--- a/packages/shared/pkg/artifacts-registry/registry_gcp.go
+++ b/packages/shared/pkg/artifacts-registry/registry_gcp.go
@@ -10,7 +10,7 @@ import (
 	"cloud.google.com/go/artifactregistry/apiv1/artifactregistrypb"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -55,7 +55,7 @@ func (g *GCPArtifactsRegistry) GetTag(ctx context.Context, templateId string, bu
 	return fmt.Sprintf("%s-docker.pkg.dev/%s/%s/%s:%s", consts.GCPRegion, consts.GCPProject, consts.DockerRegistry, templateId, buildId), nil
 }
 
-func (g *GCPArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform v1.Platform) (v1.Image, error) {
+func (g *GCPArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform containerregistry.Platform) (containerregistry.Image, error) {
 	imageUrl, err := g.GetTag(ctx, templateId, buildId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image URL: %w", err)

--- a/packages/shared/pkg/artifacts-registry/registry_local.go
+++ b/packages/shared/pkg/artifacts-registry/registry_local.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
+	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 )
 
@@ -25,7 +25,7 @@ func (g *LocalArtifactsRegistry) GetTag(ctx context.Context, templateId string, 
 	return fmt.Sprintf("%s:%s", templateId, buildId), nil
 }
 
-func (g *LocalArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform v1.Platform) (v1.Image, error) {
+func (g *LocalArtifactsRegistry) GetImage(ctx context.Context, templateId string, buildId string, platform containerregistry.Platform) (containerregistry.Image, error) {
 	imageUrl, err := g.GetTag(ctx, templateId, buildId)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image URL: %w", err)


### PR DESCRIPTION
Pass env vars from the Docker image to the start and ready commands. All ENV defined in the Docker image can now be referenced in the start and ready commands.

**Example Dockerfile**
`ENV E2B_TEST_VAR="Hello World E2B!"`

**Example e2b.toml**
`start_cmd = "echo $E2B_TEST_VAR"`

**Output**
`[start] [stdout]: Hello World E2B!`