### PR TITLE
fix repositoryNameWithTemplate

### DIFF
--- a/packages/shared/pkg/artifacts-registry/registry_aws.go
+++ b/packages/shared/pkg/artifacts-registry/registry_aws.go
@@ -68,7 +68,8 @@ func (g *AWSArtifactsRegistry) Delete(ctx context.Context, templateId string, bu
 }
 
 func (g *AWSArtifactsRegistry) GetTag(ctx context.Context, templateId string, buildId string) (string, error) {
-	res, err := g.client.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{RepositoryNames: []string{g.repositoryName}})
+	repositoryNameWithTemplate := fmt.Sprintf("%s/%s", g.repositoryName, templateId)
+	res, err := g.client.DescribeRepositories(ctx, &ecr.DescribeRepositoriesInput{RepositoryNames: []string{repositoryNameWithTemplate}})
 	if err != nil {
 		return "", fmt.Errorf("failed to describe aws ecr repository: %w", err)
 	}


### PR DESCRIPTION
We should use both repositoryName and templateId to locate registry in aws ecr