### PR TITLE
API server [PoC] - systemd-resolved not routing .consul domain queries to Consul DNS server after 5-15s

### DIFF
--- a/packages/cluster-disk-image/setup/install-consul.sh
+++ b/packages/cluster-disk-image/setup/install-consul.sh
@@ -71,6 +71,8 @@ function install_dependencies {
   if os_is_ubuntu; then
     sudo apt-get update -y
     sudo apt-get install -y curl unzip jq
+    # install dnsmasq for consul dns routing 
+    sudo apt-get install -y dnsmasq
   else
     log_error "Could not find apt-get. Cannot install dependencies on this OS."
     exit 1


### PR DESCRIPTION
### Overview ### 
**Problem:**
systemd-resolved is configured with Consul DNS server (127.0.0.1:8600) and domain routing (~consul), but queries for .consul domains fail with NXDOMAIN. Direct queries to Consul DNS work fine.

**Root Cause:**
Despite having 127.0.0.1:8600 in the DNS servers list, systemd-resolved selects 169.254.169.254 (Google metadata server) as the "Current DNS Server" instead of the Consul DNS server. This prevents proper domain routing for .consul queries.
Current Status:
Global DNS Servers: 127.0.0.1:8600 169.254.169.254
Current DNS Server: 169.254.169.254  ← Wrong server selected
DNS Domain: ~consul ~local


**Expected Behavior:**
.consul domain queries should be routed to 127.0.0.1:8600
Current DNS Server should prioritize Consul DNS for .consul domains
resolvectl query template-manager.service.consul should resolve successfully

**Workaround Attempted:**
Consul DNS server responds correctly when queried directly (dig @127.0.0.1 -p 8600)
systemd-resolved configuration appears correct but server priority is wrong

**Impact:**
Service discovery via Consul DNS integration is broken, preventing applications from resolving Consul service names through the system resolver.

### Full Background ###

**✅ Direct Consul DNS query WORKS:**
```bash
root@e2b-orch-api-hq5w:/etc/systemd/resolved.conf.d# dig @127.0.0.1 -p 8600 template-manager.service.consul
;; ANSWER SECTION:
template-manager.service.consul. 0 IN   A       10.138.0.4
```

**❌ systemd-resolved query FAILS:**
```bash
root@e2b-orch-api-hq5w:/etc/systemd/resolved.conf.d# resolvectl query template-manager.service.consul
template-manager.service.consul: resolve call failed: 'template-manager.service.consul' not found
```

This works only for 5-15 seconds after restart of systemd-resolved:
```# systemctl restart systemd-resolved```

Example:
```root@e2b-orch-api-hq5w:/etc/systemd/resolved.conf.d# resolvectl query template-manager.service.consul
template-manager.service.consul: 10.138.0.4

-- Information acquired via protocol DNS in 2.0ms.
-- Data is authenticated: no; unsigned```

**❌ nslookup through systemd-resolved FAILS:**
```bash
# nslookup template-manager.service.consul
Server:         127.0.0.53
Address:        127.0.0.53#53
** server can't find template-manager.service.consul: NXDOMAIN
```

**The configuration shows the problem:**
```bash
# resolvectl status
Global
Current DNS Server: 169.254.169.254    # ❌ Wrong server selected
DNS Servers: 127.0.0.1:8600 169.254.169.254    # ✅ Consul DNS configured
DNS Domain: ~consul ~local    # ✅ Domain configured
```

**Root cause:** systemd-resolved has `127.0.0.1:8600` configured but is using `169.254.169.254` as the current DNS server, so `.consul` queries never reach Consul.

PS: The same bug occurs on all servers running consol as dns server via resolved.d