### PR TITLE
Add user agent header

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -94,6 +94,7 @@ func NewGinServer(ctx context.Context, tel *telemetry.Client, logger *zap.Logger
 		"Origin",
 		"Content-Length",
 		"Content-Type",
+		"User-Agent",
 		// API Key header
 		"Authorization",
 		"X-API-Key",


### PR DESCRIPTION
This pull request includes a small change to the `NewGinServer` function in `packages/api/main.go`. The change adds support for the `User-Agent` header in the list of allowed headers.