### PR TITLE
Replace our own abstraction on top of the redis client

### DIFF
--- a/packages/api/internal/dns/server.go
+++ b/packages/api/internal/dns/server.go
@@ -19,18 +19,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 )
 
-// Rediser generalize RedisClient and RedisClusterClient, taken from github.com/go-redis/cache/v9
-type Rediser interface {
-	Set(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.StatusCmd
-	SetXX(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd
-	SetNX(ctx context.Context, key string, value interface{}, ttl time.Duration) *redis.BoolCmd
-
-	Get(ctx context.Context, key string) *redis.StringCmd
-	Del(ctx context.Context, keys ...string) *redis.IntCmd
-
-	Ping(ctx context.Context) *redis.StatusCmd
-}
-
 const ttl = 0
 const redisTTL = 24 * time.Hour
 
@@ -53,7 +41,7 @@ type DNS struct {
 	}
 }
 
-func New(ctx context.Context, redisClient Rediser) *DNS {
+func New(ctx context.Context, redisClient redis.UniversalClient) *DNS {
 	d := &DNS{}
 
 	if redisClient != nil && !reflect.ValueOf(redisClient).IsNil() {

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -23,7 +23,6 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
 	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
-	"github.com/e2b-dev/infra/packages/api/internal/dns"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	template_manager "github.com/e2b-dev/infra/packages/api/internal/template-manager"
@@ -116,7 +115,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client) *APIStore {
 		zap.L().Fatal("initializing Nomad client", zap.Error(err))
 	}
 
-	var redisClient dns.Rediser
+	var redisClient redis.UniversalClient
 	if redisClusterUrl := os.Getenv("REDIS_CLUSTER_URL"); redisClusterUrl != "" {
 		// For managed Redis Cluster in GCP we should use Cluster Client, because
 		// > Redis node endpoints can change and can be recycled as nodes are added and removed over time.

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -48,7 +49,7 @@ func New(
 	tracer trace.Tracer,
 	nomadClient *nomadapi.Client,
 	posthogClient *analyticscollector.PosthogClient,
-	redisClient dns.Rediser,
+	redisClient redis.UniversalClient,
 	dbClient *db.DB,
 ) (*Orchestrator, error) {
 	analyticsInstance, err := analyticscollector.NewAnalytics()


### PR DESCRIPTION
We have our own `Rediser` abstraction on top of the client and cluster client implementations. We can use `redis.UniversalClient` that is delivered by redis library that we are using.