### PR TITLE
Fix a race condition in a test

### DIFF
--- a/packages/api/internal/cache/instance/lifecycle_cache_test.go
+++ b/packages/api/internal/cache/instance/lifecycle_cache_test.go
@@ -12,19 +12,19 @@ import (
 )
 
 type testLifecycleCacheItem struct {
-	expired *bool
+	expired *atomic.Bool
 }
 
 func (t *testLifecycleCacheItem) IsExpired() bool {
-	return *t.expired
+	return t.expired.Load()
 }
 
 func (t *testLifecycleCacheItem) SetExpired() {
-	*t.expired = true
+	t.expired.Store(true)
 }
 
 func newCache(t *testing.T) (*lifecycleCache[*testLifecycleCacheItem], context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	cache := newLifecycleCache[*testLifecycleCacheItem]()
 	go cache.Start(ctx)
@@ -40,13 +40,19 @@ func TestLifecycleCacheInit(t *testing.T) {
 	assert.Equal(t, uint64(0), cache.Metrics().Evictions)
 }
 
+func makeAtomicBool(value bool) *atomic.Bool {
+	var result atomic.Bool
+	result.Store(value)
+	return &result
+}
+
 func TestLifecycleCacheSetIfAbsent(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	assert.Equal(t, 1, cache.Len())
@@ -57,9 +63,9 @@ func TestLifecycleCacheGet(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	item, ok := cache.Get("test")
@@ -72,9 +78,9 @@ func TestLifecycleCacheGetAndRemove(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	item, ok := cache.GetAndRemove("test")
@@ -87,9 +93,9 @@ func TestLifecycleCacheRemove(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	ok := cache.Remove("test")
@@ -101,9 +107,9 @@ func TestLifecycleCacheItems(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	items := cache.Items()
@@ -117,9 +123,9 @@ func TestLifecycleCacheLen(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	assert.Equal(t, 1, cache.Len())
@@ -129,9 +135,9 @@ func TestLifecycleCacheHasNonExpired(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	assert.True(t, cache.Has("test", false))
@@ -146,13 +152,13 @@ func TestLifecycleCacheHasExpired(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	// Set the item as expired
-	expired = true
+	expired.Store(true)
 
 	assert.False(t, cache.Has("test", false))
 	assert.True(t, cache.Has("test", true))
@@ -169,13 +175,13 @@ func TestLifecycleCacheHasEvicting(t *testing.T) {
 		close(evictCalled)
 	})
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	// Set the item as expired
-	expired = true
+	expired.Store(true)
 
 	// Wait for the eviction process to start but not complete
 	time.Sleep(200 * time.Millisecond)
@@ -204,12 +210,12 @@ func TestLifecycleCacheOnEvictionCalled(t *testing.T) {
 		evictCalled = true
 	})
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
-	expired = true
+	expired.Store(true)
 
 	time.Sleep(1 * time.Second)
 
@@ -221,9 +227,9 @@ func TestLifecycleCacheEvictionNotCalledWhenItemIsNotExpired(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	time.Sleep(1 * time.Second)
@@ -235,9 +241,9 @@ func TestLifecycleCacheEvictionCalledWhenItemIsRemoved(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	cache.SetIfAbsent("test", &testLifecycleCacheItem{
-		expired: &expired,
+		expired: expired,
 	})
 
 	cache.Remove("test")
@@ -251,10 +257,10 @@ func TestLifecycleCacheManyItems(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 	for i := 0; i < 100; i++ {
 		cache.SetIfAbsent(fmt.Sprintf("test-%d", i), &testLifecycleCacheItem{
-			expired: &expired,
+			expired: expired,
 		})
 	}
 
@@ -276,9 +282,9 @@ func TestLifecycleCacheConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			expired := false
+			expired := makeAtomicBool(false)
 			cache.SetIfAbsent(fmt.Sprintf("test-%d", i), &testLifecycleCacheItem{
-				expired: &expired,
+				expired: expired,
 			})
 		}(i)
 	}
@@ -311,7 +317,7 @@ func TestLifecycleCacheConcurrentEviction(t *testing.T) {
 	cache, cancel := newCache(t)
 	defer cancel()
 
-	expired := false
+	expired := makeAtomicBool(false)
 
 	wg := sync.WaitGroup{}
 	for i := 0; i < 100; i++ {
@@ -319,13 +325,13 @@ func TestLifecycleCacheConcurrentEviction(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			cache.SetIfAbsent(fmt.Sprintf("test-%d", i), &testLifecycleCacheItem{
-				expired: &expired,
+				expired: expired,
 			})
 		}(i)
 	}
 	wg.Wait()
 
-	expired = true
+	expired.Store(true)
 
 	time.Sleep(1 * time.Second)
 
@@ -346,9 +352,9 @@ func TestLifecycleCacheConcurrentEvictionOnEviction(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			expired := true
+			expired := makeAtomicBool(true)
 			cache.SetIfAbsent(fmt.Sprintf("test-%d", i), &testLifecycleCacheItem{
-				expired: &expired,
+				expired: expired,
 			})
 		}(i)
 	}


### PR DESCRIPTION
Before:

```
=== RUN   TestLifecycleCacheHasEvicting
==================
WARNING: DATA RACE
Read at 0x00c0001a2ecf by goroutine 495:
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.(*testLifecycleCacheItem).IsExpired()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache_test.go:19 +0x40
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.(*lifecycleCache[go.shape.*uint8]).Start()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache.go:59 +0x1e0
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.newCache.gowrap1()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache_test.go:30 +0x58

Previous write at 0x00c0001a2ecf by goroutine 494:
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.TestLifecycleCacheHasEvicting()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache_test.go:178 +0x1d0
  testing.tRunner()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1851 +0x40

Goroutine 495 (running) created at:
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.newCache()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache_test.go:30 +0x128
  github.com/e2b-dev/infra/packages/api/internal/cache/instance.TestLifecycleCacheHasEvicting()
      /Users/djeebus/code/e2b/infra/packages/api/internal/cache/instance/lifecycle_cache_test.go:162 +0x2c
  testing.tRunner()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1851 +0x40

Goroutine 494 (running) created at:
  testing.(*T).Run()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /Users/djeebus/go/go1.24.3/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:93 +0x110
==================
    testing.go:1490: race detected during execution of test
--- FAIL: TestLifecycleCacheHasEvicting (0.60s)
```