### PR TITLE
Fix regression for envd watcher

### DIFF
--- a/packages/envd/internal/services/filesystem/watch_sync.go
+++ b/packages/envd/internal/services/filesystem/watch_sync.go
@@ -33,7 +33,8 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error creating watcher: %w", err))
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
+	// We don't want to cancel the context when the request is finished
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
 	err = w.Add(utils.FsnotifyPath(watchPath, recursive))
 	if err != nil {

--- a/tests/integration/internal/tests/envd/watcher_test.go
+++ b/tests/integration/internal/tests/envd/watcher_test.go
@@ -1,0 +1,80 @@
+package envd
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/envd/filesystem"
+	"github.com/e2b-dev/infra/tests/integration/internal/setup"
+	"github.com/e2b-dev/infra/tests/integration/internal/utils"
+)
+
+func TestWatcher(t *testing.T) {
+	c := setup.GetAPIClient()
+	sbx := utils.SetupSandboxWithCleanup(t, c)
+	envdClient := setup.GetEnvdClient(t, t.Context())
+
+	// Create a test directory
+	watchDir := "/tmp/watch_test"
+	utils.CreateDir(t, sbx, watchDir)
+
+	// Create watcher
+	createReq := connect.NewRequest(&filesystem.CreateWatcherRequest{
+		Path:      watchDir,
+		Recursive: false,
+	})
+	setup.SetSandboxHeader(createReq.Header(), sbx.SandboxID)
+	setup.SetUserHeader(createReq.Header(), "user")
+
+	createResp, err := envdClient.FilesystemClient.CreateWatcher(t.Context(), createReq)
+	require.NoError(t, err)
+	require.NotNil(t, createResp)
+	assert.NotEmpty(t, createResp.Msg.WatcherId)
+	watcherId := createResp.Msg.WatcherId
+
+	// Get events (should be empty initially)
+	getReq := connect.NewRequest(&filesystem.GetWatcherEventsRequest{
+		WatcherId: watcherId,
+	})
+	setup.SetSandboxHeader(getReq.Header(), sbx.SandboxID)
+	setup.SetUserHeader(getReq.Header(), "user")
+
+	getResp, err := envdClient.FilesystemClient.GetWatcherEvents(t.Context(), getReq)
+	require.NoError(t, err)
+	assert.Empty(t, getResp.Msg.Events)
+
+	testFile := fmt.Sprintf("%s/test.txt", watchDir)
+	utils.UploadFile(t, t.Context(), sbx, envdClient, testFile, "hello world")
+
+	var events []*filesystem.FilesystemEvent
+	require.Eventually(t, func() bool {
+		getResp, err := envdClient.FilesystemClient.GetWatcherEvents(t.Context(), getReq)
+		require.NoError(t, err)
+		events = getResp.Msg.Events
+		return len(events) > 0
+	}, 5*time.Second, 20*time.Millisecond, "Expected to receive file system events")
+	require.NotEmpty(t, events)
+	assert.Equal(t, filesystem.EventType_EVENT_TYPE_CREATE, events[0].Type)
+	assert.Equal(t, "test.txt", events[0].Name)
+
+	// Remove watcher
+	removeReq := connect.NewRequest(&filesystem.RemoveWatcherRequest{
+		WatcherId: watcherId,
+	})
+	setup.SetSandboxHeader(removeReq.Header(), sbx.SandboxID)
+	setup.SetUserHeader(removeReq.Header(), "user")
+
+	removeResp, err := envdClient.FilesystemClient.RemoveWatcher(t.Context(), removeReq)
+	require.NoError(t, err)
+	assert.NotNil(t, removeResp)
+
+	// Verify watcher is removed (should fail)
+	getResp2, err := envdClient.FilesystemClient.GetWatcherEvents(t.Context(), getReq)
+	assert.Error(t, err)
+	assert.Nil(t, getResp2)
+}

--- a/tests/integration/internal/tests/envd/watcher_test.go
+++ b/tests/integration/internal/tests/envd/watcher_test.go
@@ -75,6 +75,6 @@ func TestWatcher(t *testing.T) {
 
 	// Verify watcher is removed (should fail)
 	getResp2, err := envdClient.FilesystemClient.GetWatcherEvents(t.Context(), getReq)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, getResp2)
 }


### PR DESCRIPTION
- This pull request fixes an issue where watcher was closed right after the request for create was completed (introduced in [#981](https://github.com/e2b-dev/infra/pull/981/files#diff-834039e24b75798bfaf83a9fc463fdb0f5d07445d59ea3d823957da0f8dc3c30))
- Added a integration test (fails without the patch)