### PR TITLE
Fix template manager connection

### DIFF
--- a/packages/api/internal/template-manager/client.go
+++ b/packages/api/internal/template-manager/client.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	host                = os.Getenv("TEMPLATE_MANAGER_ADDRESS")
+	host                = os.Getenv("TEMPLATE_MANAGER_HOST")
 	healthCheckInterval = 5 * time.Second
 )
 

--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -69,7 +69,7 @@ job "api" {
 
       env {
         ORCHESTRATOR_PORT              = "${orchestrator_port}"
-        TEMPLATE_MANAGER_ADDRESS       = "${template_manager_address}"
+        TEMPLATE_MANAGER_HOST          = "${template_manager_host}"
         POSTGRES_CONNECTION_STRING     = "${postgres_connection_string}"
         SUPABASE_JWT_SECRETS           = "${supabase_jwt_secrets}"
         CLICKHOUSE_CONNECTION_STRING   = "${clickhouse_connection_string}"

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -71,7 +71,7 @@ resource "nomad_job" "api" {
     // It might be possible there could be problems if we are rolling updates for both API and Loki at the same time., so maybe increasing this to > 3 makes sense.
     prevent_colocation             = var.api_machine_count > 2
     orchestrator_port              = var.orchestrator_port
-    template_manager_address       = "http://template-manager.service.consul:${var.template_manager_port}"
+    template_manager_host          = "template-manager.service.consul:${var.template_manager_port}"
     otel_collector_grpc_endpoint   = "localhost:${var.otel_collector_grpc_port}"
     loki_address                   = "http://loki.service.consul:${var.loki_service_port.port}"
     logs_collector_address         = "http://localhost:${var.logs_proxy_port.port}"


### PR DESCRIPTION
Because of `http://` prefix the url parses to resolves `http://template-manager.service.consul:5008:443`

Also renamed the environment variable to prevent confusion.

```
2025-06-23T23:00:01.527Z  ERROR  failed to get health status of template manager  {"service": "orchestration-api", "internal": true, "pid": 1, "error": "failed to exit idle mode: invalid target address http://template-manager.service.consul:5008, error info: address http://template-manager.service.consul:5008:443: too many colons in address"}
github.com/e2b-dev/infra/packages/api/internal/template-manager.(*GRPCClient).healthCheckSync
	/build/api/internal/template-manager/client.go:91
```