### PR TITLE
Fix error types returned from API

### DIFF
--- a/packages/api/internal/handlers/teams.go
+++ b/packages/api/internal/handlers/teams.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/team"
@@ -17,8 +16,7 @@ func (a *APIStore) GetTeams(c *gin.Context) {
 
 	results, err := a.sqlcDB.GetTeamsWithUsersTeams(ctx, userID)
 	if err != nil {
-		zap.L().Error("error when starting transaction", zap.Error(err))
-		c.JSON(http.StatusInternalServerError, "Error when starting transaction")
+		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when starting transaction")
 
 		return
 	}
@@ -28,8 +26,7 @@ func (a *APIStore) GetTeams(c *gin.Context) {
 		// We create a new API key for the CLI and backwards compatibility with API Keys hashing
 		apiKey, err := team.CreateAPIKey(ctx, a.db, row.Team.ID, userID, "CLI login/configure")
 		if err != nil {
-			zap.L().Error("error when creating API key", zap.Error(err))
-			c.JSON(http.StatusInternalServerError, "Error when creating API key")
+			a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when creating team API key")
 
 			return
 		}


### PR DESCRIPTION
This pull request refactors error handling in API handlers to use a centralized method for sending error responses, making sure the correct error type is returned (json, not a string)