### PR TITLE
Update team api keys to SQLC

### DIFF
--- a/packages/api/internal/handlers/apikey.go
+++ b/packages/api/internal/handlers/apikey.go
@@ -42,7 +42,7 @@ func (a *APIStore) PatchApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 	teamID := a.GetTeamInfo(c).Team.ID
 
 	now := time.Now()
-	err = a.sqlcDB.UpdateTeamApiKey(ctx, queries.UpdateTeamApiKeyParams{
+	_, err = a.sqlcDB.UpdateTeamApiKey(ctx, queries.UpdateTeamApiKeyParams{
 		Name:      body.Name,
 		UpdatedAt: &now,
 		ID:        apiKeyIDParsed,

--- a/packages/db/queries/update_team_api_key.sql
+++ b/packages/db/queries/update_team_api_key.sql
@@ -1,2 +1,3 @@
--- name: UpdateTeamApiKey :exec
-UPDATE "public"."team_api_keys" SET name = @name , updated_at = @updated_at WHERE id = @id AND team_id = @team_id;
+-- name: UpdateTeamApiKey :one
+UPDATE "public"."team_api_keys" SET name = @name , updated_at = @updated_at WHERE id = @id AND team_id = @team_id
+RETURNING id;

--- a/packages/db/queries/update_team_api_key.sql.go
+++ b/packages/db/queries/update_team_api_key.sql.go
@@ -12,8 +12,9 @@ import (
 	"github.com/google/uuid"
 )
 
-const updateTeamApiKey = `-- name: UpdateTeamApiKey :exec
+const updateTeamApiKey = `-- name: UpdateTeamApiKey :one
 UPDATE "public"."team_api_keys" SET name = $1 , updated_at = $2 WHERE id = $3 AND team_id = $4
+RETURNING id
 `
 
 type UpdateTeamApiKeyParams struct {
@@ -23,12 +24,14 @@ type UpdateTeamApiKeyParams struct {
 	TeamID    uuid.UUID
 }
 
-func (q *Queries) UpdateTeamApiKey(ctx context.Context, arg UpdateTeamApiKeyParams) error {
-	_, err := q.db.Exec(ctx, updateTeamApiKey,
+func (q *Queries) UpdateTeamApiKey(ctx context.Context, arg UpdateTeamApiKeyParams) (uuid.UUID, error) {
+	row := q.db.QueryRow(ctx, updateTeamApiKey,
 		arg.Name,
 		arg.UpdatedAt,
 		arg.ID,
 		arg.TeamID,
 	)
-	return err
+	var id uuid.UUID
+	err := row.Scan(&id)
+	return id, err
 }


### PR DESCRIPTION
This pull request refactors the API key update logic to use a new SQLC-generated query for updating team API keys