### PR TITLE
Propagate `ErrorObjectNotExist` from AWS and GCP storage providers when calling `.Size()`

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -220,6 +220,11 @@ func (a *AWSBucketStorageObjectProvider) Size() (int64, error) {
 
 	resp, err := a.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &a.bucketName, Key: &a.path})
 	if err != nil {
+		var nsk *types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return 0, ErrorObjectNotExist
+		}
+
 		return 0, err
 	}
 

--- a/packages/shared/pkg/storage/storage_cache.go
+++ b/packages/shared/pkg/storage/storage_cache.go
@@ -90,7 +90,8 @@ var _ StorageObjectProvider = (*CachedFileObjectProvider)(nil)
 func (c *CachedFileObjectProvider) WriteTo(dst io.Writer) (int64, error) {
 	totalSize, err := c.Size()
 	if err != nil {
-		return 0, fmt.Errorf("failed to get size of object: %w", err)
+
+		return 0, err
 	}
 
 	for offset := int64(0); offset < totalSize; offset += c.chunkSize {

--- a/packages/shared/pkg/storage/storage_cache.go
+++ b/packages/shared/pkg/storage/storage_cache.go
@@ -90,7 +90,6 @@ var _ StorageObjectProvider = (*CachedFileObjectProvider)(nil)
 func (c *CachedFileObjectProvider) WriteTo(dst io.Writer) (int64, error) {
 	totalSize, err := c.Size()
 	if err != nil {
-
 		return 0, err
 	}
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -143,6 +143,10 @@ func (g *GCPBucketStorageObjectProvider) Size() (int64, error) {
 
 	attrs, err := g.handle.Attrs(ctx)
 	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return 0, ErrorObjectNotExist
+		}
+
 		return 0, fmt.Errorf("failed to get GCS object (%s) attributes: %w", g.path, err)
 	}
 


### PR DESCRIPTION
- This should also correctly propagate the error in `WriteTo` in the cached provider.