### PR TITLE
Docs: Remove dashboard domain setting instructions from self-host documentation

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -105,11 +105,6 @@ When using CLI you can pass domain as well
 E2B_DOMAIN=<your-domain> e2b <command>
 ```
 
-#### Dashboard
-
-You can also set your domain in the dashboard at [Developer settings](https://e2b.dev/dashboard?tab=developer)
-
-
 #### Monitoring and logging jobs
 
 To access the nomad web UI, go to https://nomad.<your-domain.com>. Go to sign in, and when prompted for an API token, you can find this in GCP Secrets Manager. From here, you can see nomad jobs and tasks for both client and server, including logging.


### PR DESCRIPTION
The self-host.md was outdated, since the Dashboard has no Developer Settings anymore.