### PR TITLE
Ensure workdir exists before running a command

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -88,6 +88,11 @@ func New(
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
+	// Check if the cwd resolved path exists
+	if _, err := os.Stat(resolvedPath); errors.Is(err, os.ErrNotExist) {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("cwd '%s' does not exist", resolvedPath))
+	}
+
 	cmd.Dir = resolvedPath
 
 	var formattedVars []string

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.2.7"
+	Version = "0.2.8"
 
 	commitSHA string
 


### PR DESCRIPTION
Ensure the working directory exists before executing any command. Running commands in a non-existent directory can cause unpredictable behavior, including silent failures, incorrect error messages, or commands executing in unexpected locations (such as the parent directory or system root).

This solution fails immediately when the directory doesn't exist to communicate the reason to the user. This a difference from how Dockerfile behaves, but keeps the behavior clear as it's a bit unexpected situation.