### PR TITLE
Restrict template cache with cluster ID

### DIFF
--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -113,7 +113,7 @@ func (c *TemplateCache) Get(ctx context.Context, aliasOrEnvID string, teamID uui
 		}
 
 		if cluster != clusterID {
-			return nil, nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: fmt.Sprintf("Template '%s' is not available on cluster", aliasOrEnvID), Err: fmt.Errorf("template '%s' is not available on cluster '%s'", aliasOrEnvID, clusterID)}
+			return nil, nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: fmt.Sprintf("Template '%s' is not available in requested cluster", aliasOrEnvID), Err: fmt.Errorf("template '%s' is not available in requested cluster '%s'", aliasOrEnvID, clusterID)}
 		}
 
 		templateInfo = &TemplateInfo{
@@ -138,7 +138,7 @@ func (c *TemplateCache) Get(ctx context.Context, aliasOrEnvID string, teamID uui
 		}
 
 		if templateInfo.clusterID != clusterID {
-			return nil, nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: fmt.Sprintf("Template '%s' is not available on cluster", aliasOrEnvID), Err: fmt.Errorf("template '%s' is not available on cluster '%s'", aliasOrEnvID, clusterID)}
+			return nil, nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: fmt.Sprintf("Template '%s' is not available in requested cluster", aliasOrEnvID), Err: fmt.Errorf("template '%s' is not available in requested cluster '%s'", aliasOrEnvID, clusterID)}
 		}
 	}
 

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -76,8 +77,13 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	_, templateSpan := a.Tracer.Start(ctx, "get-template")
 	defer templateSpan.End()
 
+	clusterID := uuid.Nil
+	if teamInfo.Team.ClusterID != nil {
+		clusterID = *teamInfo.Team.ClusterID
+	}
+
 	// Check if team has access to the environment
-	env, build, checkErr := a.templateCache.Get(ctx, cleanedAliasOrEnvID, teamInfo.Team.ID, true)
+	env, build, checkErr := a.templateCache.Get(ctx, cleanedAliasOrEnvID, teamInfo.Team.ID, clusterID, true)
 	if checkErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when getting template", checkErr.Err)
 		a.sendAPIStoreError(c, checkErr.Code, checkErr.ClientMsg)


### PR DESCRIPTION
Currently, when I am running a cluster for my team and I want to spawn a public template, it will try and fail until the timeout for spawning is hit. This is because the base template is not built on a remote cluster, but because it's public, it's assumed it's there.

We want to add a check into the template cache that will also compare clusters, so we can return some user-friendly error message.