### PR TITLE
Fix pagination query

### DIFF
--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -242,7 +242,7 @@ func snapshotsToPaginatedSandboxes(snapshots []queries.GetSnapshotsWithCursorRow
 				State:       api.Paused,
 				EnvdVersion: envdVersion,
 			},
-			PaginationTimestamp: snapshot.CreatedAt.Time,
+			PaginationTimestamp: snapshot.SandboxStartedAt.Time,
 		}
 
 		if snapshot.Metadata != nil {

--- a/packages/db/queries/get_snapshots_with_cursor.sql
+++ b/packages/db/queries/get_snapshots_with_cursor.sql
@@ -20,10 +20,10 @@ WHERE
     e.team_id = @team_id
     AND s.metadata @> @metadata
     AND (
-        s.created_at < @cursor_time
+        s.sandbox_started_at < @cursor_time
         OR
-        (s.created_at = @cursor_time AND s.sandbox_id > @cursor_id)
+        (s.sandbox_started_at = @cursor_time AND s.sandbox_id > @cursor_id)
     )
     AND NOT (s.sandbox_id = ANY (@snapshot_exclude_sbx_ids::text[]))
-ORDER BY s.created_at DESC, s.sandbox_id
+ORDER BY s.sandbox_started_at DESC, s.sandbox_id
 LIMIT $1;

--- a/packages/db/queries/get_snapshots_with_cursor.sql.go
+++ b/packages/db/queries/get_snapshots_with_cursor.sql.go
@@ -35,12 +35,12 @@ WHERE
     e.team_id = $2
     AND s.metadata @> $3
     AND (
-        s.created_at < $4
+        s.sandbox_started_at < $4
         OR
-        (s.created_at = $4 AND s.sandbox_id > $5)
+        (s.sandbox_started_at = $4 AND s.sandbox_id > $5)
     )
     AND NOT (s.sandbox_id = ANY ($6::text[]))
-ORDER BY s.created_at DESC, s.sandbox_id
+ORDER BY s.sandbox_started_at DESC, s.sandbox_id
 LIMIT $1
 `
 

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -240,7 +240,7 @@ func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 	sandbox2ID := sbx2.SandboxID
 
 	// Pause the second sandbox
-	pauseSandbox(t, c, sandbox2ID)
+	pauseSandbox(t, c, sandbox1ID)
 
 	// Test pagination with limit
 	var limit int32 = 1

--- a/tests/integration/internal/tests/api/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandbox_list_test.go
@@ -239,7 +239,7 @@ func TestSandboxListPaginationRunningAndPaused(t *testing.T) {
 	sandbox1ID := sbx1.SandboxID
 	sandbox2ID := sbx2.SandboxID
 
-	// Pause the second sandbox
+	// Pause the first sandbox
 	pauseSandbox(t, c, sandbox1ID)
 
 	// Test pagination with limit


### PR DESCRIPTION
# Description

The problem is that we created the cursor from `StartedAt`, but the query was using `CreatedAt` at DB, causing a potential race condition. 