### PR TITLE
Skip evict if the sandbox is already being removed

### DIFF
--- a/packages/api/internal/orchestrator/evictor/evict.go
+++ b/packages/api/internal/orchestrator/evictor/evict.go
@@ -29,7 +29,7 @@ func (e *Evictor) Start(ctx context.Context) {
 			items := e.store.ExpiredItems()
 
 			for _, item := range items {
-				if item.IsExpired() {
+				if item.IsExpired() && item.GetState() == instance.StateRunning {
 					go func() {
 						removeType := instance.RemoveTypeKill
 						if item.AutoPause {


### PR DESCRIPTION
Don't try to evict, if the sandbox is already being removed (it was only printing unnecessary errors)