### PR TITLE
Make sure we are comparing service id, not just node id

### DIFF
--- a/packages/api/internal/edge/cluster_instances.go
+++ b/packages/api/internal/edge/cluster_instances.go
@@ -132,7 +132,7 @@ func (d clusterSynchronizationStore) PoolExists(ctx context.Context, s api.Clust
 }
 
 func (d clusterSynchronizationStore) PoolInsert(ctx context.Context, item api.ClusterOrchestratorNode) {
-	zap.L().Info("Adding instance into cluster pool", l.WithClusterID(d.cluster.ID), l.WithNodeID(item.NodeID), l.WithServiceInstanceID(instance.ServiceInstanceID))
+	zap.L().Info("Adding instance into cluster pool", l.WithClusterID(d.cluster.ID), l.WithNodeID(item.NodeID), l.WithServiceInstanceID(item.ServiceInstanceID))
 
 	instance := &ClusterInstance{
 		NodeID: item.NodeID,


### PR DESCRIPTION
Fix for a development environment where the orchestrator can restart on the same node and get a new instance ID.

When the instance ID changes (even if the node ID is still the same), we want to properly trigger pool removal.


