### PR TITLE
Update self-host.md gcloud instructions

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -20,6 +20,11 @@
 
 - [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
   - Used for managing the infrastructure on Google Cloud
+  - Be sure to authenticate:
+    ```sh
+    gcloud auth login
+    gcloud auth application-default login
+    ```
 
 - [Golang](https://go.dev/doc/install)
 


### PR DESCRIPTION
Can get issue when running `switch-env` without properly logging in with gcloud CLI
```
│ Error: Failed to get existing workspaces: querying Cloud Storage failed: Get "https://storage.googleapis.com/storage/v1/b/...
```