### PR TITLE
Enable async inserts in Clickhouse

### DIFF
--- a/packages/nomad/configs/clickhouse/users.xml
+++ b/packages/nomad/configs/clickhouse/users.xml
@@ -10,6 +10,11 @@
                 <ip>10.0.0.0/8</ip> <!-- restrict to internal traffic -->
             </networks>
             <profile>default</profile>
+
+            <!-- https://clickhouse.com/docs/optimize/asynchronous-inserts -->
+            <async_insert>1</async_insert>
+            <wait_for_async_insert>1</wait_for_async_insert>
+
             <quota>default</quota>
             <access_management>1</access_management>
         </${username}>


### PR DESCRIPTION
# Description

We are already using this for ingestion from otel collectors, as you can see here in [config](https://github.com/e2b-dev/infra/blob/d7ee9161c3d619b5e13aee861f21b8f0c07e0813/packages/otel-collector/otel-collector.yaml#L146). But there's no reason why to not have it globally

If you are interested in details, you can find more in [docs](https://clickhouse.com/docs/optimize/asynchronous-inserts)

