### PR TITLE
Stop passing around a tracer

### DIFF
--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -77,8 +76,6 @@ func buildTemplate(
 	sbxlogger.SetSandboxLoggerExternal(logger)
 	sbxlogger.SetSandboxLoggerInternal(logger)
 
-	tracer := otel.Tracer("test")
-
 	logger.Info("building template", l.WithTemplateID(templateID), l.WithBuildID(buildID))
 
 	// The sandbox map is shared between the server and the proxy
@@ -123,7 +120,7 @@ func buildTemplate(
 		}
 	}()
 
-	networkPool, err := network.NewPool(ctx, noop.MeterProvider{}, 8, 8, clientID, tracer)
+	networkPool, err := network.NewPool(ctx, noop.MeterProvider{}, 8, 8, clientID)
 	if err != nil {
 		return fmt.Errorf("could not create network pool: %w", err)
 	}
@@ -160,7 +157,6 @@ func buildTemplate(
 	}
 	builder := build.NewBuilder(
 		logger,
-		tracer,
 		persistenceTemplate,
 		persistenceBuild,
 		artifactRegistry,

--- a/packages/orchestrator/cmd/mock-nbd/mock.go
+++ b/packages/orchestrator/cmd/mock-nbd/mock.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pojntfx/go-nbd/pkg/backend"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
@@ -150,8 +149,7 @@ func MockNbd(ctx context.Context, device *DeviceWithClose, index int, devicePool
 		}
 	}()
 
-	tracer := otel.Tracer("test")
-	mnt = nbd.NewDirectPathMount(ctx, tracer, device, devicePool)
+	mnt = nbd.NewDirectPathMount(ctx, device, devicePool)
 
 	go func() {
 		<-ctx.Done()

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -6,11 +6,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.sandbox")
 
 const (
 	healthCheckInterval = 20 * time.Second
@@ -30,7 +32,7 @@ type Checks struct {
 
 var ErrChecksStopped = errors.New("checks stopped")
 
-func NewChecks(ctx context.Context, tracer trace.Tracer, sandbox *Sandbox, useClickhouseMetrics bool) (*Checks, error) {
+func NewChecks(ctx context.Context, sandbox *Sandbox, useClickhouseMetrics bool) (*Checks, error) {
 	_, childSpan := tracer.Start(ctx, "checks-create")
 	defer childSpan.End()
 

--- a/packages/orchestrator/internal/sandbox/diffcreator.go
+++ b/packages/orchestrator/internal/sandbox/diffcreator.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/bits-and-blooms/bitset"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/rootfs"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -29,7 +28,6 @@ func (r *RootfsDiffCreator) process(ctx context.Context, out io.Writer) (*header
 }
 
 type MemoryDiffCreator struct {
-	tracer     trace.Tracer
 	memfile    *storage.TemporaryMemfile
 	dirtyPages *bitset.BitSet
 	blockSize  int64
@@ -52,7 +50,6 @@ func (r *MemoryDiffCreator) process(ctx context.Context, out io.Writer) (h *head
 
 	return header.WriteDiffWithTrace(
 		ctx,
-		r.tracer,
 		memfileSource,
 		r.blockSize,
 		r.dirtyPages,

--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -9,8 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
@@ -56,7 +54,7 @@ type PostInitJSONBody struct {
 	AccessToken *string            `json:"accessToken,omitempty"`
 }
 
-func (s *Sandbox) initEnvd(ctx context.Context, tracer trace.Tracer, envVars map[string]string, accessToken *string) error {
+func (s *Sandbox) initEnvd(ctx context.Context, envVars map[string]string, accessToken *string) error {
 	childCtx, childSpan := tracer.Start(ctx, "envd-init")
 	defer childSpan.End()
 

--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -25,6 +26,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.sandbox.fc")
 
 type ProcessOptions struct {
 	// InitScriptPath is the path to the init script that will be executed inside the VM on kernel start.
@@ -62,7 +65,6 @@ type Process struct {
 
 func NewProcess(
 	ctx context.Context,
-	tracer trace.Tracer,
 	slot *network.Slot,
 	files *storage.SandboxFiles,
 	versions FirecrackerVersions,
@@ -125,7 +127,6 @@ func NewProcess(
 
 func (p *Process) configure(
 	ctx context.Context,
-	tracer trace.Tracer,
 	sbxMetadata sbxlogger.LoggerMetadata,
 	stdoutExternal io.Writer,
 	stderrExternal io.Writer,
@@ -204,7 +205,6 @@ func (p *Process) configure(
 
 func (p *Process) Create(
 	ctx context.Context,
-	tracer trace.Tracer,
 	loggerMetadata sbxlogger.LoggerMetadata,
 	vCPUCount int64,
 	memoryMB int64,
@@ -216,7 +216,6 @@ func (p *Process) Create(
 
 	err := p.configure(
 		ctx,
-		tracer,
 		loggerMetadata,
 		options.Stdout,
 		options.Stderr,
@@ -316,7 +315,6 @@ func (p *Process) Create(
 
 func (p *Process) Resume(
 	ctx context.Context,
-	tracer trace.Tracer,
 	mmdsMetadata *MmdsMetadata,
 	uffdSocketPath string,
 	snapfile template.File,
@@ -327,7 +325,6 @@ func (p *Process) Resume(
 
 	err := p.configure(
 		childCtx,
-		tracer,
 		mmdsMetadata,
 		nil,
 		nil,
@@ -443,7 +440,7 @@ func (p *Process) Stop() error {
 	return nil
 }
 
-func (p *Process) Pause(ctx context.Context, tracer trace.Tracer) error {
+func (p *Process) Pause(ctx context.Context) error {
 	ctx, childSpan := tracer.Start(ctx, "pause-fc")
 	defer childSpan.End()
 
@@ -451,7 +448,7 @@ func (p *Process) Pause(ctx context.Context, tracer trace.Tracer) error {
 }
 
 // CreateSnapshot VM needs to be paused before creating a snapshot.
-func (p *Process) CreateSnapshot(ctx context.Context, tracer trace.Tracer, snapfilePath string, memfilePath string) error {
+func (p *Process) CreateSnapshot(ctx context.Context, snapfilePath string, memfilePath string) error {
 	ctx, childSpan := tracer.Start(ctx, "create-snapshot-fc")
 	defer childSpan.End()
 

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/Merovius/nbd/nbdnl"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
@@ -29,8 +29,9 @@ const (
 	disconnectTimeout = 30 * time.Second
 )
 
+var tracer = otel.Tracer("orchestrator.internal.sandbox.nbd")
+
 type DirectPathMount struct {
-	tracer   trace.Tracer
 	ctx      context.Context // nolint:containedctx // todo: refactor so this can be removed
 	cancelfn context.CancelFunc
 
@@ -47,11 +48,10 @@ type DirectPathMount struct {
 	handlersWg sync.WaitGroup
 }
 
-func NewDirectPathMount(ctx context.Context, tracer trace.Tracer, b block.Device, devicePool *DevicePool) *DirectPathMount {
+func NewDirectPathMount(ctx context.Context, b block.Device, devicePool *DevicePool) *DirectPathMount {
 	ctx, cancelfn := context.WithCancel(context.WithoutCancel(ctx))
 
 	return &DirectPathMount{
-		tracer:      tracer,
 		Backend:     b,
 		ctx:         ctx,
 		cancelfn:    cancelfn,
@@ -185,7 +185,7 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 }
 
 func (d *DirectPathMount) Close(ctx context.Context) error {
-	childCtx, childSpan := d.tracer.Start(ctx, "direct-path-mount-close")
+	childCtx, childSpan := tracer.Start(ctx, "direct-path-mount-close")
 	defer childSpan.End()
 
 	var errs []error

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -29,7 +28,7 @@ type Pool struct {
 	slotStorage Storage
 }
 
-func NewPool(ctx context.Context, meterProvider metric.MeterProvider, newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string, tracer trace.Tracer) (*Pool, error) {
+func NewPool(ctx context.Context, meterProvider metric.MeterProvider, newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string) (*Pool, error) {
 	newSlots := make(chan *Slot, newSlotsPoolSize-1)
 	reusedSlots := make(chan *Slot, reusedSlotsPoolSize)
 
@@ -45,7 +44,7 @@ func NewPool(ctx context.Context, meterProvider metric.MeterProvider, newSlotsPo
 		return nil, fmt.Errorf("failed to create reused slot counter: %w", err)
 	}
 
-	slotStorage, err := NewStorage(vrtSlotsSize, nodeID, tracer)
+	slotStorage, err := NewStorage(vrtSlotsSize, nodeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create slot storage: %w", err)
 	}
@@ -112,7 +111,7 @@ func (p *Pool) populate(ctx context.Context) error {
 	}
 }
 
-func (p *Pool) Get(ctx context.Context, tracer trace.Tracer, allowInternet bool) (*Slot, error) {
+func (p *Pool) Get(ctx context.Context, allowInternet bool) (*Slot, error) {
 	var slot *Slot
 
 	select {
@@ -133,7 +132,7 @@ func (p *Pool) Get(ctx context.Context, tracer trace.Tracer, allowInternet bool)
 		}
 	}
 
-	err := slot.ConfigureInternet(ctx, tracer, allowInternet)
+	err := slot.ConfigureInternet(ctx, allowInternet)
 	if err != nil {
 		return nil, fmt.Errorf("error setting slot internet access: %w", err)
 	}
@@ -141,8 +140,8 @@ func (p *Pool) Get(ctx context.Context, tracer trace.Tracer, allowInternet bool)
 	return slot, nil
 }
 
-func (p *Pool) Return(ctx context.Context, tracer trace.Tracer, slot *Slot) error {
-	err := slot.ResetInternet(ctx, tracer)
+func (p *Pool) Return(ctx context.Context, slot *Slot) error {
+	err := slot.ResetInternet(ctx)
 	if err != nil {
 		// Cleanup the slot if resetting internet fails
 		if cerr := p.cleanup(slot); cerr != nil {

--- a/packages/orchestrator/internal/sandbox/network/slot.go
+++ b/packages/orchestrator/internal/sandbox/network/slot.go
@@ -9,12 +9,15 @@ import (
 	"sync/atomic"
 
 	"github.com/containernetworking/plugins/pkg/ns"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	netutils "k8s.io/utils/net"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.sandbox.network")
 
 const (
 	defaultHostNetworkCIDR = "10.11.0.0/16"
@@ -234,7 +237,7 @@ func (s *Slot) CloseFirewall() error {
 	return nil
 }
 
-func (s *Slot) ConfigureInternet(ctx context.Context, tracer trace.Tracer, allowInternet bool) (e error) {
+func (s *Slot) ConfigureInternet(ctx context.Context, allowInternet bool) (e error) {
 	_, span := tracer.Start(ctx, "slot-internet-configure", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 		attribute.Bool("allow_internet", allowInternet),
@@ -269,7 +272,7 @@ func (s *Slot) ConfigureInternet(ctx context.Context, tracer trace.Tracer, allow
 	return nil
 }
 
-func (s *Slot) ResetInternet(ctx context.Context, tracer trace.Tracer) error {
+func (s *Slot) ResetInternet(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "slot-internet-reset", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 	))

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"os"
 
-	"go.opentelemetry.io/otel/trace"
-
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
@@ -17,9 +15,9 @@ type Storage interface {
 }
 
 // NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
-func NewStorage(slotsSize int, nodeID string, tracer trace.Tracer) (Storage, error) {
+func NewStorage(slotsSize int, nodeID string) (Storage, error) {
 	if env.IsDevelopment() || localNamespaceStorageSwitch == "true" {
-		return NewStorageLocal(slotsSize, tracer)
+		return NewStorageLocal(slotsSize)
 	}
 
 	return NewStorageKV(slotsSize, nodeID)

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
@@ -18,12 +17,11 @@ type StorageLocal struct {
 	foreignNs    map[string]struct{}
 	acquiredNs   map[string]struct{}
 	acquiredNsMu sync.Mutex
-	tracer       trace.Tracer
 }
 
 const netNamespacesDir = "/var/run/netns"
 
-func NewStorageLocal(slotsSize int, tracer trace.Tracer) (*StorageLocal, error) {
+func NewStorageLocal(slotsSize int) (*StorageLocal, error) {
 	// get namespaces that we want to always skip
 	foreignNs, err := getForeignNamespaces()
 	if err != nil {
@@ -41,12 +39,11 @@ func NewStorageLocal(slotsSize int, tracer trace.Tracer) (*StorageLocal, error) 
 		slotsSize:    slotsSize,
 		acquiredNs:   make(map[string]struct{}, slotsSize),
 		acquiredNsMu: sync.Mutex{},
-		tracer:       tracer,
 	}, nil
 }
 
 func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
-	spanCtx, span := s.tracer.Start(ctx, "network-namespace-acquire")
+	spanCtx, span := tracer.Start(ctx, "network-namespace-acquire")
 	defer span.End()
 
 	acquireTimeoutCtx, acquireCancel := context.WithTimeout(spanCtx, time.Millisecond*500)

--- a/packages/orchestrator/internal/sandbox/rootfs/direct.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/direct.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sync/atomic"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
@@ -14,9 +14,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-type DirectProvider struct {
-	tracer trace.Tracer
+var tracer = otel.Tracer("orchestrator.internal.sandbox.rootfs")
 
+type DirectProvider struct {
 	cache *block.Cache
 	path  string
 
@@ -26,7 +26,7 @@ type DirectProvider struct {
 	exporting atomic.Bool
 }
 
-func NewDirectProvider(tracer trace.Tracer, rootfs block.ReadonlyDevice, path string) (Provider, error) {
+func NewDirectProvider(rootfs block.ReadonlyDevice, path string) (Provider, error) {
 	size, err := rootfs.Size()
 	if err != nil {
 		return nil, fmt.Errorf("error getting device size: %w", err)
@@ -40,9 +40,8 @@ func NewDirectProvider(tracer trace.Tracer, rootfs block.ReadonlyDevice, path st
 	}
 
 	return &DirectProvider{
-		tracer: tracer,
-		cache:  cache,
-		path:   path,
+		cache: cache,
+		path:  path,
 
 		finishedOperations: make(chan struct{}, 1),
 	}, nil
@@ -57,7 +56,7 @@ func (o *DirectProvider) ExportDiff(
 	out io.Writer,
 	stopSandbox func(context.Context) error,
 ) (*header.DiffMetadata, error) {
-	ctx, childSpan := o.tracer.Start(ctx, "direct-provider-export")
+	ctx, childSpan := tracer.Start(ctx, "direct-provider-export")
 	defer childSpan.End()
 
 	o.exporting.CompareAndSwap(false, true)

--- a/packages/orchestrator/internal/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/nbd.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"syscall"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
@@ -29,11 +28,9 @@ type NBDProvider struct {
 
 	finishedOperations chan struct{}
 	devicePool         *nbd.DevicePool
-
-	tracer trace.Tracer
 }
 
-func NewNBDProvider(ctx context.Context, tracer trace.Tracer, rootfs block.ReadonlyDevice, cachePath string, devicePool *nbd.DevicePool) (Provider, error) {
+func NewNBDProvider(ctx context.Context, rootfs block.ReadonlyDevice, cachePath string, devicePool *nbd.DevicePool) (Provider, error) {
 	size, err := rootfs.Size()
 	if err != nil {
 		return nil, fmt.Errorf("error getting device size: %w", err)
@@ -48,10 +45,9 @@ func NewNBDProvider(ctx context.Context, tracer trace.Tracer, rootfs block.Reado
 
 	overlay := block.NewOverlay(rootfs, cache, blockSize)
 
-	mnt := nbd.NewDirectPathMount(ctx, tracer, overlay, devicePool)
+	mnt := nbd.NewDirectPathMount(ctx, overlay, devicePool)
 
 	return &NBDProvider{
-		tracer:             tracer,
 		mnt:                mnt,
 		overlay:            overlay,
 		ready:              utils.NewSetOnce[string](),
@@ -75,7 +71,7 @@ func (o *NBDProvider) ExportDiff(
 	out io.Writer,
 	closeSandbox func(ctx context.Context) error,
 ) (*header.DiffMetadata, error) {
-	childCtx, childSpan := o.tracer.Start(parentCtx, "cow-export")
+	childCtx, childSpan := tracer.Start(parentCtx, "cow-export")
 	defer childSpan.End()
 
 	cache, err := o.overlay.EjectCache()
@@ -115,7 +111,7 @@ func (o *NBDProvider) ExportDiff(
 }
 
 func (o *NBDProvider) Close(ctx context.Context) error {
-	childCtx, childSpan := o.tracer.Start(ctx, "cow-close")
+	childCtx, childSpan := tracer.Start(ctx, "cow-close")
 	defer childSpan.End()
 
 	var errs []error

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	globalconfig "github.com/e2b-dev/infra/packages/orchestrator/internal/config"
@@ -119,7 +118,6 @@ type networkSlotRes struct {
 // IMPORTANT: You must Close() the sandbox after you are done with it.
 func CreateSandbox(
 	ctx context.Context,
-	tracer trace.Tracer,
 	networkPool *network.Pool,
 	devicePool *nbd.DevicePool,
 	config Config,
@@ -149,7 +147,7 @@ func CreateSandbox(
 		allowInternet = *config.AllowInternetAccess
 	}
 
-	ipsCh := getNetworkSlotAsync(ctx, tracer, networkPool, cleanup, allowInternet)
+	ipsCh := getNetworkSlotAsync(ctx, networkPool, cleanup, allowInternet)
 	defer func() {
 		// Ensure the slot is received from chan so the slot is cleaned up properly in cleanup
 		<-ipsCh
@@ -174,14 +172,12 @@ func CreateSandbox(
 	if rootfsCachePath == "" {
 		rootfsProvider, err = rootfs.NewNBDProvider(
 			ctx,
-			tracer,
 			rootFS,
 			sandboxFiles.SandboxCacheRootfsPath(),
 			devicePool,
 		)
 	} else {
 		rootfsProvider, err = rootfs.NewDirectProvider(
-			tracer,
 			rootFS,
 			// Populate direct cache directly from the source file
 			// This is needed for marking all blocks as dirty and being able to read them directly
@@ -222,7 +218,6 @@ func CreateSandbox(
 	}
 	fcHandle, err := fc.NewProcess(
 		ctx,
-		tracer,
 		ips.slot,
 		sandboxFiles,
 		fcVersions,
@@ -237,7 +232,6 @@ func CreateSandbox(
 
 	err = fcHandle.Create(
 		ctx,
-		tracer,
 		sbxlogger.SandboxMetadata{
 			SandboxID:  runtime.SandboxID,
 			TemplateID: runtime.TemplateID,
@@ -282,7 +276,7 @@ func CreateSandbox(
 		exit: exit,
 	}
 
-	checks, err := NewChecks(ctx, tracer, sbx, false)
+	checks, err := NewChecks(ctx, sbx, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create health check: %w", err)
 	}
@@ -290,13 +284,13 @@ func CreateSandbox(
 
 	cleanup.AddPriority(func(ctx context.Context) error {
 		// Stop the sandbox first if it is still running, otherwise do nothing
-		return sbx.Stop(ctx, tracer)
+		return sbx.Stop(ctx)
 	})
 
 	go func() {
 		// If the process exists, stop the sandbox properly
 		fcErr := fcHandle.Exit.Wait()
-		err := sbx.Stop(context.WithoutCancel(ctx), tracer)
+		err := sbx.Stop(context.WithoutCancel(ctx))
 
 		exit.SetError(errors.Join(err, fcErr))
 	}()
@@ -308,7 +302,6 @@ func CreateSandbox(
 // IMPORTANT: You must Close() the sandbox after you are done with it.
 func ResumeSandbox(
 	ctx context.Context,
-	tracer trace.Tracer,
 	networkPool *network.Pool,
 	t template.Template,
 	config Config,
@@ -338,7 +331,7 @@ func ResumeSandbox(
 		allowInternet = *config.AllowInternetAccess
 	}
 
-	ipsCh := getNetworkSlotAsync(ctx, tracer, networkPool, cleanup, allowInternet)
+	ipsCh := getNetworkSlotAsync(ctx, networkPool, cleanup, allowInternet)
 	defer func() {
 		// Ensure the slot is received from chan so the slot is cleaned up properly in cleanup
 		<-ipsCh
@@ -361,7 +354,6 @@ func ResumeSandbox(
 
 	rootfsOverlay, err := rootfs.NewNBDProvider(
 		ctx,
-		tracer,
 		readonlyRootfs,
 		sandboxFiles.SandboxCacheRootfsPath(),
 		devicePool,
@@ -388,7 +380,6 @@ func ResumeSandbox(
 
 	fcUffd, err := serveMemory(
 		ctx,
-		tracer,
 		cleanup,
 		memfile,
 		fcUffdPath,
@@ -422,7 +413,6 @@ func ResumeSandbox(
 	}
 	fcHandle, fcErr := fc.NewProcess(
 		uffdStartCtx,
-		tracer,
 		ips.slot,
 		sandboxFiles,
 		// The versions need to base exactly the same as the paused sandbox template because of the FC compatibility.
@@ -450,7 +440,6 @@ func ResumeSandbox(
 	logsCollectorIP := os.Getenv("LOGS_COLLECTOR_PUBLIC_IP")
 	fcStartErr := fcHandle.Resume(
 		uffdStartCtx,
-		tracer,
 		&fc.MmdsMetadata{
 			SandboxId:            runtime.SandboxID,
 			TemplateId:           runtime.TemplateID,
@@ -499,7 +488,7 @@ func ResumeSandbox(
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox
 	// This is to prevent race condition of reporting unhealthy sandbox
-	checks, err := NewChecks(ctx, tracer, sbx, useClickhouseMetrics)
+	checks, err := NewChecks(ctx, sbx, useClickhouseMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create health check: %w", err)
 	}
@@ -508,12 +497,11 @@ func ResumeSandbox(
 
 	cleanup.AddPriority(func(ctx context.Context) error {
 		// Stop the sandbox first if it is still running, otherwise do nothing
-		return sbx.Stop(ctx, tracer)
+		return sbx.Stop(ctx)
 	})
 
 	err = sbx.WaitForEnvd(
 		ctx,
-		tracer,
 		defaultEnvdTimeout,
 	)
 	if err != nil {
@@ -529,7 +517,7 @@ func ResumeSandbox(
 		case <-fcHandle.Exit.Done():
 		}
 
-		err := sbx.Stop(context.WithoutCancel(ctx), tracer)
+		err := sbx.Stop(context.WithoutCancel(ctx))
 
 		uffdWaitErr := fcUffd.Exit().Wait()
 		fcErr := fcHandle.Exit.Wait()
@@ -552,7 +540,7 @@ func (s *Sandbox) Close(ctx context.Context) error {
 }
 
 // Stop kills the sandbox.
-func (s *Sandbox) Stop(ctx context.Context, tracer trace.Tracer) error {
+func (s *Sandbox) Stop(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "sandbox-close")
 	defer span.End()
 
@@ -584,7 +572,6 @@ func (s *Sandbox) FirecrackerVersions() fc.FirecrackerVersions {
 
 func (s *Sandbox) Pause(
 	ctx context.Context,
-	tracer trace.Tracer,
 	m metadata.Template,
 ) (*Snapshot, error) {
 	ctx, childSpan := tracer.Start(ctx, "sandbox-snapshot")
@@ -603,7 +590,7 @@ func (s *Sandbox) Pause(
 	// Stop the health check before pausing the VM
 	s.Checks.Stop()
 
-	if err := s.process.Pause(ctx, tracer); err != nil {
+	if err := s.process.Pause(ctx); err != nil {
 		return nil, fmt.Errorf("failed to pause VM: %w", err)
 	}
 
@@ -630,7 +617,6 @@ func (s *Sandbox) Pause(
 
 	err = s.process.CreateSnapshot(
 		ctx,
-		tracer,
 		snapfile.Path(),
 		memfile.Path(),
 	)
@@ -651,11 +637,9 @@ func (s *Sandbox) Pause(
 	// Start POSTPROCESSING
 	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
 		ctx,
-		tracer,
 		buildID,
 		originalMemfile.Header(),
 		&MemoryDiffCreator{
-			tracer:     tracer,
 			memfile:    memfile,
 			dirtyPages: s.memory.Dirty(),
 			blockSize:  originalMemfile.BlockSize(),
@@ -670,7 +654,6 @@ func (s *Sandbox) Pause(
 
 	rootfsDiff, rootfsDiffHeader, err := pauseProcessRootfs(
 		ctx,
-		tracer,
 		buildID,
 		originalRootfs.Header(),
 		&RootfsDiffCreator{
@@ -700,7 +683,6 @@ func (s *Sandbox) Pause(
 
 func pauseProcessMemory(
 	ctx context.Context,
-	tracer trace.Tracer,
 	buildId uuid.UUID,
 	originalHeader *header.Header,
 	diffCreator DiffCreator,
@@ -766,7 +748,6 @@ func pauseProcessMemory(
 
 func pauseProcessRootfs(
 	ctx context.Context,
-	tracer trace.Tracer,
 	buildId uuid.UUID,
 	originalHeader *header.Header,
 	diffCreator DiffCreator,
@@ -823,7 +804,6 @@ func pauseProcessRootfs(
 
 func getNetworkSlotAsync(
 	ctx context.Context,
-	tracer trace.Tracer,
 	networkPool *network.Pool,
 	cleanup *Cleanup,
 	allowInternet bool,
@@ -836,7 +816,7 @@ func getNetworkSlotAsync(
 	go func() {
 		defer close(r)
 
-		ips, err := networkPool.Get(ctx, tracer, allowInternet)
+		ips, err := networkPool.Get(ctx, allowInternet)
 		if err != nil {
 			r <- networkSlotRes{nil, fmt.Errorf("failed to get network slot: %w", err)}
 			return
@@ -848,7 +828,7 @@ func getNetworkSlotAsync(
 
 			// We can run this cleanup asynchronously, as it is not important for the sandbox lifecycle
 			go func(ctx context.Context) {
-				returnErr := networkPool.Return(ctx, tracer, ips)
+				returnErr := networkPool.Return(ctx, ips)
 				if returnErr != nil {
 					zap.L().Error("failed to return network slot", zap.Error(returnErr))
 				}
@@ -865,7 +845,6 @@ func getNetworkSlotAsync(
 
 func serveMemory(
 	ctx context.Context,
-	tracer trace.Tracer,
 	cleanup *Cleanup,
 	memfile block.ReadonlyDevice,
 	socketPath string,
@@ -896,10 +875,7 @@ func serveMemory(
 	return fcUffd, nil
 }
 
-func (s *Sandbox) WaitForExit(
-	ctx context.Context,
-	tracer trace.Tracer,
-) error {
+func (s *Sandbox) WaitForExit(ctx context.Context) error {
 	ctx, childSpan := tracer.Start(ctx, "sandbox-wait-for-exit")
 	defer childSpan.End()
 
@@ -922,7 +898,6 @@ func (s *Sandbox) WaitForExit(
 
 func (s *Sandbox) WaitForEnvd(
 	ctx context.Context,
-	tracer trace.Tracer,
 	timeout time.Duration,
 ) (e error) {
 	ctx, childSpan := tracer.Start(ctx, "sandbox-wait-for-start")
@@ -952,7 +927,7 @@ func (s *Sandbox) WaitForEnvd(
 		}
 	}()
 
-	initErr := s.initEnvd(syncCtx, tracer, s.Config.Envd.Vars, s.Config.Envd.AccessToken)
+	initErr := s.initEnvd(syncCtx, s.Config.Envd.Vars, s.Config.Envd.AccessToken)
 	if initErr != nil {
 		return fmt.Errorf("failed to init new envd: %w", initErr)
 	} else {

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"golang.org/x/sync/semaphore"
 
@@ -31,7 +30,6 @@ type server struct {
 	info              *service.ServiceInfo
 	sandboxes         *smap.Map[*sandbox.Sandbox]
 	proxy             *proxy.SandboxProxy
-	tracer            trace.Tracer
 	networkPool       *network.Pool
 	templateCache     *template.Cache
 	pauseMu           sync.Mutex
@@ -61,7 +59,6 @@ type ServiceConfig struct {
 	NetworkPool      *network.Pool
 	DevicePool       *nbd.DevicePool
 	TemplateCache    *template.Cache
-	Tracer           trace.Tracer
 	Info             *service.ServiceInfo
 	Proxy            *proxy.SandboxProxy
 	Sandboxes        *smap.Map[*sandbox.Sandbox]
@@ -81,7 +78,6 @@ func New(
 	}
 	srv.server = &server{
 		info:              cfg.Info,
-		tracer:            cfg.Tracer,
 		proxy:             srv.proxy,
 		sandboxes:         cfg.Sandboxes,
 		networkPool:       cfg.NetworkPool,

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -27,6 +28,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
+var tracer = otel.Tracer("orchestrator.internal.server")
+
 const (
 	requestTimeout              = 60 * time.Second
 	maxStartingInstancesPerNode = 3
@@ -38,7 +41,7 @@ func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	defer cancel()
 
 	// set up tracing
-	ctx, childSpan := s.tracer.Start(ctx, "sandbox-create")
+	ctx, childSpan := tracer.Start(ctx, "sandbox-create")
 	defer childSpan.End()
 
 	childSpan.SetAttributes(
@@ -90,7 +93,6 @@ func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 
 	sbx, err := sandbox.ResumeSandbox(
 		ctx,
-		s.tracer,
 		s.networkPool,
 		template,
 		sandbox.Config{
@@ -130,7 +132,7 @@ func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 
 	s.sandboxes.Insert(req.Sandbox.SandboxId, sbx)
 	go func() {
-		ctx, childSpan := s.tracer.Start(context.WithoutCancel(ctx), "sandbox-create-stop", trace.WithNewRoot())
+		ctx, childSpan := tracer.Start(context.WithoutCancel(ctx), "sandbox-create-stop", trace.WithNewRoot())
 		defer childSpan.End()
 
 		waitErr := sbx.Wait(ctx)
@@ -197,7 +199,7 @@ func (s *server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 }
 
 func (s *server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequest) (*emptypb.Empty, error) {
-	ctx, childSpan := s.tracer.Start(ctx, "sandbox-update")
+	ctx, childSpan := tracer.Start(ctx, "sandbox-update")
 	defer childSpan.End()
 
 	childSpan.SetAttributes(
@@ -243,7 +245,7 @@ func (s *server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequ
 }
 
 func (s *server) List(ctx context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListResponse, error) {
-	_, childSpan := s.tracer.Start(ctx, "sandbox-list")
+	_, childSpan := tracer.Start(ctx, "sandbox-list")
 	defer childSpan.End()
 
 	items := s.sandboxes.Items()
@@ -276,7 +278,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	ctx, cancel := context.WithTimeoutCause(ctxConn, requestTimeout, fmt.Errorf("request timed out"))
 	defer cancel()
 
-	ctx, childSpan := s.tracer.Start(ctx, "sandbox-delete")
+	ctx, childSpan := tracer.Start(ctx, "sandbox-delete")
 	defer childSpan.End()
 
 	childSpan.SetAttributes(
@@ -304,7 +306,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	// Start the cleanup in a goroutine—the initial kill request should be send as the first thing in stop, and at this point you cannot route to the sandbox anymore.
 	// We don't wait for the whole cleanup to finish here.
 	go func() {
-		err := sbx.Stop(ctx, s.tracer)
+		err := sbx.Stop(ctx)
 		if err != nil {
 			sbxlogger.I(sbx).Error("error stopping sandbox", logger.WithSandboxID(in.SandboxId), zap.Error(err))
 		}
@@ -338,7 +340,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 }
 
 func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest) (*emptypb.Empty, error) {
-	ctx, childSpan := s.tracer.Start(ctx, "sandbox-pause")
+	ctx, childSpan := tracer.Start(ctx, "sandbox-pause")
 	defer childSpan.End()
 
 	// setup launch darkly
@@ -369,10 +371,10 @@ func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 		// sbx.Stop sometimes blocks for several seconds,
 		// so we don't want to block the request and do the cleanup in a goroutine after we already removed sandbox from cache and proxy.
 		go func() {
-			ctx, childSpan := s.tracer.Start(ctx, "sandbox-pause-stop")
+			ctx, childSpan := tracer.Start(ctx, "sandbox-pause-stop")
 			defer childSpan.End()
 
-			err := sbx.Stop(ctx, s.tracer)
+			err := sbx.Stop(ctx)
 			if err != nil {
 				sbxlogger.I(sbx).Error("error stopping sandbox after snapshot", logger.WithSandboxID(in.SandboxId), zap.Error(err))
 			}
@@ -390,7 +392,7 @@ func (s *server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 		KernelVersion:      fcVersions.KernelVersion,
 		FirecrackerVersion: fcVersions.FirecrackerVersion,
 	})
-	snapshot, err := sbx.Pause(ctx, s.tracer, meta)
+	snapshot, err := sbx.Pause(ctx, meta)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error snapshotting sandbox", err, telemetry.WithSandboxID(in.SandboxId))
 

--- a/packages/orchestrator/internal/server/sandboxes_test.go
+++ b/packages/orchestrator/internal/server/sandboxes_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -70,7 +69,6 @@ func Test_server_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &server{
 				sandboxes: smap.New[*sandbox.Sandbox](),
-				tracer:    noop.NewTracerProvider().Tracer(""),
 				info:      &service.ServiceInfo{},
 			}
 			for _, sbx := range tt.data {

--- a/packages/orchestrator/internal/server/template_cache.go
+++ b/packages/orchestrator/internal/server/template_cache.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *server) ListCachedBuilds(ctx context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListCachedBuildsResponse, error) {
-	_, childSpan := s.tracer.Start(ctx, "list-cached-templates")
+	_, childSpan := tracer.Start(ctx, "list-cached-templates")
 	defer childSpan.End()
 
 	var builds []*orchestrator.CachedBuildInfo

--- a/packages/orchestrator/internal/template/build/commands/command.go
+++ b/packages/orchestrator/internal/template/build/commands/command.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -14,7 +13,6 @@ import (
 type Command interface {
 	Execute(
 		ctx context.Context,
-		tracer trace.Tracer,
 		logger *zap.Logger,
 		proxy *proxy.SandboxProxy,
 		sandboxID string,

--- a/packages/orchestrator/internal/template/build/commands/env.go
+++ b/packages/orchestrator/internal/template/build/commands/env.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"strings"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -21,7 +20,6 @@ var _ Command = (*Env)(nil)
 
 func (e *Env) Execute(
 	ctx context.Context,
-	tracer trace.Tracer,
 	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
@@ -43,7 +41,7 @@ func (e *Env) Execute(
 	envVars := maps.Clone(cmdMetadata.EnvVars)
 	for i := 0; i < len(args)-1; i += 2 {
 		k := args[i]
-		v, err := evaluateValue(ctx, tracer, proxy, sandboxID, args[i+1])
+		v, err := evaluateValue(ctx, proxy, sandboxID, args[i+1])
 		if err != nil {
 			return metadata.Context{}, fmt.Errorf("failed to evaluate environment variable %s: %w", k, err)
 		}
@@ -57,14 +55,12 @@ func (e *Env) Execute(
 
 func evaluateValue(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	envValue string,
 ) (string, error) {
 	err := sandboxtools.RunCommandWithOutput(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		fmt.Sprintf(`printf "%s"`, envValue),

--- a/packages/orchestrator/internal/template/build/commands/executor.go
+++ b/packages/orchestrator/internal/template/build/commands/executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -17,10 +18,10 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
+var tracer = otel.Tracer("orchestrator.internal.template.build.commands")
+
 type CommandExecutor struct {
 	buildcontext.BuildContext
-
-	tracer trace.Tracer
 
 	buildStorage storage.StorageProvider
 	proxy        *proxy.SandboxProxy
@@ -28,14 +29,11 @@ type CommandExecutor struct {
 
 func NewCommandExecutor(
 	buildContext buildcontext.BuildContext,
-	tracer trace.Tracer,
 	buildStorage storage.StorageProvider,
 	proxy *proxy.SandboxProxy,
 ) *CommandExecutor {
 	return &CommandExecutor{
 		BuildContext: buildContext,
-
-		tracer: tracer,
 
 		buildStorage: buildStorage,
 		proxy:        proxy,
@@ -78,7 +76,7 @@ func (ce *CommandExecutor) Execute(
 	step *templatemanager.TemplateStep,
 	cmdMetadata metadata.Context,
 ) (metadata.Context, error) {
-	ctx, span := ce.tracer.Start(ctx, "apply-command", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "apply-command", trace.WithAttributes(
 		attribute.String("prefix", prefix),
 		attribute.String("sandbox.id", sbx.Runtime.SandboxID),
 		attribute.String("step.type", step.Type),
@@ -94,7 +92,6 @@ func (ce *CommandExecutor) Execute(
 
 	cmdMetadata, err = cmd.Execute(
 		ctx,
-		ce.tracer,
 		ce.UserLogger,
 		ce.proxy,
 		sbx.Runtime.SandboxID,

--- a/packages/orchestrator/internal/template/build/commands/run.go
+++ b/packages/orchestrator/internal/template/build/commands/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -20,7 +19,6 @@ var _ Command = (*Run)(nil)
 
 func (r *Run) Execute(
 	ctx context.Context,
-	tracer trace.Tracer,
 	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
@@ -44,7 +42,6 @@ func (r *Run) Execute(
 	cmd := args[0]
 	err := sandboxtools.RunCommandWithLogger(
 		ctx,
-		tracer,
 		proxy,
 		logger,
 		zapcore.InfoLevel,

--- a/packages/orchestrator/internal/template/build/commands/user.go
+++ b/packages/orchestrator/internal/template/build/commands/user.go
@@ -20,7 +20,6 @@ var _ Command = (*User)(nil)
 
 func (u *User) Execute(
 	ctx context.Context,
-	tracer trace.Tracer,
 	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
@@ -38,7 +37,6 @@ func (u *User) Execute(
 
 	err := sandboxtools.RunCommandWithLogger(
 		ctx,
-		tracer,
 		proxy,
 		logger,
 		zapcore.InfoLevel,
@@ -67,7 +65,6 @@ func saveUserMeta(
 ) (metadata.Context, error) {
 	err := sandboxtools.RunCommandWithOutput(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		fmt.Sprintf(`printf "%s"`, user),

--- a/packages/orchestrator/internal/template/build/commands/workdir.go
+++ b/packages/orchestrator/internal/template/build/commands/workdir.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -20,7 +19,6 @@ var _ Command = (*Workdir)(nil)
 
 func (w *Workdir) Execute(
 	ctx context.Context,
-	tracer trace.Tracer,
 	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
@@ -38,7 +36,6 @@ func (w *Workdir) Execute(
 
 	err := sandboxtools.RunCommandWithLogger(
 		ctx,
-		tracer,
 		proxy,
 		logger,
 		zapcore.InfoLevel,
@@ -54,12 +51,11 @@ func (w *Workdir) Execute(
 		return metadata.Context{}, fmt.Errorf("failed to create workdir: %w", err)
 	}
 
-	return saveWorkdirMeta(ctx, tracer, proxy, sandboxID, cmdMetadata, workdirArg)
+	return saveWorkdirMeta(ctx, proxy, sandboxID, cmdMetadata, workdirArg)
 }
 
 func saveWorkdirMeta(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	cmdMetadata metadata.Context,
@@ -67,7 +63,6 @@ func saveWorkdirMeta(
 ) (metadata.Context, error) {
 	err := sandboxtools.RunCommandWithOutput(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		fmt.Sprintf(`printf "%s"`, workdir),

--- a/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.template.build.core.filesystem")
 
 const (
 	// creates an inode for every bytes-per-inode byte of space on the disk
@@ -27,7 +30,7 @@ const (
 	ToMBShift = 20
 )
 
-func Make(ctx context.Context, tracer trace.Tracer, rootfsPath string, sizeMb int64, blockSize int64) error {
+func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64) error {
 	ctx, tuneSpan := tracer.Start(ctx, "make-ext4")
 	defer tuneSpan.End()
 
@@ -56,7 +59,7 @@ func Make(ctx context.Context, tracer trace.Tracer, rootfsPath string, sizeMb in
 	return cmd.Run()
 }
 
-func Mount(ctx context.Context, tracer trace.Tracer, rootfsPath string, mountPoint string) error {
+func Mount(ctx context.Context, rootfsPath string, mountPoint string) error {
 	ctx, mountSpan := tracer.Start(ctx, "mount-ext4")
 	defer mountSpan.End()
 
@@ -75,7 +78,7 @@ func Mount(ctx context.Context, tracer trace.Tracer, rootfsPath string, mountPoi
 	return nil
 }
 
-func Unmount(ctx context.Context, tracer trace.Tracer, rootfsPath string) error {
+func Unmount(ctx context.Context, rootfsPath string) error {
 	ctx, unmountSpan := tracer.Start(ctx, "unmount-ext4")
 	defer unmountSpan.End()
 
@@ -94,7 +97,7 @@ func Unmount(ctx context.Context, tracer trace.Tracer, rootfsPath string) error 
 	return nil
 }
 
-func MakeWritable(ctx context.Context, tracer trace.Tracer, rootfsPath string) error {
+func MakeWritable(ctx context.Context, rootfsPath string) error {
 	ctx, tuneSpan := tracer.Start(ctx, "tune-ext4-writable")
 	defer tuneSpan.End()
 
@@ -109,7 +112,7 @@ func MakeWritable(ctx context.Context, tracer trace.Tracer, rootfsPath string) e
 	return cmd.Run()
 }
 
-func Enlarge(ctx context.Context, tracer trace.Tracer, rootfsPath string, addSize int64) (int64, error) {
+func Enlarge(ctx context.Context, rootfsPath string, addSize int64) (int64, error) {
 	ctx, resizeSpan := tracer.Start(ctx, "enlarge-ext4")
 	defer resizeSpan.End()
 
@@ -119,10 +122,10 @@ func Enlarge(ctx context.Context, tracer trace.Tracer, rootfsPath string, addSiz
 	}
 	finalSize := stat.Size() + addSize
 
-	return Resize(ctx, tracer, rootfsPath, finalSize)
+	return Resize(ctx, rootfsPath, finalSize)
 }
 
-func Resize(ctx context.Context, tracer trace.Tracer, rootfsPath string, targetSize int64) (int64, error) {
+func Resize(ctx context.Context, rootfsPath string, targetSize int64) (int64, error) {
 	ctx, resizeSpan := tracer.Start(ctx, "resize-ext4")
 	defer resizeSpan.End()
 
@@ -147,7 +150,7 @@ func Resize(ctx context.Context, tracer trace.Tracer, rootfsPath string, targetS
 	return stat.Size(), err
 }
 
-func Shrink(ctx context.Context, tracer trace.Tracer, rootfsPath string) (int64, error) {
+func Shrink(ctx context.Context, rootfsPath string) (int64, error) {
 	ctx, resizeSpan := tracer.Start(ctx, "shrink-ext4")
 	defer resizeSpan.End()
 
@@ -172,7 +175,7 @@ func Shrink(ctx context.Context, tracer trace.Tracer, rootfsPath string) (int64,
 	return stat.Size(), err
 }
 
-func GetFreeSpace(ctx context.Context, tracer trace.Tracer, rootfsPath string, blockSize int64) (int64, error) {
+func GetFreeSpace(ctx context.Context, rootfsPath string, blockSize int64) (int64, error) {
 	_, statSpan := tracer.Start(ctx, "stat-ext4-file")
 	defer statSpan.End()
 
@@ -225,7 +228,7 @@ func CheckIntegrity(rootfsPath string, fix bool) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func ReadFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, filePath string) (string, error) {
+func ReadFile(ctx context.Context, rootfsPath string, filePath string) (string, error) {
 	_, statSpan := tracer.Start(ctx, "ext4-read-file")
 	defer statSpan.End()
 
@@ -243,7 +246,7 @@ func ReadFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, fileP
 	return string(out), nil
 }
 
-func RemoveFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, filePath string) error {
+func RemoveFile(ctx context.Context, rootfsPath string, filePath string) error {
 	_, statSpan := tracer.Start(ctx, "ext4-remove-file")
 	defer statSpan.End()
 
@@ -261,7 +264,7 @@ func RemoveFile(ctx context.Context, tracer trace.Tracer, rootfsPath string, fil
 // MountOverlayFS mounts an overlay filesystem with the specified layers at the given mount point.
 // It requires kernel version 6.8 or later to use the fsconfig interface for overlayfs.
 // Older mount syscall is not used because it has lowerdirs character limit (4096 characters).
-func MountOverlayFS(ctx context.Context, tracer trace.Tracer, layers []string, mountPoint string) error {
+func MountOverlayFS(ctx context.Context, layers []string, mountPoint string) error {
 	_, mountSpan := tracer.Start(ctx, "mount-overlay-fs", trace.WithAttributes(
 		attribute.String("mount", mountPoint),
 		attribute.StringSlice("layers", layers),

--- a/packages/orchestrator/internal/template/build/core/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
@@ -24,6 +24,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.template.build.core.oci")
 
 const (
 	ToMBShift            = 20
@@ -35,7 +37,7 @@ var DefaultPlatform = containerregistry.Platform{
 	Architecture: "amd64",
 }
 
-func GetPublicImage(ctx context.Context, tracer trace.Tracer, tag string, authProvider auth.RegistryAuthProvider) (containerregistry.Image, error) {
+func GetPublicImage(ctx context.Context, tag string, authProvider auth.RegistryAuthProvider) (containerregistry.Image, error) {
 	childCtx, childSpan := tracer.Start(ctx, "pull-public-docker-image")
 	defer childSpan.End()
 
@@ -67,7 +69,7 @@ func GetPublicImage(ctx context.Context, tracer trace.Tracer, tag string, authPr
 	return img, nil
 }
 
-func GetImage(ctx context.Context, tracer trace.Tracer, artifactRegistry artifactsregistry.ArtifactsRegistry, templateId string, buildId string) (containerregistry.Image, error) {
+func GetImage(ctx context.Context, artifactRegistry artifactsregistry.ArtifactsRegistry, templateId string, buildId string) (containerregistry.Image, error) {
 	childCtx, childSpan := tracer.Start(ctx, "pull-docker-image")
 	defer childSpan.End()
 
@@ -99,16 +101,16 @@ func GetImageSize(img containerregistry.Image) (int64, error) {
 	return imageSize, nil
 }
 
-func ToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, img containerregistry.Image, rootfsPath string, maxSize int64, blockSize int64) (int64, error) {
+func ToExt4(ctx context.Context, logger *zap.Logger, img containerregistry.Image, rootfsPath string, maxSize int64, blockSize int64) (int64, error) {
 	ctx, childSpan := tracer.Start(ctx, "oci-to-ext4")
 	defer childSpan.End()
 
-	err := filesystem.Make(ctx, tracer, rootfsPath, maxSize>>ToMBShift, blockSize)
+	err := filesystem.Make(ctx, rootfsPath, maxSize>>ToMBShift, blockSize)
 	if err != nil {
 		return 0, fmt.Errorf("error creating ext4 file: %w", err)
 	}
 
-	err = ExtractToExt4(ctx, tracer, logger, img, rootfsPath)
+	err = ExtractToExt4(ctx, logger, img, rootfsPath)
 	if err != nil {
 		return 0, fmt.Errorf("error extracting image to ext4 filesystem: %w", err)
 	}
@@ -120,7 +122,7 @@ func ToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, img co
 	}
 
 	// The filesystem is first created with the maximum size, so we need to shrink it to the actual size
-	size, err := filesystem.Shrink(ctx, tracer, rootfsPath)
+	size, err := filesystem.Shrink(ctx, rootfsPath)
 	if err != nil {
 		return 0, fmt.Errorf("error shrinking ext4 filesystem: %w", err)
 	}
@@ -134,7 +136,7 @@ func ToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, img co
 	return size, nil
 }
 
-func ExtractToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, img containerregistry.Image, rootfsPath string) error {
+func ExtractToExt4(ctx context.Context, logger *zap.Logger, img containerregistry.Image, rootfsPath string) error {
 	ctx, childSpan := tracer.Start(ctx, "extract-to-ext4")
 	defer childSpan.End()
 
@@ -148,12 +150,12 @@ func ExtractToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger,
 		}
 	}()
 
-	err = filesystem.Mount(ctx, tracer, rootfsPath, tmpMount)
+	err = filesystem.Mount(ctx, rootfsPath, tmpMount)
 	if err != nil {
 		return fmt.Errorf("error mounting ext4 filesystem: %w", err)
 	}
 	defer func() {
-		if unmountErr := filesystem.Unmount(context.WithoutCancel(ctx), tracer, tmpMount); unmountErr != nil {
+		if unmountErr := filesystem.Unmount(context.WithoutCancel(ctx), tmpMount); unmountErr != nil {
 			zap.L().Error("error unmounting ext4 filesystem", zap.Error(unmountErr))
 		}
 	}()
@@ -163,7 +165,7 @@ func ExtractToExt4(ctx context.Context, tracer trace.Tracer, logger *zap.Logger,
 		zap.String("tmp_mount", tmpMount),
 	)
 
-	err = unpackRootfs(ctx, tracer, logger, img, tmpMount)
+	err = unpackRootfs(ctx, logger, img, tmpMount)
 	if err != nil {
 		return fmt.Errorf("error extracting tar to directory: %w", err)
 	}
@@ -190,7 +192,7 @@ func ParseEnvs(envs []string) map[string]string {
 	return envMap
 }
 
-func unpackRootfs(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, srcImage containerregistry.Image, destDir string) (err error) {
+func unpackRootfs(ctx context.Context, logger *zap.Logger, srcImage containerregistry.Image, destDir string) (err error) {
 	ctx, childSpan := tracer.Start(ctx, "unpack-rootfs")
 	defer childSpan.End()
 
@@ -203,7 +205,7 @@ func unpackRootfs(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, 
 	}()
 
 	// Create export of layers in the temporary directory
-	layers, err := createExport(ctx, tracer, logger, srcImage, ociPath)
+	layers, err := createExport(ctx, logger, srcImage, ociPath)
 	if err != nil {
 		return fmt.Errorf("while creating export of source image: %w", err)
 	}
@@ -217,25 +219,25 @@ func unpackRootfs(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, 
 		go os.RemoveAll(mountPath)
 	}()
 
-	err = filesystem.MountOverlayFS(ctx, tracer, layers, mountPath)
+	err = filesystem.MountOverlayFS(ctx, layers, mountPath)
 	if err != nil {
 		return fmt.Errorf("while mounting overlayfs with layers: %w", err)
 	}
 	defer func() {
-		if unmountErr := filesystem.Unmount(context.WithoutCancel(ctx), tracer, mountPath); unmountErr != nil {
+		if unmountErr := filesystem.Unmount(context.WithoutCancel(ctx), mountPath); unmountErr != nil {
 			zap.L().Error("error unmounting overlayfs mount point", zap.Error(unmountErr))
 		}
 	}()
 
 	// List files in the mount point
-	files, err := listFiles(ctx, tracer, mountPath)
+	files, err := listFiles(ctx, mountPath)
 	if err != nil {
 		return fmt.Errorf("while listing files in overlayfs: %w", err)
 	}
 	logger.Info("Root filesystem structure: " + strings.Join(files, ", "))
 
 	// Copy files from the overlayfs mount point to the destination directory
-	err = copyFiles(ctx, tracer, mountPath, destDir)
+	err = copyFiles(ctx, mountPath, destDir)
 	if err != nil {
 		return fmt.Errorf("while copying files from overlayfs to destination directory: %w", err)
 	}
@@ -243,7 +245,7 @@ func unpackRootfs(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, 
 	return nil
 }
 
-func listFiles(ctx context.Context, tracer trace.Tracer, dir string) ([]string, error) {
+func listFiles(ctx context.Context, dir string) ([]string, error) {
 	_, childSpan := tracer.Start(ctx, "list-files")
 	defer childSpan.End()
 
@@ -258,7 +260,7 @@ func listFiles(ctx context.Context, tracer trace.Tracer, dir string) ([]string, 
 }
 
 // copyFiles uses rsync to copy files from the source directory to the destination directory.
-func copyFiles(ctx context.Context, tracer trace.Tracer, src, dest string) error {
+func copyFiles(ctx context.Context, src, dest string) error {
 	_, childSpan := tracer.Start(ctx, "copy-files")
 	defer childSpan.End()
 
@@ -284,7 +286,7 @@ func copyFiles(ctx context.Context, tracer trace.Tracer, src, dest string) error
 // and returns the paths of the extracted layers. The layers are extracted in reverse order
 // to maintain the correct order for overlayFS.
 // The layers are extracted in parallel to speed up the process.
-func createExport(ctx context.Context, tracer trace.Tracer, logger *zap.Logger, srcImage containerregistry.Image, path string) ([]string, error) {
+func createExport(ctx context.Context, logger *zap.Logger, srcImage containerregistry.Image, path string) ([]string, error) {
 	ctx, childSpan := tracer.Start(ctx, "create-oci-export")
 	defer childSpan.End()
 

--- a/packages/orchestrator/internal/template/build/core/oci/oci_test.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/core/oci/auth"
@@ -55,7 +54,6 @@ func createFileTar(t *testing.T, fileName string) *bytes.Buffer {
 func TestCreateExportLayersOrder(t *testing.T) {
 	ctx := t.Context()
 
-	tracer := noop.NewTracerProvider().Tracer("test")
 	logger := zap.NewNop()
 
 	// Create a dummy image with some layers
@@ -83,7 +81,7 @@ func TestCreateExportLayersOrder(t *testing.T) {
 
 	// Export the layers
 	dir := t.TempDir()
-	layers, err := createExport(ctx, tracer, logger, img, dir)
+	layers, err := createExport(ctx, logger, img, dir)
 	require.NoError(t, err)
 	require.NotNil(t, layers)
 
@@ -130,7 +128,6 @@ func authHandler(handler http.Handler, username, password string) http.Handler {
 
 func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 	ctx := context.Background()
-	tracer := noop.NewTracerProvider().Tracer("test")
 
 	// Create a test image
 	testImage := empty.Image
@@ -189,7 +186,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NotNil(t, authOption)
 
 		// Now test GetPublicImage
-		img, err := GetPublicImage(ctx, tracer, imageRef, authProvider)
+		img, err := GetPublicImage(ctx, imageRef, authProvider)
 		require.NoError(t, err)
 		require.NotNil(t, img)
 
@@ -239,7 +236,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NotNil(t, authOption)
 
 		// Now test GetPublicImage
-		img, err := GetPublicImage(ctx, tracer, imageRef, authProvider)
+		img, err := GetPublicImage(ctx, imageRef, authProvider)
 		require.Error(t, err)
 		require.Nil(t, img)
 	})
@@ -264,7 +261,7 @@ func TestGetPublicImageWithGeneralAuth(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get image without auth provider (nil)
-		img, err := GetPublicImage(ctx, tracer, imageRef, nil)
+		img, err := GetPublicImage(ctx, imageRef, nil)
 		require.NoError(t, err)
 		require.NotNil(t, img)
 

--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dustin/go-humanize"
 	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/config"
@@ -23,6 +23,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
+
+var tracer = otel.Tracer("orchestrator.internal.template.build.core.rootfs")
 
 const (
 	// Max size of the rootfs file in MB.
@@ -67,7 +69,6 @@ func New(
 
 func (r *Rootfs) CreateExt4Filesystem(
 	ctx context.Context,
-	tracer trace.Tracer,
 	logger *zap.Logger,
 	rootfsPath string,
 	provisionScript string,
@@ -87,9 +88,9 @@ func (r *Rootfs) CreateExt4Filesystem(
 	var img containerregistry.Image
 	var err error
 	if r.template.FromImage != "" {
-		img, err = oci.GetPublicImage(childCtx, tracer, r.template.FromImage, r.template.RegistryAuthProvider)
+		img, err = oci.GetPublicImage(childCtx, r.template.FromImage, r.template.RegistryAuthProvider)
 	} else {
-		img, err = oci.GetImage(childCtx, tracer, r.artifactRegistry, r.template.TemplateID, r.metadata.BuildID)
+		img, err = oci.GetImage(childCtx, r.artifactRegistry, r.template.TemplateID, r.metadata.BuildID)
 	}
 	if err != nil {
 		return containerregistry.Config{}, fmt.Errorf("error requesting docker image: %w", err)
@@ -113,7 +114,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 	telemetry.ReportEvent(childCtx, "set up filesystem")
 
 	logger.Info("Creating file system and pulling Docker image")
-	ext4Size, err := oci.ToExt4(ctx, tracer, logger, img, rootfsPath, maxRootfsSize, r.template.RootfsBlockSize())
+	ext4Size, err := oci.ToExt4(ctx, logger, img, rootfsPath, maxRootfsSize, r.template.RootfsBlockSize())
 	if err != nil {
 		return containerregistry.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
 	}
@@ -121,13 +122,13 @@ func (r *Rootfs) CreateExt4Filesystem(
 
 	logger.Debug("Filesystem cleanup")
 	// Make rootfs writable, be default it's readonly
-	err = filesystem.MakeWritable(ctx, tracer, rootfsPath)
+	err = filesystem.MakeWritable(ctx, rootfsPath)
 	if err != nil {
 		return containerregistry.Config{}, fmt.Errorf("error making rootfs file writable: %w", err)
 	}
 
 	// Resize rootfs
-	rootfsFreeSpace, err := filesystem.GetFreeSpace(ctx, tracer, rootfsPath, r.template.RootfsBlockSize())
+	rootfsFreeSpace, err := filesystem.GetFreeSpace(ctx, rootfsPath, r.template.RootfsBlockSize())
 	if err != nil {
 		return containerregistry.Config{}, fmt.Errorf("error getting free space: %w", err)
 	}
@@ -141,7 +142,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 		zap.Int64("size_free", rootfsFreeSpace),
 	)
 	if diskAdd > 0 {
-		_, err := filesystem.Enlarge(ctx, tracer, rootfsPath, diskAdd)
+		_, err := filesystem.Enlarge(ctx, rootfsPath, diskAdd)
 		if err != nil {
 			return containerregistry.Config{}, fmt.Errorf("error enlarging rootfs: %w", err)
 		}

--- a/packages/orchestrator/internal/template/build/layer/create_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/create_sandbox.go
@@ -57,7 +57,6 @@ func (cs *CreateSandbox) Sandbox(
 	// In case of a new sandbox, base template ID is now used as the potentially exported template base ID.
 	sbx, err := sandbox.CreateSandbox(
 		ctx,
-		layerExecutor.tracer,
 		layerExecutor.networkPool,
 		layerExecutor.devicePool,
 		cs.config,
@@ -83,7 +82,6 @@ func (cs *CreateSandbox) Sandbox(
 
 	err = sbx.WaitForEnvd(
 		ctx,
-		layerExecutor.tracer,
 		waitEnvdTimeout,
 	)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -21,10 +21,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
+var tracer = otel.Tracer("orchestrator.internal.template.build.layer")
+
 type LayerExecutor struct {
 	buildcontext.BuildContext
 
-	tracer trace.Tracer
 	logger *zap.Logger
 
 	networkPool     *network.Pool
@@ -40,7 +41,6 @@ type LayerExecutor struct {
 func NewLayerExecutor(
 	buildContext buildcontext.BuildContext,
 	logger *zap.Logger,
-	tracer trace.Tracer,
 	networkPool *network.Pool,
 	devicePool *nbd.DevicePool,
 	templateCache *sbxtemplate.Cache,
@@ -54,7 +54,6 @@ func NewLayerExecutor(
 		BuildContext: buildContext,
 
 		logger: logger,
-		tracer: tracer,
 
 		networkPool:     networkPool,
 		devicePool:      devicePool,
@@ -72,7 +71,7 @@ func (lb *LayerExecutor) BuildLayer(
 	ctx context.Context,
 	cmd LayerBuildCommand,
 ) (metadata.Template, error) {
-	ctx, childSpan := lb.tracer.Start(ctx, "run-in-sandbox")
+	ctx, childSpan := tracer.Start(ctx, "run-in-sandbox")
 	defer childSpan.End()
 
 	localTemplate, err := cmd.SourceTemplate.Get(ctx, lb.templateCache)
@@ -133,7 +132,7 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 	ctx context.Context,
 	sbx *sandbox.Sandbox,
 ) error {
-	ctx, childSpan := lb.tracer.Start(ctx, "update-envd")
+	ctx, childSpan := tracer.Start(ctx, "update-envd")
 	defer childSpan.End()
 
 	envdVersion, err := envd.GetEnvdVersion(ctx)
@@ -146,7 +145,6 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 	tmpEnvdPath := "/tmp/envd_updated"
 	err = sandboxtools.CopyFile(
 		ctx,
-		lb.tracer,
 		lb.proxy,
 		sbx.Runtime.SandboxID,
 		"root",
@@ -166,7 +164,6 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 
 	err = sandboxtools.RunCommandWithLogger(
 		ctx,
-		lb.tracer,
 		lb.proxy,
 		lb.UserLogger,
 		zap.DebugLevel,
@@ -183,7 +180,6 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 	// Error is ignored because it's expected the envd connection will be lost
 	_ = sandboxtools.RunCommand(
 		ctx,
-		lb.tracer,
 		lb.proxy,
 		sbx.Runtime.SandboxID,
 		"systemctl restart envd",
@@ -193,7 +189,6 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 	// Step 4: Wait for envd to initialize
 	err = sbx.WaitForEnvd(
 		ctx,
-		lb.tracer,
 		waitEnvdTimeout,
 	)
 	if err != nil {
@@ -209,7 +204,7 @@ func (lb *LayerExecutor) PauseAndUpload(
 	hash string,
 	meta metadata.Template,
 ) error {
-	ctx, childSpan := lb.tracer.Start(ctx, "pause-and-upload")
+	ctx, childSpan := tracer.Start(ctx, "pause-and-upload")
 	defer childSpan.End()
 
 	lb.UserLogger.Debug(fmt.Sprintf("Saving layer: %s", meta.Template.BuildID))
@@ -217,7 +212,6 @@ func (lb *LayerExecutor) PauseAndUpload(
 	// snapshot is automatically cleared by the templateCache eviction
 	snapshot, err := sbx.Pause(
 		ctx,
-		lb.tracer,
 		meta,
 	)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
@@ -32,7 +32,6 @@ func (rs *ResumeSandbox) Sandbox(
 ) (*sandbox.Sandbox, error) {
 	sbx, err := sandbox.ResumeSandbox(
 		ctx,
-		layerExecutor.tracer,
 		layerExecutor.networkPool,
 		template,
 		rs.config,

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -53,7 +53,6 @@ type BaseBuilder struct {
 	buildcontext.BuildContext
 
 	logger *zap.Logger
-	tracer trace.Tracer
 	proxy  *proxy.SandboxProxy
 
 	templateStorage  storage.StorageProvider
@@ -69,7 +68,6 @@ type BaseBuilder struct {
 func New(
 	buildContext buildcontext.BuildContext,
 	logger *zap.Logger,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	templateStorage storage.StorageProvider,
 	devicePool *nbd.DevicePool,
@@ -83,7 +81,6 @@ func New(
 		BuildContext: buildContext,
 
 		logger: logger,
-		tracer: tracer,
 		proxy:  proxy,
 
 		templateStorage:  templateStorage,
@@ -179,7 +176,6 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 
 	rootfs, memfile, envsImg, err := constructLayerFilesFromOCI(
 		ctx,
-		bb.tracer,
 		bb.BuildContext,
 		baseMetadata.Template.BuildID,
 		bb.artifactRegistry,
@@ -282,7 +278,6 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 	actionExecutor := layer.NewFunctionAction(func(ctx context.Context, sbx *sandbox.Sandbox, meta metadata.Template) (metadata.Template, error) {
 		err = sandboxtools.SyncChangesToDisk(
 			ctx,
-			bb.tracer,
 			bb.proxy,
 			sbx.Runtime.SandboxID,
 		)

--- a/packages/orchestrator/internal/template/build/phases/base/files.go
+++ b/packages/orchestrator/internal/template/build/phases/base/files.go
@@ -7,7 +7,6 @@ import (
 
 	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/buildcontext"
@@ -19,7 +18,6 @@ import (
 
 func constructLayerFilesFromOCI(
 	ctx context.Context,
-	tracer trace.Tracer,
 	buildContext buildcontext.BuildContext,
 	// The base build ID can be different from the final requested template build ID.
 	baseBuildID string,
@@ -43,7 +41,7 @@ func constructLayerFilesFromOCI(
 	if err != nil {
 		return nil, nil, containerregistry.Config{}, fmt.Errorf("error getting provision script: %w", err)
 	}
-	imgConfig, err := rtfs.CreateExt4Filesystem(childCtx, tracer, buildContext.UserLogger, rootfsPath, provisionScript, provisionLogPrefix)
+	imgConfig, err := rtfs.CreateExt4Filesystem(childCtx, buildContext.UserLogger, rootfsPath, provisionScript, provisionLogPrefix)
 	if err != nil {
 		return nil, nil, containerregistry.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/phases/base/provision.go
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.go
@@ -66,7 +66,7 @@ func (bb *BaseBuilder) provisionSandbox(
 	provisionScriptResultPath string,
 	logExternalPrefix string,
 ) (e error) {
-	ctx, childSpan := bb.tracer.Start(ctx, "provision-sandbox")
+	ctx, childSpan := tracer.Start(ctx, "provision-sandbox")
 	defer childSpan.End()
 
 	zapWriter := &zapio.Writer{Log: bb.UserLogger, Level: zap.DebugLevel}
@@ -75,7 +75,6 @@ func (bb *BaseBuilder) provisionSandbox(
 
 	sbx, err := sandbox.CreateSandbox(
 		ctx,
-		bb.tracer,
 		bb.networkPool,
 		bb.devicePool,
 		sandboxConfig,
@@ -103,7 +102,6 @@ func (bb *BaseBuilder) provisionSandbox(
 
 	err = sbx.WaitForExit(
 		ctx,
-		bb.tracer,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to wait for sandbox start: %w", err)
@@ -111,11 +109,11 @@ func (bb *BaseBuilder) provisionSandbox(
 	bb.UserLogger.Info("Sandbox template provisioned")
 
 	// Verify the provisioning script exit status
-	exitStatus, err := filesystem.ReadFile(ctx, bb.tracer, rootfsPath, provisionScriptResultPath)
+	exitStatus, err := filesystem.ReadFile(ctx, rootfsPath, provisionScriptResultPath)
 	if err != nil {
 		return fmt.Errorf("error reading provision result: %w", err)
 	}
-	defer filesystem.RemoveFile(ctx, bb.tracer, rootfsPath, provisionScriptResultPath)
+	defer filesystem.RemoveFile(ctx, rootfsPath, provisionScriptResultPath)
 
 	// Fallback to "1" if the file is empty or not found
 	if exitStatus == "" {
@@ -136,7 +134,7 @@ func (bb *BaseBuilder) enlargeDiskAfterProvisioning(
 	rootfsPath := rootfs.Path()
 
 	// Resize rootfs to accommodate for the provisioning script size change
-	rootfsFreeSpace, err := filesystem.GetFreeSpace(ctx, bb.tracer, rootfsPath, template.RootfsBlockSize())
+	rootfsFreeSpace, err := filesystem.GetFreeSpace(ctx, rootfsPath, template.RootfsBlockSize())
 	if err != nil {
 		return fmt.Errorf("error getting free space: %w", err)
 	}
@@ -150,7 +148,7 @@ func (bb *BaseBuilder) enlargeDiskAfterProvisioning(
 		zap.L().Debug("no need to enlarge rootfs, skipping")
 		return nil
 	}
-	rootfsFinalSize, err := filesystem.Enlarge(ctx, bb.tracer, rootfsPath, sizeDiff)
+	rootfsFinalSize, err := filesystem.Enlarge(ctx, rootfsPath, sizeDiff)
 	if err != nil {
 		// Debug filesystem stats on error
 		cmd := exec.Command("tune2fs", "-l", rootfsPath)

--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -33,8 +33,6 @@ var tracer = otel.Tracer("orchestrator.template.build.phases.finalize")
 type PostProcessingBuilder struct {
 	buildcontext.BuildContext
 
-	tracer trace.Tracer
-
 	templateStorage storage.StorageProvider
 	proxy           *proxy.SandboxProxy
 
@@ -43,15 +41,12 @@ type PostProcessingBuilder struct {
 
 func New(
 	buildContext buildcontext.BuildContext,
-	tracer trace.Tracer,
 	templateStorage storage.StorageProvider,
 	proxy *proxy.SandboxProxy,
 	layerExecutor *layer.LayerExecutor,
 ) *PostProcessingBuilder {
 	return &PostProcessingBuilder{
 		BuildContext: buildContext,
-
-		tracer: tracer,
 
 		templateStorage: templateStorage,
 		proxy:           proxy,
@@ -173,7 +168,6 @@ func (ppb *PostProcessingBuilder) postProcessingFn() layer.FunctionActionFn {
 			// Ensure all changes are synchronized to disk so the sandbox can be restarted
 			err := sandboxtools.SyncChangesToDisk(
 				ctx,
-				ppb.tracer,
 				ppb.proxy,
 				sbx.Runtime.SandboxID,
 			)
@@ -187,7 +181,6 @@ func (ppb *PostProcessingBuilder) postProcessingFn() layer.FunctionActionFn {
 		err := runConfiguration(
 			ctx,
 			ppb.BuildContext,
-			ppb.tracer,
 			ppb.proxy,
 			sbx.Runtime.SandboxID,
 		)
@@ -214,7 +207,6 @@ func (ppb *PostProcessingBuilder) postProcessingFn() layer.FunctionActionFn {
 			startCmdRun.Go(func() error {
 				err := sandboxtools.RunCommandWithConfirmation(
 					commandsCtx,
-					ppb.tracer,
 					ppb.proxy,
 					ppb.UserLogger,
 					zapcore.InfoLevel,

--- a/packages/orchestrator/internal/template/build/phases/finalize/configure.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/configure.go
@@ -8,7 +8,6 @@ import (
 	tt "text/template"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -32,7 +31,6 @@ type ConfigurationParams struct {
 func runConfiguration(
 	ctx context.Context,
 	bc buildcontext.BuildContext,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 ) error {
@@ -52,7 +50,6 @@ func runConfiguration(
 
 	err = sandboxtools.RunCommandWithLogger(
 		configCtx,
-		tracer,
 		proxy,
 		bc.UserLogger,
 		zapcore.DebugLevel,

--- a/packages/orchestrator/internal/template/build/phases/finalize/ready.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/ready.go
@@ -25,7 +25,7 @@ func (ppb *PostProcessingBuilder) runReadyCommand(
 	readyCmd string,
 	cmdMetadata metadata.Context,
 ) error {
-	ctx, span := ppb.tracer.Start(ctx, "run-ready-command")
+	ctx, span := tracer.Start(ctx, "run-ready-command")
 	defer span.End()
 
 	ppb.UserLogger.Info("Waiting for template to be ready")
@@ -40,7 +40,6 @@ func (ppb *PostProcessingBuilder) runReadyCommand(
 	for {
 		err := sandboxtools.RunCommandWithLogger(
 			ctx,
-			ppb.tracer,
 			ppb.proxy,
 			ppb.UserLogger,
 			zapcore.InfoLevel,

--- a/packages/orchestrator/internal/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/builder.go
@@ -39,7 +39,6 @@ type StepBuilder struct {
 	step       *templatemanager.TemplateStep
 
 	logger *zap.Logger
-	tracer trace.Tracer
 	proxy  *proxy.SandboxProxy
 
 	layerExecutor   *layer.LayerExecutor
@@ -51,7 +50,6 @@ type StepBuilder struct {
 func New(
 	buildContext buildcontext.BuildContext,
 	logger *zap.Logger,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	layerExecutor *layer.LayerExecutor,
 	commandExecutor *commands.CommandExecutor,
@@ -67,7 +65,6 @@ func New(
 		step:       step,
 
 		logger: logger,
-		tracer: tracer,
 		proxy:  proxy,
 
 		layerExecutor:   layerExecutor,
@@ -198,7 +195,6 @@ func (sb *StepBuilder) Build(
 
 		err = sandboxtools.SyncChangesToDisk(
 			ctx,
-			sb.tracer,
 			sb.proxy,
 			sbx.Runtime.SandboxID,
 		)

--- a/packages/orchestrator/internal/template/build/phases/steps/factory.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/factory.go
@@ -1,7 +1,6 @@
 package steps
 
 import (
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
@@ -16,7 +15,6 @@ import (
 func CreateStepPhases(
 	bc buildcontext.BuildContext,
 	logger *zap.Logger,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	layerExecutor *layer.LayerExecutor,
 	commandExecutor *commands.CommandExecutor,
@@ -30,7 +28,6 @@ func CreateStepPhases(
 			New(
 				bc,
 				logger,
-				tracer,
 				proxy,
 				layerExecutor,
 				commandExecutor,

--- a/packages/orchestrator/internal/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/internal/template/build/sandboxtools/command.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -24,7 +23,6 @@ const commandHardTimeout = 1 * time.Hour
 
 func RunCommandWithOutput(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	command string,
@@ -33,7 +31,6 @@ func RunCommandWithOutput(
 ) error {
 	return runCommandWithAllOptions(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		command,
@@ -46,7 +43,6 @@ func RunCommandWithOutput(
 
 func RunCommand(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	command string,
@@ -54,7 +50,6 @@ func RunCommand(
 ) error {
 	return runCommandWithAllOptions(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		command,
@@ -67,7 +62,6 @@ func RunCommand(
 
 func RunCommandWithLogger(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	logger *zap.Logger,
 	lvl zapcore.Level,
@@ -78,7 +72,6 @@ func RunCommandWithLogger(
 ) error {
 	return RunCommandWithConfirmation(
 		ctx,
-		tracer,
 		proxy,
 		logger,
 		lvl,
@@ -93,7 +86,6 @@ func RunCommandWithLogger(
 
 func RunCommandWithConfirmation(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	logger *zap.Logger,
 	lvl zapcore.Level,
@@ -105,7 +97,6 @@ func RunCommandWithConfirmation(
 ) error {
 	return runCommandWithAllOptions(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		command,
@@ -120,7 +111,6 @@ func RunCommandWithConfirmation(
 
 func runCommandWithAllOptions(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	command string,
@@ -223,13 +213,11 @@ func logStream(logger *zap.Logger, lvl zapcore.Level, id string, name string, co
 // to be able to re-create the sandbox without resume.
 func SyncChangesToDisk(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 ) error {
 	return RunCommand(
 		ctx,
-		tracer,
 		proxy,
 		sandboxID,
 		"sync",

--- a/packages/orchestrator/internal/template/build/sandboxtools/file.go
+++ b/packages/orchestrator/internal/template/build/sandboxtools/file.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc"
@@ -25,9 +25,10 @@ var client = http.Client{
 	Timeout: fileCopyTimeout,
 }
 
+var tracer = otel.Tracer("orchestrator.internal.template.build.sandboxtools")
+
 func CopyFile(
 	ctx context.Context,
-	tracer trace.Tracer,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	user string,

--- a/packages/orchestrator/internal/template/server/create_template.go
+++ b/packages/orchestrator/internal/template/server/create_template.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templatemanager.TemplateCreateRequest) (*emptypb.Empty, error) {
-	_, childSpan := s.tracer.Start(ctx, "template-create")
+	_, childSpan := tracer.Start(ctx, "template-create")
 	defer childSpan.End()
 
 	cfg := templateRequest.Template
@@ -101,7 +101,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 			}
 		}()
 
-		ctx, buildSpan := s.tracer.Start(ctx, "template-background-build")
+		ctx, buildSpan := tracer.Start(ctx, "template-background-build")
 		defer buildSpan.End()
 
 		// Watch for build cancellation requests

--- a/packages/orchestrator/internal/template/server/delete_template.go
+++ b/packages/orchestrator/internal/template/server/delete_template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -15,8 +16,10 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
+var tracer = otel.Tracer("orchestrator.internal.template.server")
+
 func (s *ServerStore) TemplateBuildDelete(ctx context.Context, in *templatemanager.TemplateBuildDeleteRequest) (*emptypb.Empty, error) {
-	childCtx, childSpan := s.tracer.Start(ctx, "template-delete-request", trace.WithAttributes(
+	childCtx, childSpan := tracer.Start(ctx, "template-delete-request", trace.WithAttributes(
 		telemetry.WithTemplateID(in.TemplateID),
 		telemetry.WithBuildID(in.BuildID),
 	))
@@ -39,7 +42,7 @@ func (s *ServerStore) TemplateBuildDelete(ctx context.Context, in *templatemanag
 		})
 	}
 
-	err = template.Delete(childCtx, s.tracer, s.artifactsregistry, s.templateStorage, in.TemplateID, in.BuildID)
+	err = template.Delete(childCtx, s.artifactsregistry, s.templateStorage, in.TemplateID, in.BuildID)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/orchestrator/internal/template/server/main.go
+++ b/packages/orchestrator/internal/template/server/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/grpcserver"
@@ -31,7 +30,6 @@ import (
 
 type ServerStore struct {
 	templatemanager.UnimplementedTemplateServiceServer
-	tracer            trace.Tracer
 	logger            *zap.Logger
 	builder           *build.Builder
 	buildCache        *cache.BuildCache
@@ -46,7 +44,6 @@ type ServerStore struct {
 
 func New(
 	ctx context.Context,
-	tracer trace.Tracer,
 	meterProvider metric.MeterProvider,
 	logger *zap.Logger,
 	buildLogger *zap.Logger,
@@ -79,7 +76,6 @@ func New(
 	}
 	builder := build.NewBuilder(
 		logger,
-		tracer,
 		templatePersistence,
 		buildPersistance,
 		artifactsregistry,
@@ -92,7 +88,6 @@ func New(
 	)
 
 	store := &ServerStore{
-		tracer:            tracer,
 		logger:            logger,
 		builder:           builder,
 		buildCache:        buildCache,

--- a/packages/orchestrator/internal/template/server/template_status.go
+++ b/packages/orchestrator/internal/template/server/template_status.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *ServerStore) TemplateBuildStatus(ctx context.Context, in *template_manager.TemplateStatusRequest) (*template_manager.TemplateBuildStatusResponse, error) {
-	_, ctxSpan := s.tracer.Start(ctx, "template-build-status-request")
+	_, ctxSpan := tracer.Start(ctx, "template-build-status-request")
 	defer ctxSpan.End()
 
 	buildInfo, err := s.buildCache.Get(in.BuildID)

--- a/packages/orchestrator/internal/template/server/upload_layer_files_template.go
+++ b/packages/orchestrator/internal/template/server/upload_layer_files_template.go
@@ -12,7 +12,7 @@ import (
 const signedUrlExpiration = time.Minute * 30
 
 func (s *ServerStore) InitLayerFileUpload(ctx context.Context, in *templatemanager.InitLayerFileUploadRequest) (*templatemanager.InitLayerFileUploadResponse, error) {
-	_, childSpan := s.tracer.Start(ctx, "template-create")
+	_, childSpan := tracer.Start(ctx, "template-create")
 	defer childSpan.End()
 
 	// default to scope by template ID

--- a/packages/orchestrator/internal/template/template/main.go
+++ b/packages/orchestrator/internal/template/template/main.go
@@ -5,14 +5,16 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel"
 
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-func Delete(ctx context.Context, tracer trace.Tracer, artifactRegistry artifactsregistry.ArtifactsRegistry, templateStorage storage.StorageProvider, templateId string, buildId string) error {
+var tracer = otel.Tracer("orchestrator.internal.template.template")
+
+func Delete(ctx context.Context, artifactRegistry artifactsregistry.ArtifactsRegistry, templateStorage storage.StorageProvider, templateId string, buildId string) error {
 	childCtx, childSpan := tracer.Start(ctx, "delete-template")
 	defer childSpan.End()
 

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -229,9 +229,7 @@ func run(port, proxyPort uint) (success bool) {
 		zap.L().Fatal("failed to create sandbox proxy", zap.Error(err))
 	}
 
-	tracer := tel.TracerProvider.Tracer(serviceName)
-
-	networkPool, err := network.NewPool(ctx, tel.MeterProvider, network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, nodeID, tracer)
+	networkPool, err := network.NewPool(ctx, tel.MeterProvider, network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, nodeID)
 	if err != nil {
 		zap.L().Fatal("failed to create network pool", zap.Error(err))
 	}
@@ -357,7 +355,6 @@ func run(port, proxyPort uint) (success bool) {
 			NetworkPool:      networkPool,
 			DevicePool:       devicePool,
 			TemplateCache:    templateCache,
-			Tracer:           tracer,
 			Info:             serviceInfo,
 			Proxy:            sandboxProxy,
 			Sandboxes:        sandboxes,
@@ -403,7 +400,6 @@ func run(port, proxyPort uint) (success bool) {
 	if slices.Contains(services, service.TemplateManager) {
 		tmpl, err := tmplserver.New(
 			ctx,
-			tracer,
 			tel.MeterProvider,
 			globalLogger,
 			tmplSbxLoggerExternal,

--- a/packages/shared/pkg/storage/header/diff.go
+++ b/packages/shared/pkg/storage/header/diff.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/bits-and-blooms/bitset"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -17,12 +17,14 @@ const (
 	RootfsBlockSize = 2 << 11
 )
 
+var tracer = otel.Tracer("shared.pkg.storage.header")
+
 var (
 	EmptyHugePage = make([]byte, HugepageSize)
 	EmptyBlock    = make([]byte, RootfsBlockSize)
 )
 
-func WriteDiffWithTrace(ctx context.Context, tracer trace.Tracer, source io.ReaderAt, blockSize int64, dirty *bitset.BitSet, diff io.Writer) (*DiffMetadata, error) {
+func WriteDiffWithTrace(ctx context.Context, source io.ReaderAt, blockSize int64, dirty *bitset.BitSet, diff io.Writer) (*DiffMetadata, error) {
 	_, childSpan := tracer.Start(ctx, "create-diff")
 	defer childSpan.End()
 	childSpan.SetAttributes(attribute.Int64("dirty.length", int64(dirty.Count())))


### PR DESCRIPTION
Now that we're setting the global tracer, we don't need to pass around the instance of one. This allows us to see what package a span was created in, as well as simplifying how we add traces.