### PR TITLE
Test basic template building in the CI

### DIFF
--- a/packages/api/internal/template-manager/build_client.go
+++ b/packages/api/internal/template-manager/build_client.go
@@ -27,11 +27,8 @@ func (bc *BuildClient) GetLogs(ctx context.Context, templateID, buildID string, 
 			continue
 		}
 
-		// Return the first non-empty logs, the providers are ordered by most up-to-date data
-		if len(l) > 0 {
-			logsTotal = l
-			break
-		}
+		// Return the first non-error logs, the providers are ordered by most up-to-date data
+		return l
 	}
 
 	return logsTotal

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -47,8 +47,8 @@ test/%:
 	go test -v ./internal/main_test.go -count=1 && \
 	TEST_PATH="./internal/tests/$(subst test/,,$@)"; \
 	case "$${TEST_PATH}" in \
-		*.go) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 ;; \
-		*) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 ;; \
+		*.go) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
+		*) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
 	esac
 
 .PHONY: connect-orchestrator

--- a/tests/integration/internal/api/client.gen.go
+++ b/tests/integration/internal/api/client.gen.go
@@ -148,7 +148,7 @@ type ClientInterface interface {
 	GetSandboxesSandboxIDLogs(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetSandboxesSandboxIDMetrics request
-	GetSandboxesSandboxIDMetrics(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetSandboxesSandboxIDMetrics(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PostSandboxesSandboxIDPause request
 	PostSandboxesSandboxIDPause(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -198,8 +198,21 @@ type ClientInterface interface {
 	// GetTemplatesTemplateIDBuildsBuildIDStatus request
 	GetTemplatesTemplateIDBuildsBuildIDStatus(ctx context.Context, templateID TemplateID, buildID BuildID, params *GetTemplatesTemplateIDBuildsBuildIDStatusParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetTemplatesTemplateIDFilesHash request
+	GetTemplatesTemplateIDFilesHash(ctx context.Context, templateID TemplateID, hash string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetV2Sandboxes request
 	GetV2Sandboxes(ctx context.Context, params *GetV2SandboxesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostV2TemplatesWithBody request with any body
+	PostV2TemplatesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostV2Templates(ctx context.Context, body PostV2TemplatesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostV2TemplatesTemplateIDBuildsBuildIDWithBody request with any body
+	PostV2TemplatesTemplateIDBuildsBuildIDWithBody(ctx context.Context, templateID TemplateID, buildID BuildID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostV2TemplatesTemplateIDBuildsBuildID(ctx context.Context, templateID TemplateID, buildID BuildID, body PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) PostAccessTokensWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -454,8 +467,8 @@ func (c *Client) GetSandboxesSandboxIDLogs(ctx context.Context, sandboxID Sandbo
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSandboxesSandboxIDMetrics(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSandboxesSandboxIDMetricsRequest(c.Server, sandboxID)
+func (c *Client) GetSandboxesSandboxIDMetrics(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDMetricsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSandboxesSandboxIDMetricsRequest(c.Server, sandboxID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -682,8 +695,68 @@ func (c *Client) GetTemplatesTemplateIDBuildsBuildIDStatus(ctx context.Context, 
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetTemplatesTemplateIDFilesHash(ctx context.Context, templateID TemplateID, hash string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetTemplatesTemplateIDFilesHashRequest(c.Server, templateID, hash)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetV2Sandboxes(ctx context.Context, params *GetV2SandboxesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetV2SandboxesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostV2TemplatesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostV2TemplatesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostV2Templates(ctx context.Context, body PostV2TemplatesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostV2TemplatesRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostV2TemplatesTemplateIDBuildsBuildIDWithBody(ctx context.Context, templateID TemplateID, buildID BuildID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostV2TemplatesTemplateIDBuildsBuildIDRequestWithBody(c.Server, templateID, buildID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostV2TemplatesTemplateIDBuildsBuildID(ctx context.Context, templateID TemplateID, buildID BuildID, body PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostV2TemplatesTemplateIDBuildsBuildIDRequest(c.Server, templateID, buildID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1162,20 +1235,16 @@ func NewGetSandboxesMetricsRequest(server string, params *GetSandboxesMetricsPar
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if params.Metadata != nil {
-
-			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "metadata", runtime.ParamLocationQuery, *params.Metadata); err != nil {
-				return nil, err
-			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-				return nil, err
-			} else {
-				for k, v := range parsed {
-					for _, v2 := range v {
-						queryValues.Add(k, v2)
-					}
+		if queryFrag, err := runtime.StyleParamWithLocation("form", false, "sandbox_ids", runtime.ParamLocationQuery, params.SandboxIds); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
 				}
 			}
-
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -1330,7 +1399,7 @@ func NewGetSandboxesSandboxIDLogsRequest(server string, sandboxID SandboxID, par
 }
 
 // NewGetSandboxesSandboxIDMetricsRequest generates requests for GetSandboxesSandboxIDMetrics
-func NewGetSandboxesSandboxIDMetricsRequest(server string, sandboxID SandboxID) (*http.Request, error) {
+func NewGetSandboxesSandboxIDMetricsRequest(server string, sandboxID SandboxID, params *GetSandboxesSandboxIDMetricsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1353,6 +1422,44 @@ func NewGetSandboxesSandboxIDMetricsRequest(server string, sandboxID SandboxID) 
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Start != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "start", runtime.ParamLocationQuery, *params.Start); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.End != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "end", runtime.ParamLocationQuery, *params.End); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -1875,7 +1982,64 @@ func NewGetTemplatesTemplateIDBuildsBuildIDStatusRequest(server string, template
 
 		}
 
+		if params.Level != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "level", runtime.ParamLocationQuery, *params.Level); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetTemplatesTemplateIDFilesHashRequest generates requests for GetTemplatesTemplateIDFilesHash
+func NewGetTemplatesTemplateIDFilesHashRequest(server string, templateID TemplateID, hash string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "templateID", runtime.ParamLocationPath, templateID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "hash", runtime.ParamLocationPath, hash)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/templates/%s/files/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -1983,6 +2147,100 @@ func NewGetV2SandboxesRequest(server string, params *GetV2SandboxesParams) (*htt
 	return req, nil
 }
 
+// NewPostV2TemplatesRequest calls the generic PostV2Templates builder with application/json body
+func NewPostV2TemplatesRequest(server string, body PostV2TemplatesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostV2TemplatesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostV2TemplatesRequestWithBody generates requests for PostV2Templates with any type of body
+func NewPostV2TemplatesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/templates")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewPostV2TemplatesTemplateIDBuildsBuildIDRequest calls the generic PostV2TemplatesTemplateIDBuildsBuildID builder with application/json body
+func NewPostV2TemplatesTemplateIDBuildsBuildIDRequest(server string, templateID TemplateID, buildID BuildID, body PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostV2TemplatesTemplateIDBuildsBuildIDRequestWithBody(server, templateID, buildID, "application/json", bodyReader)
+}
+
+// NewPostV2TemplatesTemplateIDBuildsBuildIDRequestWithBody generates requests for PostV2TemplatesTemplateIDBuildsBuildID with any type of body
+func NewPostV2TemplatesTemplateIDBuildsBuildIDRequestWithBody(server string, templateID TemplateID, buildID BuildID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "templateID", runtime.ParamLocationPath, templateID)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "buildID", runtime.ParamLocationPath, buildID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v2/templates/%s/builds/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 func (c *Client) applyEditors(ctx context.Context, req *http.Request, additionalEditors []RequestEditorFn) error {
 	for _, r := range c.RequestEditors {
 		if err := r(ctx, req); err != nil {
@@ -2085,7 +2343,7 @@ type ClientWithResponsesInterface interface {
 	GetSandboxesSandboxIDLogsWithResponse(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDLogsParams, reqEditors ...RequestEditorFn) (*GetSandboxesSandboxIDLogsResponse, error)
 
 	// GetSandboxesSandboxIDMetricsWithResponse request
-	GetSandboxesSandboxIDMetricsWithResponse(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*GetSandboxesSandboxIDMetricsResponse, error)
+	GetSandboxesSandboxIDMetricsWithResponse(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDMetricsParams, reqEditors ...RequestEditorFn) (*GetSandboxesSandboxIDMetricsResponse, error)
 
 	// PostSandboxesSandboxIDPauseWithResponse request
 	PostSandboxesSandboxIDPauseWithResponse(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*PostSandboxesSandboxIDPauseResponse, error)
@@ -2135,8 +2393,21 @@ type ClientWithResponsesInterface interface {
 	// GetTemplatesTemplateIDBuildsBuildIDStatusWithResponse request
 	GetTemplatesTemplateIDBuildsBuildIDStatusWithResponse(ctx context.Context, templateID TemplateID, buildID BuildID, params *GetTemplatesTemplateIDBuildsBuildIDStatusParams, reqEditors ...RequestEditorFn) (*GetTemplatesTemplateIDBuildsBuildIDStatusResponse, error)
 
+	// GetTemplatesTemplateIDFilesHashWithResponse request
+	GetTemplatesTemplateIDFilesHashWithResponse(ctx context.Context, templateID TemplateID, hash string, reqEditors ...RequestEditorFn) (*GetTemplatesTemplateIDFilesHashResponse, error)
+
 	// GetV2SandboxesWithResponse request
 	GetV2SandboxesWithResponse(ctx context.Context, params *GetV2SandboxesParams, reqEditors ...RequestEditorFn) (*GetV2SandboxesResponse, error)
+
+	// PostV2TemplatesWithBodyWithResponse request with any body
+	PostV2TemplatesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostV2TemplatesResponse, error)
+
+	PostV2TemplatesWithResponse(ctx context.Context, body PostV2TemplatesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostV2TemplatesResponse, error)
+
+	// PostV2TemplatesTemplateIDBuildsBuildIDWithBodyWithResponse request with any body
+	PostV2TemplatesTemplateIDBuildsBuildIDWithBodyWithResponse(ctx context.Context, templateID TemplateID, buildID BuildID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostV2TemplatesTemplateIDBuildsBuildIDResponse, error)
+
+	PostV2TemplatesTemplateIDBuildsBuildIDWithResponse(ctx context.Context, templateID TemplateID, buildID BuildID, body PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PostV2TemplatesTemplateIDBuildsBuildIDResponse, error)
 }
 
 type PostAccessTokensResponse struct {
@@ -2431,7 +2702,7 @@ func (r PostSandboxesResponse) StatusCode() int {
 type GetSandboxesMetricsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]RunningSandboxWithMetrics
+	JSON200      *SandboxesWithMetrics
 	JSON400      *N400
 	JSON401      *N401
 	JSON500      *N500
@@ -2531,6 +2802,7 @@ type GetSandboxesSandboxIDMetricsResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]SandboxMetric
+	JSON400      *N400
 	JSON401      *N401
 	JSON404      *N404
 	JSON500      *N500
@@ -2842,6 +3114,32 @@ func (r GetTemplatesTemplateIDBuildsBuildIDStatusResponse) StatusCode() int {
 	return 0
 }
 
+type GetTemplatesTemplateIDFilesHashResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *TemplateBuildFileUpload
+	JSON400      *N400
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetTemplatesTemplateIDFilesHashResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetTemplatesTemplateIDFilesHashResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetV2SandboxesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2861,6 +3159,54 @@ func (r GetV2SandboxesResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r GetV2SandboxesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostV2TemplatesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *Template
+	JSON400      *N400
+	JSON401      *N401
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r PostV2TemplatesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostV2TemplatesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostV2TemplatesTemplateIDBuildsBuildIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *N401
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r PostV2TemplatesTemplateIDBuildsBuildIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostV2TemplatesTemplateIDBuildsBuildIDResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3052,8 +3398,8 @@ func (c *ClientWithResponses) GetSandboxesSandboxIDLogsWithResponse(ctx context.
 }
 
 // GetSandboxesSandboxIDMetricsWithResponse request returning *GetSandboxesSandboxIDMetricsResponse
-func (c *ClientWithResponses) GetSandboxesSandboxIDMetricsWithResponse(ctx context.Context, sandboxID SandboxID, reqEditors ...RequestEditorFn) (*GetSandboxesSandboxIDMetricsResponse, error) {
-	rsp, err := c.GetSandboxesSandboxIDMetrics(ctx, sandboxID, reqEditors...)
+func (c *ClientWithResponses) GetSandboxesSandboxIDMetricsWithResponse(ctx context.Context, sandboxID SandboxID, params *GetSandboxesSandboxIDMetricsParams, reqEditors ...RequestEditorFn) (*GetSandboxesSandboxIDMetricsResponse, error) {
+	rsp, err := c.GetSandboxesSandboxIDMetrics(ctx, sandboxID, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -3216,6 +3562,15 @@ func (c *ClientWithResponses) GetTemplatesTemplateIDBuildsBuildIDStatusWithRespo
 	return ParseGetTemplatesTemplateIDBuildsBuildIDStatusResponse(rsp)
 }
 
+// GetTemplatesTemplateIDFilesHashWithResponse request returning *GetTemplatesTemplateIDFilesHashResponse
+func (c *ClientWithResponses) GetTemplatesTemplateIDFilesHashWithResponse(ctx context.Context, templateID TemplateID, hash string, reqEditors ...RequestEditorFn) (*GetTemplatesTemplateIDFilesHashResponse, error) {
+	rsp, err := c.GetTemplatesTemplateIDFilesHash(ctx, templateID, hash, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetTemplatesTemplateIDFilesHashResponse(rsp)
+}
+
 // GetV2SandboxesWithResponse request returning *GetV2SandboxesResponse
 func (c *ClientWithResponses) GetV2SandboxesWithResponse(ctx context.Context, params *GetV2SandboxesParams, reqEditors ...RequestEditorFn) (*GetV2SandboxesResponse, error) {
 	rsp, err := c.GetV2Sandboxes(ctx, params, reqEditors...)
@@ -3223,6 +3578,40 @@ func (c *ClientWithResponses) GetV2SandboxesWithResponse(ctx context.Context, pa
 		return nil, err
 	}
 	return ParseGetV2SandboxesResponse(rsp)
+}
+
+// PostV2TemplatesWithBodyWithResponse request with arbitrary body returning *PostV2TemplatesResponse
+func (c *ClientWithResponses) PostV2TemplatesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostV2TemplatesResponse, error) {
+	rsp, err := c.PostV2TemplatesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostV2TemplatesResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostV2TemplatesWithResponse(ctx context.Context, body PostV2TemplatesJSONRequestBody, reqEditors ...RequestEditorFn) (*PostV2TemplatesResponse, error) {
+	rsp, err := c.PostV2Templates(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostV2TemplatesResponse(rsp)
+}
+
+// PostV2TemplatesTemplateIDBuildsBuildIDWithBodyWithResponse request with arbitrary body returning *PostV2TemplatesTemplateIDBuildsBuildIDResponse
+func (c *ClientWithResponses) PostV2TemplatesTemplateIDBuildsBuildIDWithBodyWithResponse(ctx context.Context, templateID TemplateID, buildID BuildID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostV2TemplatesTemplateIDBuildsBuildIDResponse, error) {
+	rsp, err := c.PostV2TemplatesTemplateIDBuildsBuildIDWithBody(ctx, templateID, buildID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostV2TemplatesTemplateIDBuildsBuildIDResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostV2TemplatesTemplateIDBuildsBuildIDWithResponse(ctx context.Context, templateID TemplateID, buildID BuildID, body PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PostV2TemplatesTemplateIDBuildsBuildIDResponse, error) {
+	rsp, err := c.PostV2TemplatesTemplateIDBuildsBuildID(ctx, templateID, buildID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostV2TemplatesTemplateIDBuildsBuildIDResponse(rsp)
 }
 
 // ParsePostAccessTokensResponse parses an HTTP response from a PostAccessTokensWithResponse call
@@ -3727,7 +4116,7 @@ func ParseGetSandboxesMetricsResponse(rsp *http.Response) (*GetSandboxesMetricsR
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []RunningSandboxWithMetrics
+		var dest SandboxesWithMetrics
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -3913,6 +4302,13 @@ func ParseGetSandboxesSandboxIDMetricsResponse(rsp *http.Response) (*GetSandboxe
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest N401
@@ -4434,6 +4830,60 @@ func ParseGetTemplatesTemplateIDBuildsBuildIDStatusResponse(rsp *http.Response) 
 	return response, nil
 }
 
+// ParseGetTemplatesTemplateIDFilesHashResponse parses an HTTP response from a GetTemplatesTemplateIDFilesHashWithResponse call
+func ParseGetTemplatesTemplateIDFilesHashResponse(rsp *http.Response) (*GetTemplatesTemplateIDFilesHashResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetTemplatesTemplateIDFilesHashResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest TemplateBuildFileUpload
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetV2SandboxesResponse parses an HTTP response from a GetV2SandboxesWithResponse call
 func ParseGetV2SandboxesResponse(rsp *http.Response) (*GetV2SandboxesResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -4462,6 +4912,86 @@ func ParseGetV2SandboxesResponse(rsp *http.Response) (*GetV2SandboxesResponse, e
 		}
 		response.JSON400 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostV2TemplatesResponse parses an HTTP response from a PostV2TemplatesWithResponse call
+func ParsePostV2TemplatesResponse(rsp *http.Response) (*PostV2TemplatesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostV2TemplatesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest Template
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostV2TemplatesTemplateIDBuildsBuildIDResponse parses an HTTP response from a PostV2TemplatesTemplateIDBuildsBuildIDWithResponse call
+func ParsePostV2TemplatesTemplateIDBuildsBuildIDResponse(rsp *http.Response) (*PostV2TemplatesTemplateIDBuildsBuildIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostV2TemplatesTemplateIDBuildsBuildIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
 		var dest N401
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/tests/integration/internal/api/models.gen.go
+++ b/tests/integration/internal/api/models.gen.go
@@ -17,6 +17,14 @@ const (
 	Supabase2TeamAuthScopes  = "Supabase2TeamAuth.Scopes"
 )
 
+// Defines values for LogLevel.
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelError LogLevel = "error"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+)
+
 // Defines values for NodeStatus.
 const (
 	NodeStatusConnecting NodeStatus = "connecting"
@@ -39,6 +47,18 @@ const (
 	TemplateBuildStatusWaiting  TemplateBuildStatus = "waiting"
 )
 
+// BuildLogEntry defines model for BuildLogEntry.
+type BuildLogEntry struct {
+	// Level State of the sandbox
+	Level LogLevel `json:"level"`
+
+	// Message Log message content
+	Message string `json:"message"`
+
+	// Timestamp Timestamp of the log entry
+	Timestamp time.Time `json:"timestamp"`
+}
+
 // CPUCount CPU cores for the sandbox
 type CPUCount = int32
 
@@ -48,16 +68,14 @@ type CreatedAccessToken struct {
 	CreatedAt time.Time `json:"createdAt"`
 
 	// Id Identifier of the access token
-	Id openapi_types.UUID `json:"id"`
+	Id   openapi_types.UUID       `json:"id"`
+	Mask IdentifierMaskingDetails `json:"mask"`
 
 	// Name Name of the access token
 	Name string `json:"name"`
 
-	// Token Raw value of the access token
+	// Token The fully created access token
 	Token string `json:"token"`
-
-	// TokenMask Mask of the access token
-	TokenMask string `json:"tokenMask"`
 }
 
 // CreatedTeamAPIKey defines model for CreatedTeamAPIKey.
@@ -72,11 +90,9 @@ type CreatedTeamAPIKey struct {
 	// Key Raw value of the API key
 	Key string `json:"key"`
 
-	// KeyMask Mask of the API key
-	KeyMask string `json:"keyMask"`
-
 	// LastUsed Last time this API key was used
-	LastUsed *time.Time `json:"lastUsed"`
+	LastUsed *time.Time               `json:"lastUsed"`
+	Mask     IdentifierMaskingDetails `json:"mask"`
 
 	// Name Name of the API key
 	Name string `json:"name"`
@@ -94,12 +110,28 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+// IdentifierMaskingDetails defines model for IdentifierMaskingDetails.
+type IdentifierMaskingDetails struct {
+	// MaskedValuePrefix Prefix used in masked version of the token or key
+	MaskedValuePrefix string `json:"maskedValuePrefix"`
+
+	// MaskedValueSuffix Suffix used in masked version of the token or key
+	MaskedValueSuffix string `json:"maskedValueSuffix"`
+
+	// Prefix Prefix that identifies the token or key type
+	Prefix string `json:"prefix"`
+
+	// ValueLength Length of the token or key
+	ValueLength int `json:"valueLength"`
+}
+
 // ListedSandbox defines model for ListedSandbox.
 type ListedSandbox struct {
 	// Alias Alias of the template
 	Alias *string `json:"alias,omitempty"`
 
 	// ClientID Identifier of the client
+	// Deprecated:
 	ClientID string `json:"clientID"`
 
 	// CpuCount CPU cores for the sandbox
@@ -124,6 +156,9 @@ type ListedSandbox struct {
 	// TemplateID Identifier of the template from which is the sandbox created
 	TemplateID string `json:"templateID"`
 }
+
+// LogLevel State of the sandbox
+type LogLevel string
 
 // MemoryMB Memory for the sandbox in MB
 type MemoryMB = int32
@@ -165,8 +200,17 @@ type Node struct {
 	// AllocatedMemoryMiB Amount of allocated memory in MiB
 	AllocatedMemoryMiB int32 `json:"allocatedMemoryMiB"`
 
+	// ClusterID Identifier of the cluster
+	ClusterID *string `json:"clusterID"`
+
+	// Commit Commit of the orchestrator
+	Commit string `json:"commit"`
+
 	// CreateFails Number of sandbox create fails
 	CreateFails uint64 `json:"createFails"`
+
+	// CreateSuccesses Number of sandbox create successes
+	CreateSuccesses uint64 `json:"createSuccesses"`
 
 	// NodeID Identifier of the node
 	NodeID string `json:"nodeID"`
@@ -189,8 +233,17 @@ type NodeDetail struct {
 	// CachedBuilds List of cached builds id on the node
 	CachedBuilds []string `json:"cachedBuilds"`
 
+	// ClusterID Identifier of the cluster
+	ClusterID *string `json:"clusterID"`
+
+	// Commit Commit of the orchestrator
+	Commit string `json:"commit"`
+
 	// CreateFails Number of sandbox create fails
 	CreateFails uint64 `json:"createFails"`
+
+	// CreateSuccesses Number of sandbox create successes
+	CreateSuccesses uint64 `json:"createSuccesses"`
 
 	// NodeID Identifier of the node
 	NodeID string `json:"nodeID"`
@@ -223,42 +276,17 @@ type ResumedSandbox struct {
 	Timeout *int32 `json:"timeout,omitempty"`
 }
 
-// RunningSandboxWithMetrics defines model for RunningSandboxWithMetrics.
-type RunningSandboxWithMetrics struct {
-	// Alias Alias of the template
-	Alias *string `json:"alias,omitempty"`
-
-	// ClientID Identifier of the client
-	ClientID string `json:"clientID"`
-
-	// CpuCount CPU cores for the sandbox
-	CpuCount CPUCount `json:"cpuCount"`
-
-	// EndAt Time when the sandbox will expire
-	EndAt time.Time `json:"endAt"`
-
-	// MemoryMB Memory for the sandbox in MB
-	MemoryMB MemoryMB         `json:"memoryMB"`
-	Metadata *SandboxMetadata `json:"metadata,omitempty"`
-	Metrics  *[]SandboxMetric `json:"metrics,omitempty"`
-
-	// SandboxID Identifier of the sandbox
-	SandboxID string `json:"sandboxID"`
-
-	// StartedAt Time when the sandbox was started
-	StartedAt time.Time `json:"startedAt"`
-
-	// TemplateID Identifier of the template from which is the sandbox created
-	TemplateID string `json:"templateID"`
-}
-
 // Sandbox defines model for Sandbox.
 type Sandbox struct {
 	// Alias Alias of the template
 	Alias *string `json:"alias,omitempty"`
 
 	// ClientID Identifier of the client
+	// Deprecated:
 	ClientID string `json:"clientID"`
+
+	// Domain Base domain where the sandbox traffic is accessible
+	Domain *string `json:"domain"`
 
 	// EnvdAccessToken Access token used for envd communication
 	EnvdAccessToken *string `json:"envdAccessToken,omitempty"`
@@ -279,10 +307,14 @@ type SandboxDetail struct {
 	Alias *string `json:"alias,omitempty"`
 
 	// ClientID Identifier of the client
+	// Deprecated:
 	ClientID string `json:"clientID"`
 
 	// CpuCount CPU cores for the sandbox
 	CpuCount CPUCount `json:"cpuCount"`
+
+	// Domain Base domain where the sandbox traffic is accessible
+	Domain *string `json:"domain"`
 
 	// EndAt Time when the sandbox will expire
 	EndAt time.Time `json:"endAt"`
@@ -336,11 +368,17 @@ type SandboxMetric struct {
 	// CpuUsedPct CPU usage percentage
 	CpuUsedPct float32 `json:"cpuUsedPct"`
 
-	// MemTotalMiB Total memory in MiB
-	MemTotalMiB int64 `json:"memTotalMiB"`
+	// DiskTotal Total disk space in bytes
+	DiskTotal int64 `json:"diskTotal"`
 
-	// MemUsedMiB Memory used in MiB
-	MemUsedMiB int64 `json:"memUsedMiB"`
+	// DiskUsed Disk used in bytes
+	DiskUsed int64 `json:"diskUsed"`
+
+	// MemTotal Total memory in bytes
+	MemTotal int64 `json:"memTotal"`
+
+	// MemUsed Memory used in bytes
+	MemUsed int64 `json:"memUsed"`
 
 	// Timestamp Timestamp of the metric entry
 	Timestamp time.Time `json:"timestamp"`
@@ -348,6 +386,11 @@ type SandboxMetric struct {
 
 // SandboxState State of the sandbox
 type SandboxState string
+
+// SandboxesWithMetrics defines model for SandboxesWithMetrics.
+type SandboxesWithMetrics struct {
+	Sandboxes map[string]SandboxMetric `json:"sandboxes"`
+}
 
 // Team defines model for Team.
 type Team struct {
@@ -373,11 +416,9 @@ type TeamAPIKey struct {
 	// Id Identifier of the API key
 	Id openapi_types.UUID `json:"id"`
 
-	// KeyMask Mask of the API key
-	KeyMask string `json:"keyMask"`
-
 	// LastUsed Last time this API key was used
-	LastUsed *time.Time `json:"lastUsed"`
+	LastUsed *time.Time               `json:"lastUsed"`
+	Mask     IdentifierMaskingDetails `json:"mask"`
 
 	// Name Name of the API key
 	Name string `json:"name"`
@@ -434,8 +475,14 @@ type TemplateBuild struct {
 	// BuildID Identifier of the build
 	BuildID string `json:"buildID"`
 
+	// LogEntries Build logs structured
+	LogEntries []BuildLogEntry `json:"logEntries"`
+
 	// Logs Build logs
 	Logs []string `json:"logs"`
+
+	// Reason Message with the status reason, currently reporting only for error status
+	Reason *string `json:"reason,omitempty"`
 
 	// Status Status of the template
 	Status TemplateBuildStatus `json:"status"`
@@ -446,6 +493,15 @@ type TemplateBuild struct {
 
 // TemplateBuildStatus Status of the template
 type TemplateBuildStatus string
+
+// TemplateBuildFileUpload defines model for TemplateBuildFileUpload.
+type TemplateBuildFileUpload struct {
+	// Present Whether the file is already present in the cache
+	Present bool `json:"present"`
+
+	// Url Url where the file should be uploaded to
+	Url *string `json:"url,omitempty"`
+}
 
 // TemplateBuildRequest defines model for TemplateBuildRequest.
 type TemplateBuildRequest struct {
@@ -461,11 +517,62 @@ type TemplateBuildRequest struct {
 	// MemoryMB Memory for the sandbox in MB
 	MemoryMB *MemoryMB `json:"memoryMB,omitempty"`
 
+	// ReadyCmd Ready check command to execute in the template after the build
+	ReadyCmd *string `json:"readyCmd,omitempty"`
+
 	// StartCmd Start command to execute in the template after the build
 	StartCmd *string `json:"startCmd,omitempty"`
 
 	// TeamID Identifier of the team
 	TeamID *string `json:"teamID,omitempty"`
+}
+
+// TemplateBuildRequestV2 defines model for TemplateBuildRequestV2.
+type TemplateBuildRequestV2 struct {
+	// Alias Alias of the template
+	Alias string `json:"alias"`
+
+	// CpuCount CPU cores for the sandbox
+	CpuCount *CPUCount `json:"cpuCount,omitempty"`
+
+	// MemoryMB Memory for the sandbox in MB
+	MemoryMB *MemoryMB `json:"memoryMB,omitempty"`
+
+	// TeamID Identifier of the team
+	TeamID *string `json:"teamID,omitempty"`
+}
+
+// TemplateBuildStartV2 defines model for TemplateBuildStartV2.
+type TemplateBuildStartV2 struct {
+	// Force Whether the whole build should be forced to run regardless of the cache
+	Force *bool `json:"force,omitempty"`
+
+	// FromImage Image to use as a base for the template build
+	FromImage string `json:"fromImage"`
+
+	// ReadyCmd Ready check command to execute in the template after the build
+	ReadyCmd *string `json:"readyCmd,omitempty"`
+
+	// StartCmd Start command to execute in the template after the build
+	StartCmd *string `json:"startCmd,omitempty"`
+
+	// Steps List of steps to execute in the template build
+	Steps *[]TemplateStep `json:"steps,omitempty"`
+}
+
+// TemplateStep Step in the template build process
+type TemplateStep struct {
+	// Args Arguments for the step
+	Args *[]string `json:"args,omitempty"`
+
+	// FilesHash Hash of the files used in the step
+	FilesHash *string `json:"filesHash,omitempty"`
+
+	// Force Whether the step should be forced to run regardless of the cache
+	Force *bool `json:"force,omitempty"`
+
+	// Type Type of the step
+	Type string `json:"type"`
 }
 
 // TemplateUpdateRequest defines model for TemplateUpdateRequest.
@@ -521,8 +628,8 @@ type GetSandboxesParams struct {
 
 // GetSandboxesMetricsParams defines parameters for GetSandboxesMetrics.
 type GetSandboxesMetricsParams struct {
-	// Metadata Metadata query used to filter the sandboxes (e.g. "user=abc&app=prod"). Each key and values must be URL encoded.
-	Metadata *string `form:"metadata,omitempty" json:"metadata,omitempty"`
+	// SandboxIds Comma-separated list of sandbox IDs to get metrics for
+	SandboxIds []string `form:"sandbox_ids" json:"sandbox_ids"`
 }
 
 // GetSandboxesSandboxIDLogsParams defines parameters for GetSandboxesSandboxIDLogs.
@@ -532,6 +639,13 @@ type GetSandboxesSandboxIDLogsParams struct {
 
 	// Limit Maximum number of logs that should be returned
 	Limit *int32 `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetSandboxesSandboxIDMetricsParams defines parameters for GetSandboxesSandboxIDMetrics.
+type GetSandboxesSandboxIDMetricsParams struct {
+	// Start Starting timestamp of the metrics that should be returned in milliseconds
+	Start *int64 `form:"start,omitempty" json:"start,omitempty"`
+	End   *int64 `form:"end,omitempty" json:"end,omitempty"`
 }
 
 // PostSandboxesSandboxIDRefreshesJSONBody defines parameters for PostSandboxesSandboxIDRefreshes.
@@ -554,7 +668,8 @@ type GetTemplatesParams struct {
 // GetTemplatesTemplateIDBuildsBuildIDStatusParams defines parameters for GetTemplatesTemplateIDBuildsBuildIDStatus.
 type GetTemplatesTemplateIDBuildsBuildIDStatusParams struct {
 	// LogsOffset Index of the starting build log that should be returned with the template
-	LogsOffset *int32 `form:"logsOffset,omitempty" json:"logsOffset,omitempty"`
+	LogsOffset *int32    `form:"logsOffset,omitempty" json:"logsOffset,omitempty"`
+	Level      *LogLevel `form:"level,omitempty" json:"level,omitempty"`
 }
 
 // GetV2SandboxesParams defines parameters for GetV2Sandboxes.
@@ -604,3 +719,9 @@ type PatchTemplatesTemplateIDJSONRequestBody = TemplateUpdateRequest
 
 // PostTemplatesTemplateIDJSONRequestBody defines body for PostTemplatesTemplateID for application/json ContentType.
 type PostTemplatesTemplateIDJSONRequestBody = TemplateBuildRequest
+
+// PostV2TemplatesJSONRequestBody defines body for PostV2Templates for application/json ContentType.
+type PostV2TemplatesJSONRequestBody = TemplateBuildRequestV2
+
+// PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody defines body for PostV2TemplatesTemplateIDBuildsBuildID for application/json ContentType.
+type PostV2TemplatesTemplateIDBuildsBuildIDJSONRequestBody = TemplateBuildStartV2

--- a/tests/integration/internal/tests/api/templates/build_template_test.go
+++ b/tests/integration/internal/tests/api/templates/build_template_test.go
@@ -1,0 +1,291 @@
+package api_templates
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/tests/integration/internal/api"
+	"github.com/e2b-dev/infra/tests/integration/internal/setup"
+	"github.com/e2b-dev/infra/tests/integration/internal/utils"
+)
+
+const (
+	EnableDebugLogs = false
+
+	ForceBaseBuild = false
+	BuildTimeout   = 5 * time.Minute
+)
+
+type BuildLogHandler func(alias string, entry api.BuildLogEntry)
+
+func buildTemplate(
+	tb testing.TB,
+	templateAlias string,
+	data api.TemplateBuildStartV2,
+	logHandler BuildLogHandler,
+) bool {
+	tb.Helper()
+
+	ctx, cancel := context.WithTimeout(tb.Context(), BuildTimeout)
+	defer cancel()
+
+	c := setup.GetAPIClient()
+
+	// Request build
+	resp, err := c.PostV2TemplatesWithResponse(ctx, api.TemplateBuildRequestV2{
+		Alias:    templateAlias,
+		CpuCount: utils.ToPtr[int32](2),
+		MemoryMB: utils.ToPtr[int32](1024),
+	}, setup.WithAPIKey())
+	require.NoError(tb, err)
+	require.Equal(tb, http.StatusAccepted, resp.StatusCode())
+	require.NotNil(tb, resp.JSON202)
+
+	// Start build
+	startResp, err := c.PostV2TemplatesTemplateIDBuildsBuildIDWithResponse(
+		ctx,
+		resp.JSON202.TemplateID,
+		resp.JSON202.BuildID,
+		data,
+		setup.WithAPIKey(),
+	)
+	require.NoError(tb, err)
+	assert.Equal(tb, http.StatusAccepted, startResp.StatusCode())
+
+	logLevel := api.LogLevelInfo
+	if EnableDebugLogs {
+		logLevel = api.LogLevelDebug
+	}
+
+	// Check build status
+	offset := 0
+	for {
+		statusResp, err := c.GetTemplatesTemplateIDBuildsBuildIDStatusWithResponse(
+			ctx,
+			resp.JSON202.TemplateID,
+			resp.JSON202.BuildID,
+			&api.GetTemplatesTemplateIDBuildsBuildIDStatusParams{
+				LogsOffset: utils.ToPtr(int32(offset)),
+				Level:      &logLevel,
+			},
+			setup.WithAPIKey(),
+		)
+		require.NoError(tb, err)
+		assert.Equal(tb, http.StatusOK, statusResp.StatusCode())
+		require.NotNil(tb, statusResp.JSON200)
+
+		offset += len(statusResp.JSON200.LogEntries)
+		for _, entry := range statusResp.JSON200.LogEntries {
+			logHandler(templateAlias, entry)
+		}
+
+		switch statusResp.JSON200.Status {
+		case api.TemplateBuildStatusReady:
+			tb.Log("Build completed successfully")
+			return true
+		case api.TemplateBuildStatusError:
+			tb.Fatalf("Build failed: %v", statusResp.JSON200.Reason)
+			return false
+		}
+
+		time.Sleep(time.Second)
+	}
+}
+
+func defaultBuildLogHandler(tb testing.TB) BuildLogHandler {
+	tb.Helper()
+
+	return func(alias string, entry api.BuildLogEntry) {
+		tb.Logf("%s: [%s] %s", alias, entry.Level, entry.Message)
+	}
+}
+
+func TestTemplateBuildRUN(t *testing.T) {
+	testCases := []struct {
+		name         string
+		templateName string
+		buildConfig  api.TemplateBuildStartV2
+	}{
+		{
+			name:         "Single RUN command",
+			templateName: "test-ubuntu-run",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "RUN",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"echo 'Hello, World!'"}),
+					},
+				}),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, buildTemplate(t, tc.templateName, tc.buildConfig, defaultBuildLogHandler(t)))
+		})
+	}
+}
+
+func TestTemplateBuildENV(t *testing.T) {
+	testCases := []struct {
+		name         string
+		templateName string
+		buildConfig  api.TemplateBuildStartV2
+	}{
+		{
+			name:         "ENV variable persistence",
+			templateName: "test-ubuntu-env",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"ENV_VAR", "Hello, World!"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{": \"${ENV_VAR:?ENV_VAR is not set or empty}\"; echo \"$ENV_VAR\""}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV variable persistence for start command",
+			templateName: "test-ubuntu-env-start",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"ENV_VAR", "Hello, World!"}),
+					},
+				}),
+				StartCmd: utils.ToPtr(": \"${ENV_VAR:?ENV_VAR is not set or empty}\"; echo \"$ENV_VAR\""),
+				ReadyCmd: utils.ToPtr("sleep 5"),
+			},
+		},
+		{
+			name:         "ENV variable recursive",
+			templateName: "test-ubuntu-env-recursive",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"PATH", "${PATH}:/my/path"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{"[[ \"$PATH\" == *:/my/path ]] || exit 1"}),
+					},
+				}),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, buildTemplate(t, tc.templateName, tc.buildConfig, defaultBuildLogHandler(t)))
+		})
+	}
+}
+
+func TestTemplateBuildWORKDIR(t *testing.T) {
+	testCases := []struct {
+		name         string
+		templateName string
+		buildConfig  api.TemplateBuildStartV2
+	}{
+		{
+			name:         "WORKDIR persistence",
+			templateName: "test-ubuntu-workdir-persistence",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "WORKDIR",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"/app"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{"[[ \"$(pwd)\" == \"/app\" ]] || exit 1"}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "WORKDIR persistence in start command",
+			templateName: "test-ubuntu-workdir-start",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: "ubuntu:22.04",
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "WORKDIR",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"/app"}),
+					},
+				}),
+				StartCmd: utils.ToPtr("[[ \"$(pwd)\" == \"/app\" ]] || exit 1"),
+				ReadyCmd: utils.ToPtr("sleep 5"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, buildTemplate(t, tc.templateName, tc.buildConfig, defaultBuildLogHandler(t)))
+		})
+	}
+}
+
+func TestTemplateBuildCache(t *testing.T) {
+	alias := "test-ubuntu-cache"
+	template := api.TemplateBuildStartV2{
+		FromImage: "ubuntu:22.04",
+		Steps: utils.ToPtr([]api.TemplateStep{
+			{
+				Type: "ENV",
+				Args: utils.ToPtr([]string{"ENV_VAR", "Hello, World!"}),
+			},
+			{
+				Type: "RUN",
+				Args: utils.ToPtr([]string{": \"${ENV_VAR:?ENV_VAR is not set or empty}\"; echo \"$ENV_VAR\""}),
+			},
+		}),
+	}
+
+	assert.True(t, buildTemplate(t, alias, template, defaultBuildLogHandler(t)))
+
+	messages := make([]string, 0)
+	assert.True(t, buildTemplate(t, alias, template, func(alias string, entry api.BuildLogEntry) {
+		messages = append(messages, entry.Message)
+		defaultBuildLogHandler(t)(alias, entry)
+	}))
+	assert.Condition(t, func() bool {
+		for _, msg := range messages {
+			if strings.Contains(msg, "CACHED [builder 1/2] ENV ENV_VAR Hello, World!") {
+				return true
+			}
+		}
+		return false
+	}, "Expected to contain cached ENV layer")
+}

--- a/tests/integration/internal/tests/api/templates/request_build_test.go
+++ b/tests/integration/internal/tests/api/templates/request_build_test.go
@@ -11,18 +11,15 @@ import (
 
 	"github.com/e2b-dev/infra/tests/integration/internal/api"
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
+	"github.com/e2b-dev/infra/tests/integration/internal/utils"
 )
-
-func int32Pointer(i int32) *int32 {
-	return &i
-}
 
 func TestRequestTemplateBuild(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(2),
-		MemoryMB: int32Pointer(1024),
+		CpuCount: utils.ToPtr[int32](2),
+		MemoryMB: utils.ToPtr[int32](1024),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusAccepted, resp.StatusCode())
@@ -32,8 +29,8 @@ func TestRequestTemplateTooLowCPU(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(0),
-		MemoryMB: int32Pointer(1024),
+		CpuCount: utils.ToPtr[int32](0),
+		MemoryMB: utils.ToPtr[int32](1024),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -44,8 +41,8 @@ func TestRequestTemplateTooLowRAM(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(2),
-		MemoryMB: int32Pointer(32),
+		CpuCount: utils.ToPtr[int32](2),
+		MemoryMB: utils.ToPtr[int32](32),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -56,8 +53,8 @@ func TestRequestTemplateTooHighCPU(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(1024),
-		MemoryMB: int32Pointer(1024),
+		CpuCount: utils.ToPtr[int32](1024),
+		MemoryMB: utils.ToPtr[int32](1024),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -68,8 +65,8 @@ func TestRequestTemplateTooHighMemory(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(2),
-		MemoryMB: int32Pointer(1024 * 1024),
+		CpuCount: utils.ToPtr[int32](2),
+		MemoryMB: utils.ToPtr[int32](1024 * 1024),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())
@@ -80,8 +77,8 @@ func TestRequestTemplateMemoryNonDivisibleBy2(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	resp, err := c.PostTemplatesWithResponse(t.Context(), api.TemplateBuildRequest{
-		CpuCount: int32Pointer(2),
-		MemoryMB: int32Pointer(1001),
+		CpuCount: utils.ToPtr[int32](2),
+		MemoryMB: utils.ToPtr[int32](1001),
 	}, setup.WithAccessToken())
 	assert.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode())

--- a/tests/integration/internal/utils/ptr.go
+++ b/tests/integration/internal/utils/ptr.go
@@ -1,0 +1,5 @@
+package utils
+
+func ToPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
Add basic template building tests to the integration testing in the CI. More tests and edge cases will follow as part of future PRs

Fixes also Data Race in the
`func (c *TemplatesBuildCache) SetStatus(buildID uuid.UUID, status envbuild.Status, reason *string)`
method when setting the status while requesting the item in
`(c *TemplatesBuildCache) Get(ctx context.Context, buildID uuid.UUID, templateID string) (TemplateBuildInfo, error)`

- [x] Depends on https://github.com/e2b-dev/infra/pull/885 as it fixes critical issues tested in the included tests