### PR TITLE
Increase the healthy deadline

### DIFF
--- a/packages/nomad/api.hcl
+++ b/packages/nomad/api.hcl
@@ -48,7 +48,7 @@ job "api" {
       # Time to wait for the canary to be healthy
       min_healthy_time = "10s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
-      healthy_deadline = "180s"
+      healthy_deadline = "300s"
       # Whether to promote the canary if the rest of the group is not healthy
       auto_promote     = true
     }


### PR DESCRIPTION
This should prevent situation where API takes little bit longer to start and nomad marks the deploy as unsuccessful 