### PR TITLE
Make sure logs collector ip is named properly and its always just IPv4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ module "nomad" {
 
   # API
   api_machine_count                         = var.api_cluster_size
-  logs_proxy_address                        = "http://${module.cluster.logs_proxy_ip}"
+  logs_collector_public_ip                  = module.cluster.logs_proxy_ip
   api_port                                  = var.api_port
   environment                               = var.environment
   google_service_account_key                = module.init.google_service_account_key

--- a/packages/nomad/main.tf
+++ b/packages/nomad/main.tf
@@ -402,7 +402,7 @@ locals {
     bucket_name                  = var.fc_env_pipeline_bucket_name
     orchestrator_checksum        = data.external.orchestrator_checksum.result.hex
     logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
-    logs_collector_public_ip     = var.logs_proxy_address
+    logs_collector_public_ip     = var.logs_collector_public_ip
     otel_tracing_print           = var.otel_tracing_print
     template_bucket_name         = var.template_bucket_name
     otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
@@ -489,7 +489,7 @@ resource "nomad_job" "template_manager" {
     build_cache_bucket_name      = var.build_cache_bucket_name
     otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
     logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
-    logs_collector_public_ip     = var.logs_proxy_address
+    logs_collector_public_ip     = var.logs_collector_public_ip
     orchestrator_services        = "template-manager"
     allow_sandbox_internet       = var.allow_sandbox_internet
     clickhouse_connection_string = local.clickhouse_connection_string

--- a/packages/nomad/variables.tf
+++ b/packages/nomad/variables.tf
@@ -67,7 +67,7 @@ variable "sandbox_access_token_hash_seed" {
   type = string
 }
 
-variable "logs_proxy_address" {
+variable "logs_collector_public_ip" {
   type = string
 }
 

--- a/packages/orchestrator/internal/sandbox/network/firewall.go
+++ b/packages/orchestrator/internal/sandbox/network/firewall.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
-	"strings"
 
 	"github.com/google/nftables"
 	"github.com/google/nftables/expr"
@@ -238,8 +237,7 @@ func (fw *Firewall) ResetAllowedCustom() error {
 
 	// Allow Logs Collector IP for logs
 	if ip := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP"); ip != "" {
-		ip = strings.TrimPrefix(ip, "http://") + "/32"
-		initIps = append(initIps, ip)
+		initIps = append(initIps, ip+"/32")
 	}
 
 	initData, err := set.AddressStringsToSetData(initIps)

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -429,13 +430,19 @@ func ResumeSandbox(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get snapfile: %w", err)
 	}
+
+	logsCollectorAddress := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP")
+	if logsCollectorAddress != "" && !strings.HasPrefix("http://", logsCollectorAddress) {
+		logsCollectorAddress = "http://" + logsCollectorAddress
+	}
+
 	fcStartErr := fcHandle.Resume(
 		uffdStartCtx,
 		tracer,
 		&fc.MmdsMetadata{
 			SandboxId:            runtime.SandboxID,
 			TemplateId:           runtime.TemplateID,
-			LogsCollectorAddress: os.Getenv("LOGS_COLLECTOR_PUBLIC_IP"),
+			LogsCollectorAddress: logsCollectorAddress,
 			TraceId:              traceID,
 			TeamId:               runtime.TeamID,
 		},

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -431,18 +430,14 @@ func ResumeSandbox(
 		return nil, fmt.Errorf("failed to get snapfile: %w", err)
 	}
 
-	logsCollectorAddress := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP")
-	if logsCollectorAddress != "" && !strings.HasPrefix(logsCollectorAddress, "http://") {
-		logsCollectorAddress = "http://" + logsCollectorAddress
-	}
-
+	logsCollectorIP := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP")
 	fcStartErr := fcHandle.Resume(
 		uffdStartCtx,
 		tracer,
 		&fc.MmdsMetadata{
 			SandboxId:            runtime.SandboxID,
 			TemplateId:           runtime.TemplateID,
-			LogsCollectorAddress: logsCollectorAddress,
+			LogsCollectorAddress: fmt.Sprintf("http://%s", logsCollectorIP),
 			TraceId:              traceID,
 			TeamId:               runtime.TeamID,
 		},

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -432,7 +432,7 @@ func ResumeSandbox(
 	}
 
 	logsCollectorAddress := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP")
-	if logsCollectorAddress != "" && !strings.HasPrefix("http://", logsCollectorAddress) {
+	if logsCollectorAddress != "" && !strings.HasPrefix(logsCollectorAddress, "http://") {
 		logsCollectorAddress = "http://" + logsCollectorAddress
 	}
 


### PR DESCRIPTION
Needed for K8s support, where you can set env with host/pod ip, but you cannot adjust it with, for example, `http://` prefix.