### PR TITLE
Improve template permission and not found errors

### DIFF
--- a/packages/api/internal/handlers/template_request_build.go
+++ b/packages/api/internal/handlers/template_request_build.go
@@ -108,7 +108,7 @@ func (a *APIStore) BuildTemplate(ctx context.Context, req BuildTemplateRequest) 
 
 		if template.TeamID != req.Team.ID {
 			return nil, &api.APIError{
-				Err:       err,
+				Err:       fmt.Errorf("template '%s' is not accessible for the team '%s'", aliasOrTemplateID, req.Team.ID.String()),
 				ClientMsg: fmt.Sprintf("Template '%s' is not accessible for the team '%s'", aliasOrTemplateID, req.Team.ID.String()),
 				Code:      http.StatusForbidden,
 			}


### PR DESCRIPTION
Improve template permission and not found errors.

Before:
404: Error when getting template `templateID` for team `teamID`

After:
404: Template `templateAlias (if provided, otherwise templateID)` not found
403: Template `templateAlias (if provided, otherwise templateID)` is not accessible for the team `teamID`

Note:
This change makes it more transparent to foreign teams to see if a template alias already exists (because they can now distinguish between not access and template not existing).