### PR TITLE
Fix the cache key

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
-        key: ${{ runner.os }}-go-build-${{ hashFiles('go.work', 'go.work.sum') }}
+        key: ${{ runner.os }}-go-build-${{ hashFiles('go.work', 'go.work.sum', 'packages/*/go.mod', 'packages/*/go.sum', 'tests/*/go.mod', 'tests/*/go.sum') }}
 
     - name: Build Packages
       run: |


### PR DESCRIPTION
`go.work.sum` is excluded from the repo since #869 , so the shortcut introduced in #1016 no longer works. This change looks up all go.mod/go.sum files without requiring full recursion.