### PR TITLE
Fix sandbox metadata synchronization

### DIFF
--- a/packages/api/internal/cache/instance/operations.go
+++ b/packages/api/internal/cache/instance/operations.go
@@ -63,41 +63,37 @@ func (c *InstanceCache) Add(ctx context.Context, instance *InstanceInfo, newlyCr
 		zap.Time("end_time", instance.GetEndTime()),
 	)
 
-	if instance.Instance == nil {
-		return fmt.Errorf("instance doesn't contain info about inself")
-	}
-
-	if instance.Instance.SandboxID == "" {
+	if instance.SandboxID == "" {
 		return fmt.Errorf("instance is missing sandbox ID")
 	}
 
 	if instance.TeamID == uuid.Nil {
-		return fmt.Errorf("instance %s is missing team ID", instance.Instance.SandboxID)
+		return fmt.Errorf("instance %s is missing team ID", instance.SandboxID)
 	}
 
-	if instance.Instance.ClientID == "" {
-		return fmt.Errorf("instance %s is missing client ID", instance.Instance.ClientID)
+	if instance.ClientID == "" {
+		return fmt.Errorf("instance %s is missing client ID", instance.ClientID)
 	}
 
-	if instance.Instance.TemplateID == "" {
-		return fmt.Errorf("instance %s is missing env ID", instance.Instance.TemplateID)
+	if instance.TemplateID == "" {
+		return fmt.Errorf("instance %s is missing env ID", instance.TemplateID)
 	}
 
 	endTime := instance.GetEndTime()
 
 	if instance.StartTime.IsZero() || endTime.IsZero() || instance.StartTime.After(endTime) {
-		return fmt.Errorf("instance %s has invalid start(%s)/end(%s) times", instance.Instance.SandboxID, instance.StartTime, endTime)
+		return fmt.Errorf("instance %s has invalid start(%s)/end(%s) times", instance.SandboxID, instance.StartTime, endTime)
 	}
 
 	if endTime.Sub(instance.StartTime) > instance.MaxInstanceLength {
 		instance.SetEndTime(instance.StartTime.Add(instance.MaxInstanceLength))
 	}
 
-	c.Set(instance.Instance.SandboxID, instance, newlyCreated)
+	c.Set(instance.SandboxID, instance, newlyCreated)
 	c.UpdateCounters(ctx, instance, 1, newlyCreated)
 
 	// Release the reservation if it exists
-	c.reservations.release(instance.Instance.SandboxID)
+	c.reservations.release(instance.SandboxID)
 
 	return nil
 }

--- a/packages/api/internal/cache/instance/reservation.go
+++ b/packages/api/internal/cache/instance/reservation.go
@@ -51,7 +51,7 @@ func (c *InstanceCache) list(teamID uuid.UUID) (instanceIDs []string) {
 		currentTeamID := value.TeamID
 
 		if currentTeamID == teamID {
-			instanceIDs = append(instanceIDs, value.Instance.SandboxID)
+			instanceIDs = append(instanceIDs, value.SandboxID)
 		}
 	}
 

--- a/packages/api/internal/cache/instance/reservation_test.go
+++ b/packages/api/internal/cache/instance/reservation_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
 
-	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
@@ -75,15 +74,14 @@ func TestReservation_ResumeAlreadyRunningSandbox(t *testing.T) {
 	defer cancel()
 
 	info := &InstanceInfo{
+		ClientID:   consts.ClientID,
+		SandboxID:  sandboxID,
+		TemplateID: "test",
+
 		TeamID:            teamID,
 		StartTime:         time.Now(),
 		endTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,
-		Instance: &api.Sandbox{
-			ClientID:   consts.ClientID,
-			SandboxID:  sandboxID,
-			TemplateID: "test",
-		},
 	}
 	err := cache.Add(context.Background(), info, false)
 	assert.NoError(t, err)

--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -60,7 +60,7 @@ func (c *InstanceCache) Sync(ctx context.Context, instances []*InstanceInfo, nod
 
 	// Use a map for faster lookup
 	for _, instance := range instances {
-		instanceMap[instance.Instance.SandboxID] = instance
+		instanceMap[instance.SandboxID] = instance
 	}
 
 	// Delete instances that are not in Orchestrator anymore
@@ -71,15 +71,15 @@ func (c *InstanceCache) Sync(ctx context.Context, instances []*InstanceInfo, nod
 		if time.Since(item.StartTime) <= syncSandboxRemoveGracePeriod {
 			continue
 		}
-		_, found := instanceMap[item.Instance.SandboxID]
+		_, found := instanceMap[item.SandboxID]
 		if !found {
-			c.cache.Remove(item.Instance.SandboxID)
+			c.cache.Remove(item.SandboxID)
 		}
 	}
 
 	// Add instances that are not in the cache with the default TTL
 	for _, instance := range instances {
-		if c.Exists(instance.Instance.SandboxID) {
+		if c.Exists(instance.SandboxID) {
 			continue
 		}
 		err := c.Add(ctx, instance, false)

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -53,10 +53,10 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 
 		// Sandbox exists and belongs to the team - return running sandbox info
 		sandbox := api.SandboxDetail{
-			ClientID:        info.Instance.ClientID,
-			TemplateID:      info.Instance.TemplateID,
-			Alias:           info.Instance.Alias,
-			SandboxID:       info.Instance.SandboxID,
+			ClientID:        info.ClientID,
+			TemplateID:      info.TemplateID,
+			Alias:           info.Alias,
+			SandboxID:       info.SandboxID,
 			StartedAt:       info.StartTime,
 			CpuCount:        api.CPUCount(info.VCpu),
 			MemoryMB:        api.MemoryMB(info.RamMB),

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -147,7 +147,7 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 	// Running Sandbox IDs
 	runningSandboxesIDs := make([]string, 0)
 	for _, info := range runningSandboxes {
-		runningSandboxesIDs = append(runningSandboxesIDs, utils.ShortID(info.Instance.SandboxID))
+		runningSandboxesIDs = append(runningSandboxesIDs, utils.ShortID(info.SandboxID))
 	}
 
 	if slices.Contains(states, api.Running) {
@@ -263,10 +263,10 @@ func instanceInfoToPaginatedSandboxes(runningSandboxes []*instance.InstanceInfo)
 	for _, info := range runningSandboxes {
 		sandbox := utils.PaginatedSandbox{
 			ListedSandbox: api.ListedSandbox{
-				ClientID:    info.Instance.ClientID,
+				ClientID:    info.ClientID,
 				TemplateID:  info.BaseTemplateID,
-				Alias:       info.Instance.Alias,
-				SandboxID:   info.Instance.SandboxID,
+				Alias:       info.Alias,
+				SandboxID:   info.SandboxID,
 				StartedAt:   info.StartTime,
 				CpuCount:    api.CPUCount(info.VCpu),
 				MemoryMB:    api.MemoryMB(info.RamMB),

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -53,7 +53,7 @@ func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyt
 	instanceIds := make([]string, len(instances))
 	executionIds := make([]string, len(instances))
 	for idx, i := range instances {
-		instanceIds[idx] = i.Instance.SandboxID
+		instanceIds[idx] = i.SandboxID
 		executionIds[idx] = i.ExecutionID
 	}
 

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -310,9 +310,9 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 			posthogClient,
 			o.analytics,
 			info.TeamID.String(),
-			info.Instance.SandboxID,
+			info.SandboxID,
 			info.ExecutionID,
-			info.Instance.TemplateID,
+			info.TemplateID,
 			info.VCpu,
 			info.RamMB,
 			info.TotalDiskSizeMB,
@@ -330,7 +330,7 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 		node.CPUUsage.Add(-info.VCpu)
 		node.RamUsage.Add(-info.RamMB)
 
-		o.dns.Remove(ctx, info.Instance.SandboxID, node.Info.IPAddress)
+		o.dns.Remove(ctx, info.SandboxID, node.Info.IPAddress)
 
 		if node.client == nil {
 			zap.L().Error("client for node not found", logger.WithNodeID(info.Node.NodeID))
@@ -344,7 +344,7 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 			if err != nil {
 				info.PauseDone(err)
 
-				return fmt.Errorf("failed to auto pause sandbox '%s': %w", info.Instance.SandboxID, err)
+				return fmt.Errorf("failed to auto pause sandbox '%s': %w", info.SandboxID, err)
 			}
 
 			// We explicitly unmark as pausing here to avoid a race condition
@@ -352,11 +352,11 @@ func (o *Orchestrator) getDeleteInstanceFunction(
 			o.instanceCache.UnmarkAsPausing(info)
 			info.PauseDone(nil)
 		} else {
-			req := &orchestrator.SandboxDeleteRequest{SandboxId: info.Instance.SandboxID}
+			req := &orchestrator.SandboxDeleteRequest{SandboxId: info.SandboxID}
 			client, ctx := node.getClient(ctx)
-			_, err := client.Sandbox.Delete(node.GetSandboxDeleteCtx(ctx, info.Instance.SandboxID, info.ExecutionID), req)
+			_, err := client.Sandbox.Delete(node.GetSandboxDeleteCtx(ctx, info.SandboxID, info.ExecutionID), req)
 			if err != nil {
-				return fmt.Errorf("failed to delete sandbox '%s': %w", info.Instance.SandboxID, err)
+				return fmt.Errorf("failed to delete sandbox '%s': %w", info.SandboxID, err)
 			}
 		}
 
@@ -431,7 +431,7 @@ func (o *Orchestrator) getInsertInstanceFunction(parentCtx context.Context, time
 			node.CPUUsage.Add(info.VCpu)
 			node.RamUsage.Add(info.RamMB)
 
-			o.dns.Add(ctx, info.Instance.SandboxID, node.Info.IPAddress)
+			o.dns.Add(ctx, info.SandboxID, node.Info.IPAddress)
 		}
 
 		o.teamMetricsObserver.Add(ctx, info.TeamID, created)
@@ -447,9 +447,9 @@ func (o *Orchestrator) getInsertInstanceFunction(parentCtx context.Context, time
 				parentCtx,
 				o.analytics,
 				info.TeamID.String(),
-				info.Instance.SandboxID,
+				info.SandboxID,
 				info.ExecutionID,
-				info.Instance.TemplateID,
+				info.TemplateID,
 				info.BuildID.String(),
 				info.VCpu,
 				info.RamMB,

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -24,6 +24,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	ut "github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const (
@@ -143,6 +144,7 @@ func (o *Orchestrator) CreateSandbox(
 			Snapshot:            isResume,
 			AutoPause:           &autoPause,
 			AllowInternetAccess: allowInternetAccess,
+			TotalDiskSizeMb:     ut.FromPtr(build.TotalDiskSizeMb),
 		},
 		StartTime: timestamppb.New(startTime),
 		EndTime:   timestamppb.New(endTime),
@@ -262,7 +264,10 @@ func (o *Orchestrator) CreateSandbox(
 	endTime = startTime.Add(timeout)
 
 	instanceInfo := instance.NewInstanceInfo(
-		&sbx,
+		sbx.SandboxID,
+		sbx.TemplateID,
+		sbx.ClientID,
+		sbx.Alias,
 		executionID,
 		team.Team.ID,
 		build.ID,

--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -17,7 +17,7 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, sandboxID string, durat
 		return apiErr
 	}
 
-	err := o.UpdateSandbox(ctx, sbx.Instance.SandboxID, sbx.GetEndTime(), sbx.Node.ClusterID, sbx.Node.NodeID)
+	err := o.UpdateSandbox(ctx, sbx.SandboxID, sbx.GetEndTime(), sbx.Node.ClusterID, sbx.Node.NodeID)
 	if err != nil {
 		zap.L().Warn("Error when setting sandbox timeout", zap.Error(err), logger.WithSandboxID(sandboxID))
 		return &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error when setting sandbox timeout", Err: err}

--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -9,7 +9,6 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/google/uuid"
 
-	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/cache/instance"
 	nNode "github.com/e2b-dev/infra/packages/api/internal/node"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
@@ -61,12 +60,10 @@ func (o *Orchestrator) getSandboxes(ctx context.Context, node *nNode.NodeInfo) (
 		sandboxesInfo = append(
 			sandboxesInfo,
 			instance.NewInstanceInfo(
-				&api.Sandbox{
-					SandboxID:  config.SandboxId,
-					TemplateID: config.TemplateId,
-					Alias:      config.Alias,
-					ClientID:   consts.ClientID,
-				},
+				config.SandboxId,
+				config.TemplateId,
+				consts.ClientID,
+				config.Alias,
 				config.ExecutionId,
 				teamID,
 				buildID,

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -257,7 +257,7 @@ func (o *Orchestrator) AdminNodes() []*api.Node {
 	for _, sbx := range o.instanceCache.Items() {
 		n, ok := nodes[sbx.Node.NomadNodeShortID]
 		if !ok {
-			zap.L().Error("node for sandbox wasn't found", logger.WithNodeID(sbx.Node.NodeID), logger.WithClusterID(sbx.Node.ClusterID), logger.WithSandboxID(sbx.Instance.SandboxID))
+			zap.L().Error("node for sandbox wasn't found", logger.WithNodeID(sbx.Node.NodeID), logger.WithClusterID(sbx.Node.ClusterID), logger.WithSandboxID(sbx.SandboxID))
 			continue
 		}
 
@@ -316,16 +316,16 @@ func (o *Orchestrator) AdminNodeDetail(nomadNodeShortID string) (*api.NodeDetail
 			}
 
 			node.Sandboxes = append(node.Sandboxes, api.ListedSandbox{
-				Alias:      sbx.Instance.Alias,
+				Alias:      sbx.Alias,
 				ClientID:   consts.ClientID,
 				CpuCount:   api.CPUCount(sbx.VCpu),
 				MemoryMB:   api.MemoryMB(sbx.RamMB),
 				DiskSizeMB: api.DiskSizeMB(sbx.TotalDiskSizeMB),
 				EndAt:      sbx.GetEndTime(),
 				Metadata:   metadata,
-				SandboxID:  sbx.Instance.SandboxID,
+				SandboxID:  sbx.SandboxID,
 				StartedAt:  sbx.StartTime,
-				TemplateID: sbx.Instance.TemplateID,
+				TemplateID: sbx.TemplateID,
 			})
 		}
 	}

--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -33,8 +33,8 @@ func (o *Orchestrator) PauseInstance(
 	defer span.End()
 
 	snapshotConfig := &db.SnapshotInfo{
-		BaseTemplateID:      sbx.Instance.TemplateID,
-		SandboxID:           sbx.Instance.SandboxID,
+		BaseTemplateID:      sbx.TemplateID,
+		SandboxID:           sbx.SandboxID,
 		SandboxStartedAt:    sbx.StartTime,
 		VCPU:                sbx.VCpu,
 		RAMMB:               sbx.RamMB,
@@ -42,7 +42,7 @@ func (o *Orchestrator) PauseInstance(
 		Metadata:            sbx.Metadata,
 		KernelVersion:       sbx.KernelVersion,
 		FirecrackerVersion:  sbx.FirecrackerVersion,
-		EnvdVersion:         sbx.Instance.EnvdVersion,
+		EnvdVersion:         sbx.EnvdVersion,
 		EnvdSecured:         sbx.EnvdAccessToken != nil,
 		AllowInternetAccess: sbx.AllowInternetAccess,
 	}
@@ -97,9 +97,9 @@ func snapshotInstance(ctx context.Context, orch *Orchestrator, sbx *instance.Ins
 	}
 
 	_, err = client.Sandbox.Pause(
-		node.GetSandboxDeleteCtx(childCtx, sbx.Instance.SandboxID, sbx.ExecutionID),
+		node.GetSandboxDeleteCtx(childCtx, sbx.SandboxID, sbx.ExecutionID),
 		&orchestrator.SandboxPauseRequest{
-			SandboxId:  sbx.Instance.SandboxID,
+			SandboxId:  sbx.SandboxID,
 			TemplateId: templateID,
 			BuildId:    buildID,
 		},
@@ -119,5 +119,5 @@ func snapshotInstance(ctx context.Context, orch *Orchestrator, sbx *instance.Ins
 		return ErrPauseQueueExhausted{}
 	}
 
-	return fmt.Errorf("failed to pause sandbox '%s': %w", sbx.Instance.SandboxID, err)
+	return fmt.Errorf("failed to pause sandbox '%s': %w", sbx.SandboxID, err)
 }

--- a/packages/shared/pkg/utils/ptr.go
+++ b/packages/shared/pkg/utils/ptr.go
@@ -6,6 +6,15 @@ func ToPtr[T any](v T) *T {
 	return &v
 }
 
+func FromPtr[T any](s *T) T {
+	if s == nil {
+		var zero T
+		return zero
+	}
+
+	return *s
+}
+
 func Sprintp[T any](s *T) string {
 	if s == nil {
 		return "<nil>"


### PR DESCRIPTION
Fix sandbox metadata synchronization for `EnvdVersion` and `TotalDiskSizeMB` by populating correct fields in the struct.

The issue caused invalid synchronization data after API deployment, causing paused sandboxes to have 0 DiskSize and null envd version.