### PR TITLE
Fix pausing nonexisting sandbox

### DIFF
--- a/tests/integration/internal/tests/api/sandbox_test.go
+++ b/tests/integration/internal/tests/api/sandbox_test.go
@@ -106,3 +106,18 @@ func TestSandboxResumeWithSecuredEnvd(t *testing.T) {
 	assert.Equal(t, sbxResume.JSON201.SandboxID, sbxCreate.JSON201.SandboxID)
 	assert.Equal(t, sbxResume.JSON201.EnvdAccessToken, sbxCreate.JSON201.EnvdAccessToken)
 }
+
+func TestSandboxPauseNonFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := setup.GetAPIClient()
+
+	r, err := c.PostSandboxesSandboxIDPauseWithResponse(ctx, "not-found", setup.WithAPIKey())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, http.StatusNotFound, r.StatusCode())
+	require.NotNil(t, r.JSON404)
+}


### PR DESCRIPTION
# Description

When pausing a nonexisting sandbox, we should return 404. Due to a bug, we were reporting 500.