### PR TITLE
Fix data race in DiffStore cache eviction

### DIFF
--- a/packages/orchestrator/internal/sandbox/build/cache_test.go
+++ b/packages/orchestrator/internal/sandbox/build/cache_test.go
@@ -1,8 +1,22 @@
 package build
 
+// Race Condition Tests:
+// To reproduce the data race condition reported in the cache eviction callbacks,
+// run the following tests with the race detector enabled:
+//
+// Run all race tests:    go test -race -v -run "TestDiffStore.*Race"
+// Run first race test:   go test -race -v -run TestDiffStoreConcurrentEvictionRace
+// Run second race test:  go test -race -v -run TestDiffStoreResetDeleteRace
+//
+// These tests simulate the race condition where multiple OnEviction callbacks
+// run concurrently and both try to access the same key in the resetDelete method,
+// causing a race when closing the cancel channel.
+
 import (
 	"context"
+	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -275,4 +289,148 @@ func TestDiffStoreOldestFromCache(t *testing.T) {
 
 	found = store.Has(diff3)
 	assert.True(t, found)
+}
+
+// TestDiffStoreConcurrentEvictionRace simulates the data race condition where
+// multiple eviction callbacks run concurrently and both try to close the same
+// cancel channel in resetDelete method. This test should be run with the race
+// detector enabled: go test -race
+func TestDiffStoreConcurrentEvictionRace(t *testing.T) {
+	cachePath := createTempDir(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Use very short TTL and delay to trigger rapid evictions
+	ttl := 10 * time.Millisecond
+	delay := 50 * time.Millisecond
+	store, err := NewDiffStore(
+		ctx,
+		cachePath,
+		ttl,
+		delay,
+		0.0, // Set to 0% to trigger disk space evictions
+	)
+	t.Cleanup(store.Close)
+	assert.NoError(t, err)
+
+	// Number of concurrent operations to create race conditions
+	numGoroutines := 50
+	numIterations := 100
+
+	var wg sync.WaitGroup
+
+	// Create multiple goroutines that add and remove items rapidly
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(goroutineID int) {
+			defer wg.Done()
+
+			for j := 0; j < numIterations; j++ {
+				// Create diffs with same buildID but different iterations
+				// This increases chances of race conditions
+				buildID := fmt.Sprintf("build-%d", goroutineID%10) // Limit to 10 different build IDs
+				diff := newDiff(t, cachePath, buildID, Rootfs, blockSize)
+
+				// Add to store
+				store.Add(diff)
+
+				// Small delay to allow TTL expiration and concurrent access
+				time.Sleep(time.Microsecond * 100)
+
+				// Try to trigger manual deletion which can race with TTL eviction
+				if j%10 == 0 {
+					store.deleteOldestFromCache()
+				}
+
+				// Occasionally try to access the item, which calls resetDelete
+				if j%5 == 0 {
+					store.Get(diff)
+				}
+			}
+		}(i)
+	}
+
+	// Additional goroutine that continuously tries to delete oldest items
+	// to increase race condition probability
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numIterations*2; i++ {
+			store.deleteOldestFromCache()
+			time.Sleep(time.Microsecond * 50)
+		}
+	}()
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+
+	// Allow some time for pending deletions to complete
+	time.Sleep(delay * 2)
+
+	// Test passes if no race condition panic occurs
+	// The race detector will catch the race if it occurs
+}
+
+// TestDiffStoreResetDeleteRace specifically targets the resetDelete method
+// race condition by simulating the exact scenario from the race report
+func TestDiffStoreResetDeleteRace(t *testing.T) {
+	cachePath := createTempDir(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Very short TTL to trigger evictions quickly
+	ttl := 5 * time.Millisecond
+	delay := 100 * time.Millisecond
+	store, err := NewDiffStore(
+		ctx,
+		cachePath,
+		ttl,
+		delay,
+		100.0,
+	)
+	t.Cleanup(store.Close)
+	assert.NoError(t, err)
+
+	// Create a base build ID for generating test diffs
+	buildID := "race-test-build"
+
+	var wg sync.WaitGroup
+	const numConcurrentOps = 100
+
+	// Simulate the exact race condition:
+	// 1. Add item to cache
+	// 2. Schedule it for deletion (creates entry in pdSizes)
+	// 3. Multiple goroutines try to reset the deletion simultaneously
+
+	for i := 0; i < numConcurrentOps; i++ {
+		wg.Add(1)
+		go func(iteration int) {
+			defer wg.Done()
+
+			// Create a unique diff for this iteration to increase concurrency
+			iterDiff := newDiff(t, cachePath, fmt.Sprintf("%s-%d", buildID, iteration), Rootfs, blockSize)
+
+			// Add to store
+			store.Add(iterDiff)
+
+			// Immediately schedule for deletion to populate pdSizes
+			store.scheduleDelete(iterDiff.CacheKey(), 1024)
+
+			// Small random delay to desynchronize goroutines slightly
+			time.Sleep(time.Duration(iteration%10) * time.Microsecond)
+
+			// This call to Get() will trigger resetDelete, which is where the race occurs
+			// Multiple goroutines calling resetDelete on the same key can race
+			store.Get(iterDiff)
+
+			// Also try direct resetDelete calls to increase race probability
+			store.resetDelete(iterDiff.CacheKey())
+		}(i)
+	}
+
+	// Wait for all goroutines
+	wg.Wait()
+
+	// Allow cleanup to complete
+	time.Sleep(delay * 2)
 }


### PR DESCRIPTION
Fix data race in DiffStore cache eviction. The main data race was caused by reusing the same `err` variable from the outer scope.