### PR TITLE
Remove embedded context from Dispatch, Checks, and DirectPathMount

### DIFF
--- a/packages/orchestrator/cmd/mock-nbd/mock.go
+++ b/packages/orchestrator/cmd/mock-nbd/mock.go
@@ -149,7 +149,7 @@ func MockNbd(ctx context.Context, device *DeviceWithClose, index int, devicePool
 		}
 	}()
 
-	mnt = nbd.NewDirectPathMount(ctx, device, devicePool)
+	mnt = nbd.NewDirectPathMount(device, devicePool)
 
 	go func() {
 		<-ctx.Done()

--- a/packages/orchestrator/internal/metrics/sandboxes.go
+++ b/packages/orchestrator/internal/metrics/sandboxes.go
@@ -168,7 +168,7 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 
 				wg.Go(func() error { // nolint:contextcheck // TODO: fix this later
 					// Make sure the sandbox doesn't change while we are getting metrics (the slot could be assigned to another sandbox)
-					sbxMetrics, err := sbx.Checks.GetMetrics(timeoutGetMetrics)
+					sbxMetrics, err := sbx.Checks.GetMetrics(ctx, timeoutGetMetrics)
 					if err != nil {
 						// Sandbox has stopped
 						if errors.Is(err, sandbox.ErrChecksStopped) {

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -22,7 +22,6 @@ const (
 type Checks struct {
 	sandbox *Sandbox
 
-	ctx       context.Context // nolint:containedctx // todo: refactor so this can be removed
 	cancelCtx context.CancelCauseFunc
 
 	healthy atomic.Bool
@@ -32,16 +31,10 @@ type Checks struct {
 
 var ErrChecksStopped = errors.New("checks stopped")
 
-func NewChecks(ctx context.Context, sandbox *Sandbox, useClickhouseMetrics bool) (*Checks, error) {
-	_, childSpan := tracer.Start(ctx, "checks-create")
-	defer childSpan.End()
-
+func NewChecks(sandbox *Sandbox, useClickhouseMetrics bool) (*Checks, error) {
 	// Create background context, passed ctx is from create/resume request and will be canceled after the request is processed.
-	ctx, cancel := context.WithCancelCause(context.Background())
 	h := &Checks{
 		sandbox:              sandbox,
-		ctx:                  ctx,
-		cancelCtx:            cancel,
 		healthy:              atomic.Bool{}, // defaults to `false`
 		UseClickhouseMetrics: useClickhouseMetrics,
 	}
@@ -52,35 +45,37 @@ func NewChecks(ctx context.Context, sandbox *Sandbox, useClickhouseMetrics bool)
 	return h, nil
 }
 
-func (c *Checks) Start() {
-	c.logHealth()
+func (c *Checks) Start(ctx context.Context) {
+	ctx, c.cancelCtx = context.WithCancelCause(ctx)
+
+	c.logHealth(ctx)
 }
 
 func (c *Checks) Stop() {
 	c.cancelCtx(ErrChecksStopped)
 }
 
-func (c *Checks) logHealth() {
+func (c *Checks) logHealth(ctx context.Context) {
 	healthTicker := time.NewTicker(healthCheckInterval)
 	defer func() {
 		healthTicker.Stop()
 	}()
 
 	// Get metrics and health status on sandbox startup
-	go c.Healthcheck(false)
+	go c.Healthcheck(ctx, false)
 
 	for {
 		select {
 		case <-healthTicker.C:
-			c.Healthcheck(false)
-		case <-c.ctx.Done():
+			c.Healthcheck(ctx, false)
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (c *Checks) Healthcheck(alwaysReport bool) {
-	ok, err := c.GetHealth(healthCheckTimeout)
+func (c *Checks) Healthcheck(ctx context.Context, alwaysReport bool) {
+	ok, err := c.GetHealth(ctx, healthCheckTimeout)
 	// Sandbox stopped
 	if errors.Is(err, ErrChecksStopped) {
 		return

--- a/packages/orchestrator/internal/sandbox/health.go
+++ b/packages/orchestrator/internal/sandbox/health.go
@@ -10,8 +10,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
-func (c *Checks) GetHealth(timeout time.Duration) (bool, error) {
-	ctx, cancel := context.WithTimeout(c.ctx, timeout)
+func (c *Checks) GetHealth(ctx context.Context, timeout time.Duration) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	address := fmt.Sprintf("http://%s:%d/health", c.sandbox.Slot.HostIPString(), consts.DefaultEnvdServerPort)

--- a/packages/orchestrator/internal/sandbox/metrics.go
+++ b/packages/orchestrator/internal/sandbox/metrics.go
@@ -29,8 +29,8 @@ type Metrics struct {
 	MemUsedMiB int64 `json:"mem_used_mib"` // Used virtual memory in MiB
 }
 
-func (c *Checks) GetMetrics(timeout time.Duration) (*Metrics, error) {
-	ctx, cancel := context.WithTimeout(c.ctx, timeout)
+func (c *Checks) GetMetrics(ctx context.Context, timeout time.Duration) (*Metrics, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	address := fmt.Sprintf("http://%s:%d/metrics", c.sandbox.Slot.HostIPString(), consts.DefaultEnvdServerPort)

--- a/packages/orchestrator/internal/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/internal/sandbox/nbd/dispatch.go
@@ -52,7 +52,6 @@ type Response struct {
 }
 
 type Dispatch struct {
-	ctx              context.Context // nolint:containedctx // todo: refactor so this can be removed
 	fp               io.ReadWriteCloser
 	responseHeader   []byte
 	writeLock        sync.Mutex
@@ -63,12 +62,11 @@ type Dispatch struct {
 	fatal            chan error
 }
 
-func NewDispatch(ctx context.Context, fp io.ReadWriteCloser, prov Provider) *Dispatch {
+func NewDispatch(fp io.ReadWriteCloser, prov Provider) *Dispatch {
 	d := &Dispatch{
 		responseHeader: make([]byte, 16),
 		fp:             fp,
 		prov:           prov,
-		ctx:            ctx,
 		fatal:          make(chan error, 1),
 	}
 
@@ -114,7 +112,7 @@ func (d *Dispatch) writeResponse(respError uint32, respHandle uint64, chunk []by
  * This dispatches incoming NBD requests sequentially to the provider.
  *
  */
-func (d *Dispatch) Handle() error {
+func (d *Dispatch) Handle(ctx context.Context) error {
 	buffer := make([]byte, dispatchBufferSize)
 	wp := 0
 
@@ -135,8 +133,8 @@ func (d *Dispatch) Handle() error {
 			select {
 			case err := <-d.fatal:
 				return err
-			case <-d.ctx.Done():
-				return d.ctx.Err()
+			case <-ctx.Done():
+				return ctx.Err()
 			default:
 			}
 
@@ -162,7 +160,7 @@ func (d *Dispatch) Handle() error {
 					return fmt.Errorf("not supported: Flush")
 				case NBDCmdRead:
 					rp += 28
-					err := d.cmdRead(request.Handle, request.From, request.Length)
+					err := d.cmdRead(ctx, request.Handle, request.From, request.Length)
 					if err != nil {
 						return err
 					}
@@ -175,7 +173,7 @@ func (d *Dispatch) Handle() error {
 					data := make([]byte, request.Length)
 					copy(data, buffer[rp:rp+int(request.Length)])
 					rp += int(request.Length)
-					err := d.cmdWrite(request.Handle, request.From, data)
+					err := d.cmdWrite(ctx, request.Handle, request.From, data)
 					if err != nil {
 						return err
 					}
@@ -200,7 +198,7 @@ func (d *Dispatch) Handle() error {
 	}
 }
 
-func (d *Dispatch) cmdRead(cmdHandle uint64, cmdFrom uint64, cmdLength uint32) error {
+func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64, cmdLength uint32) error {
 	d.shuttingDownLock.Lock()
 	if !d.shuttingDown {
 		d.pendingResponses.Add(1)
@@ -222,7 +220,7 @@ func (d *Dispatch) cmdRead(cmdHandle uint64, cmdFrom uint64, cmdLength uint32) e
 
 		// Wait until either the ReadAt completed, or our context is cancelled...
 		select {
-		case <-d.ctx.Done():
+		case <-ctx.Done():
 			return d.writeResponse(1, handle, []byte{})
 		case err := <-errchan:
 			if err != nil {
@@ -249,7 +247,7 @@ func (d *Dispatch) cmdRead(cmdHandle uint64, cmdFrom uint64, cmdLength uint32) e
 	return nil
 }
 
-func (d *Dispatch) cmdWrite(cmdHandle uint64, cmdFrom uint64, cmdData []byte) error {
+func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint64, cmdData []byte) error {
 	d.shuttingDownLock.Lock()
 	if !d.shuttingDown {
 		d.pendingResponses.Add(1)
@@ -269,7 +267,7 @@ func (d *Dispatch) cmdWrite(cmdHandle uint64, cmdFrom uint64, cmdData []byte) er
 
 		// Wait until either the WriteAt completed, or our context is cancelled...
 		select {
-		case <-d.ctx.Done():
+		case <-ctx.Done():
 			return d.writeResponse(1, handle, []byte{})
 		case err := <-errchan:
 			if err != nil {

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct.go
@@ -32,9 +32,7 @@ const (
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd")
 
 type DirectPathMount struct {
-	ctx      context.Context // nolint:containedctx // todo: refactor so this can be removed
-	cancelfn context.CancelFunc
-
+	cancelfn   context.CancelFunc
 	devicePool *DevicePool
 
 	Backend     block.Device
@@ -48,13 +46,9 @@ type DirectPathMount struct {
 	handlersWg sync.WaitGroup
 }
 
-func NewDirectPathMount(ctx context.Context, b block.Device, devicePool *DevicePool) *DirectPathMount {
-	ctx, cancelfn := context.WithCancel(context.WithoutCancel(ctx))
-
+func NewDirectPathMount(b block.Device, devicePool *DevicePool) *DirectPathMount {
 	return &DirectPathMount{
 		Backend:     b,
-		ctx:         ctx,
-		cancelfn:    cancelfn,
 		blockSize:   4096,
 		devicePool:  devicePool,
 		socksClient: make([]*os.File, 0),
@@ -64,6 +58,8 @@ func NewDirectPathMount(ctx context.Context, b block.Device, devicePool *DeviceP
 }
 
 func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err error) {
+	ctx, d.cancelfn = context.WithCancel(ctx)
+
 	defer func() {
 		// Set the device index to the one returned, correctly capture error values
 		d.deviceIndex = retDeviceIndex
@@ -102,13 +98,13 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 			}
 			server.Close()
 
-			dispatch := NewDispatch(d.ctx, serverc, d.Backend) // nolint:contextcheck // TODO: fix this later
+			dispatch := NewDispatch(serverc, d.Backend) // nolint:contextcheck // TODO: fix this later
 			// Start reading commands on the socket and dispatching them to our provider
 			d.handlersWg.Add(1)
 			go func() {
 				defer d.handlersWg.Done()
 
-				handleErr := dispatch.Handle()
+				handleErr := dispatch.Handle(ctx)
 				// The error is expected to happen if the nbd (socket connection) is closed
 				zap.L().Info("closing handler for NBD commands",
 					zap.Error(handleErr),
@@ -159,8 +155,8 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 		}
 
 		select {
-		case <-d.ctx.Done():
-			return math.MaxUint32, errors.Join(err, d.ctx.Err())
+		case <-ctx.Done():
+			return math.MaxUint32, errors.Join(err, ctx.Err())
 		case <-time.After(25 * time.Millisecond):
 		}
 	}
@@ -168,8 +164,8 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 	// Wait until it's connected...
 	for {
 		select {
-		case <-d.ctx.Done():
-			return math.MaxUint32, d.ctx.Err()
+		case <-ctx.Done():
+			return math.MaxUint32, ctx.Err()
 		default:
 		}
 
@@ -185,19 +181,21 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 }
 
 func (d *DirectPathMount) Close(ctx context.Context) error {
-	childCtx, childSpan := tracer.Start(ctx, "direct-path-mount-close")
-	defer childSpan.End()
+	ctx, span := tracer.Start(ctx, "direct-path-mount-close")
+	defer span.End()
 
 	var errs []error
 
 	idx := d.deviceIndex
 
 	// First cancel the context, which will stop waiting on pending readAt/writeAt...
-	telemetry.ReportEvent(childCtx, "canceling context")
-	d.cancelfn()
+	telemetry.ReportEvent(ctx, "canceling context")
+	if d.cancelfn != nil {
+		d.cancelfn()
+	}
 
 	// Close all server socket pairs...
-	telemetry.ReportEvent(childCtx, "closing socket pairs server")
+	telemetry.ReportEvent(ctx, "closing socket pairs server")
 	for _, v := range d.socksServer {
 		err := v.Close()
 		if err != nil {
@@ -206,25 +204,25 @@ func (d *DirectPathMount) Close(ctx context.Context) error {
 	}
 
 	// Now wait until the handlers return
-	telemetry.ReportEvent(childCtx, "await handlers return")
+	telemetry.ReportEvent(ctx, "await handlers return")
 	d.handlersWg.Wait()
 
 	// Now wait for any pending responses to be sent
-	telemetry.ReportEvent(childCtx, "waiting for pending responses")
+	telemetry.ReportEvent(ctx, "waiting for pending responses")
 	for _, d := range d.dispatchers {
 		d.Drain()
 	}
 
 	// Disconnect NBD
 	if idx != math.MaxUint32 {
-		err := disconnectNBDWithTimeout(childCtx, idx, disconnectTimeout)
+		err := disconnectNBDWithTimeout(ctx, idx, disconnectTimeout)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error disconnecting NBD: %w", err))
 		}
 	}
 
 	// Close all client socket pairs...
-	telemetry.ReportEvent(childCtx, "closing socket pairs client")
+	telemetry.ReportEvent(ctx, "closing socket pairs client")
 	for _, v := range d.socksClient {
 		err := v.Close()
 		if err != nil {
@@ -234,7 +232,7 @@ func (d *DirectPathMount) Close(ctx context.Context) error {
 
 	// Release the device back to the pool, retry if it is in use
 	if idx != math.MaxUint32 {
-		telemetry.ReportEvent(childCtx, "releasing device to the pool")
+		telemetry.ReportEvent(ctx, "releasing device to the pool")
 		err := d.devicePool.ReleaseDeviceWithRetry(idx)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error releasing overlay device: %w", err))

--- a/packages/orchestrator/internal/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/nbd.go
@@ -30,7 +30,7 @@ type NBDProvider struct {
 	devicePool         *nbd.DevicePool
 }
 
-func NewNBDProvider(ctx context.Context, rootfs block.ReadonlyDevice, cachePath string, devicePool *nbd.DevicePool) (Provider, error) {
+func NewNBDProvider(rootfs block.ReadonlyDevice, cachePath string, devicePool *nbd.DevicePool) (Provider, error) {
 	size, err := rootfs.Size()
 	if err != nil {
 		return nil, fmt.Errorf("error getting device size: %w", err)
@@ -45,7 +45,7 @@ func NewNBDProvider(ctx context.Context, rootfs block.ReadonlyDevice, cachePath 
 
 	overlay := block.NewOverlay(rootfs, cache, blockSize)
 
-	mnt := nbd.NewDirectPathMount(ctx, overlay, devicePool)
+	mnt := nbd.NewDirectPathMount(overlay, devicePool)
 
 	return &NBDProvider{
 		mnt:                mnt,

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -172,7 +172,6 @@ func CreateSandbox(
 	var rootfsProvider rootfs.Provider
 	if rootfsCachePath == "" {
 		rootfsProvider, err = rootfs.NewNBDProvider(
-			ctx,
 			rootFS,
 			sandboxFiles.SandboxCacheRootfsPath(),
 			devicePool,
@@ -361,7 +360,6 @@ func ResumeSandbox(
 	telemetry.ReportEvent(ctx, "got template rootfs")
 
 	rootfsOverlay, err := rootfs.NewNBDProvider(
-		ctx,
 		readonlyRootfs,
 		sandboxFiles.SandboxCacheRootfsPath(),
 		devicePool,

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -301,7 +301,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	s.sandboxes.Remove(in.SandboxId)
 
 	// Check health metrics before stopping the sandbox
-	sbx.Checks.Healthcheck(true) // nolint:contextcheck // TODO: fix this later
+	sbx.Checks.Healthcheck(ctx, true) // nolint:contextcheck // TODO: fix this later
 
 	// Start the cleanup in a goroutine—the initial kill request should be send as the first thing in stop, and at this point you cannot route to the sandbox anymore.
 	// We don't wait for the whole cleanup to finish here.


### PR DESCRIPTION
This removes a few key blockers to improving tracing, and makes the linters a little happierrr