### PR TITLE
Fix external sandbox logs from services

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -225,10 +225,11 @@ func run() int {
 	}()
 
 	logger := zap.Must(l.NewLogger(ctx, l.LoggerConfig{
-		ServiceName: serviceName,
-		IsInternal:  true,
-		IsDebug:     env.IsDebug(),
-		Cores:       []zapcore.Core{l.GetOTELCore(tel.LogsProvider, serviceName)},
+		ServiceName:   serviceName,
+		IsInternal:    true,
+		IsDebug:       env.IsDebug(),
+		Cores:         []zapcore.Core{l.GetOTELCore(tel.LogsProvider, serviceName)},
+		EnableConsole: true,
 	}))
 	defer logger.Sync()
 	zap.ReplaceGlobals(logger)

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -60,10 +60,11 @@ func run() int {
 	}()
 
 	logger := zap.Must(e2bLogger.NewLogger(ctx, e2bLogger.LoggerConfig{
-		ServiceName: serviceName,
-		IsInternal:  true,
-		IsDebug:     env.IsDebug(),
-		Cores:       []zapcore.Core{e2bLogger.GetOTELCore(tel.LogsProvider, serviceName)},
+		ServiceName:   serviceName,
+		IsInternal:    true,
+		IsDebug:       env.IsDebug(),
+		Cores:         []zapcore.Core{e2bLogger.GetOTELCore(tel.LogsProvider, serviceName)},
+		EnableConsole: true,
 	}))
 	defer func() {
 		err := logger.Sync()

--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -54,9 +54,10 @@ func buildTemplate(parentCtx context.Context, kernelVersion, fcVersion, template
 
 	clientID := "build-template-cmd"
 	logger, err := l.NewLogger(ctx, l.LoggerConfig{
-		ServiceName: clientID,
-		IsInternal:  true,
-		IsDebug:     true,
+		ServiceName:   clientID,
+		IsInternal:    true,
+		IsDebug:       true,
+		EnableConsole: true,
 	})
 	if err != nil {
 		return fmt.Errorf("could not create logger: %w", err)

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -151,10 +151,11 @@ func run(port, proxyPort uint) (success bool) {
 	}()
 
 	globalLogger := zap.Must(logger.NewLogger(ctx, logger.LoggerConfig{
-		ServiceName: serviceName,
-		IsInternal:  true,
-		IsDebug:     env.IsDebug(),
-		Cores:       []zapcore.Core{logger.GetOTELCore(tel.LogsProvider, serviceName)},
+		ServiceName:   serviceName,
+		IsInternal:    true,
+		IsDebug:       env.IsDebug(),
+		Cores:         []zapcore.Core{logger.GetOTELCore(tel.LogsProvider, serviceName)},
+		EnableConsole: true,
 	}))
 	defer func(l *zap.Logger) {
 		err := l.Sync()

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -26,6 +26,8 @@ type LoggerConfig struct {
 	InitialFields []zap.Field
 	// Cores additional processing cores for the logger.
 	Cores []zapcore.Core
+	// EnableConsole enables console logging.
+	EnableConsole bool
 }
 
 func NewLogger(_ context.Context, loggerConfig LoggerConfig) (*zap.Logger, error) {
@@ -36,22 +38,22 @@ func NewLogger(_ context.Context, loggerConfig LoggerConfig) (*zap.Logger, error
 		level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 
+	// Console logging configuration
 	config := zap.Config{
 		DisableStacktrace: loggerConfig.DisableStacktrace,
 		// Takes stacktraces more liberally
 		Development: true,
 		Sampling:    nil,
 
-		// Console core
-		Encoding:      "console",
-		EncoderConfig: GetConsoleEncoderConfig(),
-		Level:         level,
-		OutputPaths: []string{
-			"stdout",
-		},
-		ErrorOutputPaths: []string{
-			"stderr",
-		},
+		Encoding:         "console",
+		EncoderConfig:    GetConsoleEncoderConfig(),
+		Level:            level,
+		OutputPaths:      []string{},
+		ErrorOutputPaths: []string{},
+	}
+	if loggerConfig.EnableConsole {
+		config.OutputPaths = []string{"stdout"}
+		config.ErrorOutputPaths = []string{"stderr"}
 	}
 
 	cores := make([]zapcore.Core, 0)

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -23,6 +23,7 @@ type SandboxLoggerConfig struct {
 func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config SandboxLoggerConfig) *zap.Logger {
 	level := zap.NewAtomicLevelAt(zap.DebugLevel)
 
+	enableConsole := false
 	var core zapcore.Core
 	if !config.IsInternal && config.CollectorAddress != "" {
 		// Add Vector exporter to the core
@@ -35,6 +36,7 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 		)
 	} else {
 		core = logger.GetOTELCore(loggerProvider, config.ServiceName)
+		enableConsole = true
 	}
 
 	lg, err := logger.NewLogger(ctx, logger.LoggerConfig{
@@ -45,7 +47,8 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 		InitialFields: []zap.Field{
 			zap.String("logger", config.ServiceName),
 		},
-		Cores: []zapcore.Core{core},
+		Cores:         []zapcore.Core{core},
+		EnableConsole: enableConsole,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fix external sandbox logs from services. This fixes printing logs meant for sandboxes to the console from the API/Orchestrator.