### PR TITLE
Report envd version for clock drift warns

### DIFF
--- a/packages/orchestrator/internal/metrics/sandboxes.go
+++ b/packages/orchestrator/internal/metrics/sandboxes.go
@@ -197,6 +197,7 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 								logger.WithSandboxID(sbx.Runtime.SandboxID),
 								logger.WithTeamID(sbx.Runtime.TeamID),
 								logger.WithTemplateID(sbx.Runtime.TemplateID),
+								zap.String("envd_version", sbx.Config.Envd.Version),
 								zap.Time("sandbox_start", sbx.StartedAt),
 								zap.Int64("clock_host", hostTm),
 								zap.Int64("clock_sbx", sbxTm),


### PR DESCRIPTION
Added envd version for easier debugging and query analytics 