### PR TITLE
Fix edge pool race condition

### DIFF
--- a/packages/api/internal/edge/pool.go
+++ b/packages/api/internal/edge/pool.go
@@ -40,9 +40,6 @@ func NewPool(ctx context.Context, tel *telemetry.Client, db *client.Client, trac
 		clusters: smap.New[*Cluster](),
 	}
 
-	// Periodically sync clusters with the database
-	go p.startSync()
-
 	// Shutdown function to gracefully close the pool
 	go func() {
 		<-ctx.Done()
@@ -51,6 +48,9 @@ func NewPool(ctx context.Context, tel *telemetry.Client, db *client.Client, trac
 
 	store := poolSynchronizationStore{pool: p}
 	p.synchronization = synchronization.NewSynchronize(p.tracer, "clusters-pool", "Clusters pool", store)
+
+	// Periodically sync clusters with the database
+	go p.startSync()
 
 	return p, nil
 }

--- a/packages/api/internal/edge/pool.go
+++ b/packages/api/internal/edge/pool.go
@@ -50,13 +50,9 @@ func NewPool(ctx context.Context, tel *telemetry.Client, db *client.Client, trac
 	p.synchronization = synchronization.NewSynchronize(p.tracer, "clusters-pool", "Clusters pool", store)
 
 	// Periodically sync clusters with the database
-	go p.startSync()
+	go p.synchronization.Start(poolSyncInterval, poolSyncTimeout, true)
 
 	return p, nil
-}
-
-func (p *Pool) startSync() {
-	p.synchronization.Start(poolSyncInterval, poolSyncTimeout, true)
 }
 
 func (p *Pool) GetClusterById(id uuid.UUID) (*Cluster, bool) {


### PR DESCRIPTION
Goroutine with sync start was executed before we initialized the struct that was run in that goroutine so this was leading to a race condition if goroutine creation was fast enough.