### PR TITLE
Feat: Add Supabase auth headers to api CORS policy

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -97,6 +97,9 @@ func NewGinServer(ctx context.Context, tel *telemetry.Client, logger *zap.Logger
 		// API Key header
 		"Authorization",
 		"X-API-Key",
+		// Supabase headers
+		"X-Supabase-Token",
+		"X-Supabase-Team",
 		// Custom headers sent from SDK
 		"browser",
 		"lang",


### PR DESCRIPTION
In order to enable usage of the `e2b` SDK inside a browser environment + authorizing to the api via the user's `Supabase Token`, this PR updates the CORS `AllowedHeaders` policy accordingly