### PR TITLE
Fix base layer corrupted filesystem

### DIFF
--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -149,7 +149,7 @@ func (b *Builder) Build(ctx context.Context, template storage.TemplateFiles, con
 		return nil, fmt.Errorf("error getting envd version: %w", err)
 	}
 
-	uploadErrGroup, _ := errgroup.WithContext(ctx)
+	var uploadErrGroup errgroup.Group
 	defer func() {
 		// Wait for all template layers to be uploaded even if the build fails
 		err := uploadErrGroup.Wait()
@@ -162,7 +162,7 @@ func (b *Builder) Build(ctx context.Context, template storage.TemplateFiles, con
 		Config:         config,
 		Template:       template,
 		UserLogger:     postProcessor,
-		UploadErrGroup: uploadErrGroup,
+		UploadErrGroup: &uploadErrGroup,
 		EnvdVersion:    envdVersion,
 		CacheScope:     cacheScope,
 		IsV1Build:      isV1Build,
@@ -195,6 +195,7 @@ func runBuild(
 		bc,
 		builder.logger,
 		builder.tracer,
+		builder.proxy,
 		builder.templateStorage,
 		builder.devicePool,
 		builder.networkPool,

--- a/packages/orchestrator/internal/template/build/layer/create_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/create_sandbox.go
@@ -20,12 +20,18 @@ import (
 type CreateSandbox struct {
 	config     sandbox.Config
 	fcVersions fc.FirecrackerVersions
+
+	rootfsCachePath string
 }
 
 var _ SandboxCreator = (*CreateSandbox)(nil)
 
 func NewCreateSandbox(config sandbox.Config, fcVersions fc.FirecrackerVersions) *CreateSandbox {
-	return &CreateSandbox{config: config, fcVersions: fcVersions}
+	return &CreateSandbox{config: config, fcVersions: fcVersions, rootfsCachePath: ""}
+}
+
+func NewCreateSandboxFromCache(config sandbox.Config, fcVersions fc.FirecrackerVersions, rootfsCachePath string) *CreateSandbox {
+	return &CreateSandbox{config: config, fcVersions: fcVersions, rootfsCachePath: rootfsCachePath}
 }
 
 func (f *CreateSandbox) Sandbox(
@@ -61,7 +67,7 @@ func (f *CreateSandbox) Sandbox(
 		f.fcVersions,
 		template,
 		layerTimeout,
-		"",
+		f.rootfsCachePath,
 		fc.ProcessOptions{
 			InitScriptPath:      constants.SystemdInitPath,
 			KernelLogs:          env.IsDevelopment(),

--- a/packages/orchestrator/internal/template/build/layer/interfaces.go
+++ b/packages/orchestrator/internal/template/build/layer/interfaces.go
@@ -7,7 +7,6 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	sbxtemplate "github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 const (
@@ -29,9 +28,14 @@ type ActionExecutor interface {
 	Execute(ctx context.Context, sbx *sandbox.Sandbox, meta metadata.Template) (metadata.Template, error)
 }
 
+// SourceTemplateProvider provides the source template for the layer build
+type SourceTemplateProvider interface {
+	Get(ctx context.Context, templateCache *sbxtemplate.Cache) (sbxtemplate.Template, error)
+}
+
 // LayerBuildCommand encapsulates all parameters needed for building a layer
 type LayerBuildCommand struct {
-	SourceTemplate storage.TemplateFiles
+	SourceTemplate SourceTemplateProvider
 	CurrentLayer   metadata.Template
 	Hash           string
 	UpdateEnvd     bool

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -75,14 +75,7 @@ func (lb *LayerExecutor) BuildLayer(
 	ctx, childSpan := lb.tracer.Start(ctx, "run-in-sandbox")
 	defer childSpan.End()
 
-	localTemplate, err := lb.templateCache.GetTemplate(
-		ctx,
-		cmd.SourceTemplate.BuildID,
-		cmd.SourceTemplate.KernelVersion,
-		cmd.SourceTemplate.FirecrackerVersion,
-		false,
-		true,
-	)
+	localTemplate, err := cmd.SourceTemplate.Get(ctx, lb.templateCache)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("get template snapshot: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/layer/source_template.go
+++ b/packages/orchestrator/internal/template/build/layer/source_template.go
@@ -1,0 +1,53 @@
+package layer
+
+import (
+	"context"
+	"fmt"
+
+	sbxtemplate "github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+var _ SourceTemplateProvider = (*CacheSourceTemplateProvider)(nil)
+
+type CacheSourceTemplateProvider struct {
+	files storage.TemplateFiles
+}
+
+func NewCacheSourceTemplateProvider(
+	files storage.TemplateFiles,
+) *CacheSourceTemplateProvider {
+	return &CacheSourceTemplateProvider{
+		files: files,
+	}
+}
+
+func (cstp *CacheSourceTemplateProvider) Get(ctx context.Context, templateCache *sbxtemplate.Cache) (sbxtemplate.Template, error) {
+	template, err := templateCache.GetTemplate(
+		ctx,
+		cstp.files.BuildID,
+		cstp.files.KernelVersion,
+		cstp.files.FirecrackerVersion,
+		false,
+		true,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get template snapshot: %w", err)
+	}
+
+	return template, nil
+}
+
+var _ SourceTemplateProvider = (*DirectSourceTemplateProvider)(nil)
+
+type DirectSourceTemplateProvider struct {
+	SourceTemplate sbxtemplate.Template
+}
+
+func NewDirectSourceTemplateProvider(template sbxtemplate.Template) *DirectSourceTemplateProvider {
+	return &DirectSourceTemplateProvider{SourceTemplate: template}
+}
+
+func (dstp *DirectSourceTemplateProvider) Get(_ context.Context, _ *sbxtemplate.Cache) (sbxtemplate.Template, error) {
+	return dstp.SourceTemplate, nil
+}

--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -126,8 +126,10 @@ func (ppb *PostProcessingBuilder) Build(
 
 	actionExecutor := layer.NewFunctionAction(ppb.postProcessingFn())
 
+	templateProvider := layer.NewCacheSourceTemplateProvider(sourceLayer.Metadata.Template)
+
 	finalLayer, err := ppb.layerExecutor.BuildLayer(ctx, layer.LayerBuildCommand{
-		SourceTemplate: sourceLayer.Metadata.Template,
+		SourceTemplate: templateProvider,
 		CurrentLayer:   currentLayer.Metadata,
 		Hash:           currentLayer.Hash,
 		UpdateEnvd:     sourceLayer.Cached,

--- a/packages/orchestrator/internal/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/builder.go
@@ -185,8 +185,10 @@ func (sb *StepBuilder) Build(
 		return meta, nil
 	})
 
+	templateProvider := layer.NewCacheSourceTemplateProvider(sourceLayer.Metadata.Template)
+
 	meta, err := sb.layerExecutor.BuildLayer(ctx, layer.LayerBuildCommand{
-		SourceTemplate: sourceLayer.Metadata.Template,
+		SourceTemplate: templateProvider,
 		CurrentLayer:   currentLayer.Metadata,
 		Hash:           currentLayer.Hash,
 		UpdateEnvd:     sourceLayer.Cached,


### PR DESCRIPTION
Fix base layer corrupted filesystem. The issue was caused by a missing `sync` call to synchronize all file changes from memory before pausing the base layer. The changes need to be synchronized, because the finalize layer is always a sandbox creation (which doesn't reuse the memory -> like OS crash).