### PR TITLE
Send edge sandbox catalog as gRPC metadata

### DIFF
--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -242,7 +242,7 @@ func (o *Orchestrator) syncNodeState(ctx context.Context, node *Node, instanceCa
 		}
 
 		node.setStatus(nodeStatus)
-		node.setMetadata(nodeInfo, nodeInfo.NodeId, nodeInfo.ServiceId)
+		node.setMetadata(nodeInfo, nodeInfo.NodeId)
 
 		activeInstances, instancesErr := o.getSandboxes(ctx, node.Info)
 		if instancesErr != nil {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -349,7 +349,7 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 		} else {
 			req := &orchestrator.SandboxDeleteRequest{SandboxId: info.Instance.SandboxID}
 			client, ctx := node.GetClient(ctx)
-			_, err := client.Sandbox.Delete(ctx, req)
+			_, err := client.Sandbox.Delete(node.GetSandboxDeleteCtx(ctx, info.Instance.SandboxID, info.ExecutionID), req)
 			if err != nil {
 				return fmt.Errorf("failed to delete sandbox '%s': %w", info.Instance.SandboxID, err)
 			}

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -242,7 +242,7 @@ func (o *Orchestrator) syncNodeState(ctx context.Context, node *Node, instanceCa
 		}
 
 		node.setStatus(nodeStatus)
-		node.setMetadata(nodeInfo, nodeInfo.NodeId)
+		node.setMetadata(nodeInfo, nodeInfo.NodeId, nodeInfo.ServiceId)
 
 		activeInstances, instancesErr := o.getSandboxes(ctx, node.Info)
 		if instancesErr != nil {

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -107,8 +107,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 			client:   client,
 			clientMd: make(metadata.MD),
 
-			Info:              node,
-			serviceInstanceID: nodeInfo.ServiceId,
+			Info: node,
 
 			meta:           getNodeMetadata(nodeInfo, node.ID, nodeInfo.ServiceId),
 			buildCache:     buildCache,
@@ -141,7 +140,6 @@ func (o *Orchestrator) connectToClusterNode(cluster *edge.Cluster, i *edge.Clust
 		Info: &node.NodeInfo{
 			ID: poolNodeID,
 		},
-		serviceInstanceID: i.ServiceInstanceID,
 
 		status: OrchestratorToApiNodeStateMapper[i.GetStatus()],
 		meta: nodeMetadata{

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -107,7 +107,9 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 			client:   client,
 			clientMd: make(metadata.MD),
 
-			Info:           node,
+			Info:              node,
+			serviceInstanceID: nodeInfo.ServiceId,
+
 			meta:           getNodeMetadata(nodeInfo, node.ID),
 			buildCache:     buildCache,
 			status:         nodeStatus,
@@ -139,6 +141,7 @@ func (o *Orchestrator) connectToClusterNode(cluster *edge.Cluster, i *edge.Clust
 		Info: &node.NodeInfo{
 			ID: poolNodeID,
 		},
+		serviceInstanceID: i.ServiceInstanceID,
 
 		status: OrchestratorToApiNodeStateMapper[i.GetStatus()],
 		meta: nodeMetadata{

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -110,7 +110,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 			Info:              node,
 			serviceInstanceID: nodeInfo.ServiceId,
 
-			meta:           getNodeMetadata(nodeInfo, node.ID),
+			meta:           getNodeMetadata(nodeInfo, node.ID, nodeInfo.ServiceId),
 			buildCache:     buildCache,
 			status:         nodeStatus,
 			sbxsInProgress: smap.New[*sbxInProgress](),

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -109,7 +109,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, node *node.NodeInfo) e
 
 			Info: node,
 
-			meta:           getNodeMetadata(nodeInfo, node.ID, nodeInfo.ServiceId),
+			meta:           getNodeMetadata(nodeInfo, node.ID),
 			buildCache:     buildCache,
 			status:         nodeStatus,
 			sbxsInProgress: smap.New[*sbxInProgress](),

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -203,7 +203,7 @@ func (o *Orchestrator) CreateSandbox(
 		})
 
 		client, childCtx := node.GetClient(childCtx)
-		_, err = client.Sandbox.Create(childCtx, sbxRequest)
+		_, err = client.Sandbox.Create(node.GetSandboxCreateCtx(childCtx, sbxRequest), sbxRequest)
 		// The request is done, we will either add it to the cache or remove it from the node
 		if err == nil {
 			// The sandbox was created successfully

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -283,13 +283,6 @@ func (o *Orchestrator) CreateSandbox(
 		}
 	}
 
-	// we need to inform remote cluster proxy about newly spawned sandbox so it's registered in sandbox traffic proxy
-	err = o.RegisterSandboxInsideClusterCatalog(childCtx, node, startTime, sbxRequest.Sandbox)
-	if err != nil {
-		telemetry.ReportError(ctx, "failed to register sandbox in cluster catalog", err)
-		zap.L().Error("Failed to register sandbox in cluster catalog", logger.WithSandboxID(sbx.SandboxID), zap.Error(err))
-	}
-
 	return &sbx, nil
 }
 

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -17,16 +17,5 @@ func (o *Orchestrator) DeleteInstance(ctx context.Context, sandboxID string, pau
 		zap.Bool("pause", pause),
 	)
 
-	c, _ := o.instanceCache.Get(sandboxID)
-	if c != nil {
-		node := o.GetNode(c.Node.ID)
-		if node != nil {
-			err := o.RemoveSandboxFromClusterCatalog(ctx, node, sandboxID, c.ExecutionID)
-			if err != nil {
-				zap.L().Error("Failed to remove sandbox from cluster catalog", logger.WithSandboxID(sandboxID), zap.Error(err))
-			}
-		}
-	}
-
 	return o.instanceCache.Delete(sandboxID, pause)
 }

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -107,7 +107,7 @@ func (n *Node) setStatus(status api.NodeStatus) {
 	}
 }
 
-func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse, nodeID string, serviceInstanceID string) {
+func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse, nodeID string) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 	n.meta = getNodeMetadata(i, nodeID)

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -291,6 +291,7 @@ func (n *Node) GetClient(ctx context.Context) (*grpclient.GRPCClient, context.Co
 }
 
 func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.SandboxCreateRequest) context.Context {
+	// Skip local cluster. It should be okay to send it here, but we don't want to do it until we explicitly support it.
 	if n.ClusterID == uuid.Nil {
 		return metadata.NewOutgoingContext(ctx, n.clientMd)
 	}
@@ -310,6 +311,11 @@ func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.Sandbo
 }
 
 func (n *Node) GetSandboxDeleteCtx(ctx context.Context, sandboxID string, executionID string) context.Context {
+	// Skip local cluster. It should be okay to send it here, but we don't want to do it until we explicitly support it.
+	if n.ClusterID == uuid.Nil {
+		return metadata.NewOutgoingContext(ctx, n.clientMd)
+	}
+
 	md := edge.SerializeSandboxCatalogDeleteEvent(
 		edge.SandboxCatalogDeleteEvent{
 			SandboxID:   sandboxID,

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -110,7 +110,7 @@ func (n *Node) setStatus(status api.NodeStatus) {
 func (n *Node) setMetadata(i *orchestratorinfo.ServiceInfoResponse, nodeID string, serviceInstanceID string) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
-	n.meta = getNodeMetadata(i, nodeID, serviceInstanceID)
+	n.meta = getNodeMetadata(i, nodeID)
 }
 
 func (n *Node) metadata() nodeMetadata {
@@ -327,11 +327,11 @@ func (n *Node) GetSandboxDeleteCtx(ctx context.Context, sandboxID string, execut
 	return metadata.NewOutgoingContext(ctx, metadata.Join(n.clientMd, md))
 }
 
-func getNodeMetadata(n *orchestratorinfo.ServiceInfoResponse, orchestratorID string, serviceInstanceID string) nodeMetadata {
+func getNodeMetadata(n *orchestratorinfo.ServiceInfoResponse, orchestratorID string) nodeMetadata {
 	if n == nil {
 		return nodeMetadata{
 			orchestratorID:    orchestratorID,
-			serviceInstanceID: serviceInstanceID,
+			serviceInstanceID: "unknown",
 
 			commit:  "unknown",
 			version: "unknown",

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -31,7 +31,11 @@ type sbxInProgress struct {
 }
 
 type nodeMetadata struct {
-	orchestratorID    string
+	// Orchestrator ID is currently the same as node ID.
+	orchestratorID string
+
+	// Service instance ID is unique identifier for every orchestrator process, after restart it will change.
+	// In the future, we want to migrate to using this ID instead of node ID for tracking orchestrators-
 	serviceInstanceID string
 
 	commit  string

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/uuid"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/metric"
@@ -23,7 +22,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/db"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -165,47 +163,6 @@ func (o *Orchestrator) startStatusLogging(ctx context.Context) {
 			)
 		}
 	}
-}
-
-func (o *Orchestrator) RegisterSandboxInsideClusterCatalog(ctx context.Context, node *Node, sbxStartTime time.Time, sandboxConfig *orchestrator.SandboxConfig) error {
-	if node.ClusterID == uuid.Nil {
-		return nil
-	}
-
-	cluster, ok := o.clusters.GetClusterById(node.ClusterID)
-	if !ok {
-		return fmt.Errorf("failed to get cluster by ID: %s", node.ClusterID.String())
-	}
-
-	i, ok := cluster.GetInstanceByNodeID(node.ClusterNodeID)
-	if !ok {
-		return fmt.Errorf("failed to get cluster instance by cluster %s and node ID: %s", node.ClusterID.String(), node.ClusterNodeID)
-	}
-
-	err := cluster.RegisterSandboxInCatalog(ctx, i.ServiceInstanceID, sbxStartTime, sandboxConfig)
-	if err != nil {
-		return fmt.Errorf("failed to register sandbox in cluster catalog: %w", err)
-	}
-
-	return nil
-}
-
-func (o *Orchestrator) RemoveSandboxFromClusterCatalog(ctx context.Context, node *Node, sandboxID string, executionID string) error {
-	if node.ClusterID == uuid.Nil {
-		return nil
-	}
-
-	cluster, ok := o.clusters.GetClusterById(node.ClusterID)
-	if !ok {
-		return fmt.Errorf("failed to get cluster by ID: %s", node.ClusterID.String())
-	}
-
-	err := cluster.RemoveSandboxFromCatalog(ctx, sandboxID, executionID)
-	if err != nil {
-		return fmt.Errorf("failed to register sandbox in cluster catalog: %w", err)
-	}
-
-	return nil
 }
 
 func (o *Orchestrator) Close(ctx context.Context) error {

--- a/packages/client-proxy/internal/edge-pass-through/events.go
+++ b/packages/client-proxy/internal/edge-pass-through/events.go
@@ -1,0 +1,68 @@
+package edgepassthrough
+
+func (s *NodePassThroughServer) eventsHandler(md metadata.MD) (func(error), error) {
+	eventTypeHeaders := md.Get(edge.EventTypeHeader)
+	if len(eventTypeHeaders) == 0 {
+		return nil, nil
+	}
+
+	if len(eventTypeHeaders) > 1 {
+		return nil, status.Errorf(codes.InvalidArgument, "multiple event types are not supported: %v", eventTypeHeaders)
+	}
+
+	eventType := eventTypeHeaders[0]
+	switch eventType {
+	case edge.CatalogCreateEventType:
+		return s.catalogCreateEventHandler(md)
+	case edge.CatalogDeleteEventType:
+		return s.catalogDeleteEventHandler(md)
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "event type %s is not supported", eventType)
+	}
+}
+
+func (s *NodePassThroughServer) catalogCreateEventHandler(md metadata.MD) (func(error), error) {
+	c, err := edge.ParseSandboxCatalogCreateEvent(md)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.catalog.StoreSandbox(
+		c.SandboxID,
+		&sandboxes.SandboxInfo{
+			OrchestratorID:          c.OrchestratorID,
+			ExecutionID:             c.ExecutionID,
+			SandboxStartedAt:        c.SandboxStartTime,
+			SandboxMaxLengthInHours: c.SandboxMaxLengthInHours,
+		},
+		time.Duration(c.SandboxMaxLengthInHours)*time.Hour,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store sandbox in catalog: %w", err)
+	}
+
+	return func(err error) {
+		if err == nil {
+			return
+		}
+
+		deleteErr := s.catalog.DeleteSandbox(c.SandboxID, c.ExecutionID)
+		if deleteErr != nil {
+			zap.L().Error("Failed to delete sandbox in catalog after failing request", zap.Error(deleteErr))
+		}
+	}, nil
+}
+
+func (s *NodePassThroughServer) catalogDeleteEventHandler(md metadata.MD) (func(error), error) {
+	d, err := edge.ParseSandboxCatalogDeleteEvent(md)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.catalog.DeleteSandbox(d.SandboxID, d.ExecutionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete sandbox from catalog: %w", err)
+	}
+
+	return nil, nil
+}

--- a/packages/client-proxy/internal/edge-pass-through/events.go
+++ b/packages/client-proxy/internal/edge-pass-through/events.go
@@ -1,5 +1,18 @@
 package edgepassthrough
 
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/e2b-dev/infra/packages/proxy/internal/edge/sandboxes"
+	"github.com/e2b-dev/infra/packages/shared/pkg/edge"
+)
+
 func (s *NodePassThroughServer) eventsHandler(md metadata.MD) (func(error), error) {
 	eventTypeHeaders := md.Get(edge.EventTypeHeader)
 	if len(eventTypeHeaders) == 0 {

--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -237,6 +237,10 @@ func (s *NodePassThroughServer) eventsHandler(md metadata.MD) (func(error), erro
 		return nil, nil
 	}
 
+	if len(eventTypeHeaders) > 1 {
+		return nil, status.Errorf(codes.InvalidArgument, "multiple event types are not supported: %v", eventTypeHeaders)
+	}
+
 	eventType := eventTypeHeaders[0]
 	switch eventType {
 	case edge.CatalogCreateEventType:

--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -98,7 +98,7 @@ func (s *NodePassThroughServer) director(ctx context.Context) (*grpc.ClientConn,
 //
 // Core implementation is just following methods that are handling forwarding, proper closing and propagating of errors from both sides of the stream.
 // The handler is called for every request that is not handled by any other gRPC service.
-func (s *NodePassThroughServer) handler(srv interface{}, serverStream grpc.ServerStream) error {
+func (s *NodePassThroughServer) handler(srv interface{}, serverStream grpc.ServerStream) (err error) {
 	fullMethodName, ok := grpc.MethodFromServerStream(serverStream)
 	if !ok {
 		return status.Errorf(codes.Internal, "low lever server stream not exists in context")
@@ -125,19 +125,18 @@ func (s *NodePassThroughServer) handler(srv interface{}, serverStream grpc.Serve
 	clientCtx, clientCancel := context.WithCancel(s.ctx)
 	defer clientCancel()
 
+	clientStream, err := grpc.NewClientStream(clientCtx, clientStreamDescForProxying, clientConnection, fullMethodName)
+	if err != nil {
+		return err
+	}
+
 	callback, err := s.eventsHandler(md)
 	if err != nil {
 		return status.Errorf(codes.Internal, "failed to handle events: %v", err)
 	}
 
-	var returnErr error
 	if callback != nil {
-		defer callback(returnErr)
-	}
-
-	clientStream, err := grpc.NewClientStream(clientCtx, clientStreamDescForProxying, clientConnection, fullMethodName)
-	if err != nil {
-		return err
+		defer callback(err)
 	}
 
 	// Explicitly *do not close* s2cErrChan and c2sErrChan, otherwise the select below will not terminate.
@@ -159,7 +158,6 @@ func (s *NodePassThroughServer) handler(srv interface{}, serverStream grpc.Serve
 				// to cancel the clientStream to the backend, let all of its goroutines be freed up by the CancelFunc and
 				// exit with an error to the stack
 				clientCancel()
-				returnErr = s2cErr
 				return status.Errorf(codes.Internal, "failed proxying s2c: %v", s2cErr)
 			}
 		case c2sErr := <-c2sErrChan:
@@ -169,7 +167,6 @@ func (s *NodePassThroughServer) handler(srv interface{}, serverStream grpc.Serve
 			serverStream.SetTrailer(clientStream.Trailer())
 			// c2sErr will contain RPC error from client code. If not io.EOF return the RPC error as server stream error.
 			if c2sErr != io.EOF {
-				returnErr = c2sErr
 				return c2sErr
 			}
 			return nil
@@ -229,71 +226,4 @@ func (s *NodePassThroughServer) forwardServerToClient(src grpc.ServerStream, dst
 	}()
 
 	return ret
-}
-
-func (s *NodePassThroughServer) eventsHandler(md metadata.MD) (func(error), error) {
-	eventTypeHeaders := md.Get(edge.EventTypeHeader)
-	if len(eventTypeHeaders) == 0 {
-		return nil, nil
-	}
-
-	if len(eventTypeHeaders) > 1 {
-		return nil, status.Errorf(codes.InvalidArgument, "multiple event types are not supported: %v", eventTypeHeaders)
-	}
-
-	eventType := eventTypeHeaders[0]
-	switch eventType {
-	case edge.CatalogCreateEventType:
-		return s.catalogCreateEventHandler(md)
-	case edge.CatalogDeleteEventType:
-		return s.catalogDeleteEventHandler(md)
-	default:
-		return nil, status.Errorf(codes.InvalidArgument, "event type %s is not supported", eventType)
-	}
-}
-
-func (s *NodePassThroughServer) catalogCreateEventHandler(md metadata.MD) (func(error), error) {
-	c, err := edge.ParseSandboxCatalogCreateEvent(md)
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.catalog.StoreSandbox(
-		c.SandboxID,
-		&sandboxes.SandboxInfo{
-			OrchestratorID:          c.OrchestratorID,
-			ExecutionID:             c.ExecutionID,
-			SandboxStartedAt:        c.SandboxStartTime,
-			SandboxMaxLengthInHours: c.SandboxMaxLengthInHours,
-		},
-		time.Duration(c.SandboxMaxLengthInHours)*time.Hour,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to store sandbox in catalog: %w", err)
-	}
-
-	return func(err error) {
-		if err == nil {
-			return
-		}
-
-		deleteErr := s.catalog.DeleteSandbox(c.SandboxID, c.ExecutionID)
-		if deleteErr != nil {
-			zap.L().Error("Failed to delete sandbox in catalog after failing request", zap.Error(deleteErr))
-		}
-	}, nil
-}
-
-func (s *NodePassThroughServer) catalogDeleteEventHandler(md metadata.MD) (func(error), error) {
-	d, err := edge.ParseSandboxCatalogDeleteEvent(md)
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.catalog.DeleteSandbox(d.SandboxID, d.ExecutionID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to delete sandbox from catalog: %w", err)
-	}
-
-	return nil, nil
 }

--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -2,11 +2,8 @@ package edgepassthrough
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"time"
 
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -18,7 +15,6 @@ import (
 	e2borchestrators "github.com/e2b-dev/infra/packages/proxy/internal/edge/pool"
 	"github.com/e2b-dev/infra/packages/proxy/internal/edge/sandboxes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
-	"github.com/e2b-dev/infra/packages/shared/pkg/edge"
 	api "github.com/e2b-dev/infra/packages/shared/pkg/http/edge"
 )
 

--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -232,50 +232,63 @@ func (s *NodePassThroughServer) forwardServerToClient(src grpc.ServerStream, dst
 }
 
 func (s *NodePassThroughServer) eventsHandler(md metadata.MD) (func(error), error) {
-	c, err := edge.HandleSandboxCatalogCreateEvent(md)
+	eventTypeHeaders := md.Get(edge.EventTypeHeader)
+	if len(eventTypeHeaders) == 0 {
+		return nil, nil
+	}
+
+	eventType := eventTypeHeaders[0]
+	switch eventType {
+	case edge.CatalogCreateEventType:
+		return s.catalogCreateEventHandler(md)
+	case edge.CatalogDeleteEventType:
+		return s.catalogDeleteEventHandler(md)
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "event type %s is not supported", eventType)
+	}
+}
+
+func (s *NodePassThroughServer) catalogCreateEventHandler(md metadata.MD) (func(error), error) {
+	c, err := edge.ParseSandboxCatalogCreateEvent(md)
 	if err != nil {
 		return nil, err
 	}
 
-	if c != nil {
-		err := s.catalog.StoreSandbox(
-			c.SandboxID,
-			&sandboxes.SandboxInfo{
-				OrchestratorID:          c.OrchestratorID,
-				ExecutionID:             c.ExecutionID,
-				SandboxStartedAt:        c.SandboxStartTime,
-				SandboxMaxLengthInHours: c.SandboxMaxLengthInHours,
-			},
-			time.Duration(c.SandboxMaxLengthInHours)*time.Hour,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to store sandbox in catalog: %w", err)
-		}
-
-		return func(err error) {
-			if err == nil {
-				return
-			}
-
-			deleteErr := s.catalog.DeleteSandbox(c.SandboxID, c.ExecutionID)
-			if deleteErr != nil {
-				zap.L().Error("Failed to delete sandbox in catalog after failing request", zap.Error(deleteErr))
-			}
-		}, nil
+	err = s.catalog.StoreSandbox(
+		c.SandboxID,
+		&sandboxes.SandboxInfo{
+			OrchestratorID:          c.OrchestratorID,
+			ExecutionID:             c.ExecutionID,
+			SandboxStartedAt:        c.SandboxStartTime,
+			SandboxMaxLengthInHours: c.SandboxMaxLengthInHours,
+		},
+		time.Duration(c.SandboxMaxLengthInHours)*time.Hour,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to store sandbox in catalog: %w", err)
 	}
 
-	d, err := edge.HandleSandboxCatalogDeleteEvent(md)
+	return func(err error) {
+		if err == nil {
+			return
+		}
+
+		deleteErr := s.catalog.DeleteSandbox(c.SandboxID, c.ExecutionID)
+		if deleteErr != nil {
+			zap.L().Error("Failed to delete sandbox in catalog after failing request", zap.Error(deleteErr))
+		}
+	}, nil
+}
+
+func (s *NodePassThroughServer) catalogDeleteEventHandler(md metadata.MD) (func(error), error) {
+	d, err := edge.ParseSandboxCatalogDeleteEvent(md)
 	if err != nil {
 		return nil, err
 	}
 
-	if d != nil {
-		err := s.catalog.DeleteSandbox(d.SandboxID, d.ExecutionID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to delete sandbox from catalog: %w", err)
-		}
-
-		return func(err error) {}, nil
+	err = s.catalog.DeleteSandbox(d.SandboxID, d.ExecutionID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete sandbox from catalog: %w", err)
 	}
 
 	return nil, nil

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -194,7 +194,7 @@ func run() int {
 
 	// Edge Pass Through Proxy for direct communication with orchestrator nodes
 	grpcListener := muxServer.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc")) // handler requests for gRPC pass through
-	grpcSrv := edgepassthrough.NewNodePassThroughServer(ctx, orchestrators, info, authorizationManager)
+	grpcSrv := edgepassthrough.NewNodePassThroughServer(ctx, orchestrators, info, authorizationManager, catalog)
 
 	// Edge REST API
 	restHttpHandler := edge.NewGinServer(logger, edgeApiStore, edgeApiSwagger, tracer, authorizationManager)

--- a/packages/shared/pkg/edge/events.go
+++ b/packages/shared/pkg/edge/events.go
@@ -1,0 +1,147 @@
+package edge
+
+import (
+	"errors"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+const (
+	eventTypeHeader = "event-type"
+
+	catalogCreateEventType = "sandbox-catalog-create"
+	catalogDeleteEventType = "sandbox-catalog-delete"
+
+	sbxIdHeader               = "sandbox-id"
+	sbxExecutionIdHeader      = "execution-id"
+	sbxOrchestratorIdHeader   = "orchestrator-id"
+	sbxMaxLengthInHoursHeader = "sandbox-max-length-in-hours"
+	sbxStartTimeHeader        = "sandbox-start-time"
+)
+
+var (
+	ErrSandboxCreateEventRequiredFieldsMissing = errors.New("required fields missing for sandbox create event")
+	ErrSandboxDeleteEventRequiredFieldsMissing = errors.New("required fields missing for sandbox delete event")
+
+	ErrSandboxCreationParse = errors.New("failed to parse sandbox creation event metadata")
+	ErrSandboxLifetimeParse = errors.New("failed to parse sandbox max lifetime event metadata")
+)
+
+type SandboxCatalogCreateEvent struct {
+	SandboxID               string
+	ExecutionID             string
+	OrchestratorID          string
+	SandboxMaxLengthInHours int64
+	SandboxStartTime        time.Time // Formatted as RFC3339 (ISO 8601)
+}
+
+type SandboxCatalogDeleteEvent struct {
+	SandboxID   string
+	ExecutionID string
+}
+
+func SerializeSandboxCatalogCreateEvent(e SandboxCatalogCreateEvent) metadata.MD {
+	return metadata.New(
+		map[string]string{
+			eventTypeHeader: catalogCreateEventType,
+
+			sbxIdHeader:               e.SandboxID,
+			sbxExecutionIdHeader:      e.ExecutionID,
+			sbxOrchestratorIdHeader:   e.OrchestratorID,
+			sbxStartTimeHeader:        e.SandboxStartTime.Format(time.RFC3339),
+			sbxMaxLengthInHoursHeader: strconv.Itoa(int(e.SandboxMaxLengthInHours)),
+		},
+	)
+}
+
+func SerializeSandboxCatalogDeleteEvent(e SandboxCatalogDeleteEvent) metadata.MD {
+	return metadata.New(
+		map[string]string{
+			eventTypeHeader: catalogDeleteEventType,
+
+			sbxIdHeader:          e.SandboxID,
+			sbxExecutionIdHeader: e.ExecutionID,
+		},
+	)
+}
+
+func HandleSandboxCatalogCreateEvent(md metadata.MD) (e *SandboxCatalogCreateEvent, err error) {
+	v, f := getMetadataValue(md, eventTypeHeader)
+	if !f || v != catalogCreateEventType {
+		return nil, nil
+	}
+
+	sandboxID, found := getMetadataValue(md, sbxIdHeader)
+	if !found {
+		return nil, ErrSandboxCreateEventRequiredFieldsMissing
+	}
+
+	executionID, found := getMetadataValue(md, sbxExecutionIdHeader)
+	if !found {
+		return nil, ErrSandboxCreateEventRequiredFieldsMissing
+	}
+
+	orchestratorID, found := getMetadataValue(md, sbxOrchestratorIdHeader)
+	if !found {
+		return nil, ErrSandboxCreateEventRequiredFieldsMissing
+	}
+
+	maxLengthInHoursStr, found := getMetadataValue(md, sbxMaxLengthInHoursHeader)
+	if !found {
+		return nil, ErrSandboxCreateEventRequiredFieldsMissing
+	}
+
+	maxLengthInHours, err := strconv.Atoi(maxLengthInHoursStr)
+	if err != nil {
+		return nil, ErrSandboxLifetimeParse
+	}
+
+	sandboxStartTimeStr, found := getMetadataValue(md, sbxStartTimeHeader)
+	if !found {
+		return nil, ErrSandboxCreateEventRequiredFieldsMissing
+	}
+
+	sandboxStartTime, err := time.Parse(time.RFC3339, sandboxStartTimeStr)
+	if err != nil {
+		return nil, ErrSandboxCreationParse
+	}
+
+	return &SandboxCatalogCreateEvent{
+		SandboxID:               sandboxID,
+		ExecutionID:             executionID,
+		OrchestratorID:          orchestratorID,
+		SandboxMaxLengthInHours: int64(maxLengthInHours),
+		SandboxStartTime:        sandboxStartTime,
+	}, nil
+}
+
+func HandleSandboxCatalogDeleteEvent(md metadata.MD) (e *SandboxCatalogDeleteEvent, err error) {
+	v, f := getMetadataValue(md, eventTypeHeader)
+	if !f || v != catalogDeleteEventType {
+		return nil, nil
+	}
+
+	sandboxID, found := getMetadataValue(md, sbxIdHeader)
+	if !found {
+		return nil, ErrSandboxDeleteEventRequiredFieldsMissing
+	}
+
+	executionID, found := getMetadataValue(md, sbxExecutionIdHeader)
+	if !found {
+		return nil, ErrSandboxDeleteEventRequiredFieldsMissing
+	}
+
+	return &SandboxCatalogDeleteEvent{
+		SandboxID:   sandboxID,
+		ExecutionID: executionID,
+	}, nil
+}
+
+func getMetadataValue(md metadata.MD, key string) (value string, found bool) {
+	if values, ok := md[key]; ok && len(values) > 0 {
+		return values[0], true
+	}
+	return "", false
+}


### PR DESCRIPTION
Remove the need to call the Edge REST API for sandbox registry/remove from cluster shared cache.

This PR introduces changes that will move sandbox catalog create/delete requests directly into sandbox start/delete/pause metadata. It should simplify the process of calling and speed up startup, because it's no longer another request.