### PR TITLE
Make metrics long sandbox ID compatible

### DIFF
--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/auth"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
+	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -21,6 +22,7 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 	ctx := c.Request.Context()
 	ctx, span := a.Tracer.Start(ctx, "sandbox-metrics")
 	defer span.End()
+	sandboxID = utils.ShortID(sandboxID)
 
 	team := c.Value(auth.TeamContextKey).(authcache.AuthTeamInfo).Team
 

--- a/packages/api/internal/handlers/sandboxes_list_metrics.go
+++ b/packages/api/internal/handlers/sandboxes_list_metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/auth"
 	authcache "github.com/e2b-dev/infra/packages/api/internal/cache/auth"
+	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -27,6 +28,10 @@ func (a *APIStore) getSandboxesMetrics(
 ) (map[string]api.SandboxMetric, error) {
 	ctx, span := a.Tracer.Start(ctx, "fetch-sandboxes-metrics")
 	defer span.End()
+
+	for i, id := range sandboxIDs {
+		sandboxIDs[i] = utils.ShortID(id)
+	}
 
 	telemetry.SetAttributes(ctx,
 		telemetry.WithTeamID(teamID.String()),


### PR DESCRIPTION
# Description

Cut out the second part from sandbox id if passed