### PR TITLE
Always use actual service instance ID during gRPC call 

### DIFF
--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -224,7 +224,7 @@ func (o *Orchestrator) syncNodeState(ctx context.Context, node *Node, instanceCa
 	syncRetrySuccess := false
 
 	for range syncMaxRetries {
-		client, ctx := node.GetClient(ctx)
+		client, ctx := node.getClient(ctx)
 		nodeInfo, err := client.Info.ServiceInfo(ctx, &emptypb.Empty{})
 		if err != nil {
 			zap.L().Error("Error getting node info", zap.Error(err), logger.WithNodeID(node.Info.NodeID))
@@ -351,7 +351,7 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 			info.PauseDone(nil)
 		} else {
 			req := &orchestrator.SandboxDeleteRequest{SandboxId: info.Instance.SandboxID}
-			client, ctx := node.GetClient(ctx)
+			client, ctx := node.getClient(ctx)
 			_, err := client.Sandbox.Delete(node.GetSandboxDeleteCtx(ctx, info.Instance.SandboxID, info.ExecutionID), req)
 			if err != nil {
 				return fmt.Errorf("failed to delete sandbox '%s': %w", info.Instance.SandboxID, err)

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
@@ -89,9 +88,6 @@ func (o *Orchestrator) connectToNode(ctx context.Context, discovered nomadServic
 
 	clusterID := uuid.Nil
 	orchestratorNode := &Node{
-		client:   client,
-		clientMd: make(metadata.MD),
-
 		Info: &node.NodeInfo{
 			NomadNodeShortID: discovered.NomadNodeShortID,
 
@@ -100,6 +96,9 @@ func (o *Orchestrator) connectToNode(ctx context.Context, discovered nomadServic
 			IPAddress: discovered.IPAddress,
 		},
 
+		client: client,
+		status: nodeStatus,
+
 		meta: nodeMetadata{
 			serviceInstanceID: nodeInfo.ServiceId,
 			commit:            nodeInfo.ServiceCommit,
@@ -107,7 +106,6 @@ func (o *Orchestrator) connectToNode(ctx context.Context, discovered nomadServic
 		},
 
 		buildCache:     buildCache,
-		status:         nodeStatus,
 		sbxsInProgress: smap.New[*sbxInProgress](),
 		createFails:    atomic.Uint64{},
 	}
@@ -118,7 +116,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, discovered nomadServic
 
 func (o *Orchestrator) connectToClusterNode(cluster *edge.Cluster, i *edge.ClusterInstance) {
 	// this way we don't need to worry about multiple clusters with the same node ID in shared pool
-	poolGrpc := cluster.GetGRPC(i.ServiceInstanceID)
+	clusterGRPC := cluster.GetGRPC(i.ServiceInstanceID)
 
 	buildCache := ttlcache.New[string, interface{}]()
 	go buildCache.Start()
@@ -130,9 +128,6 @@ func (o *Orchestrator) connectToClusterNode(cluster *edge.Cluster, i *edge.Clust
 	}
 
 	orchestratorNode := &Node{
-		client:   poolGrpc.Client,
-		clientMd: poolGrpc.Metadata,
-
 		Info: &node.NodeInfo{
 			NomadNodeShortID: node.UnknownNomadNodeShortID,
 
@@ -140,6 +135,7 @@ func (o *Orchestrator) connectToClusterNode(cluster *edge.Cluster, i *edge.Clust
 			NodeID:    i.NodeID,
 		},
 
+		client: clusterGRPC.Client,
 		status: nodeStatus,
 		meta: nodeMetadata{
 			serviceInstanceID: i.ServiceInstanceID,
@@ -180,6 +176,6 @@ func (o *Orchestrator) GetClient(ctx context.Context, clusterID uuid.UUID, nodeI
 		return nil, nil, fmt.Errorf("node '%s' not found in cluster '%s'", nodeID, clusterID)
 	}
 
-	client, ctx := n.GetClient(ctx)
+	client, ctx := n.getClient(ctx)
 	return client, ctx, nil
 }

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -210,7 +210,7 @@ func (o *Orchestrator) CreateSandbox(
 			CPUs:      build.Vcpu,
 		})
 
-		client, childCtx := node.GetClient(childCtx)
+		client, childCtx := node.getClient(childCtx)
 		_, err = client.Sandbox.Create(node.GetSandboxCreateCtx(childCtx, sbxRequest), sbxRequest)
 		// The request is done, we will either add it to the cache or remove it from the node
 		if err == nil {

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -66,8 +66,6 @@ type Node struct {
 	createFails   atomic.Uint64
 }
 
-var emptyMetadata = metadata.New(map[string]string{})
-
 func (n *Node) Close() {
 	n.buildCache.Stop()
 }

--- a/packages/api/internal/orchestrator/node.go
+++ b/packages/api/internal/orchestrator/node.go
@@ -202,10 +202,13 @@ func (n *Node) InsertBuild(buildID string) {
 	n.buildCache.Set(buildID, struct{}{}, 2*time.Minute)
 }
 
+// Ensures that GRPC client request context always has the latest service instance ID
 func (n *Node) getClient(ctx context.Context) (*grpclient.GRPCClient, context.Context) {
 	return n.client, metadata.NewOutgoingContext(ctx, n.getClientMetadata())
 }
 
+// Generates metadata with the current service instance ID
+// to ensure we always use the latest ID (e.g. after orchestrator restarts)
 func (n *Node) getClientMetadata() metadata.MD {
 	return metadata.New(map[string]string{consts.EdgeRpcServiceInstanceIDHeader: n.metadata().serviceInstanceID})
 }


### PR DESCRIPTION
Context: For clusters, we are adding the service instance ID to requests used in the edge proxy to determine which orchestrator/template builder should route the request. This ID changes when the orchestrator is restarted.

In production environments, we are not supporting orchestrator restarts. It should never happen to have the same node ID and changed service instance ID, but when developing, restarts are allowed. This was causing the API to be unable to communicate with the orchestrator, because the service instance ID was outdated, as it was issued only during cluster node connection and was never updated.
