### PR TITLE
Add curl to the default installed packages

### DIFF
--- a/packages/orchestrator/internal/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.sh
@@ -10,7 +10,7 @@ echo "Making configuration immutable"
 chattr +i /etc/resolv.conf
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat"
+PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""


### PR DESCRIPTION
Add curl to the default installed packages. This fixes the wait_for_port helper dependency