### PR TITLE
Update fsnotify 

### DIFF
--- a/packages/envd/go.mod
+++ b/packages/envd/go.mod
@@ -7,7 +7,7 @@ require (
 	connectrpc.com/connect v1.18.1
 	connectrpc.com/cors v0.1.0
 	github.com/creack/pty v1.1.23
-	github.com/e2b-dev/fsnotify v0.0.0-20241216145137-2fe5d32bcb51
+	github.com/e2b-dev/fsnotify v0.0.1
 	github.com/e2b-dev/infra/packages/shared v0.0.0
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/google/uuid v1.6.0

--- a/packages/envd/go.sum
+++ b/packages/envd/go.sum
@@ -23,8 +23,8 @@ github.com/dchest/uniuri v1.2.0/go.mod h1:fSzm4SLHzNZvWLvWJew423PhAzkpNQYq+uNLq4
 github.com/dprotaso/go-yit v0.0.0-20191028211022-135eb7262960/go.mod h1:9HQzr9D/0PGwMEbC3d5AB7oi67+h4TsQqItC1GVYG58=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 h1:PRxIJD8XjimM5aTknUK9w6DHLDox2r2M3DI4i2pnd3w=
 github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5qlB+mlV1okblJqcSMtR4c52UKxDiX9GRBS8+Q=
-github.com/e2b-dev/fsnotify v0.0.0-20241216145137-2fe5d32bcb51 h1:eo4W23CTT43LdwJ5i+CCYZrsu/c4BkK7JGG5ozrwNuA=
-github.com/e2b-dev/fsnotify v0.0.0-20241216145137-2fe5d32bcb51/go.mod h1:49MToyZ6q0q2rwa5A77Gdh9p3gqmoID22vEJeAYyNDs=
+github.com/e2b-dev/fsnotify v0.0.1 h1:7j0I98HD6VehAuK/bcslvW4QDynAULtOuMZtImihjVk=
+github.com/e2b-dev/fsnotify v0.0.1/go.mod h1:jAuDjregRrUixKneTRQwPI847nNuPFg3+n5QM/ku/JM=
 github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0omw=
 github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.2.8"
+	Version = "0.2.9"
 
 	commitSHA string
 


### PR DESCRIPTION
This pull request includes a couple of small changes in fsnotify, namely:
- Skip the folder in recursive mode if the user doesn't have permissions
 e2b-dev/fsnotify#3

- inotify: fix race when adding/removing watches while a watched path is being
  deleted fsnotify/fsnotify#678, fsnotify/fsnotify#686

- inotify: don't send empty event if a watched path is unmounted fsnotify/fsnotify#655

- inotify: don't register duplicate watches when watching both a symlink and its
  target; previously that would get "half-added" and removing the second would
  panic fsnotify/fsnotify#679