### PR TITLE
Ignore size changes for clickhouse disk

### DIFF
--- a/packages/cluster/clickhouse-cluster/main.tf
+++ b/packages/cluster/clickhouse-cluster/main.tf
@@ -58,6 +58,10 @@ resource "google_compute_disk" "stateful_disk" {
   zone = var.gcp_zone
 
   size = 100
+
+  lifecycle {
+    ignore_changes = [size]
+  }
 }
 
 resource "google_compute_per_instance_config" "instances" {

--- a/variables.tf
+++ b/variables.tf
@@ -306,7 +306,7 @@ Example:
   }
 ]
 EOT
-default     = ""
+  default     = ""
 }
 
 variable "prefix" {


### PR DESCRIPTION
This pull request introduces a lifecycle configuration to the `google_compute_disk.stateful_disk` resource in the Terraform configuration, ensuring that changes to the disk size are ignored during subsequent applies. This helps prevent unintended disk resizing operations that could disrupt stateful workloads.
