### PR TITLE
Update Dockerfile - force use golang:1.24-bullseye

### DIFF
--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.24-bullseye AS builder
 
 WORKDIR /build/shared
 


### PR DESCRIPTION
As of August 14:
  golang:1.24 (latest):
  - Based on Debian 13 "Trixie" (new stable)
  - Has glibc 2.41 (very new)
  - Created: August 12, 2025

  golang:1.24-bullseye:
  - Based on Debian 11 "Bullseye" (old-old stable, released 2021)
  - Has glibc 2.31 (older, stable)
  - Compatible with your server's glibc 2.35

The build with new glibc will fail to run client nodes due mismatched glibc versions: local/orchestrator: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by local/orchestrator)