### PR TITLE
Increase inotify watch limit in the provision script

### DIFF
--- a/packages/orchestrator/internal/template/build/provision.sh
+++ b/packages/orchestrator/internal/template/build/provision.sh
@@ -74,6 +74,9 @@ fallocate -l 128M /swap/swapfile
 chmod 600 /swap/swapfile
 mkswap /swap/swapfile
 
+echo "Increasing inotify watch limit"
+echo 'fs.inotify.max_user_watches=65536' | sudo tee -a /etc/sysctl.conf
+
 echo "Don't wait for ttyS0 (serial console kernel logs)"
 # This is required when the Firecracker kernel args has specified console=ttyS0
 systemctl mask serial-getty@ttyS0.service


### PR DESCRIPTION
# Description

Increase the max user watches settings to `65536` from current `8192`.

If you try to watch the root directory for `base` template you will get following error:
```
no space left on device
```

When you try to run 
```
sudo inotifywatch -v -t 1 -r /
```

it returns 
```
Establishing watches...
Setting up watch(es) on /
Failed to watch /; upper limit on inotify watches reached!
Please increase the amount of inotify watches allowed per user via `/proc/sys/fs/inotify/max_user_watches'.
```

After increasing it
```
Establishing watches...
Setting up watch(es) on /
OK, / is now being watched.
Total of 8286 watches.
```

This is for base template, code interpreter has around 16k