### PR TITLE
Add versioning and lifecycle rules to the terraform state bucket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,21 @@ init:
 	@ printf "Initializing Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
 	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
 	gcloud storage buckets create gs://$(TERRAFORM_STATE_BUCKET) --location $(GCP_REGION) --project $(GCP_PROJECT_ID) --default-storage-class STANDARD  --uniform-bucket-level-access > /dev/null 2>&1 || true
+
+	# Enable object versioning (keeps deleted/replaced objects as older versions)
+	gcloud storage buckets update gs://$(TERRAFORM_STATE_BUCKET) --versioning --soft-delete-duration=30d
+
+	# Create a temporary file for lifecycle rules
+	$(eval LIFECYCLE_FILE := $(shell mktemp))
+
+	# Set lifecycle rules to delete non-live objects after 30 days or more than 50 newer versions
+	echo '{"rule":[{"action":{"type":"Delete"},"condition":{"isLive":false,"age":30}},{"action":{"type":"Delete"},"condition":{"numNewerVersions":50}}]}' > $(LIFECYCLE_FILE)
+	gcloud storage buckets update gs://$(TERRAFORM_STATE_BUCKET) --lifecycle-file=$(LIFECYCLE_FILE)
+
+	# Remove the temporary lifecycle file
+	@ rm -f $(LIFECYCLE_FILE)
+
+
 	$(TF) init -input=false -reconfigure -backend-config="bucket=${TERRAFORM_STATE_BUCKET}"
 	$(tf_vars) $(TF) apply -target=module.init -target=module.buckets -auto-approve -input=false -compact-warnings
 	$(MAKE) -C packages/cluster-disk-image init build


### PR DESCRIPTION
Enhancements to Terraform state bucket management:

* Enabled object versioning and soft delete for the Terraform state bucket to retain deleted or replaced objects for 30 days.
* Added lifecycle rules to automatically delete non-live objects older than 30 days and to remove objects if there are more than 50 newer versions, using a temporary lifecycle configuration file during initialization.