### PR TITLE
Nodes sync race condition

### DIFF
--- a/packages/api/internal/edge/cluster.go
+++ b/packages/api/internal/edge/cluster.go
@@ -125,8 +125,14 @@ func (c *Cluster) GetTemplateBuilderByNodeID(nodeID string) (*ClusterInstance, e
 	return instance, nil
 }
 
-func (c *Cluster) GetInstanceByNodeID(nodeID string) (*ClusterInstance, bool) {
-	return c.instances.Get(nodeID)
+func (c *Cluster) GetByServiceInstanceID(serviceInstanceID string) (*ClusterInstance, bool) {
+	for _, instance := range c.instances.Items() {
+		if instance.ServiceInstanceID == serviceInstanceID {
+			return instance, true
+		}
+	}
+
+	return nil, false
 }
 
 func (c *Cluster) GetAvailableTemplateBuilder(ctx context.Context) (*ClusterInstance, error) {

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -181,9 +181,12 @@ func (o *Orchestrator) syncClusterNode(ctx context.Context, node *nodemanager.No
 		return fmt.Errorf("cluster not found")
 	}
 
-	_, found := cluster.GetInstanceByNodeID(node.ID)
+	// We want to find not just node, but explicitly node with expected service instance ID
+	// because node can stay same and instance id will change after node restart, witch should trigger node de-registration from pool.
+	instanceID := node.Metadata().ServiceInstanceID
+	_, found := cluster.GetByServiceInstanceID(instanceID)
 	if !found {
-		return fmt.Errorf("node instance not found")
+		return fmt.Errorf("node instance not found with instance ID '%s'", instanceID)
 	}
 
 	// Unified call for syncing node state across different node types

--- a/packages/api/internal/orchestrator/nodemanager/metadata.go
+++ b/packages/api/internal/orchestrator/nodemanager/metadata.go
@@ -14,7 +14,7 @@ import (
 type NodeMetadata struct {
 	// Service instance ID is unique identifier for every orchestrator process, after restart it will change.
 	// In the future, we want to migrate to using this ID instead of node ID for tracking orchestrators-
-	serviceInstanceID string
+	ServiceInstanceID string
 
 	Commit  string
 	Version string
@@ -36,7 +36,7 @@ func (n *Node) Metadata() NodeMetadata {
 // Generates Metadata with the current service instance ID
 // to ensure we always use the latest ID (e.g. after orchestrator restarts)
 func (n *Node) getClientMetadata() metadata.MD {
-	return metadata.New(map[string]string{consts.EdgeRpcServiceInstanceIDHeader: n.Metadata().serviceInstanceID})
+	return metadata.New(map[string]string{consts.EdgeRpcServiceInstanceIDHeader: n.Metadata().ServiceInstanceID})
 }
 
 func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.SandboxCreateRequest) context.Context {
@@ -52,7 +52,7 @@ func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.Sandbo
 			SandboxStartTime:        req.StartTime.AsTime(),
 
 			ExecutionID:    req.Sandbox.ExecutionId,
-			OrchestratorID: n.Metadata().serviceInstanceID,
+			OrchestratorID: n.Metadata().ServiceInstanceID,
 		},
 	)
 

--- a/packages/api/internal/orchestrator/nodemanager/node.go
+++ b/packages/api/internal/orchestrator/nodemanager/node.go
@@ -81,7 +81,7 @@ func New(
 	go buildCache.Start()
 
 	nodeMetadata := NodeMetadata{
-		serviceInstanceID: nodeInfo.ServiceId,
+		ServiceInstanceID: nodeInfo.ServiceId,
 		Commit:            nodeInfo.ServiceCommit,
 		Version:           nodeInfo.ServiceVersion,
 	}
@@ -120,7 +120,7 @@ func NewClusterNode(ctx context.Context, client *grpclient.GRPCClient, clusterID
 	go buildCache.Start()
 
 	nodeMetadata := NodeMetadata{
-		serviceInstanceID: i.ServiceInstanceID,
+		ServiceInstanceID: i.ServiceInstanceID,
 		Commit:            i.ServiceVersionCommit,
 		Version:           i.ServiceVersion,
 	}

--- a/packages/api/internal/orchestrator/nodemanager/sync.go
+++ b/packages/api/internal/orchestrator/nodemanager/sync.go
@@ -35,7 +35,7 @@ func (n *Node) Sync(ctx context.Context, tracer trace.Tracer, instanceCache *ins
 		n.setStatus(nodeStatus)
 		n.setMetadata(
 			NodeMetadata{
-				serviceInstanceID: nodeInfo.ServiceId,
+				ServiceInstanceID: nodeInfo.ServiceId,
 				Commit:            nodeInfo.ServiceCommit,
 				Version:           nodeInfo.ServiceVersion,
 			},


### PR DESCRIPTION
- (2b9091d9bb99d9cc6d8a0744b2688742bc705883) Fix issue when a long blocked run of `PoolExists/PoolUpdate` can cause a timeout for the whole sync run. This issue occurred when the orchestrator failed and the sync was blocked due to a timeout in the gRPC info service of one node, while the other node was simply hanging. 
- (c8540f72a74a1b14a078a12bb906dae089586301) Fixing race condition when orchestrator on same node restarter faster than next round of service discovery finishes, so api cluster sync pool never realized node disappeared and node de-registration was never triggered, leaving existing node with matching node id but outdated service instance id.