### PR TITLE
Fix microVM clock drifts to the future

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -32,12 +32,17 @@ type ProcessOptions struct {
 
 	// KernelLogs is a flag to enable kernel logs output to the process stdout.
 	KernelLogs bool
+
 	// SystemdToKernelLogs is a flag to enable systemd logs output to the console.
 	// It enabled the kernel logs by default too.
 	SystemdToKernelLogs bool
 
+	// KvmClock is a flag to enable kvm-clock as the clocksource for the kernel.
+	KvmClock bool
+
 	// Stdout is the writer to which the process stdout will be written.
 	Stdout io.Writer
+
 	// Stderr is the writer to which the process stderr will be written.
 	Stderr io.Writer
 }
@@ -251,11 +256,16 @@ func (p *Process) Create(
 		"i8042.nokbd":      "",
 		"i8042.noaux":      "",
 		"random.trust_cpu": "on",
-		"clocksource":      "kvm-clock",
 	}
+
+	if options.KvmClock {
+		args["clocksource"] = "kvm-clock"
+	}
+
 	if options.SystemdToKernelLogs {
 		args["systemd.journald.forward_to_console"] = ""
 	}
+
 	if options.KernelLogs || options.SystemdToKernelLogs {
 		// Forward kernel logs to the ttyS0, which will be picked up by the stdout of FC process
 		delete(args, "quiet")

--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -270,8 +270,6 @@ echo "System Init"`), Mode: 0o777},
 		map[string]string{
 			// Enable envd service autostart
 			"etc/systemd/system/multi-user.target.wants/envd.service": "etc/systemd/system/envd.service",
-			// Enable chrony service autostart
-			"etc/systemd/system/multi-user.target.wants/chrony.service": "etc/systemd/system/chrony.service",
 		},
 	)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/layer/create_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/create_sandbox.go
@@ -15,6 +15,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // CreateSandbox creates sandboxes for new templates
@@ -25,6 +26,10 @@ type CreateSandbox struct {
 
 	rootfsCachePath string
 }
+
+const (
+	minEnvdVersionForKVMClock = "0.2.11" // Minimum version of envd that supports KVM clock
+)
 
 var _ SandboxCreator = (*CreateSandbox)(nil)
 
@@ -54,6 +59,11 @@ func (cs *CreateSandbox) Sandbox(
 
 	template := sbxtemplate.NewMaskTemplate(sourceTemplate, sbxtemplate.WithMemfile(memfile))
 
+	kvmClock, err := utils.IsGTEVersion(cs.config.Envd.Version, minEnvdVersionForKVMClock)
+	if err != nil {
+		return nil, fmt.Errorf("error comparing envd version: %w", err)
+	}
+
 	// In case of a new sandbox, base template ID is now used as the potentially exported template base ID.
 	sbx, err := sandbox.CreateSandbox(
 		ctx,
@@ -74,6 +84,7 @@ func (cs *CreateSandbox) Sandbox(
 			InitScriptPath:      constants.SystemdInitPath,
 			KernelLogs:          env.IsDevelopment(),
 			SystemdToKernelLogs: false,
+			KvmClock:            kvmClock,
 		},
 		nil,
 	)

--- a/packages/orchestrator/internal/template/build/phases/base/provision.go
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.go
@@ -90,6 +90,8 @@ func (bb *BaseBuilder) provisionSandbox(
 			// the sandbox is then started with systemd and without kernel logs.
 			KernelLogs: true,
 
+			KvmClock: true,
+
 			// Show provision script logs to the user
 			Stdout: logsWriter,
 			Stderr: logsWriter,

--- a/packages/orchestrator/internal/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.sh
@@ -3,14 +3,11 @@ set -eu
 
 echo "Starting provisioning script"
 
-# fix: dpkg-statoverride: warning: --update given but /var/log/chrony does not exist
-mkdir -p /var/log/chrony
-
 echo "Making configuration immutable"
 {{ .BusyBox }} chattr +i /etc/resolv.conf
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl"
+PACKAGES="systemd systemd-sysv openssh-server sudo linuxptp socat curl"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""
@@ -41,24 +38,6 @@ echo "if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; if [ -f ~/.profile ]; then
 
 echo "Remove root password"
 passwd -d root
-
-echo "Setting up chrony"
-mkdir -p /etc/chrony
-cat <<EOF >/etc/chrony/chrony.conf
-refclock PHC /dev/ptp0 poll -1 dpoll -1 offset 0 trust prefer
-makestep 1 -1
-EOF
-# Add a proxy config, as some environments expects it there (e.g. timemaster in Node Dockerimage)
-echo "include /etc/chrony/chrony.conf" >/etc/chrony.conf
-# Set chrony to run as root
-mkdir -p /etc/systemd/system/chrony.service.d
-cat <<EOF >/etc/systemd/system/chrony.service.d/override.conf
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/chronyd
-User=root
-Group=root
-EOF
 
 echo "Setting up SSH"
 mkdir -p /etc/ssh


### PR DESCRIPTION
Removing the Chrony service from template provisioning.
KVM clocks are used for every new template build and for every sandbox with envd version >= `0.2.11`.

Currently, there is an issue that templates with `0.2.11` versions that are already built can experience future time drifts as we are using Chrony and also KVM clock for clock sync. We cannot bump envd version and stop using KVM clock for this version, as we removed clock sync locks from envd.