### PR TITLE
Handle Unexpected EOF for ReadAt in AWS S3 storage provider

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -169,7 +169,7 @@ func (a *AWSBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, 
 
 	defer resp.Body.Close()
 
-	// When the object is smaller thant requested range there will be unexpected EOF,
+	// When the object is smaller than requested range there will be unexpected EOF,
 	// but backend expects to return EOF in this case.
 	n, err = io.ReadFull(resp.Body, buff)
 	if errors.Is(err, io.ErrUnexpectedEOF) {

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -169,7 +169,14 @@ func (a *AWSBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, 
 
 	defer resp.Body.Close()
 
-	return io.ReadFull(resp.Body, buff)
+	// When the object is smaller thant requested range there will be unexpected EOF,
+	// but backend expects to return EOF in this case.
+	n, err = io.ReadFull(resp.Body, buff)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		err = io.EOF
+	}
+
+	return n, err
 }
 
 func (a *AWSBucketStorageObjectProvider) Size() (int64, error) {


### PR DESCRIPTION
`io.ReadFull` will in that case return `ioErrUnexpectedEOF`, but service is expecting to receive `io.EOF` to know we that file download is complited.