### PR TITLE
Fix build user creation

### DIFF
--- a/packages/orchestrator/internal/template/build/command/user.go
+++ b/packages/orchestrator/internal/template/build/command/user.go
@@ -41,7 +41,7 @@ func (u *User) Execute(
 		zapcore.InfoLevel,
 		prefix,
 		sandboxID,
-		"adduser "+userArg,
+		fmt.Sprintf("adduser -disabled-password --gecos \"\" %s || true", userArg),
 		sandboxtools.CommandMetadata{
 			User:    "root",
 			EnvVars: cmdMetadata.EnvVars,


### PR DESCRIPTION
Fix build user creation with no password and also exit with 0 when the user already exists