### PR TITLE
Traffic proxy working without client part

### DIFF
--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
-	reverse_proxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
+	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -26,22 +26,22 @@ const (
 )
 
 type SandboxProxy struct {
-	proxy *reverse_proxy.Proxy
+	proxy *reverseproxy.Proxy
 }
 
 func NewSandboxProxy(meterProvider metric.MeterProvider, port uint, sandboxes *smap.Map[*sandbox.Sandbox]) (*SandboxProxy, error) {
-	proxy := reverse_proxy.New(
+	proxy := reverseproxy.New(
 		port,
 		idleTimeout,
 		func(r *http.Request) (*pool.Destination, error) {
-			sandboxId, port, err := reverse_proxy.ParseHost(r.Host)
+			sandboxId, port, err := reverseproxy.ParseHost(r.Host)
 			if err != nil {
 				return nil, err
 			}
 
 			sbx, found := sandboxes.Get(sandboxId)
 			if !found {
-				return nil, reverse_proxy.NewErrSandboxNotFound(sandboxId)
+				return nil, reverseproxy.NewErrSandboxNotFound(sandboxId)
 			}
 
 			url := &url.URL{

--- a/packages/shared/pkg/proxy/host.go
+++ b/packages/shared/pkg/proxy/host.go
@@ -6,6 +6,11 @@ import (
 )
 
 func ParseHost(host string) (sandboxID string, port uint64, err error) {
+	// Keep only the left-most subdomain part, i.e. everything before the
+	if dot := strings.Index(host, "."); dot != -1 {
+		host = host[:dot]
+	}
+
 	hostParts := strings.Split(host, "-")
 	if len(hostParts) < 2 {
 		return "", 0, &ErrInvalidHost{}

--- a/packages/shared/pkg/proxy/host.go
+++ b/packages/shared/pkg/proxy/host.go
@@ -6,10 +6,15 @@ import (
 )
 
 func ParseHost(host string) (sandboxID string, port uint64, err error) {
-	// Keep only the left-most subdomain part, i.e. everything before the
-	if dot := strings.Index(host, "."); dot != -1 {
-		host = host[:dot]
+	dot := strings.Index(host, ".")
+
+	// There must be always domain part used
+	if dot == -1 {
+		return "", 0, &ErrInvalidHost{}
 	}
+
+	// Keep only the left-most subdomain part, i.e. everything before the
+	host = host[:dot]
 
 	hostParts := strings.Split(host, "-")
 	if len(hostParts) < 2 {

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestHelloName(t *testing.T) {
+func TestHostParser(t *testing.T) {
 	tests := []struct {
 		name     string
 		host     string
@@ -69,6 +69,27 @@ func TestHelloName(t *testing.T) {
 			wantID:   "isv6ril5xadwn1k9t2jye",
 			wantPort: 49983,
 			wantErr:  &ErrInvalidSandboxPort{},
+		},
+		{
+			name:     "sandbox-host-without-domain",
+			host:     "49983-isv6ril5xadwn1k9t2jye",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  &ErrInvalidHost{},
+		},
+		{
+			name:     "sandbox-host-with-missing-domain-and-port",
+			host:     "49983-isv6ril5xadwn1k9t2jye:8080",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  &ErrInvalidHost{},
+		},
+		{
+			name:     "sandbox-host-with-missing-domain",
+			host:     "49983-isv6ril5xadwn1k9t2jye",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  &ErrInvalidHost{},
 		},
 	}
 

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -22,6 +22,13 @@ func TestHelloName(t *testing.T) {
 			wantErr:  nil,
 		},
 		{
+			name:     "sandbox-host-with-client-id-and-dash-domain",
+			host:     "49983-isv6ril5xadwn1k9t2jye-6532622b.e2b-test.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
 			name:     "sandbox-host-with-client-id-and-subdomain",
 			host:     "49983-isv6ril5xadwn1k9t2jye-6532622b.demo.e2b.app",
 			wantID:   "isv6ril5xadwn1k9t2jye",
@@ -31,6 +38,13 @@ func TestHelloName(t *testing.T) {
 		{
 			name:     "sandbox-host-without-client-id",
 			host:     "49983-isv6ril5xadwn1k9t2jye.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
+			name:     "sandbox-host-with-dash-domain-and-without-client-id",
+			host:     "49983-isv6ril5xadwn1k9t2jye.e2b-test.app",
 			wantID:   "isv6ril5xadwn1k9t2jye",
 			wantPort: 49983,
 			wantErr:  nil,

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -1,0 +1,86 @@
+package proxy
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestHelloName(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantID   string
+		wantPort uint64
+		wantErr  error
+	}{
+		{
+			name:     "sandbox-host-with-client-id",
+			host:     "49983-isv6ril5xadwn1k9t2jye-6532622b.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
+			name:     "sandbox-host-with-client-id-and-subdomain",
+			host:     "49983-isv6ril5xadwn1k9t2jye-6532622b.demo.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
+			name:     "sandbox-host-without-client-id",
+			host:     "49983-isv6ril5xadwn1k9t2jye.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
+			name:     "sandbox-host-with-subdomain-and-without-client-id",
+			host:     "49983-isv6ril5xadwn1k9t2jye.demo.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  nil,
+		},
+		{
+			name:     "sandbox-host-without-port-part",
+			host:     "isv6ril5xadwn1k9t2jye.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  &ErrInvalidHost{},
+		},
+		{
+			name:     "sandbox-host-with-invalid-port-part",
+			host:     "abcd-isv6ril5xadwn1k9t2jye.e2b.app",
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+			wantErr:  &ErrInvalidSandboxPort{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, gotPort, err := ParseHost(tt.host)
+
+			// Compare error presence and, when present, the concrete type.
+			if (err != nil) != (tt.wantErr != nil) {
+				t.Fatalf("ParseHost(%q) error = %v, wantErr %v", tt.host, err, tt.wantErr)
+			}
+
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) || reflect.TypeOf(err) != reflect.TypeOf(tt.wantErr) {
+					t.Fatalf("ParseHost(%q) error type = %T, want %T", tt.host, err, tt.wantErr)
+				}
+				return // no further checks when an error was expected
+			}
+
+			if gotID != tt.wantID {
+				t.Errorf("ParseHost(%q) sandboxID = %q, want %q", tt.host, gotID, tt.wantID)
+			}
+
+			if gotPort != tt.wantPort {
+				t.Errorf("ParseHost(%q) port = %d, want %d", tt.host, gotPort, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
After this change, we can stop sending the client part during sending traffic to the sandbox.