### PR TITLE
Update self-host.md to contain Google Cloud Quota troubleshoot guide

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -146,3 +146,18 @@ You can build your own kernel and Firecracker version from source by running `ma
 - `make import TARGET={resource} ID={resource_id}` - imports the already created resources into the terraform state
 - `make setup-ssh` - sets up the ssh key for the environment (useful for remote-debugging)
 - `make connect-orchestrator` - establish the ssh connection to the remote orchestrator (for testing API locally)
+
+---
+
+## Google Cloud Troubleshooting
+**Quotas not available** 
+
+If you can't find the quota in `All Quotas` in GCP's Console, then create and delete a dummy VM before proceeding to step 2 in self-deploy guide. This will create additional quotas and policies in GCP 
+```
+gcloud compute instances create dummy-init   --project=YOUR-PROJECT-ID   --zone=YOUR-ZONE   --machine-type=e2-medium   --boot-disk-type=pd-ssd   --no-address
+```
+Wait a minute and destroy the VM:
+```
+gcloud compute instances delete dummy-init --zone=YOUR-ZONE --quiet
+```
+Now, you should see the right quota options in `All Quotas` and be able to request the correct size. 


### PR DESCRIPTION
Added section on how to initiate quotas before deploying e2b - not sure if the guide should be this user friendly, but could save quite some time a less experienced GCP person :) 