### PR TITLE
A bunch of misc non-code fixes

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum', '**/go.mod') }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('go.work', 'go.work.sum') }}
 
     - name: Build Packages
       run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+gcloud 534.0.0
 packer 1.13.1
 terraform 1.5.7

--- a/packages/api/.gitignore
+++ b/packages/api/.gitignore
@@ -1,5 +1,6 @@
 bin
 mkfcenv.tar.gz
 .env
-.shared
-.db
+/.clickhouse
+/.db
+/.shared

--- a/packages/cluster/scripts/start-client.sh
+++ b/packages/cluster/scripts/start-client.sh
@@ -20,13 +20,13 @@ exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&
 DISK="/dev/disk/by-id/google-persistent-disk-1"
 MOUNT_POINT="/orchestrator"
 
-# # Step 1: Format the disk with XFS and 65K block size
+# Step 1: Format the disk with XFS and 65K block size
 sudo mkfs.xfs -f -b size=4096 $DISK
 
 # Step 2: Create the mount point
 sudo mkdir -p $MOUNT_POINT
 
-# # Step 4: Mount the disk with
+# Step 3: Mount the disk with
 sudo mount -o noatime $DISK $MOUNT_POINT
 
 sudo mkdir -p /orchestrator/sandbox


### PR DESCRIPTION
- .tool-versions: add gcloud cli
- Makefile: support `make plan-only-jobs && make apply`
- Makefile: test now runs every package referenced in go.work
- Makefile: `make fmt` now runs `terraform fmt`
- Makefile: `make lint` now runs golangci-lint on all packages referenced in go.work
- build-packages github action: simplify hashFiles to avoid recursing into bad folders
- api/.gitignore: ignore folders that are created when building locally
- start-client.sh: fix numbering and double hashes