### PR TITLE
Do not cache when building a template, only when starting a sandbox

### DIFF
--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -101,11 +101,12 @@ func (c *Cache) GetTemplate(
 	kernelVersion,
 	firecrackerVersion string,
 	isSnapshot bool,
+	isBuilding bool,
 ) (Template, error) {
 	persistence := c.persistence
 	// Because of the template caching, if we enable the shared cache feature flag,
 	// it will start working only for new orchestrators or new builds.
-	if c.useNFSCache(isSnapshot) {
+	if c.useNFSCache(isBuilding, isSnapshot) {
 		zap.L().Info("using local template cache", zap.String("path", c.rootCachePath))
 		persistence = storage.NewCachedProvider(c.rootCachePath, persistence)
 	}
@@ -192,7 +193,13 @@ func (c *Cache) AddSnapshot(
 	return nil
 }
 
-func (c *Cache) useNFSCache(isSnapshot bool) bool {
+func (c *Cache) useNFSCache(isBuilding bool, isSnapshot bool) bool {
+	if isBuilding {
+		// caching this layer doesn't speed up the next sandbox launch,
+		// as the previous template isn't used to load the oen that's being built.
+		return false
+	}
+
 	if c.rootCachePath == "" {
 		// can't enable cache if we don't have a cache path
 		return false

--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -196,7 +196,7 @@ func (c *Cache) AddSnapshot(
 func (c *Cache) useNFSCache(isBuilding bool, isSnapshot bool) bool {
 	if isBuilding {
 		// caching this layer doesn't speed up the next sandbox launch,
-		// as the previous template isn't used to load the oen that's being built.
+		// as the previous template isn't used to load the one that's being built.
 		return false
 	}
 

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -56,6 +56,7 @@ func (s *server) Create(ctxConn context.Context, req *orchestrator.SandboxCreate
 		req.GetSandbox().GetKernelVersion(),
 		req.GetSandbox().GetFirecrackerVersion(),
 		req.GetSandbox().GetSnapshot(),
+		false,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get template snapshot data: %w", err)

--- a/packages/orchestrator/internal/template/build/layer/create_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/create_sandbox.go
@@ -22,7 +22,9 @@ type CreateSandbox struct {
 	fcVersions fc.FirecrackerVersions
 }
 
-func NewCreateSandbox(config sandbox.Config, fcVersions fc.FirecrackerVersions) SandboxCreator {
+var _ SandboxCreator = (*CreateSandbox)(nil)
+
+func NewCreateSandbox(config sandbox.Config, fcVersions fc.FirecrackerVersions) *CreateSandbox {
 	return &CreateSandbox{config: config, fcVersions: fcVersions}
 }
 

--- a/packages/orchestrator/internal/template/build/layer/interfaces.go
+++ b/packages/orchestrator/internal/template/build/layer/interfaces.go
@@ -35,6 +35,6 @@ type LayerBuildCommand struct {
 	CurrentLayer   metadata.Template
 	Hash           string
 	UpdateEnvd     bool
-	SandboxCreator *CreateSandbox
+	SandboxCreator SandboxCreator
 	ActionExecutor ActionExecutor
 }

--- a/packages/orchestrator/internal/template/build/layer/interfaces.go
+++ b/packages/orchestrator/internal/template/build/layer/interfaces.go
@@ -35,6 +35,6 @@ type LayerBuildCommand struct {
 	CurrentLayer   metadata.Template
 	Hash           string
 	UpdateEnvd     bool
-	SandboxCreator SandboxCreator
+	SandboxCreator *CreateSandbox
 	ActionExecutor ActionExecutor
 }

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -78,6 +78,7 @@ func (lb *LayerExecutor) BuildLayer(
 		cmd.SourceTemplate.KernelVersion,
 		cmd.SourceTemplate.FirecrackerVersion,
 		false,
+		true,
 	)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("get template snapshot: %w", err)

--- a/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
@@ -18,7 +18,9 @@ type ResumeSandbox struct {
 	config sandbox.Config
 }
 
-func NewResumeSandbox(config sandbox.Config) SandboxCreator {
+var _ SandboxCreator = (*ResumeSandbox)(nil)
+
+func NewResumeSandbox(config sandbox.Config) *ResumeSandbox {
 	return &ResumeSandbox{config: config}
 }
 

--- a/packages/shared/pkg/storage/storage_cache.go
+++ b/packages/shared/pkg/storage/storage_cache.go
@@ -144,7 +144,7 @@ func (c *CachedFileObjectProvider) ReadAt(buff []byte, offset int64) (int, error
 	fp, err = os.Open(chunkPath)
 	if err == nil {
 		defer cleanup("failed to close chunk", fp)
-		zap.L().Debug("cache: reading from cache",
+		zap.L().Debug("cache: ReadAt: reading from cache",
 			zap.String("chunk_path", chunkPath),
 			zap.Int64("offset", offset))
 		count, err := fp.ReadAt(buff, 0) // offset is in the filename
@@ -153,7 +153,7 @@ func (c *CachedFileObjectProvider) ReadAt(buff []byte, offset int64) (int, error
 	cacheDoesNotExist := os.IsNotExist(err)
 
 	// read remote file
-	zap.L().Debug("CACHE: reading from remote",
+	zap.L().Debug("cache: ReadAt: reading from remote",
 		zap.Int64("offset", offset))
 	readCount, err := c.inner.ReadAt(buff, offset)
 	if err != nil {
@@ -161,7 +161,7 @@ func (c *CachedFileObjectProvider) ReadAt(buff []byte, offset int64) (int, error
 	}
 
 	if cacheDoesNotExist {
-		zap.L().Debug("CACHE: writing to cache",
+		zap.L().Debug("cache: ReadAt: writing to cache",
 			zap.String("chunk_path", chunkPath),
 			zap.Int64("offset", offset))
 		go c.writeBytesToLocal(offset, chunkPath, buff[:readCount])
@@ -222,8 +222,8 @@ func (c *CachedFileObjectProvider) copyChunkToStream(offset int64, dst io.Writer
 	chunkPath := c.makeChunkFilename(offset)
 	chunk, err := os.Open(chunkPath)
 	if errors.Is(err, os.ErrNotExist) {
-		zap.L().Debug("CACHE: writing cache and local at the same time",
-			zap.String("path", chunkPath),
+		zap.L().Debug("cache: WriteTo: writing cache and local at the same time",
+			zap.String("chunk_path", chunkPath),
 			zap.Int64("offset", offset))
 		if _, err = c.copyAndCacheBlock(chunkPath, offset, dst); err != nil {
 			return fmt.Errorf("failed to write data to cache: %w", err)
@@ -234,7 +234,7 @@ func (c *CachedFileObjectProvider) copyChunkToStream(offset int64, dst io.Writer
 	}
 	defer cleanup("failed to close chunk file", chunk)
 
-	zap.L().Debug("CACHE: reading from cache",
+	zap.L().Debug("cache: WriteTo: reading from cache",
 		zap.String("path", chunkPath),
 		zap.Int64("offset", offset))
 	if _, err = io.Copy(dst, chunk); err != nil {


### PR DESCRIPTION
This also cleans up logging and returns a struct rather than an interface in one place.