### PR TITLE
Removed no more needed back compatibility for build node id colum

### DIFF
--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -18,21 +17,10 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/cache/instance"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/db/queries"
-	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
-
-// Deprecated: (07-2025) Used only temporarily during migration phase to take client ID part from sandbox ID instead of from snapshot database row.
-func getSandboxIDClient(sandboxID string) (string, bool) {
-	parts := strings.Split(sandboxID, "-")
-	if len(parts) != 2 {
-		return "", false
-	}
-
-	return parts[1], true
-}
 
 func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.SandboxID) {
 	ctx := c.Request.Context()
@@ -105,23 +93,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 	var nodeID *string
 	if snap.OriginNodeID != nil {
-		// TODO: Before, we used Nomad short ID as node reference in snapshots.
-		//  This is a temporary helper to migrate to the new system where we use node ID reported by orchestrator.
-		if len(*snap.OriginNodeID) == consts.NodeIDLength {
-			n := a.orchestrator.GetNodeByNomadShortID(*snap.OriginNodeID)
-			if n != nil {
-				nodeID = &n.ID
-			}
-		} else {
-			nodeID = snap.OriginNodeID
-		}
-	} else {
-		// TODO: After migration period, we can remove this part, because all actively used snapshots will be stored in the database with the node ID.
-		// https://linear.app/e2b/issue/E2B-2662/remove-taking-client-from-sandbox-during-resume
-		sbxClientID, ok := getSandboxIDClient(sandboxID)
-		if ok {
-			nodeID = &sbxClientID
-		}
+		nodeID = snap.OriginNodeID
 	}
 
 	// Wait for any pausing for this sandbox in progress.

--- a/packages/db/migrations/20250824185633_build_node_not_nullable.sql
+++ b/packages/db/migrations/20250824185633_build_node_not_nullable.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE "public"."env_builds" SET cluster_node_id = 'unknown' WHERE cluster_node_id IS NULL;
+ALTER TABLE "public"."env_builds" ALTER COLUMN cluster_node_id SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "public"."env_builds" ALTER COLUMN cluster_node_id DROP NOT NULL;
+UPDATE "public"."env_builds" SET cluster_node_id = NULL WHERE cluster_node_id = 'unknown';
+-- +goose StatementEnd

--- a/packages/db/migrations/20250824185634_snapshot_node_not_nullable.sql
+++ b/packages/db/migrations/20250824185634_snapshot_node_not_nullable.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE "public"."snapshots" SET origin_node_id = 'unknown' WHERE origin_node_id IS NULL;
+ALTER TABLE "public"."snapshots" ALTER COLUMN origin_node_id SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "public"."snapshots" ALTER COLUMN origin_node_id DROP NOT NULL;
+UPDATE "public"."snapshots" SET origin_node_id = NULL WHERE origin_node_id = 'unknown';
+-- +goose StatementEnd

--- a/packages/db/queries/models.go
+++ b/packages/db/queries/models.go
@@ -73,7 +73,7 @@ type EnvBuild struct {
 	EnvID              *string
 	EnvdVersion        *string
 	ReadyCmd           *string
-	ClusterNodeID      *string
+	ClusterNodeID      string
 	Reason             types.JSONBStringMap
 }
 
@@ -86,7 +86,7 @@ type Snapshot struct {
 	BaseEnvID           string
 	SandboxStartedAt    pgtype.Timestamptz
 	EnvSecure           bool
-	OriginNodeID        *string
+	OriginNodeID        string
 	AllowInternetAccess *bool
 	AutoPause           bool
 }


### PR DESCRIPTION
Removed back compatibility for older snapshots and builds without a filled node ID column. Back compatibility is not more needed because nodes are already rolled.

https://linear.app/e2b/issue/E2B-2662/remove-taking-client-from-sandbox-during-resume