### PR TITLE
Fix start-docker Makefile directive in envd

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -28,7 +28,7 @@ start-docker:
 	-p 8001:8001 \
 	--rm \
 	-i envd-debug \
-	/usr/bin/envd -debug
+	/usr/bin/envd -isnotfc
 
 build-and-upload:
 	make build


### PR DESCRIPTION
# Description
Change the `start-docker` directive to use the `-isnotfc` flag instead of the `debug` one in `packages/envd` 