### PR TITLE
Fix Redis in cluster mode

### DIFF
--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -87,6 +87,7 @@ job "api" {
         OTEL_COLLECTOR_GRPC_ENDPOINT   = "${otel_collector_grpc_endpoint}"
         ADMIN_TOKEN                    = "${admin_token}"
         REDIS_URL                      = "${redis_url}"
+        REDIS_CLUSTER_URL              = "${redis_cluster_url}"
         DNS_PORT                       = "${dns_port_number}"
         SANDBOX_ACCESS_TOKEN_HASH_SEED = "${sandbox_access_token_hash_seed}"
 

--- a/packages/nomad/edge.hcl
+++ b/packages/nomad/edge.hcl
@@ -108,6 +108,7 @@ job "client-proxy" {
         OTEL_COLLECTOR_GRPC_ENDPOINT  = "${otel_collector_grpc_endpoint}"
         LOGS_COLLECTOR_ADDRESS        = "${logs_collector_address}"
         REDIS_URL                     = "${redis_url}"
+        REDIS_CLUSTER_URL             = "${redis_cluster_url}"
         LOKI_URL                      = "${loki_url}"
 
         %{ if launch_darkly_api_key != "" }

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -88,7 +88,8 @@ resource "nomad_job" "api" {
     otel_tracing_print             = var.otel_tracing_print
     nomad_acl_token                = var.nomad_acl_token_secret
     admin_token                    = var.api_admin_token
-    redis_url                      = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "${data.google_secret_manager_secret_version.redis_url.secret_data}:${var.redis_port.port}" : "redis.service.consul:${var.redis_port.port}"
+    redis_url                      = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "" : "redis.service.consul:${var.redis_port.port}"
+    redis_cluster_url              = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "${data.google_secret_manager_secret_version.redis_url.secret_data}:${var.redis_port.port}" : ""
     dns_port_number                = var.api_dns_port_number
     clickhouse_connection_string   = "clickhouse.service.consul:9000"
     clickhouse_username            = var.clickhouse_username
@@ -164,8 +165,10 @@ resource "nomad_job" "client_proxy" {
       gcp_zone    = var.gcp_zone
       environment = var.environment
 
-      redis_url = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "${data.google_secret_manager_secret_version.redis_url.secret_data}:${var.redis_port.port}" : "redis.service.consul:${var.redis_port.port}"
-      loki_url  = "http://loki.service.consul:${var.loki_service_port.port}"
+      redis_url         = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "" : "redis.service.consul:${var.redis_port.port}"
+      redis_cluster_url = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "${data.google_secret_manager_secret_version.redis_url.secret_data}:${var.redis_port.port}" : ""
+
+      loki_url = "http://loki.service.consul:${var.loki_service_port.port}"
 
       proxy_port_name   = var.edge_proxy_port.name
       proxy_port        = var.edge_proxy_port.port


### PR DESCRIPTION
Fix Redis client usage in cluster mode. This is a fix for regression introduced in: https://github.com/e2b-dev/infra/pull/769

The issue is that now the REDIS_URL will initialize just regular Redis client even when cluster one should be user. Redis requests than can error out with ERROR MOVED messages.