### PR TITLE
Fix envd symlink resolution

### DIFF
--- a/packages/envd/internal/services/filesystem/dir.go
+++ b/packages/envd/internal/services/filesystem/dir.go
@@ -156,14 +156,16 @@ func walkDir(requestedPath string, dirPath string, depth int) (entries []*rpc.En
 			return filepath.SkipDir
 		}
 
-		fileInfo, err := entry.Info()
-		if err != nil {
+		entryInfo, err := entryInfo(path)
+		if entry == nil {
 			return err
 		}
 
 		// Return the requested path as the base path instead of the symlink-resolved path
 		path = filepath.Join(requestedPath, relPath)
-		entries = append(entries, entryInfoFromFileInfo(fileInfo, path))
+		entryInfo.Path = path
+
+		entries = append(entries, entryInfo)
 		return nil
 	})
 	if err != nil {

--- a/packages/envd/internal/services/filesystem/move.go
+++ b/packages/envd/internal/services/filesystem/move.go
@@ -28,7 +28,7 @@ func (Service) Move(ctx context.Context, req *connect.Request[rpc.MoveRequest]) 
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	entry, err := os.Stat(source)
+	entry, err := os.Lstat(source)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("source path not found: %w", err))

--- a/packages/envd/internal/services/filesystem/move.go
+++ b/packages/envd/internal/services/filesystem/move.go
@@ -28,15 +28,6 @@ func (Service) Move(ctx context.Context, req *connect.Request[rpc.MoveRequest]) 
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	entry, err := os.Lstat(source)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("source path not found: %w", err))
-		}
-
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error statting source: %w", err))
-	}
-
 	uid, gid, userErr := permissions.GetUserIds(u)
 	if userErr != nil {
 		return nil, connect.NewError(connect.CodeInternal, userErr)
@@ -52,7 +43,12 @@ func (Service) Move(ctx context.Context, req *connect.Request[rpc.MoveRequest]) 
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error renaming: %w", err))
 	}
 
+	entry, err := entryInfo(destination)
+	if err != nil {
+		return nil, err
+	}
+
 	return connect.NewResponse(&rpc.MoveResponse{
-		Entry: entryInfoFromFileInfo(entry, destination),
+		Entry: entry,
 	}), nil
 }

--- a/packages/envd/internal/services/filesystem/stat.go
+++ b/packages/envd/internal/services/filesystem/stat.go
@@ -22,7 +22,7 @@ func (Service) Stat(ctx context.Context, req *connect.Request[rpc.StatRequest]) 
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	fileInfo, err := os.Stat(path)
+	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("file not found: %w", err))

--- a/packages/envd/internal/services/filesystem/stat.go
+++ b/packages/envd/internal/services/filesystem/stat.go
@@ -2,8 +2,6 @@ package filesystem
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"connectrpc.com/connect"
 
@@ -22,14 +20,10 @@ func (Service) Stat(ctx context.Context, req *connect.Request[rpc.StatRequest]) 
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
-	fileInfo, err := os.Lstat(path)
+	entry, err := entryInfo(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("file not found: %w", err))
-		}
-
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error statting file: %w", err))
+		return nil, err
 	}
 
-	return connect.NewResponse(&rpc.StatResponse{Entry: entryInfoFromFileInfo(fileInfo, path)}), nil
+	return connect.NewResponse(&rpc.StatResponse{Entry: entry}), nil
 }

--- a/packages/envd/internal/services/filesystem/stat_test.go
+++ b/packages/envd/internal/services/filesystem/stat_test.go
@@ -1,0 +1,91 @@
+package filesystem
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/envd/internal/services/spec/filesystem"
+)
+
+func TestStat(t *testing.T) {
+	t.Parallel()
+
+	// Setup temp root and user
+	root := t.TempDir()
+	// Get the actual path to the temp directory (symlinks can cause issues)
+	root, err := filepath.EvalSymlinks(root)
+	require.NoError(t, err)
+
+	u, err := user.Current()
+	require.NoError(t, err)
+
+	group, err := user.LookupGroupId(u.Gid)
+	require.NoError(t, err)
+
+	// Setup directory structure
+	testFolder := filepath.Join(root, "test")
+	err = os.MkdirAll(testFolder, 0o755)
+
+	testFile := filepath.Join(testFolder, "file.txt")
+	err = os.WriteFile(testFile, []byte("Hello, World!"), 0o644)
+	require.NoError(t, err)
+
+	linkedFile := filepath.Join(testFolder, "linked-file.txt")
+	err = os.Symlink(testFile, linkedFile)
+	require.NoError(t, err)
+
+	// Service instance
+	svc := Service{}
+
+	// Helper to inject user into context
+	injectUser := func(ctx context.Context, u *user.User) context.Context {
+		return authn.SetInfo(ctx, u)
+	}
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "Stat file directory",
+			path: testFile,
+		},
+		{
+			name: "Stat symlink to file",
+			path: linkedFile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := injectUser(context.Background(), u)
+			req := connect.NewRequest(&filesystem.StatRequest{
+				Path: tt.path,
+			})
+			resp, err := svc.Stat(ctx, req)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.Msg)
+			require.NotNil(t, resp.Msg.Entry)
+			assert.Equal(t, tt.path, resp.Msg.Entry.Path)
+			assert.Equal(t, filesystem.FileType_FILE_TYPE_FILE, resp.Msg.Entry.Type)
+			assert.Equal(t, u.Username, resp.Msg.Entry.Owner)
+			assert.Equal(t, group.Name, resp.Msg.Entry.Group)
+			assert.Equal(t, uint32(0o644), resp.Msg.Entry.Mode)
+			if tt.path == linkedFile {
+				require.NotNil(t, resp.Msg.Entry.SymlinkTarget)
+				assert.Equal(t, testFile, *resp.Msg.Entry.SymlinkTarget)
+			} else {
+				assert.Empty(t, resp.Msg.Entry.SymlinkTarget)
+			}
+
+		})
+	}
+}

--- a/packages/envd/internal/services/filesystem/stat_test.go
+++ b/packages/envd/internal/services/filesystem/stat_test.go
@@ -85,7 +85,6 @@ func TestStat(t *testing.T) {
 			} else {
 				assert.Empty(t, resp.Msg.Entry.SymlinkTarget)
 			}
-
 		})
 	}
 }

--- a/packages/envd/internal/services/filesystem/stat_test.go
+++ b/packages/envd/internal/services/filesystem/stat_test.go
@@ -33,6 +33,7 @@ func TestStat(t *testing.T) {
 	// Setup directory structure
 	testFolder := filepath.Join(root, "test")
 	err = os.MkdirAll(testFolder, 0o755)
+	require.NoError(t, err)
 
 	testFile := filepath.Join(testFolder, "file.txt")
 	err = os.WriteFile(testFile, []byte("Hello, World!"), 0o644)

--- a/packages/envd/internal/services/filesystem/utils.go
+++ b/packages/envd/internal/services/filesystem/utils.go
@@ -49,6 +49,7 @@ func getFileOwnership(fileInfo os.FileInfo) (owner, group string) {
 }
 
 func entryInfo(path string) (*rpc.EntryInfo, error) {
+	// Get file info using Lstat to handle symlinks correctly
 	fileInfo, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/packages/envd/internal/services/filesystem/utils.go
+++ b/packages/envd/internal/services/filesystem/utils.go
@@ -61,8 +61,11 @@ func entryInfoFromFileInfo(fileInfo os.FileInfo, path string) *rpc.EntryInfo {
 	}
 
 	var entryType rpc.FileType
+	var mode uint32
+
 	if symlinkTarget == nil {
 		entryType = getEntryType(fileMode)
+		mode = uint32(fileMode.Perm())
 	} else {
 		// If it's a symlink, we need to determine the type of the target
 		targetInfo, err := os.Stat(*symlinkTarget)
@@ -70,6 +73,7 @@ func entryInfoFromFileInfo(fileInfo os.FileInfo, path string) *rpc.EntryInfo {
 			entryType = rpc.FileType_FILE_TYPE_UNSPECIFIED
 		} else {
 			entryType = getEntryType(targetInfo.Mode())
+			mode = uint32(targetInfo.Mode().Perm())
 		}
 	}
 
@@ -78,7 +82,7 @@ func entryInfoFromFileInfo(fileInfo os.FileInfo, path string) *rpc.EntryInfo {
 		Type:          entryType,
 		Path:          path,
 		Size:          fileInfo.Size(),
-		Mode:          uint32(fileMode.Perm()),
+		Mode:          mode,
 		Permissions:   fileMode.String(),
 		Owner:         owner,
 		Group:         group,

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.2.5"
+	Version = "0.2.6"
 
 	commitSHA string
 


### PR DESCRIPTION
# Description

os.Stat gives information about resolved symlinks, that caused issues with `symlinkTarget` for `Stat` method.
Refactor the entryInfo method to prevent such bugs