### PR TITLE
Use context.WithoutCancel instead of context.Background

### DIFF
--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -85,8 +85,8 @@ func (s *server) Create(ctxConn context.Context, req *orchestrator.SandboxCreate
 	}
 
 	s.sandboxes.Insert(req.Sandbox.SandboxId, sbx)
-	go func() {
-		ctx, childSpan := s.tracer.Start(context.Background(), "sandbox-create-stop")
+	go func(ctx context.Context) {
+		ctx, childSpan := s.tracer.Start(ctx, "sandbox-create-stop")
 		defer childSpan.End()
 
 		waitErr := sbx.Wait(ctx)
@@ -118,7 +118,7 @@ func (s *server) Create(ctxConn context.Context, req *orchestrator.SandboxCreate
 		s.proxy.RemoveFromPool(sbx.Config.ExecutionId)
 
 		sbxlogger.E(sbx).Info("Sandbox killed")
-	}()
+	}(context.WithoutCancel(ctx))
 
 	return &orchestrator.SandboxCreateResponse{
 		ClientId: s.info.ClientId,
@@ -248,11 +248,11 @@ func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 		return nil, status.Errorf(codes.Internal, "error creating template files: %s", err)
 	}
 
-	defer func() {
+	defer func(ctx context.Context) {
 		// sbx.Stop sometimes blocks for several seconds,
 		// so we don't want to block the request and do the cleanup in a goroutine after we already removed sandbox from cache and proxy.
 		go func() {
-			ctx, childSpan := s.tracer.Start(context.Background(), "sandbox-pause-stop")
+			ctx, childSpan := s.tracer.Start(ctx, "sandbox-pause-stop")
 			defer childSpan.End()
 
 			err := sbx.Stop(ctx)
@@ -260,7 +260,7 @@ func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 				sbxlogger.I(sbx).Error("error stopping sandbox after snapshot", logger.WithSandboxID(in.SandboxId), zap.Error(err))
 			}
 		}()
-	}()
+	}(context.WithoutCancel(ctx))
 
 	snapshot, err := sbx.Pause(ctx, s.tracer, snapshotTemplateFiles)
 	if err != nil {
@@ -288,14 +288,14 @@ func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 
 	telemetry.ReportEvent(ctx, "added snapshot to template cache")
 
-	go func() {
-		err := snapshot.Upload(context.Background(), s.persistence, snapshotTemplateFiles.TemplateFiles)
+	go func(ctx context.Context) {
+		err := snapshot.Upload(ctx, s.persistence, snapshotTemplateFiles.TemplateFiles)
 		if err != nil {
 			sbxlogger.I(sbx).Error("error uploading sandbox snapshot", zap.Error(err))
 
 			return
 		}
-	}()
+	}(context.WithoutCancel(ctx))
 
 	return &emptypb.Empty{}, nil
 }

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -133,16 +133,16 @@ func (b *Builder) Build(ctx context.Context, finalMetadata storage.TemplateFiles
 
 	postProcessor.Info(fmt.Sprintf("Building template %s/%s", finalMetadata.TemplateID, finalMetadata.BuildID))
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if e == nil {
 			return
 		}
 		// Remove build files if build fails
-		removeErr := b.templateStorage.DeleteObjectsWithPrefix(context.Background(), finalMetadata.BuildID)
+		removeErr := b.templateStorage.DeleteObjectsWithPrefix(ctx, finalMetadata.BuildID)
 		if removeErr != nil {
 			e = errors.Join(e, fmt.Errorf("error removing build files: %w", removeErr))
 		}
-	}()
+	}(context.WithoutCancel(ctx))
 
 	envdVersion, err := envd.GetEnvdVersion(ctx)
 	if err != nil {

--- a/packages/orchestrator/internal/template/server/create_template.go
+++ b/packages/orchestrator/internal/template/server/create_template.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -84,10 +83,11 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 	logger := zap.New(core)
 
 	s.wg.Add(1)
-	go func() {
+	go func(ctx context.Context) {
 		defer s.wg.Done()
-		buildContext, cancelBuildContext := context.WithCancel(context.Background())
-		defer cancelBuildContext()
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
 
 		defer func() {
 			if r := recover(); r != nil {
@@ -95,27 +95,24 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 			}
 		}()
 
-		buildContext, buildSpan := s.tracer.Start(
-			trace.ContextWithSpanContext(buildContext, childSpan.SpanContext()),
-			"template-background-build",
-		)
+		ctx, buildSpan := s.tracer.Start(ctx, "template-background-build")
 		defer buildSpan.End()
 
 		// Watch for build cancellation requests
 		go func() {
 			select {
-			case <-buildContext.Done():
+			case <-ctx.Done():
 				return
 			case <-buildInfo.Result.Done:
 				res, _ := buildInfo.Result.Result()
 				if res.Status == templatemanager.TemplateBuildState_Failed {
-					cancelBuildContext()
+					cancel()
 				}
 				return
 			}
 		}()
 
-		res, err := s.builder.Build(buildContext, metadata, template, logger)
+		res, err := s.builder.Build(ctx, metadata, template, logger)
 		_ = logger.Sync()
 		if err != nil {
 			telemetry.ReportCriticalError(ctx, "error while building template", err)
@@ -126,9 +123,9 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 				RootfsSizeKey:  int32(res.RootfsSizeMB),
 				EnvdVersionKey: res.EnvdVersion,
 			})
-			telemetry.ReportEvent(buildContext, "Environment built")
+			telemetry.ReportEvent(ctx, "Environment built")
 		}
-	}()
+	}(context.WithoutCancel(ctx))
 
 	return nil, nil
 }


### PR DESCRIPTION
This helps to preserve metadata such as tracing, logging, etc.