### PR TITLE
Fix template build layer command usage

### DIFF
--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -126,7 +126,7 @@ func (ppb *PostProcessingBuilder) Build(
 	finalLayer, err := ppb.layerExecutor.BuildLayer(ctx, layer.LayerBuildCommand{
 		Hash:           currentLayer.Hash,
 		SourceLayer:    lastStepResult.Metadata,
-		ExportTemplate: ppb.Template,
+		ExportTemplate: currentLayer.Metadata.Template,
 		UpdateEnvd:     lastStepResult.Cached,
 		SandboxCreator: sandboxCreator,
 		ActionExecutor: actionExecutor,


### PR DESCRIPTION
Fix a bug where provided start and ready commands were not used when building a layer in the finalize phase by using the current layer's metadata for `ExportTemplate`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e6b2045-5f21-4985-bcd7-9d24029da29e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e6b2045-5f21-4985-bcd7-9d24029da29e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

