### PR TITLE
Add index for snapshot table

### DIFF
--- a/packages/db/migrations/20250708135400_snapshots_migrations.sql
+++ b/packages/db/migrations/20250708135400_snapshots_migrations.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX CONCURRENTLY idx_snapshots_sandbox_id ON public.snapshots (sandbox_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX CONCURRENTLY idx_snapshots_sandbox_id;
+-- +goose StatementEnd


### PR DESCRIPTION
# Description

It should optimize following query:
```sql
select * from
  "public"."envs"
where
  "id" in (select
      "public"."snapshots"."env_id"
  from
      "public"."snapshots"
  where
    "public"."snapshots"."sandbox_id"  = $1
)
and "team_id" = $2
```