### PR TITLE
Migration step to client id const

### DIFF
--- a/packages/api/internal/handlers/sandbox.go
+++ b/packages/api/internal/handlers/sandbox.go
@@ -12,7 +12,6 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
 	"github.com/e2b-dev/infra/packages/db/queries"
-	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -90,12 +89,5 @@ func (a *APIStore) startSandbox(
 		TeamID:     team.Team.ID.String(),
 	}).Info("Sandbox created", zap.String("end_time", endTime.Format("2006-01-02 15:04:05 -07:00")))
 
-	return &api.Sandbox{
-		ClientID:        consts.ClientID,
-		SandboxID:       sandbox.SandboxID,
-		TemplateID:      *build.EnvID,
-		Alias:           &alias,
-		EnvdVersion:     *build.EnvdVersion,
-		EnvdAccessToken: envdAccessToken,
-	}, nil
+	return sandbox, nil
 }

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -39,7 +39,7 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 
 		// Sandbox exists and belongs to the team - return running sandbox info
 		sandbox := api.SandboxDetail{
-			ClientID:        consts.ClientID,
+			ClientID:        info.Instance.ClientID,
 			TemplateID:      info.Instance.TemplateID,
 			Alias:           info.Instance.Alias,
 			SandboxID:       info.Instance.SandboxID,

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -247,7 +247,7 @@ func instanceInfoToPaginatedSandboxes(runningSandboxes []*instance.InstanceInfo)
 	for _, info := range runningSandboxes {
 		sandbox := utils.PaginatedSandbox{
 			ListedSandbox: api.ListedSandbox{
-				ClientID:   info.Node.ID,
+				ClientID:   info.Instance.ClientID,
 				TemplateID: info.BaseTemplateID,
 				Alias:      info.Instance.Alias,
 				SandboxID:  info.Instance.SandboxID,

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -19,6 +19,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -217,7 +218,7 @@ func (o *Orchestrator) CreateSandbox(
 	telemetry.ReportEvent(childCtx, "Created sandbox")
 
 	sbx := api.Sandbox{
-		ClientID:        node.Info.ID,
+		ClientID:        consts.ClientID,
 		SandboxID:       sandboxID,
 		TemplateID:      *build.EnvID,
 		Alias:           &alias,


### PR DESCRIPTION
# Description

Return const node id when creating sandbox
Return the "used" client id when getting/listing