### PR TITLE
Fix race condition in the FC process shutdown and cleanup

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 	txtTemplate "text/template"
 	"time"
@@ -423,12 +424,32 @@ func (p *Process) Pid() (int, error) {
 	return p.cmd.Process.Pid, nil
 }
 
+// getProcessState returns the state of the process.
+// It's used to check if the process is in the D state, because gopsutil doesn't show that.
+func getProcessState(pid int) (string, error) {
+	cmd, err := exec.Command("ps", "-o", "stat=", "-p", fmt.Sprint(pid)).Output()
+	if err != nil {
+		return "", err
+	}
+
+	state := strings.TrimSpace(string(cmd))
+
+	return state, nil
+}
+
 func (p *Process) Stop() error {
 	if p.cmd.Process == nil {
 		return fmt.Errorf("fc process not started")
 	}
 
-	err := p.cmd.Process.Signal(syscall.SIGTERM)
+	state, err := getProcessState(p.cmd.Process.Pid)
+	if err != nil {
+		zap.L().Warn("failed to get fc process state", zap.Error(err), logger.WithSandboxID(p.files.SandboxID))
+	} else if state == "D" {
+		zap.L().Info("fc process is in the D state before we call SIGTERM", logger.WithSandboxID(p.files.SandboxID))
+	}
+
+	err = p.cmd.Process.Signal(syscall.SIGTERM)
 	if err != nil {
 		zap.L().Warn("failed to send SIGTERM to fc process", zap.Error(err), logger.WithSandboxID(p.files.SandboxID))
 	}
@@ -443,6 +464,14 @@ func (p *Process) Stop() error {
 			} else {
 				zap.L().Info("sent SIGKILL to fc process because it was not responding to SIGTERM for 10 seconds", logger.WithSandboxID(p.files.SandboxID))
 			}
+
+			state, err := getProcessState(p.cmd.Process.Pid)
+			if err != nil {
+				zap.L().Warn("failed to get fc process state after sending SIGKILL", zap.Error(err), logger.WithSandboxID(p.files.SandboxID))
+			} else if state == "D" {
+				zap.L().Info("fc process is in the D state after we call SIGKILL", logger.WithSandboxID(p.files.SandboxID))
+			}
+
 		// If the FC process exited, we can return.
 		case <-p.Exit.Done:
 			return


### PR DESCRIPTION
- Add logs to check when the FC process gets into the `D` state
- Await for the FC process exit before stopping the uffd memory handler and continuing with the rest of the cleanup
  - This might have been the primary cause of the stuck syscalls
- Move the stop/cleanup in `Delete` method to a goroutine
  - This PR also add to the https://github.com/e2b-dev/infra/pull/896 that ensures the cleanup is not cancelled because of the context