### PR TITLE
Enforce max concurrent sandboxes per node in the orchestrator

### DIFF
--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -42,6 +42,10 @@ func PlaceSandbox(ctx context.Context, tracer trace.Tracer, algorithm Algorithm,
 		if preferredNode != nil {
 			node = preferredNode
 		} else {
+			if len(nodesExcluded) >= len(clusterNodes) {
+				return nil, fmt.Errorf("no nodes available")
+			}
+
 			node, err = algorithm.chooseNode(ctx, clusterNodes, nodesExcluded, nodemanager.SandboxResources{CPUs: sbxRequest.Sandbox.Vcpu, MiBMemory: sbxRequest.Sandbox.RamMb})
 			if err != nil {
 				return nil, err

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -6,6 +6,8 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
@@ -26,7 +28,9 @@ type Algorithm interface {
 func PlaceSandbox(ctx context.Context, tracer trace.Tracer, algorithm Algorithm, clusterNodes []*nodemanager.Node, preferredNode *nodemanager.Node, sbxRequest *orchestrator.SandboxCreateRequest) (*nodemanager.Node, error) {
 	nodesExcluded := make(map[string]struct{})
 	var err error
-	for attempt := range maxRetries {
+
+	attempt := 0
+	for attempt < maxRetries {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("request timed out during %d. attempt", attempt+1)
@@ -62,6 +66,12 @@ func PlaceSandbox(ctx context.Context, tracer trace.Tracer, algorithm Algorithm,
 			zap.L().Error("Failed to create sandbox", logger.WithSandboxID(sbxRequest.Sandbox.SandboxId), logger.WithNodeID(node.ID), zap.Int("attempt", attempt+1), zap.Error(utils.UnwrapGRPCError(err)))
 
 			node = nil
+
+			st, ok := status.FromError(err)
+			if !ok || st.Code() != codes.ResourceExhausted {
+				attempt++
+			}
+
 			continue
 		}
 

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -7,6 +7,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"golang.org/x/sync/semaphore"
 
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	"github.com/e2b-dev/infra/packages/clickhouse/pkg/batcher"
@@ -38,6 +39,7 @@ type server struct {
 	persistence         storage.StorageProvider
 	featureFlags        *featureflags.Client
 	sandboxEventBatcher batcher.ClickhouseInsertBatcher[clickhouse.SandboxEvent]
+	startingSandboxes   *semaphore.Weighted
 }
 
 type Service struct {
@@ -84,6 +86,7 @@ func New(
 		persistence:         persistence,
 		featureFlags:        featureFlags,
 		sandboxEventBatcher: sandboxEventBatcher,
+		startingSandboxes:   semaphore.NewWeighted(maxStartingInstancesPerNode),
 	}
 
 	meter := tel.MeterProvider.Meter("orchestrator.sandbox")

--- a/tests/integration/internal/tests/api/kill_test.go
+++ b/tests/integration/internal/tests/api/kill_test.go
@@ -27,8 +27,8 @@ func TestSandboxKill(t *testing.T) {
 			TemplateID: setup.SandboxTemplateID,
 		}, setup.WithAPIKey())
 
-		assert.NoError(t, err)
-		assert.Equal(t, http.StatusCreated, createSandboxResponse.StatusCode())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, createSandboxResponse.StatusCode())
 
 		sandboxID := createSandboxResponse.JSON201.SandboxID
 


### PR DESCRIPTION
Enforce max concurrent sandboxes per node in the orchestrator instead of API and increase retry limit

This is a next step for moving towards stateless API.

Starting 3 sandboxes concurrently on a node should be very improbable, so it's better to check during the placement instead of doing extra call to some centralized storage to get the number of concurrently starting sandboxes on the node. 