### PR TITLE
Added row lever security for cluster table

### DIFF
--- a/packages/db/migrations/20250624001047_deploy_cluster_policy.sql
+++ b/packages/db/migrations/20250624001047_deploy_cluster_policy.sql
@@ -5,4 +5,5 @@ ALTER TABLE "public"."clusters" ENABLE ROW LEVEL SECURITY;
 
 -- +goose Down
 -- +goose StatementBegin
+ALTER TABLE "public"."clusters" DISABLE ROW LEVEL SECURITY;
 -- +goose StatementEnd

--- a/packages/db/migrations/20250624001047_deploy_cluster_policy.sql
+++ b/packages/db/migrations/20250624001047_deploy_cluster_policy.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE "public"."clusters" ENABLE ROW LEVEL SECURITY;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd


### PR DESCRIPTION
Enable row-level security for the clusters table. Needed because of the Supabase access model.