### PR TITLE
Update self-host.md

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -44,9 +44,11 @@ Recommended for monitoring and logging
 Check if you can use config for terraform state management
 
 1. Go to `console.cloud.google.com` and create a new GCP project
+    > Make sure your Quota allows you to have at least 1000G for `Persistent Disk SSD (GB)` 
 2. Create `.env.prod`, `.env.staging`, or `.env.dev` from [`.env.template`](.env.template). You can pick any of them. Make sure to fill in the values. All are required if not specified otherwise.
-
     > Get Postgres database connection string from your database, e.g. [from Supabase](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection): Create a new project in Supabase and go to your project in Supabase -> Settings -> Database -> Connection Strings -> Postgres -> Direct
+    
+    > Your Postgres database needs to have enabled IPv4 access. You can do that in Connect screen
 3. Run `make switch-env ENV={prod,staging,dev}` to start using your env
 4. Run `make login-gcloud` to login to `gcloud`
 5. Run `make init`. If this errors, run it a second time--it's due to a race condition on Terraform enabling API access for the various GCP services; this can take several seconds. A full list of services that will be enabled for API access:


### PR DESCRIPTION
Small hints on what needs to be set for succesful deployment in GCP and Supabase

- Adjust Quota setting for disk space in GCP, default is 400G, which is not enough.
- By default the comms go via IPv4 from API to Supabase, hence IPv4 must be enabled, otherwise API deployment fails. 