### PR TITLE
Fixing broken client proxy graceful shutdown

### DIFF
--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -175,12 +175,12 @@ func run() int {
 		if err != nil {
 			switch {
 			case errors.Is(err, http.ErrServerClosed):
-				edgeRunLogger.Info("edge http service shutdown successfully")
+				edgeRunLogger.Info("edge service shutdown successfully")
 			case err != nil:
 				exitCode.Add(1)
-				edgeRunLogger.Error("edge http service encountered error", zap.Error(err))
+				edgeRunLogger.Error("edge service encountered error", zap.Error(err))
 			default:
-				edgeRunLogger.Info("edge http service exited without error")
+				edgeRunLogger.Info("edge service exited without error")
 			}
 		}
 	}()
@@ -202,13 +202,13 @@ func run() int {
 		// Add different handling for the error
 		switch {
 		case errors.Is(err, http.ErrServerClosed):
-			proxyRunLogger.Info("http service shutdown successfully")
+			proxyRunLogger.Info("proxy http service shutdown successfully")
 		case err != nil:
 			exitCode.Add(1)
-			proxyRunLogger.Error("http service encountered error", zap.Error(err))
+			proxyRunLogger.Error("proxy http service encountered error", zap.Error(err))
 		default:
 			// this probably shouldn't happen...
-			proxyRunLogger.Error("http service exited without error")
+			proxyRunLogger.Error("proxy http service exited without error")
 		}
 	}()
 

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -35,8 +35,8 @@ import (
 const (
 	serviceName = "client-proxy"
 
-	shutdownDrainingWait  = 30 * time.Second
-	shutdownUnhealthyWait = 30 * time.Second
+	shutdownDrainingWait  = 15 * time.Second
+	shutdownUnhealthyWait = 15 * time.Second
 
 	version = "1.0.0"
 )

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -223,10 +223,8 @@ func run() int {
 		edgeApiStore.SetDraining()
 
 		// we should wait for health check manager to notice that we are not ready for new traffic
-		if !env.IsDevelopment() {
-			shutdownLogger.Info("waiting for draining state propagation", zap.Float64("wait_in_seconds", shutdownDrainingWait.Seconds()))
-			time.Sleep(shutdownDrainingWait)
-		}
+		shutdownLogger.Info("waiting for draining state propagation", zap.Float64("wait_in_seconds", shutdownDrainingWait.Seconds()))
+		time.Sleep(shutdownDrainingWait)
 
 		proxyShutdownCtx, proxyShutdownCtxCancel := context.WithTimeout(ctx, 24*time.Hour)
 		defer proxyShutdownCtxCancel()
@@ -243,10 +241,8 @@ func run() int {
 		edgeApiStore.SetUnhealthy()
 
 		// wait for the health check manager to notice that we are not healthy at all
-		if !env.IsDevelopment() {
-			shutdownLogger.Info("waiting for unhealthy state propagation", zap.Float64("wait_in_seconds", shutdownUnhealthyWait.Seconds()))
-			time.Sleep(shutdownUnhealthyWait)
-		}
+		shutdownLogger.Info("waiting for unhealthy state propagation", zap.Float64("wait_in_seconds", shutdownUnhealthyWait.Seconds()))
+		time.Sleep(shutdownUnhealthyWait)
 
 		ginErr := edgeGinServer.Shutdown(ctx)
 		if ginErr != nil {

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,6 @@ variable "client_proxy_resources_cpu_count" {
   default = 1
 }
 
-
 variable "edge_api_port" {
   type = object({
     name = string
@@ -126,7 +125,7 @@ variable "edge_api_port" {
   default = {
     name = "edge-api"
     port = 3001
-    path = "/health"
+    path = "/health/traffic"
   }
 }
 


### PR DESCRIPTION
- Fixed health check path on load balancer (we have one path for edge service and a second only for proxy traffic).
- Removed use of `env.IsDevelopment()` that was causing to skipp shutdown waits to be skipped, because the default function output is true.
- Adjusted logging to be more clear what server was stopped