### PR TITLE
Add missing skip for placement metrics

### DIFF
--- a/packages/api/internal/orchestrator/nodemanager/placement_metrics.go
+++ b/packages/api/internal/orchestrator/nodemanager/placement_metrics.go
@@ -23,6 +23,10 @@ func (p *PlacementMetrics) Success(sandboxID string) {
 	p.removeSandbox(sandboxID)
 }
 
+func (p *PlacementMetrics) Skip(sandboxID string) {
+	p.removeSandbox(sandboxID)
+}
+
 func (p *PlacementMetrics) Fail(sandboxID string) {
 	p.createFails.Add(1)
 	p.removeSandbox(sandboxID)

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -79,6 +79,7 @@ func PlaceSandbox(ctx context.Context, tracer trace.Tracer, algorithm Algorithm,
 				zap.L().Error("Failed to create sandbox", logger.WithSandboxID(sbxRequest.Sandbox.SandboxId), logger.WithNodeID(node.ID), zap.Int("attempt", attempt+1), zap.Error(utils.UnwrapGRPCError(err)))
 				attempt++
 			} else {
+				node.PlacementMetrics.Skip(sbxRequest.Sandbox.SandboxId)
 				zap.L().Warn("Node exhausted, trying another node", logger.WithSandboxID(sbxRequest.Sandbox.SandboxId), logger.WithNodeID(node.ID))
 			}
 


### PR DESCRIPTION
If a node runs out of resources, we should not mark the attempt as a failure. But we still need to stop tracking the sandbox as currently being placed on that node.