### PR TITLE
Remove to refactor embedded storage ctx

### DIFF
--- a/packages/orchestrator/cmd/inspect-data/main.go
+++ b/packages/orchestrator/cmd/inspect-data/main.go
@@ -85,7 +85,7 @@ func main() {
 	nonEmptyCount := 0
 
 	for i := *start * blockSize; i < *end*blockSize; i += blockSize {
-		_, err := obj.ReadAt(b, i)
+		_, err := obj.ReadAt(ctx, b, i)
 		if err != nil {
 			log.Fatalf("failed to read block: %s", err)
 		}

--- a/packages/orchestrator/cmd/inspect-header/main.go
+++ b/packages/orchestrator/cmd/inspect-header/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("failed to open object: %s", err)
 	}
 
-	h, err := header.Deserialize(obj)
+	h, err := header.Deserialize(ctx, obj)
 	if err != nil {
 		log.Fatalf("failed to deserialize header: %s", err)
 	}

--- a/packages/orchestrator/cmd/simulate-headers-merge/main.go
+++ b/packages/orchestrator/cmd/simulate-headers-merge/main.go
@@ -60,12 +60,12 @@ func main() {
 		log.Fatalf("failed to open object: %s", err)
 	}
 
-	baseHeader, err := header.Deserialize(baseObj)
+	baseHeader, err := header.Deserialize(ctx, baseObj)
 	if err != nil {
 		log.Fatalf("failed to deserialize base header: %s", err)
 	}
 
-	diffHeader, err := header.Deserialize(diffObj)
+	diffHeader, err := header.Deserialize(ctx, diffObj)
 	if err != nil {
 		log.Fatalf("failed to deserialize diff header: %s", err)
 	}

--- a/packages/orchestrator/internal/sandbox/block/chunk.go
+++ b/packages/orchestrator/internal/sandbox/block/chunk.go
@@ -19,7 +19,7 @@ import (
 type Chunker struct {
 	ctx context.Context // nolint:containedctx // todo: refactor so this can be removed
 
-	base    io.ReaderAt
+	base    storage.ReaderAtCtx
 	cache   *Cache
 	metrics metrics.Metrics
 
@@ -33,7 +33,7 @@ func NewChunker(
 	ctx context.Context,
 	size,
 	blockSize int64,
-	base io.ReaderAt,
+	base storage.ReaderAtCtx,
 	cachePath string,
 	metrics metrics.Metrics,
 ) (*Chunker, error) {
@@ -163,7 +163,7 @@ func (c *Chunker) fetchToCache(off, length int64) error {
 					c.metrics.TotalBytesRetrievedMetric,
 					c.metrics.TotalRemoteReadsMetric,
 				)
-				readBytes, err := c.base.ReadAt(b, fetchOff)
+				readBytes, err := c.base.ReadAt(c.ctx, b, fetchOff)
 				if err != nil && !errors.Is(err, io.EOF) {
 					fetchSW.End(c.ctx, int64(readBytes),
 						attribute.String(result, resultTypeFailure),

--- a/packages/orchestrator/internal/sandbox/snapshot.go
+++ b/packages/orchestrator/internal/sandbox/snapshot.go
@@ -51,7 +51,7 @@ func (s *Snapshot) Upload(
 		rootfsPath = &rootfsLocalPath
 	}
 
-	templateBuild := storage.NewTemplateBuild(
+	templateBuild := NewTemplateBuild(
 		s.MemfileDiffHeader,
 		s.RootfsDiffHeader,
 		persistence,

--- a/packages/orchestrator/internal/sandbox/template/storage.go
+++ b/packages/orchestrator/internal/sandbox/template/storage.go
@@ -39,7 +39,7 @@ func NewStorage(
 			return nil, err
 		}
 
-		diffHeader, err := header.Deserialize(headerObject)
+		diffHeader, err := header.Deserialize(ctx, headerObject)
 
 		// If we can't find the diff header in storage, we switch to templates without a headers
 		if err != nil && !errors.Is(err, storage.ErrorObjectNotExist) {

--- a/packages/orchestrator/internal/sandbox/template/storage_file.go
+++ b/packages/orchestrator/internal/sandbox/template/storage_file.go
@@ -31,7 +31,7 @@ func newStorageFile(
 		return nil, err
 	}
 
-	_, err = object.WriteTo(f)
+	_, err = object.WriteTo(ctx, f)
 	if err != nil {
 		cleanupErr := os.Remove(path)
 		return nil, fmt.Errorf("NEW STORAGE failed to write to file: %w", errors.Join(err, cleanupErr))

--- a/packages/orchestrator/internal/sandbox/template_build.go
+++ b/packages/orchestrator/internal/sandbox/template_build.go
@@ -1,4 +1,4 @@
-package storage
+package sandbox
 
 import (
 	"context"
@@ -6,18 +6,19 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	headers "github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
 type TemplateBuild struct {
-	files       TemplateFiles
-	persistence StorageProvider
+	files       storage.TemplateFiles
+	persistence storage.StorageProvider
 
 	memfileHeader *headers.Header
 	rootfsHeader  *headers.Header
 }
 
-func NewTemplateBuild(memfileHeader *headers.Header, rootfsHeader *headers.Header, persistence StorageProvider, files TemplateFiles) *TemplateBuild {
+func NewTemplateBuild(memfileHeader *headers.Header, rootfsHeader *headers.Header, persistence storage.StorageProvider, files storage.TemplateFiles) *TemplateBuild {
 	return &TemplateBuild{
 		persistence: persistence,
 		files:       files,
@@ -47,7 +48,7 @@ func (t *TemplateBuild) uploadMemfileHeader(ctx context.Context, h *headers.Head
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	_, err = object.Write(serialized)
+	_, err = object.Write(ctx, serialized)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -61,7 +62,7 @@ func (t *TemplateBuild) uploadMemfile(ctx context.Context, memfilePath string) e
 		return err
 	}
 
-	err = object.WriteFromFileSystem(memfilePath)
+	err = object.WriteFromFileSystem(ctx, memfilePath)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile: %w", err)
 	}
@@ -80,7 +81,7 @@ func (t *TemplateBuild) uploadRootfsHeader(ctx context.Context, h *headers.Heade
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	_, err = object.Write(serialized)
+	_, err = object.Write(ctx, serialized)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -94,7 +95,7 @@ func (t *TemplateBuild) uploadRootfs(ctx context.Context, rootfsPath string) err
 		return err
 	}
 
-	err = object.WriteFromFileSystem(rootfsPath)
+	err = object.WriteFromFileSystem(ctx, rootfsPath)
 	if err != nil {
 		return fmt.Errorf("error when uploading rootfs: %w", err)
 	}
@@ -109,7 +110,7 @@ func (t *TemplateBuild) uploadSnapfile(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err = object.WriteFromFileSystem(path); err != nil {
+	if err = object.WriteFromFileSystem(ctx, path); err != nil {
 		return fmt.Errorf("error when uploading snapfile: %w", err)
 	}
 
@@ -123,7 +124,7 @@ func (t *TemplateBuild) uploadMetadata(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err := object.WriteFromFileSystem(path); err != nil {
+	if err := object.WriteFromFileSystem(ctx, path); err != nil {
 		return fmt.Errorf("error when uploading metadata: %w", err)
 	}
 

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -292,7 +292,7 @@ func getRootfsSize(
 		return 0, fmt.Errorf("error opening rootfs header object: %w", err)
 	}
 
-	h, err := header.Deserialize(obj)
+	h, err := header.Deserialize(ctx, obj)
 	if err != nil {
 		return 0, fmt.Errorf("error deserializing rootfs header: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/commands/copy.go
+++ b/packages/orchestrator/internal/template/build/commands/copy.go
@@ -111,7 +111,7 @@ func (c *Copy) Execute(
 	// Start writing tar data to the pipe writer in a goroutine
 	go func() {
 		defer pw.Close()
-		if _, err := obj.WriteTo(pw); err != nil {
+		if _, err := obj.WriteTo(ctx, pw); err != nil {
 			pw.CloseWithError(err)
 		}
 	}()

--- a/packages/orchestrator/internal/template/build/storage/cache/cache.go
+++ b/packages/orchestrator/internal/template/build/storage/cache/cache.go
@@ -62,7 +62,7 @@ func (h *HashIndex) LayerMetaFromHash(ctx context.Context, hash string) (LayerMe
 	}
 
 	var buf bytes.Buffer
-	_, err = obj.WriteTo(&buf)
+	_, err = obj.WriteTo(ctx, &buf)
 	if err != nil {
 		return LayerMetadata{}, fmt.Errorf("error reading layer metadata from object: %w", err)
 	}
@@ -91,7 +91,7 @@ func (h *HashIndex) SaveLayerMeta(ctx context.Context, hash string, template Lay
 		return fmt.Errorf("error marshalling layer metadata: %w", err)
 	}
 
-	_, err = obj.Write(marshaled)
+	_, err = obj.Write(ctx, marshaled)
 	if err != nil {
 		return fmt.Errorf("error writing layer metadata to object: %w", err)
 	}

--- a/packages/orchestrator/internal/template/metadata/template_metadata.go
+++ b/packages/orchestrator/internal/template/metadata/template_metadata.go
@@ -131,7 +131,7 @@ func fromTemplate(ctx context.Context, s storage.StorageProvider, files storage.
 	}
 
 	var buf bytes.Buffer
-	_, err = obj.WriteTo(&buf)
+	_, err = obj.WriteTo(ctx, &buf)
 	if err != nil {
 		return Template{}, fmt.Errorf("error reading template metadata from object: %w", err)
 	}

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -2,11 +2,14 @@ package header
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 
 	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 const metadataVersion = 2
@@ -61,10 +64,10 @@ func Serialize(metadata *Metadata, mappings []*BuildMap) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func Deserialize(in io.WriterTo) (*Header, error) {
+func Deserialize(ctx context.Context, in storage.WriterToCtx) (*Header, error) {
 	var buf bytes.Buffer
 
-	_, err := in.WriteTo(&buf)
+	_, err := in.WriteTo(ctx, &buf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write to buffer: %w", err)
 	}

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -111,8 +111,8 @@ func (a *AWSBucketStorageProvider) OpenObject(ctx context.Context, path string) 
 	}, nil
 }
 
-func (a *AWSBucketStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
-	ctx, cancel := context.WithTimeout(a.ctx, awsReadTimeout)
+func (a *AWSBucketStorageObjectProvider) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, awsReadTimeout)
 	defer cancel()
 
 	resp, err := a.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &a.bucketName, Key: &a.path})
@@ -130,8 +130,8 @@ func (a *AWSBucketStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
 	return io.Copy(dst, resp.Body)
 }
 
-func (a *AWSBucketStorageObjectProvider) WriteFromFileSystem(path string) error {
-	ctx, cancel := context.WithTimeout(a.ctx, awsWriteTimeout)
+func (a *AWSBucketStorageObjectProvider) WriteFromFileSystem(ctx context.Context, path string) error {
+	ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
 	defer cancel()
 
 	file, err := os.Open(path)
@@ -160,8 +160,8 @@ func (a *AWSBucketStorageObjectProvider) WriteFromFileSystem(path string) error 
 	return err
 }
 
-func (a *AWSBucketStorageObjectProvider) Write(data []byte) (int, error) {
-	ctx, cancel := context.WithTimeout(a.ctx, awsWriteTimeout)
+func (a *AWSBucketStorageObjectProvider) Write(ctx context.Context, data []byte) (int, error) {
+	ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
 	defer cancel()
 
 	result, err := a.client.PutObject(
@@ -183,8 +183,8 @@ func (a *AWSBucketStorageObjectProvider) Write(data []byte) (int, error) {
 	return int(*result.Size), nil
 }
 
-func (a *AWSBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, err error) {
-	ctx, cancel := context.WithTimeout(a.ctx, awsReadTimeout)
+func (a *AWSBucketStorageObjectProvider) ReadAt(ctx context.Context, buff []byte, off int64) (n int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, awsReadTimeout)
 	defer cancel()
 
 	readRange := aws.String(fmt.Sprintf("bytes=%d-%d", off, off+int64(len(buff))-1))

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -61,7 +61,7 @@ func (fs *FileSystemStorageProvider) getPath(path string) string {
 	return filepath.Join(fs.basePath, path)
 }
 
-func (f *FileSystemStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
+func (f *FileSystemStorageObjectProvider) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
 	handle, err := f.getHandle(true)
 	if err != nil {
 		return 0, err
@@ -72,7 +72,7 @@ func (f *FileSystemStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) 
 	return io.Copy(dst, handle)
 }
 
-func (f *FileSystemStorageObjectProvider) WriteFromFileSystem(path string) error {
+func (f *FileSystemStorageObjectProvider) WriteFromFileSystem(ctx context.Context, path string) error {
 	handle, err := f.getHandle(false)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (f *FileSystemStorageObjectProvider) WriteFromFileSystem(path string) error
 	return nil
 }
 
-func (f *FileSystemStorageObjectProvider) Write(data []byte) (int, error) {
+func (f *FileSystemStorageObjectProvider) Write(ctx context.Context, data []byte) (int, error) {
 	handle, err := f.getHandle(false)
 	if err != nil {
 		return 0, err
@@ -104,7 +104,7 @@ func (f *FileSystemStorageObjectProvider) Write(data []byte) (int, error) {
 	return count, err
 }
 
-func (f *FileSystemStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, err error) {
+func (f *FileSystemStorageObjectProvider) ReadAt(ctx context.Context, buff []byte, off int64) (n int, err error) {
 	handle, err := f.getHandle(true)
 	if err != nil {
 		return 0, err

--- a/packages/shared/pkg/storage/storage_fs_test.go
+++ b/packages/shared/pkg/storage/storage_fs_test.go
@@ -29,7 +29,7 @@ func TestOpenObject_ReadWrite_Size_ReadAt(t *testing.T) {
 
 	contents := []byte("hello world")
 	// write via Write
-	n, err := obj.Write(contents)
+	n, err := obj.Write(t.Context(), contents)
 	require.NoError(t, err)
 	require.Equal(t, len(contents), n)
 
@@ -40,14 +40,14 @@ func TestOpenObject_ReadWrite_Size_ReadAt(t *testing.T) {
 
 	// read the entire file back via WriteTo
 	var buf bytes.Buffer
-	n64, err := obj.WriteTo(&buf)
+	n64, err := obj.WriteTo(t.Context(), &buf)
 	require.NoError(t, err)
 	require.Equal(t, int64(len(contents)), n64)
 	require.Equal(t, contents, buf.Bytes())
 
 	// read a slice via ReadAt ("world")
 	part := make([]byte, 5)
-	nRead, err := obj.ReadAt(part, 6)
+	nRead, err := obj.ReadAt(t.Context(), part, 6)
 	require.NoError(t, err)
 	require.Equal(t, 5, nRead)
 	require.Equal(t, []byte("world"), part)
@@ -64,10 +64,10 @@ func TestWriteFromFileSystem(t *testing.T) {
 
 	obj, err := p.OpenObject(ctx, "copy/dst.txt")
 	require.NoError(t, err)
-	require.NoError(t, obj.WriteFromFileSystem(srcPath))
+	require.NoError(t, obj.WriteFromFileSystem(t.Context(), srcPath))
 
 	var buf bytes.Buffer
-	_, err = obj.WriteTo(&buf)
+	_, err = obj.WriteTo(t.Context(), &buf)
 	require.NoError(t, err)
 	require.Equal(t, payload, buf.String())
 }
@@ -79,7 +79,7 @@ func TestDelete(t *testing.T) {
 	obj, err := p.OpenObject(ctx, "to/delete.txt")
 	require.NoError(t, err)
 
-	_, err = obj.Write([]byte("bye"))
+	_, err = obj.Write(t.Context(), []byte("bye"))
 	require.NoError(t, err)
 	require.NoError(t, obj.Delete())
 
@@ -100,7 +100,7 @@ func TestDeleteObjectsWithPrefix(t *testing.T) {
 	for _, pth := range paths {
 		obj, err := p.OpenObject(ctx, pth)
 		require.NoError(t, err)
-		_, err = obj.Write([]byte("x"))
+		_, err = obj.Write(t.Context(), []byte("x"))
 		require.NoError(t, err)
 	}
 
@@ -122,6 +122,6 @@ func TestWriteToNonExistentObject(t *testing.T) {
 	require.NoError(t, err)
 
 	var sink bytes.Buffer
-	_, err = obj.WriteTo(&sink)
+	_, err = obj.WriteTo(t.Context(), &sink)
 	require.ErrorIs(t, err, ErrorObjectNotExist)
 }

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -153,8 +153,8 @@ func (g *GCPBucketStorageObjectProvider) Size() (int64, error) {
 	return attrs.Size, nil
 }
 
-func (g *GCPBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, err error) {
-	ctx, cancel := context.WithTimeout(g.ctx, googleReadTimeout)
+func (g *GCPBucketStorageObjectProvider) ReadAt(ctx context.Context, buff []byte, off int64) (n int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, googleReadTimeout)
 	defer cancel()
 
 	// The file should not be gzip compressed
@@ -183,7 +183,7 @@ func (g *GCPBucketStorageObjectProvider) ReadAt(buff []byte, off int64) (n int, 
 	return n, nil
 }
 
-func (g *GCPBucketStorageObjectProvider) Write(data []byte) (int, error) {
+func (g *GCPBucketStorageObjectProvider) Write(ctx context.Context, data []byte) (int, error) {
 	w := g.handle.NewWriter(g.ctx)
 	defer w.Close()
 
@@ -195,8 +195,8 @@ func (g *GCPBucketStorageObjectProvider) Write(data []byte) (int, error) {
 	return n, nil
 }
 
-func (g *GCPBucketStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
-	ctx, cancel := context.WithTimeout(g.ctx, googleReadTimeout)
+func (g *GCPBucketStorageObjectProvider) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, googleReadTimeout)
 	defer cancel()
 
 	reader, err := g.handle.NewReader(ctx)
@@ -219,7 +219,7 @@ func (g *GCPBucketStorageObjectProvider) WriteTo(dst io.Writer) (int64, error) {
 	return n, nil
 }
 
-func (g *GCPBucketStorageObjectProvider) WriteFromFileSystem(path string) error {
+func (g *GCPBucketStorageObjectProvider) WriteFromFileSystem(ctx context.Context, path string) error {
 	bucketName := g.storage.bucket.BucketName()
 	objectName := g.path
 	filePath := path
@@ -237,7 +237,7 @@ func (g *GCPBucketStorageObjectProvider) WriteFromFileSystem(path string) error 
 			return fmt.Errorf("failed to read file: %w", err)
 		}
 
-		if _, err = g.Write(data); err != nil {
+		if _, err = g.Write(ctx, data); err != nil {
 			return fmt.Errorf("failed to write file (%d bytes): %w", len(data), err)
 		}
 

--- a/packages/shared/pkg/storage/storage_test.go
+++ b/packages/shared/pkg/storage/storage_test.go
@@ -5,6 +5,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 
 	mock "github.com/stretchr/testify/mock"
@@ -82,8 +83,8 @@ func (_c *MockStorageObjectProvider_Delete_Call) RunAndReturn(run func() error) 
 }
 
 // ReadAt provides a mock function for the type MockStorageObjectProvider
-func (_mock *MockStorageObjectProvider) ReadAt(p []byte, off int64) (int, error) {
-	ret := _mock.Called(p, off)
+func (_mock *MockStorageObjectProvider) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	ret := _mock.Called(ctx, p, off)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReadAt")
@@ -91,16 +92,16 @@ func (_mock *MockStorageObjectProvider) ReadAt(p []byte, off int64) (int, error)
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]byte, int64) (int, error)); ok {
-		return returnFunc(p, off)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte, int64) (int, error)); ok {
+		return returnFunc(ctx, p, off)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]byte, int64) int); ok {
-		r0 = returnFunc(p, off)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte, int64) int); ok {
+		r0 = returnFunc(ctx, p, off)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func([]byte, int64) error); ok {
-		r1 = returnFunc(p, off)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []byte, int64) error); ok {
+		r1 = returnFunc(ctx, p, off)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -113,25 +114,31 @@ type MockStorageObjectProvider_ReadAt_Call struct {
 }
 
 // ReadAt is a helper method to define mock.On call
+//   - ctx context.Context
 //   - p []byte
 //   - off int64
-func (_e *MockStorageObjectProvider_Expecter) ReadAt(p interface{}, off interface{}) *MockStorageObjectProvider_ReadAt_Call {
-	return &MockStorageObjectProvider_ReadAt_Call{Call: _e.mock.On("ReadAt", p, off)}
+func (_e *MockStorageObjectProvider_Expecter) ReadAt(ctx interface{}, p interface{}, off interface{}) *MockStorageObjectProvider_ReadAt_Call {
+	return &MockStorageObjectProvider_ReadAt_Call{Call: _e.mock.On("ReadAt", ctx, p, off)}
 }
 
-func (_c *MockStorageObjectProvider_ReadAt_Call) Run(run func(p []byte, off int64)) *MockStorageObjectProvider_ReadAt_Call {
+func (_c *MockStorageObjectProvider_ReadAt_Call) Run(run func(ctx context.Context, p []byte, off int64)) *MockStorageObjectProvider_ReadAt_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []byte
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]byte)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 int64
+		var arg1 []byte
 		if args[1] != nil {
-			arg1 = args[1].(int64)
+			arg1 = args[1].([]byte)
+		}
+		var arg2 int64
+		if args[2] != nil {
+			arg2 = args[2].(int64)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -142,7 +149,7 @@ func (_c *MockStorageObjectProvider_ReadAt_Call) Return(n int, err error) *MockS
 	return _c
 }
 
-func (_c *MockStorageObjectProvider_ReadAt_Call) RunAndReturn(run func(p []byte, off int64) (int, error)) *MockStorageObjectProvider_ReadAt_Call {
+func (_c *MockStorageObjectProvider_ReadAt_Call) RunAndReturn(run func(ctx context.Context, p []byte, off int64) (int, error)) *MockStorageObjectProvider_ReadAt_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -201,8 +208,8 @@ func (_c *MockStorageObjectProvider_Size_Call) RunAndReturn(run func() (int64, e
 }
 
 // Write provides a mock function for the type MockStorageObjectProvider
-func (_mock *MockStorageObjectProvider) Write(p []byte) (int, error) {
-	ret := _mock.Called(p)
+func (_mock *MockStorageObjectProvider) Write(ctx context.Context, p []byte) (int, error) {
+	ret := _mock.Called(ctx, p)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Write")
@@ -210,16 +217,16 @@ func (_mock *MockStorageObjectProvider) Write(p []byte) (int, error) {
 
 	var r0 int
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func([]byte) (int, error)); ok {
-		return returnFunc(p)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte) (int, error)); ok {
+		return returnFunc(ctx, p)
 	}
-	if returnFunc, ok := ret.Get(0).(func([]byte) int); ok {
-		r0 = returnFunc(p)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte) int); ok {
+		r0 = returnFunc(ctx, p)
 	} else {
 		r0 = ret.Get(0).(int)
 	}
-	if returnFunc, ok := ret.Get(1).(func([]byte) error); ok {
-		r1 = returnFunc(p)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, []byte) error); ok {
+		r1 = returnFunc(ctx, p)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -232,19 +239,25 @@ type MockStorageObjectProvider_Write_Call struct {
 }
 
 // Write is a helper method to define mock.On call
+//   - ctx context.Context
 //   - p []byte
-func (_e *MockStorageObjectProvider_Expecter) Write(p interface{}) *MockStorageObjectProvider_Write_Call {
-	return &MockStorageObjectProvider_Write_Call{Call: _e.mock.On("Write", p)}
+func (_e *MockStorageObjectProvider_Expecter) Write(ctx interface{}, p interface{}) *MockStorageObjectProvider_Write_Call {
+	return &MockStorageObjectProvider_Write_Call{Call: _e.mock.On("Write", ctx, p)}
 }
 
-func (_c *MockStorageObjectProvider_Write_Call) Run(run func(p []byte)) *MockStorageObjectProvider_Write_Call {
+func (_c *MockStorageObjectProvider_Write_Call) Run(run func(ctx context.Context, p []byte)) *MockStorageObjectProvider_Write_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 []byte
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].([]byte)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -255,22 +268,22 @@ func (_c *MockStorageObjectProvider_Write_Call) Return(n int, err error) *MockSt
 	return _c
 }
 
-func (_c *MockStorageObjectProvider_Write_Call) RunAndReturn(run func(p []byte) (int, error)) *MockStorageObjectProvider_Write_Call {
+func (_c *MockStorageObjectProvider_Write_Call) RunAndReturn(run func(ctx context.Context, p []byte) (int, error)) *MockStorageObjectProvider_Write_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // WriteFromFileSystem provides a mock function for the type MockStorageObjectProvider
-func (_mock *MockStorageObjectProvider) WriteFromFileSystem(path string) error {
-	ret := _mock.Called(path)
+func (_mock *MockStorageObjectProvider) WriteFromFileSystem(ctx context.Context, path string) error {
+	ret := _mock.Called(ctx, path)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WriteFromFileSystem")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(path)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, path)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -283,19 +296,25 @@ type MockStorageObjectProvider_WriteFromFileSystem_Call struct {
 }
 
 // WriteFromFileSystem is a helper method to define mock.On call
+//   - ctx context.Context
 //   - path string
-func (_e *MockStorageObjectProvider_Expecter) WriteFromFileSystem(path interface{}) *MockStorageObjectProvider_WriteFromFileSystem_Call {
-	return &MockStorageObjectProvider_WriteFromFileSystem_Call{Call: _e.mock.On("WriteFromFileSystem", path)}
+func (_e *MockStorageObjectProvider_Expecter) WriteFromFileSystem(ctx interface{}, path interface{}) *MockStorageObjectProvider_WriteFromFileSystem_Call {
+	return &MockStorageObjectProvider_WriteFromFileSystem_Call{Call: _e.mock.On("WriteFromFileSystem", ctx, path)}
 }
 
-func (_c *MockStorageObjectProvider_WriteFromFileSystem_Call) Run(run func(path string)) *MockStorageObjectProvider_WriteFromFileSystem_Call {
+func (_c *MockStorageObjectProvider_WriteFromFileSystem_Call) Run(run func(ctx context.Context, path string)) *MockStorageObjectProvider_WriteFromFileSystem_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -306,14 +325,14 @@ func (_c *MockStorageObjectProvider_WriteFromFileSystem_Call) Return(err error) 
 	return _c
 }
 
-func (_c *MockStorageObjectProvider_WriteFromFileSystem_Call) RunAndReturn(run func(path string) error) *MockStorageObjectProvider_WriteFromFileSystem_Call {
+func (_c *MockStorageObjectProvider_WriteFromFileSystem_Call) RunAndReturn(run func(ctx context.Context, path string) error) *MockStorageObjectProvider_WriteFromFileSystem_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // WriteTo provides a mock function for the type MockStorageObjectProvider
-func (_mock *MockStorageObjectProvider) WriteTo(w io.Writer) (int64, error) {
-	ret := _mock.Called(w)
+func (_mock *MockStorageObjectProvider) WriteTo(ctx context.Context, w io.Writer) (int64, error) {
+	ret := _mock.Called(ctx, w)
 
 	if len(ret) == 0 {
 		panic("no return value specified for WriteTo")
@@ -321,16 +340,16 @@ func (_mock *MockStorageObjectProvider) WriteTo(w io.Writer) (int64, error) {
 
 	var r0 int64
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(io.Writer) (int64, error)); ok {
-		return returnFunc(w)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, io.Writer) (int64, error)); ok {
+		return returnFunc(ctx, w)
 	}
-	if returnFunc, ok := ret.Get(0).(func(io.Writer) int64); ok {
-		r0 = returnFunc(w)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, io.Writer) int64); ok {
+		r0 = returnFunc(ctx, w)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
-	if returnFunc, ok := ret.Get(1).(func(io.Writer) error); ok {
-		r1 = returnFunc(w)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, io.Writer) error); ok {
+		r1 = returnFunc(ctx, w)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -343,19 +362,25 @@ type MockStorageObjectProvider_WriteTo_Call struct {
 }
 
 // WriteTo is a helper method to define mock.On call
+//   - ctx context.Context
 //   - w io.Writer
-func (_e *MockStorageObjectProvider_Expecter) WriteTo(w interface{}) *MockStorageObjectProvider_WriteTo_Call {
-	return &MockStorageObjectProvider_WriteTo_Call{Call: _e.mock.On("WriteTo", w)}
+func (_e *MockStorageObjectProvider_Expecter) WriteTo(ctx interface{}, w interface{}) *MockStorageObjectProvider_WriteTo_Call {
+	return &MockStorageObjectProvider_WriteTo_Call{Call: _e.mock.On("WriteTo", ctx, w)}
 }
 
-func (_c *MockStorageObjectProvider_WriteTo_Call) Run(run func(w io.Writer)) *MockStorageObjectProvider_WriteTo_Call {
+func (_c *MockStorageObjectProvider_WriteTo_Call) Run(run func(ctx context.Context, w io.Writer)) *MockStorageObjectProvider_WriteTo_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 io.Writer
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(io.Writer)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 io.Writer
+		if args[1] != nil {
+			arg1 = args[1].(io.Writer)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -366,7 +391,7 @@ func (_c *MockStorageObjectProvider_WriteTo_Call) Return(n int64, err error) *Mo
 	return _c
 }
 
-func (_c *MockStorageObjectProvider_WriteTo_Call) RunAndReturn(run func(w io.Writer) (int64, error)) *MockStorageObjectProvider_WriteTo_Call {
+func (_c *MockStorageObjectProvider_WriteTo_Call) RunAndReturn(run func(ctx context.Context, w io.Writer) (int64, error)) *MockStorageObjectProvider_WriteTo_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This gets rid of a few, but not all, uses of the embedded ctx in the storage providers