### PR TITLE
Fixes in client proxy service discovery

### DIFF
--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -79,7 +79,7 @@ func (s *NodePassThroughServer) director(ctx context.Context) (*grpc.ClientConn,
 		return nil, status.Error(codes.NotFound, "node not found")
 	}
 
-	return node.Client.Connection, nil
+	return node.GetClient().Connection, nil
 }
 
 // Handler - following code implement a gRPC pass-through proxy that forwards requests to the appropriate node

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
@@ -62,7 +62,7 @@ func (a *APIStore) sendNodeRequest(ctx context.Context, serviceId string, status
 			return errors.New("failed to transform node status to orchestrator status")
 		}
 
-		_, err := o.Client.Info.ServiceStatusOverride(
+		_, err := o.GetClient().Info.ServiceStatusOverride(
 			findCtx, &orchestratorinfo.ServiceStatusChangeRequest{ServiceStatus: orchestratorStatus},
 		)
 		if err != nil {

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
@@ -82,9 +82,9 @@ func (a *APIStore) sendNodeRequest(ctx context.Context, serviceId string, status
 
 	switch status {
 	case api.Draining:
-		_, err = e.Client.V1ServiceDiscoveryNodeDrain(ctx, serviceId)
+		_, err = e.GetClient().V1ServiceDiscoveryNodeDrain(ctx, serviceId)
 	case api.Unhealthy:
-		_, err = e.Client.V1ServiceDiscoveryNodeKill(ctx, serviceId)
+		_, err = e.GetClient().V1ServiceDiscoveryNodeKill(ctx, serviceId)
 	default:
 		return errors.New("failed to transform node status to api call")
 	}

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-nodes-list.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-nodes-list.go
@@ -17,17 +17,18 @@ func (a *APIStore) V1ServiceDiscoveryNodes(c *gin.Context) {
 
 	// iterate orchestrator pool
 	for _, orchestrator := range a.orchestratorPool.GetOrchestrators() {
+		info := orchestrator.GetInfo()
 		response = append(
 			response,
 			api.ClusterNode{
-				Id:        orchestrator.ServiceId,
-				NodeId:    orchestrator.NodeId,
-				Status:    getOrchestratorStatusResolved(orchestrator.Status),
+				Id:        info.ServiceId,
+				NodeId:    info.NodeId,
+				Status:    getOrchestratorStatusResolved(info.Status),
 				Type:      api.ClusterNodeTypeOrchestrator,
-				Version:   orchestrator.SourceVersion,
-				Commit:    orchestrator.SourceCommit,
-				Host:      orchestrator.Host,
-				StartedAt: orchestrator.Startup,
+				Version:   info.SourceVersion,
+				Commit:    info.SourceCommit,
+				Host:      info.Host,
+				StartedAt: info.Startup,
 			},
 		)
 	}

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-nodes-list.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-nodes-list.go
@@ -35,17 +35,18 @@ func (a *APIStore) V1ServiceDiscoveryNodes(c *gin.Context) {
 
 	// iterate edge apis
 	for _, edge := range a.edgePool.GetNodes() {
+		info := edge.GetInfo()
 		response = append(
 			response,
 			api.ClusterNode{
-				Id:        edge.ServiceId,
-				NodeId:    edge.NodeId,
-				Status:    edge.Status,
+				Id:        info.ServiceId,
+				NodeId:    info.NodeId,
+				Status:    info.Status,
 				Type:      api.ClusterNodeTypeEdge,
-				Version:   edge.SourceVersion,
-				Commit:    edge.SourceCommit,
-				Host:      edge.Host,
-				StartedAt: edge.Startup,
+				Version:   info.SourceVersion,
+				Commit:    info.SourceCommit,
+				Host:      info.Host,
+				StartedAt: info.Startup,
 			},
 		)
 	}

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-orchestrators.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-orchestrators.go
@@ -19,18 +19,19 @@ func (a *APIStore) V1ServiceDiscoveryGetOrchestrators(c *gin.Context) {
 	response := make([]api.ClusterOrchestratorNode, 0)
 
 	for _, node := range a.orchestratorPool.GetOrchestrators() {
+		info := node.GetInfo()
 		response = append(
 			response,
 			api.ClusterOrchestratorNode{
-				Id:        node.ServiceId,
-				NodeId:    node.NodeId,
-				Version:   node.SourceVersion,
-				Commit:    node.SourceCommit,
-				Host:      node.Host,
-				StartedAt: node.Startup,
+				Id:        info.ServiceId,
+				NodeId:    info.NodeId,
+				Version:   info.SourceVersion,
+				Commit:    info.SourceCommit,
+				Host:      info.Host,
+				StartedAt: info.Startup,
 
-				Status: getOrchestratorStatusResolved(node.Status),
-				Roles:  getOrchestratorRolesResolved(node.Roles),
+				Status: getOrchestratorStatusResolved(info.Status),
+				Roles:  getOrchestratorRolesResolved(info.Roles),
 
 				MetricRamMBUsed:        node.MetricMemoryUsedInMB.Load(),
 				MetricVCpuUsed:         node.MetricVCpuUsed.Load(),

--- a/packages/client-proxy/internal/edge/handlers/store.go
+++ b/packages/client-proxy/internal/edge/handlers/store.go
@@ -12,7 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/proxy/internal/edge/info"
-	logger_provider "github.com/e2b-dev/infra/packages/proxy/internal/edge/logger-provider"
+	loggerprovider "github.com/e2b-dev/infra/packages/proxy/internal/edge/logger-provider"
 	e2borchestrators "github.com/e2b-dev/infra/packages/proxy/internal/edge/pool"
 	"github.com/e2b-dev/infra/packages/proxy/internal/edge/sandboxes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
@@ -27,7 +27,7 @@ type APIStore struct {
 	orchestratorPool  *e2borchestrators.OrchestratorsPool
 	edgePool          *e2borchestrators.EdgePool
 	sandboxes         sandboxes.SandboxesCatalog
-	queryLogsProvider logger_provider.LogsQueryProvider
+	queryLogsProvider loggerprovider.LogsQueryProvider
 }
 
 type APIUserFacingError struct {
@@ -44,7 +44,7 @@ const (
 var skipInitialOrchestratorCheck = os.Getenv("SKIP_ORCHESTRATOR_READINESS_CHECK") == "true"
 
 func NewStore(ctx context.Context, logger *zap.Logger, tracer trace.Tracer, info *info.ServiceInfo, orchestratorsPool *e2borchestrators.OrchestratorsPool, edgePool *e2borchestrators.EdgePool, catalog sandboxes.SandboxesCatalog) (*APIStore, error) {
-	queryLogsProvider, err := logger_provider.GetLogsQueryProvider()
+	queryLogsProvider, err := loggerprovider.GetLogsQueryProvider()
 	if err != nil {
 		return nil, fmt.Errorf("error when getting logs query provider: %w", err)
 	}

--- a/packages/client-proxy/internal/edge/pool/edge-pool.go
+++ b/packages/client-proxy/internal/edge/pool/edge-pool.go
@@ -53,12 +53,13 @@ func (p *EdgePool) GetNodes() map[string]*EdgeNode {
 }
 
 func (p *EdgePool) GetNode(id string) (*EdgeNode, error) {
-	o, ok := p.nodes.Get(id)
-	if !ok {
-		return nil, ErrEdgeNodeNotFound
+	for _, node := range p.nodes.Items() {
+		if node.GetInfo().ServiceId == id {
+			return node, nil
+		}
 	}
 
-	return o, nil
+	return nil, ErrEdgeNodeNotFound
 }
 
 func (p *EdgePool) keepInSync(ctx context.Context) {
@@ -101,7 +102,6 @@ func (p *EdgePool) syncNodes(ctx context.Context) {
 			defer wg.Done()
 
 			var found *EdgeNode = nil
-
 			host := fmt.Sprintf("%s:%d", sdNode.NodeIp, sdNode.NodePort)
 
 			// skip self registration
@@ -172,7 +172,7 @@ func (p *EdgePool) connectNode(ctx context.Context, node *sd.ServiceDiscoveryIte
 		return err
 	}
 
-	p.nodes.Insert(o.GetInfo().ServiceId, o)
+	p.nodes.Insert(o.GetInfo().NodeId, o)
 	return nil
 }
 
@@ -189,7 +189,7 @@ func (p *EdgePool) removeNode(ctx context.Context, node *EdgeNode) error {
 		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(info.ServiceId))
 	}
 
-	p.nodes.Remove(info.ServiceId)
+	p.nodes.Remove(info.NodeId)
 	p.logger.Info("Edge node node connection has been closed.", l.WithClusterNodeID(info.ServiceId))
 	return nil
 }

--- a/packages/client-proxy/internal/edge/pool/edge-pool.go
+++ b/packages/client-proxy/internal/edge/pool/edge-pool.go
@@ -20,7 +20,6 @@ type EdgePool struct {
 
 	nodeSelfHost string
 	nodes        *smap.Map[*EdgeNode]
-	mutex        sync.RWMutex
 
 	tracer trace.Tracer
 	logger *zap.Logger
@@ -38,7 +37,6 @@ func NewEdgePool(ctx context.Context, logger *zap.Logger, discovery sd.ServiceDi
 
 		nodeSelfHost: nodeSelfHost,
 		nodes:        smap.New[*EdgeNode](),
-		mutex:        sync.RWMutex{},
 
 		logger: logger,
 		tracer: tracer,
@@ -51,16 +49,10 @@ func NewEdgePool(ctx context.Context, logger *zap.Logger, discovery sd.ServiceDi
 }
 
 func (p *EdgePool) GetNodes() map[string]*EdgeNode {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-
 	return p.nodes.Items()
 }
 
 func (p *EdgePool) GetNode(id string) (*EdgeNode, error) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-
 	o, ok := p.nodes.Get(id)
 	if !ok {
 		return nil, ErrEdgeNodeNotFound
@@ -118,7 +110,7 @@ func (p *EdgePool) syncNodes(ctx context.Context) {
 			}
 
 			for _, node := range p.nodes.Items() {
-				if host == node.Host {
+				if host == node.GetInfo().Host {
 					found = node
 					break
 				}
@@ -149,7 +141,7 @@ func (p *EdgePool) syncNodes(ctx context.Context) {
 
 			for _, sdNode := range sdNodes {
 				host := fmt.Sprintf("%s:%d", sdNode.NodeIp, sdNode.NodePort)
-				if host == node.Host {
+				if host == node.GetInfo().Host {
 					found = true
 					break
 				}
@@ -180,11 +172,7 @@ func (p *EdgePool) connectNode(ctx context.Context, node *sd.ServiceDiscoveryIte
 		return err
 	}
 
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	p.nodes.Insert(o.ServiceId, o)
-
+	p.nodes.Insert(o.GetInfo().ServiceId, o)
 	return nil
 }
 
@@ -192,19 +180,16 @@ func (p *EdgePool) removeNode(ctx context.Context, node *EdgeNode) error {
 	_, childSpan := p.tracer.Start(ctx, "remove-edge-node")
 	defer childSpan.End()
 
-	p.logger.Info("Edge node connection is not active anymore, closing.", l.WithClusterNodeID(node.ServiceId))
+	info := node.GetInfo()
+	p.logger.Info("Edge node connection is not active anymore, closing.", l.WithClusterNodeID(info.ServiceId))
 
 	// stop background sync and close everything
 	err := node.Close()
 	if err != nil {
-		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(node.ServiceId))
+		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(info.ServiceId))
 	}
 
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
-	p.nodes.Remove(node.ServiceId)
-
-	p.logger.Info("Edge node node connection has been closed.", l.WithClusterNodeID(node.ServiceId))
+	p.nodes.Remove(info.ServiceId)
+	p.logger.Info("Edge node node connection has been closed.", l.WithClusterNodeID(info.ServiceId))
 	return nil
 }

--- a/packages/client-proxy/internal/edge/pool/edge.go
+++ b/packages/client-proxy/internal/edge/pool/edge.go
@@ -18,7 +18,7 @@ const (
 	edgeSyncMaxRetries = 3
 )
 
-type EdgeNode struct {
+type EdgeNodeInfo struct {
 	ServiceId string
 	NodeId    string
 
@@ -28,9 +28,12 @@ type EdgeNode struct {
 	Host    string
 	Status  api.ClusterNodeStatus
 	Startup time.Time
-	Client  *api.ClientWithResponses
+}
 
-	mutex sync.Mutex
+type EdgeNode struct {
+	info   EdgeNodeInfo
+	client *api.ClientWithResponses
+	mutex  sync.RWMutex
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -46,8 +49,10 @@ func NewEdgeNode(ctx context.Context, host string) (*EdgeNode, error) {
 	}
 
 	o := &EdgeNode{
-		Host:   host,
-		Client: client,
+		client: client,
+		info: EdgeNodeInfo{
+			Host: host,
+		},
 
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
@@ -87,25 +92,27 @@ func (o *EdgeNode) syncRun() error {
 	defer cancel()
 
 	for i := 0; i < edgeSyncMaxRetries; i++ {
-		res, err := o.Client.V1InfoWithResponse(ctx)
+		info := o.GetInfo()
+		res, err := o.client.V1InfoWithResponse(ctx)
 		if err != nil {
-			zap.L().Error("failed to check edge node status", l.WithClusterNodeID(o.ServiceId), zap.Error(err))
+			zap.L().Error("failed to check edge node status", l.WithClusterNodeID(info.ServiceId), zap.Error(err))
 			continue
 		}
 
 		if res.JSON200 == nil {
-			zap.L().Error("failed to check edge node status", l.WithClusterNodeID(o.ServiceId), zap.Int("status", res.StatusCode()))
+			zap.L().Error("failed to check edge node status", l.WithClusterNodeID(info.ServiceId), zap.Int("status", res.StatusCode()))
 			continue
 		}
 
 		body := res.JSON200
 
-		o.ServiceId = body.Id
-		o.NodeId = body.NodeId
-		o.Startup = body.Startup
-		o.Status = body.Status
-		o.SourceVersion = body.Version
-		o.SourceCommit = body.Commit
+		info.ServiceId = body.Id
+		info.NodeId = body.NodeId
+		info.Startup = body.Startup
+		info.Status = body.Status
+		info.SourceVersion = body.Version
+		info.SourceCommit = body.Commit
+		o.setInfo(info)
 
 		return nil
 	}
@@ -113,10 +120,32 @@ func (o *EdgeNode) syncRun() error {
 	return errors.New("failed to check edge node status")
 }
 
+func (o *EdgeNode) GetClient() *api.ClientWithResponses {
+	return o.client
+}
+
+func (o *EdgeNode) GetInfo() EdgeNodeInfo {
+	o.mutex.RLock()
+	defer o.mutex.RUnlock()
+	return o.info
+}
+
+func (o *EdgeNode) setInfo(info EdgeNodeInfo) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.info = info
+}
+
+func (o *EdgeNode) setStatus(s api.ClusterNodeStatus) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.info.Status = s
+}
+
 func (o *EdgeNode) Close() error {
 	// close sync context
 	o.ctxCancel()
-	o.Status = api.Unhealthy
+	o.setStatus(api.Unhealthy)
 	return nil
 }
 

--- a/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
@@ -137,7 +137,7 @@ func (p *OrchestratorsPool) syncNodes(ctx context.Context) {
 
 			host := fmt.Sprintf("%s:%d", sdNode.NodeIp, sdNode.NodePort)
 			for _, node := range p.nodes.Items() {
-				if host == node.Host {
+				if host == node.GetInfo().Host {
 					found = node
 					break
 				}
@@ -162,13 +162,14 @@ func (p *OrchestratorsPool) syncNodes(ctx context.Context) {
 	for _, node := range p.GetOrchestrators() {
 		wg.Add(1)
 		go func(node *OrchestratorNode) {
+			nodeInfo := node.GetInfo()
 			defer wg.Done()
 
 			found := false
 
 			for _, sdNode := range sdNodes {
 				host := fmt.Sprintf("%s:%d", sdNode.NodeIp, sdNode.NodePort)
-				if host == node.Host {
+				if host == nodeInfo.Host {
 					found = true
 					break
 				}
@@ -178,7 +179,7 @@ func (p *OrchestratorsPool) syncNodes(ctx context.Context) {
 			if !found {
 				err := p.removeNode(spanCtx, node)
 				if err != nil {
-					p.logger.Error("Error during node removal", zap.Error(err), l.WithClusterNodeID(node.ServiceId))
+					p.logger.Error("Error during node removal", zap.Error(err), l.WithClusterNodeID(nodeInfo.ServiceId))
 				}
 			}
 		}(node)
@@ -198,10 +199,10 @@ func (p *OrchestratorsPool) connectNode(ctx context.Context, node *sd.ServiceDis
 		return err
 	}
 
+	info := o.GetInfo()
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-
-	p.nodes.Insert(o.ServiceId, o)
+	p.nodes.Insert(info.ServiceId, o)
 	return nil
 }
 
@@ -209,19 +210,19 @@ func (p *OrchestratorsPool) removeNode(ctx context.Context, node *OrchestratorNo
 	_, childSpan := p.tracer.Start(ctx, "remove-orchestrator-node")
 	defer childSpan.End()
 
-	p.logger.Info("Orchestrator node node connection is not active anymore, closing.", l.WithClusterNodeID(node.ServiceId))
+	info := node.GetInfo()
+	p.logger.Info("Orchestrator node node connection is not active anymore, closing.", l.WithClusterNodeID(info.ServiceId))
 
 	// stop background sync and close everything
 	err := node.Close()
 	if err != nil {
-		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(node.ServiceId))
+		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(info.ServiceId))
 	}
 
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 
-	p.nodes.Remove(node.ServiceId)
-
-	p.logger.Info("Orchestrator node node connection has been closed.", l.WithClusterNodeID(node.ServiceId))
+	p.nodes.Remove(info.ServiceId)
+	p.logger.Info("Orchestrator node node connection has been closed.", l.WithClusterNodeID(info.ServiceId))
 	return nil
 }

--- a/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
@@ -219,9 +219,6 @@ func (p *OrchestratorsPool) removeNode(ctx context.Context, node *OrchestratorNo
 		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(info.ServiceId))
 	}
 
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-
 	p.nodes.Remove(info.ServiceId)
 	p.logger.Info("Orchestrator node node connection has been closed.", l.WithClusterNodeID(info.ServiceId))
 	return nil

--- a/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
@@ -17,9 +17,7 @@ import (
 
 type OrchestratorsPool struct {
 	discovery sd.ServiceDiscoveryAdapter
-
-	nodes *smap.Map[*OrchestratorNode]
-	mutex sync.RWMutex
+	nodes     *smap.Map[*OrchestratorNode]
 
 	tracer trace.Tracer
 	logger *zap.Logger
@@ -42,9 +40,7 @@ func NewOrchestratorsPool(
 ) *OrchestratorsPool {
 	pool := &OrchestratorsPool{
 		discovery: discovery,
-
-		nodes: smap.New[*OrchestratorNode](),
-		mutex: sync.RWMutex{},
+		nodes:     smap.New[*OrchestratorNode](),
 
 		tracer: tracerProvider.Tracer("orchestrators-pool"),
 		logger: logger,
@@ -61,17 +57,18 @@ func NewOrchestratorsPool(
 }
 
 func (p *OrchestratorsPool) GetOrchestrators() map[string]*OrchestratorNode {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
-
 	return p.nodes.Items()
 }
 
 func (p *OrchestratorsPool) GetOrchestrator(id string) (node *OrchestratorNode, ok bool) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
+	orchestrators := p.GetOrchestrators()
+	for _, node = range orchestrators {
+		if node.GetInfo().ServiceId == id {
+			return node, ok
+		}
+	}
 
-	return p.nodes.Get(id)
+	return nil, false
 }
 
 func (p *OrchestratorsPool) keepInSync(ctx context.Context) {
@@ -134,7 +131,6 @@ func (p *OrchestratorsPool) syncNodes(ctx context.Context) {
 			defer wg.Done()
 
 			var found *OrchestratorNode = nil
-
 			host := fmt.Sprintf("%s:%d", sdNode.NodeIp, sdNode.NodePort)
 			for _, node := range p.nodes.Items() {
 				if host == node.GetInfo().Host {
@@ -200,9 +196,7 @@ func (p *OrchestratorsPool) connectNode(ctx context.Context, node *sd.ServiceDis
 	}
 
 	info := o.GetInfo()
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	p.nodes.Insert(info.ServiceId, o)
+	p.nodes.Insert(info.NodeId, o)
 	return nil
 }
 
@@ -219,7 +213,7 @@ func (p *OrchestratorsPool) removeNode(ctx context.Context, node *OrchestratorNo
 		p.logger.Error("Error closing connection to node", zap.Error(err), l.WithClusterNodeID(info.ServiceId))
 	}
 
-	p.nodes.Remove(info.ServiceId)
+	p.nodes.Remove(info.NodeId)
 	p.logger.Info("Orchestrator node node connection has been closed.", l.WithClusterNodeID(info.ServiceId))
 	return nil
 }

--- a/packages/client-proxy/internal/edge/pool/orchestrator.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator.go
@@ -33,7 +33,7 @@ const (
 	OrchestratorStatusUnhealthy OrchestratorStatus = "unhealthy"
 )
 
-type OrchestratorNode struct {
+type OrchestratorNodeInfo struct {
 	ServiceId string
 	NodeId    string
 
@@ -46,15 +46,17 @@ type OrchestratorNode struct {
 	Status  OrchestratorStatus
 	Startup time.Time
 	Roles   []e2bgrpcorchestratorinfo.ServiceInfoRole
+}
 
-	Client *OrchestratorGRPCClient
-
+type OrchestratorNode struct {
 	MetricVCpuUsed         atomic.Int64
 	MetricMemoryUsedInMB   atomic.Int64
 	MetricDiskUsedInMB     atomic.Int64
 	MetricSandboxesRunning atomic.Int64
 
-	mutex sync.Mutex
+	client *OrchestratorGRPCClient
+	info   OrchestratorNodeInfo
+	mutex  sync.RWMutex
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -79,9 +81,11 @@ func NewOrchestrator(ctx context.Context, tracerProvider trace.TracerProvider, m
 	ctx, ctxCancel := context.WithCancel(ctx)
 
 	o := &OrchestratorNode{
-		Host:   host,
-		Ip:     ip,
-		Client: client,
+		client: client,
+		info: OrchestratorNodeInfo{
+			Host: host,
+			Ip:   ip,
+		},
 
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
@@ -121,20 +125,23 @@ func (o *OrchestratorNode) syncRun() error {
 	defer cancel()
 
 	for i := 0; i < orchestratorSyncMaxRetries; i++ {
-		status, err := o.Client.Info.ServiceInfo(ctx, &emptypb.Empty{})
+		freshInfo := o.GetInfo()
+
+		status, err := o.client.Info.ServiceInfo(ctx, &emptypb.Empty{})
 		if err != nil {
-			zap.L().Error("failed to check orchestrator health", l.WithClusterNodeID(o.ServiceId), zap.Error(err))
+			zap.L().Error("failed to check orchestrator health", l.WithClusterNodeID(freshInfo.ServiceId), zap.Error(err))
 			continue
 		}
 
-		o.NodeId = status.NodeId
-		o.ServiceId = status.ServiceId
-		o.Startup = status.ServiceStartup.AsTime()
-		o.Status = getMappedStatus(status.ServiceStatus)
-		o.Roles = status.ServiceRoles
+		freshInfo.NodeId = status.NodeId
+		freshInfo.ServiceId = status.ServiceId
+		freshInfo.Startup = status.ServiceStartup.AsTime()
+		freshInfo.Status = getMappedStatus(status.ServiceStatus)
+		freshInfo.Roles = status.ServiceRoles
 
-		o.SourceVersion = status.ServiceVersion
-		o.SourceCommit = status.ServiceCommit
+		freshInfo.SourceVersion = status.ServiceVersion
+		freshInfo.SourceCommit = status.ServiceCommit
+		o.setInfo(freshInfo)
 
 		o.MetricSandboxesRunning.Store(status.MetricSandboxesRunning)
 		o.MetricMemoryUsedInMB.Store(status.MetricMemoryUsedMb)
@@ -147,14 +154,36 @@ func (o *OrchestratorNode) syncRun() error {
 	return errors.New("failed to check orchestrator status")
 }
 
+func (o *OrchestratorNode) setStatus(status OrchestratorStatus) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.info.Status = status
+}
+
+func (o *OrchestratorNode) setInfo(i OrchestratorNodeInfo) {
+	o.mutex.Lock()
+	defer o.mutex.Unlock()
+	o.info = i
+}
+
+func (o *OrchestratorNode) GetInfo() OrchestratorNodeInfo {
+	o.mutex.RLock()
+	defer o.mutex.RUnlock()
+	return o.info
+}
+
+func (o *OrchestratorNode) GetClient() *OrchestratorGRPCClient {
+	return o.client
+}
+
 func (o *OrchestratorNode) Close() error {
 	// close sync context
 	o.ctxCancel()
-	o.Status = OrchestratorStatusUnhealthy
+	o.setStatus(OrchestratorStatusUnhealthy)
 
 	// close grpc client
-	if o.Client != nil {
-		err := o.Client.close()
+	if o.client != nil {
+		err := o.client.close()
 		if err != nil {
 			return err
 		}

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -97,7 +97,7 @@ func catalogResolution(sandboxId string, catalog sandboxes.SandboxesCatalog, orc
 		return "", errors.New("orchestrator not found")
 	}
 
-	return o.Ip, nil
+	return o.GetInfo().Ip, nil
 }
 
 func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port uint, catalog sandboxes.SandboxesCatalog, orchestrators *orchestratorspool.OrchestratorsPool, useCatalogResolution bool, useDnsResolution bool) (*reverseproxy.Proxy, error) {

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -51,7 +51,7 @@ var (
 	commitSHA string
 
 	useProxyCatalogResolution = os.Getenv("USE_CATALOG_RESOLUTION") == "true"
-	useDnsResolution          = os.Getenv("USE_DNS_RESOLUTION") != "true"
+	useDnsResolution          = os.Getenv("USE_DNS_RESOLUTION") != "false"
 )
 
 func run() int {


### PR DESCRIPTION
- Put edge/orchestrator node info private and accessible only via getter/setter to fix a possible race condition
- Store edge/orchestrator nodes in a pool with machine ID, not service ID, This was causing issues when the service restarted, service ID changes, but we updated it just inside node inf,o butthe  node pool key was still the same, so during request, it failed because "node was not found"