### PR TITLE
Update metadata during sync

### DIFF
--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -151,6 +151,7 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 			nodeStatus = api.NodeStatusUnhealthy
 		}
 		node.setStatus(nodeStatus)
+		node.metadata = getNodeMetadata(nodeInfo)
 
 		activeInstances, instancesErr := o.getSandboxes(ctx, node.Info)
 		if instancesErr != nil {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -152,7 +152,7 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 		}
 
 		node.setStatus(nodeStatus)
-		node.setMetadata(nodeInfo)
+		node.setMetadata(nodeInfo, nodeInfo.NodeId)
 
 		activeInstances, instancesErr := o.getSandboxes(ctx, node.Info)
 		if instancesErr != nil {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -150,8 +150,9 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *Node, nodes []*node.N
 			zap.L().Error("Unknown service info status", zap.Any("status", nodeInfo.ServiceStatus), zap.String("node_id", node.Info.ID))
 			nodeStatus = api.NodeStatusUnhealthy
 		}
+
 		node.setStatus(nodeStatus)
-		node.metadata = getNodeMetadata(nodeInfo)
+		node.setMetadata(nodeInfo)
 
 		activeInstances, instancesErr := o.getSandboxes(ctx, node.Info)
 		if instancesErr != nil {

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -78,9 +78,6 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 	go buildCache.Start()
 
 	nodeStatus := api.NodeStatusUnhealthy
-	nodeVersion := "unknown"
-	nodeCommit := "unknown"
-	orchestratorID := node.ID
 
 	ok, err := o.getNodeHealth(node)
 	if err != nil {
@@ -100,21 +97,15 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 			zap.L().Error("Unknown service info status", zap.Any("status", nodeInfo.ServiceStatus), zap.String("node_id", node.ID))
 			nodeStatus = api.NodeStatusUnhealthy
 		}
-
-		nodeVersion = nodeInfo.ServiceVersion
-		nodeCommit = nodeInfo.ServiceCommit
-		orchestratorID = nodeInfo.NodeId
 	}
 
 	o.nodes.Insert(
 		node.ID, &Node{
 			Client:         client,
 			Info:           node,
-			orchestratorID: orchestratorID,
+			metadata:       getNodeMetadata(nodeInfo),
 			buildCache:     buildCache,
 			status:         nodeStatus,
-			version:        nodeVersion,
-			commit:         nodeCommit,
 			sbxsInProgress: smap.New[*sbxInProgress](),
 			createFails:    atomic.Uint64{},
 		},

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -103,7 +103,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 		node.ID, &Node{
 			Client:         client,
 			Info:           node,
-			meta:           getNodeMetadata(nodeInfo),
+			meta:           getNodeMetadata(nodeInfo, node.ID),
 			buildCache:     buildCache,
 			status:         nodeStatus,
 			sbxsInProgress: smap.New[*sbxInProgress](),

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -103,7 +103,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 		node.ID, &Node{
 			Client:         client,
 			Info:           node,
-			metadata:       getNodeMetadata(nodeInfo),
+			meta:           getNodeMetadata(nodeInfo),
 			buildCache:     buildCache,
 			status:         nodeStatus,
 			sbxsInProgress: smap.New[*sbxInProgress](),

--- a/packages/api/internal/orchestrator/metrics.go
+++ b/packages/api/internal/orchestrator/metrics.go
@@ -22,7 +22,7 @@ func (o *Orchestrator) setupMetrics(meterProvider metric.MeterProvider) (metric.
 			for _, node := range o.nodes.Items() {
 				obs.ObserveInt64(gauge, 1, metric.WithAttributes(
 					attribute.String("status", string(node.status)),
-					attribute.String("node.id", node.orchestratorID),
+					attribute.String("node.id", node.metadata.orchestratorID),
 				))
 			}
 

--- a/packages/api/internal/orchestrator/metrics.go
+++ b/packages/api/internal/orchestrator/metrics.go
@@ -21,8 +21,8 @@ func (o *Orchestrator) setupMetrics(meterProvider metric.MeterProvider) (metric.
 		func(ctx context.Context, obs metric.Observer) error {
 			for _, node := range o.nodes.Items() {
 				obs.ObserveInt64(gauge, 1, metric.WithAttributes(
-					attribute.String("status", string(node.status)),
-					attribute.String("node.id", node.getMetadata().orchestratorID),
+					attribute.String("status", string(node.Status())),
+					attribute.String("node.id", node.metadata().orchestratorID),
 				))
 			}
 

--- a/packages/api/internal/orchestrator/metrics.go
+++ b/packages/api/internal/orchestrator/metrics.go
@@ -22,7 +22,7 @@ func (o *Orchestrator) setupMetrics(meterProvider metric.MeterProvider) (metric.
 			for _, node := range o.nodes.Items() {
 				obs.ObserveInt64(gauge, 1, metric.WithAttributes(
 					attribute.String("status", string(node.status)),
-					attribute.String("node.id", node.metadata.orchestratorID),
+					attribute.String("node.id", node.getMetadata().orchestratorID),
 				))
 			}
 

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -38,9 +38,9 @@ type Node struct {
 
 	Info *node.NodeInfo
 
-	metadata nodeMetadata
-	status   api.NodeStatus
-	mutex    sync.RWMutex
+	meta   nodeMetadata
+	status api.NodeStatus
+	mutex  sync.RWMutex
 
 	sbxsInProgress *smap.Map[*sbxInProgress]
 
@@ -84,13 +84,13 @@ func (n *Node) setStatus(status api.NodeStatus) {
 func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.metadata = getNodeMetadata(i)
+	n.meta = getNodeMetadata(i)
 }
 
-func (n *Node) getMetadata() nodeMetadata {
+func (n *Node) metadata() nodeMetadata {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
-	return n.metadata
+	return n.meta
 }
 
 func (n *Node) SendStatusChange(ctx context.Context, s api.NodeStatus) error {
@@ -142,7 +142,7 @@ func (o *Orchestrator) GetNode(nodeID string) *Node {
 func (o *Orchestrator) GetNodes() []*api.Node {
 	nodes := make(map[string]*api.Node)
 	for key, n := range o.nodes.Items() {
-		metadata := n.getMetadata()
+		metadata := n.metadata()
 		nodes[key] = &api.Node{
 			NodeID:               key,
 			Status:               n.Status(),
@@ -179,7 +179,7 @@ func (o *Orchestrator) GetNodeDetail(nodeID string) *api.NodeDetail {
 	for key, n := range o.nodes.Items() {
 		if key == nodeID {
 			builds := n.buildCache.Keys()
-			metadata := n.getMetadata()
+			metadata := n.metadata()
 			node = &api.NodeDetail{
 				NodeID:       key,
 				Status:       n.Status(),

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -81,10 +81,10 @@ func (n *Node) setStatus(status api.NodeStatus) {
 	}
 }
 
-func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse) {
+func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse, nodeID string) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.meta = getNodeMetadata(i)
+	n.meta = getNodeMetadata(i, nodeID)
 }
 
 func (n *Node) metadata() nodeMetadata {
@@ -239,10 +239,10 @@ func (o *Orchestrator) NodeCount() int {
 	return o.nodes.Count()
 }
 
-func getNodeMetadata(n *orchestratorinfo.ServiceInfoResponse) nodeMetadata {
+func getNodeMetadata(n *orchestratorinfo.ServiceInfoResponse, orchestratorID string) nodeMetadata {
 	if n == nil {
 		return nodeMetadata{
-			orchestratorID: "",
+			orchestratorID: orchestratorID,
 			commit:         "unknown",
 			version:        "unknown",
 		}


### PR DESCRIPTION
# Description

If the API discovers the orchestrator before the orchestrator is healthy, it will add it with version, commit and orchestratorID equal to `unknown` and it won't be updated.