### PR TITLE
configure the gcloud CLI to speed up some calls

### DIFF
--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -41,6 +41,11 @@ func NewGCPBucketStorageProvider(ctx context.Context, bucketName string) (*GCPBu
 		return nil, fmt.Errorf("failed to create GCS client: %w", err)
 	}
 
+	// these commands set up the gcloud CLI correctly
+	setGCloudCLIConfig(ctx, "storage/parallel_composite_upload_enabled", "True")
+	setGCloudCLIConfig(ctx, "storage/parallel_composite_upload_compatibility_check", "False")
+	setGCloudCLIConfig(ctx, "storage/parallel_composite_upload_threshold", "50M")
+
 	return &GCPBucketStorageProvider{
 		client: client,
 		bucket: client.Bucket(bucketName),


### PR DESCRIPTION
these three commands should help make things unambiguous and faster:

- `storage/parallel_composite_upload_enabled = True`: make it clear that this is something we want to use
- `storage/parallel_composite_upload_compatibility_check = False`: speed things up by skipping a call
- `storage/parallel_composite_upload_threshold = 50M`: reduce the size that triggers this from the default of 150M to 50M, using it more often.

Implementation of the commands are left TBD