### PR TITLE
Support cpu platform and disk type configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
 	$(call tfvar, GRAFANA_MANAGED) \
 	$(call tfvar, FILESTORE_CACHE_ENABLED) \
 	$(call tfvar, FILESTORE_CACHE_TIER) \
-	$(call tfvar, FILESTORE_CACHE_CAPACITY_GB)
+	$(call tfvar, FILESTORE_CACHE_CAPACITY_GB) \
+	$(call tfvar, BUILD_CLUSTER_CACHE_DISK_TYPE) \
+	$(call tfvar, CLIENT_CLUSTER_CACHE_DISK_TYPE) \
+	$(call tfvar, MIN_CPU_PLATFORM)
 
 # Login for Packer and Docker (uses gcloud user creds)
 # Login for Terraform (uses application default creds)

--- a/main.tf
+++ b/main.tf
@@ -92,8 +92,10 @@ module "cluster" {
 
   client_cluster_size_max           = var.client_cluster_size_max
   client_cluster_cache_disk_size_gb = var.client_cluster_cache_disk_size_gb
+  client_cluster_cache_disk_type    = var.client_cluster_cache_disk_type
   build_cluster_root_disk_size_gb   = var.build_cluster_root_disk_size_gb
   build_cluster_cache_disk_size_gb  = var.build_cluster_cache_disk_size_gb
+  build_cluster_cache_disk_type     = var.build_cluster_cache_disk_type
 
   api_cluster_size        = var.api_cluster_size
   build_cluster_size      = var.build_cluster_size
@@ -143,6 +145,8 @@ module "cluster" {
 
   labels = var.labels
   prefix = var.prefix
+
+  min_cpu_platform = var.min_cpu_platform
 }
 
 module "api" {

--- a/packages/cluster/build-cluster/main.tf
+++ b/packages/cluster/build-cluster/main.tf
@@ -65,7 +65,7 @@ resource "google_compute_instance_template" "build" {
 
   instance_description = var.cluster_description
   machine_type         = var.machine_type
-  min_cpu_platform     = "Intel Skylake"
+  min_cpu_platform     = var.min_cpu_platform
 
   labels = merge(
     var.labels,
@@ -99,7 +99,7 @@ resource "google_compute_instance_template" "build" {
     boot         = false
     type         = "PERSISTENT"
     disk_size_gb = var.cache_volume_disk_size_gb
-    disk_type    = "pd-ssd"
+    disk_type    = var.cache_volume_disk_type
   }
 
   network_interface {

--- a/packages/cluster/build-cluster/variables.tf
+++ b/packages/cluster/build-cluster/variables.tf
@@ -162,3 +162,11 @@ variable "docker_reverse_proxy_port" {
     health_path = string
   })
 }
+
+variable "min_cpu_platform" {
+  type = string
+}
+
+variable "cache_volume_disk_type" {
+  type = string
+}

--- a/packages/cluster/client/main.tf
+++ b/packages/cluster/client/main.tf
@@ -96,7 +96,7 @@ resource "google_compute_instance_template" "client" {
 
   instance_description = var.cluster_description
   machine_type         = var.machine_type
-  min_cpu_platform     = "Intel Skylake"
+  min_cpu_platform     = var.min_cpu_platform
 
   labels = merge(
     var.labels,
@@ -130,7 +130,7 @@ resource "google_compute_instance_template" "client" {
     boot         = false
     type         = "PERSISTENT"
     disk_size_gb = var.cache_volume_disk_size_gb
-    disk_type    = "pd-ssd"
+    disk_type    = var.cache_volume_disk_type
   }
 
   network_interface {

--- a/packages/cluster/client/variables.tf
+++ b/packages/cluster/client/variables.tf
@@ -134,8 +134,12 @@ variable "cache_volume_disk_size_gb" {
   description = "The size, in GB, of the disk for an orchestrator cache."
   type        = number
 }
-# Update Policy
 
+variable "cache_volume_disk_type" {
+  type = string
+}
+
+# Update Policy
 
 variable "instance_group_update_policy_minimal_action" {
   description = "Minimal action to be taken on an instance. You can specify either 'RESTART' to restart existing instances or 'REPLACE' to delete and create new instances from the target template. If you specify a 'RESTART', the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action."
@@ -180,4 +184,8 @@ variable "logs_health_proxy_port" {
     port        = number
     health_path = string
   })
+}
+
+variable "min_cpu_platform" {
+  type = string
 }

--- a/packages/cluster/main.tf
+++ b/packages/cluster/main.tf
@@ -156,12 +156,14 @@ module "client_cluster" {
   cluster_size              = var.client_cluster_size
   cluster_tag_name          = var.cluster_tag_name
   cache_volume_disk_size_gb = var.client_cluster_cache_disk_size_gb
+  cache_volume_disk_type    = var.client_cluster_cache_disk_type
 
   gcp_region = var.gcp_region
   gcp_zone   = var.gcp_zone
 
-  machine_type = var.client_machine_type
-  image_family = var.client_image_family
+  min_cpu_platform = var.min_cpu_platform
+  machine_type     = var.client_machine_type
+  image_family     = var.client_image_family
 
   network_name = var.network_name
 
@@ -304,10 +306,12 @@ module "build_cluster" {
   cluster_tag_name = var.cluster_tag_name
   gcp_zone         = var.gcp_zone
 
+  min_cpu_platform          = var.min_cpu_platform
   machine_type              = var.build_machine_type
   image_family              = var.build_image_family
   root_volume_disk_size_gb  = var.build_cluster_root_disk_size_gb
   cache_volume_disk_size_gb = var.build_cluster_cache_disk_size_gb
+  cache_volume_disk_type    = var.build_cluster_cache_disk_type
 
   network_name = var.network_name
 

--- a/packages/cluster/variables.tf
+++ b/packages/cluster/variables.tf
@@ -69,6 +69,10 @@ variable "build_cluster_cache_disk_size_gb" {
   type = number
 }
 
+variable "build_cluster_cache_disk_type" {
+  type = string
+}
+
 variable "edge_api_port" {
   type = object({
     name = string
@@ -124,6 +128,10 @@ variable "client_machine_type" {
 
 variable "client_cluster_cache_disk_size_gb" {
   type = number
+}
+
+variable "client_cluster_cache_disk_type" {
+  type = string
 }
 
 variable "gcp_project_id" {
@@ -275,4 +283,8 @@ variable "filestore_cache_tier" {
 variable "filestore_cache_capacity_gb" {
   type    = number
   default = 0
+}
+
+variable "min_cpu_platform" {
+  type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "build_cluster_cache_disk_size_gb" {
   default     = 200
 }
 
+variable "build_cluster_cache_disk_type" {
+  description = "The GCE cache disk type for the build machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
 variable "clickhouse_cluster_size" {
   type = number
 }
@@ -228,6 +234,12 @@ variable "client_cluster_cache_disk_size_gb" {
   default     = 500
 }
 
+variable "client_cluster_cache_disk_type" {
+  description = "The GCE cache disk type for the client machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
 variable "orchestrator_port" {
   type    = number
   default = 5008
@@ -376,4 +388,9 @@ variable "filestore_cache_capacity_gb" {
   type        = number
   description = "The capacity of the Filestore cache in GB"
   default     = 0
+}
+
+variable "min_cpu_platform" {
+  type    = string
+  default = "Intel Skylake"
 }


### PR DESCRIPTION
This exposes a few fields to customize the cpu and disk type for the build and client nodes, but keeps the defaults the same.