### PR TITLE
Fix sandbox logs ingestion from services

### DIFF
--- a/packages/nomad/logs-collector.hcl
+++ b/packages/nomad/logs-collector.hcl
@@ -153,7 +153,7 @@ source = '''
 del(.internal)
 '''
 
-# Enable debuging of logs to the console
+# Enable debugging of logs to the console
 # [sinks.console_loki]
 # type = "console"
 # inputs = ["remove_internal"]


### PR DESCRIPTION
Fix sandbox logs ingestion from services (not envd).

The issue is that after the change https://github.com/e2b-dev/infra/pull/748, field names contain `.` instead of `_`. Dot symbol is converted in OTEL collector automatically to underscore symbol, but the same doesn't happen in Vector. This PR fixes that.

This PR also adds a commented sink to help debug potential future issues.