### PR TITLE
Add multiple template managers in Nomad job

### DIFF
--- a/packages/nomad/template-manager.hcl
+++ b/packages/nomad/template-manager.hcl
@@ -1,17 +1,20 @@
-job "template-manager" {
+job "template-manager-system" {
   datacenters = ["${gcp_zone}"]
+  type = "system"
   node_pool  = "build"
   priority = 70
 
 %{ if update_stanza }
   update {
-      auto_promote      = true # Whether to promote the canary if the rest of the group is not healthy
-      canary            = 1 # Allows to spawn new version of the service before killing the old one
+      max_parallel      = 1 # Update only 1 node at a time
+      min_healthy_time  = "10s" # Time to wait for the new version to be healthy
+      healthy_deadline  = "5m" # Time to wait for the new version to be healthy, if not it will be marked as failed
       progress_deadline = "20m" # Deadline for the update to be completed
   }
 %{ endif }
 
   group "template-manager" {
+
     network {
       port "template-manager" {
         static = "${port}"


### PR DESCRIPTION
Add multiple template managers in the Nomad job. This is achieved by changing the job type from `service` to `system`. Unfortunately, service doesn't support the update strategy we need (first stop the current job, then run the new one, one by one across nodes).