### PR TITLE
Updated auth middleware error message link

### DIFF
--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -147,7 +147,7 @@ func CreateAuthenticationFunc(
 			},
 			validationFunction: teamValidationFunction,
 			contextKey:         TeamContextKey,
-			errorMessage:       "Invalid API key, please visit https://e2b.dev/docs/quickstart/api-key for more information.",
+			errorMessage:       "Invalid API key, please visit https://e2b.dev/docs/api-key for more information.",
 		},
 		&commonAuthenticator[uuid.UUID]{
 			securitySchemeName: "AccessTokenAuth",


### PR DESCRIPTION
Previous link was going to 404, replaced with a current one.