### PR TITLE
Fix download job

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          # Docker build artifacts have to ignored
+          # https://github.com/actions/toolkit/pull/1874
+          pattern: "!*.dockerbuild"
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration for the main branch. The change ensures that Docker build artifacts are excluded when downloading artifacts, which helps prevent unwanted files from being processed in subsequent workflow steps.
