### PR TITLE
Run OTEL with hugepages metrics

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -72,6 +72,19 @@ receivers:
           system.memory.utilization:
             enabled: false
 
+          # Huge pages metrics added as part of temporal patch
+          # https://github.com/e2b-dev/opentelemetry-collector-contrib/pull/1
+          system.linux.memory.huge_pages.free:
+            enabled: true
+          system.linux.memory.huge_pages.page_size:
+            enabled: true
+          system.linux.memory.huge_pages.reserved:
+            enabled: true
+          system.linux.memory.huge_pages.surplus:
+            enabled: true
+          system.linux.memory.huge_pages.total:
+            enabled: true
+
       #  filter not needed stuff (mode, type)
       #  filter /dev/loop*, maybe check fo other that are polluting
       filesystem:

--- a/iac/provider-gcp/nomad/jobs/otel-collector.hcl
+++ b/iac/provider-gcp/nomad/jobs/otel-collector.hcl
@@ -44,7 +44,7 @@ job "otel-collector" {
 
       config {
         network_mode = "host"
-        image        = "public.ecr.aws/e2b/tools/opentelemetry-collector-contrib:0.135.0-with-hugepages-metrics-amd64"
+        image        = "e2bdev/opentelemetry-collector-contrib:0.135.0-with-hugepages-metrics"
 
         volumes = [
           "local/config:/config",

--- a/iac/provider-gcp/nomad/jobs/otel-collector.hcl
+++ b/iac/provider-gcp/nomad/jobs/otel-collector.hcl
@@ -44,7 +44,7 @@ job "otel-collector" {
 
       config {
         network_mode = "host"
-        image        = "otel/opentelemetry-collector-contrib:0.130.0"
+        image        = "public.ecr.aws/e2b/tools/opentelemetry-collector-contrib:0.135.0-with-hugepages-metrics-amd64"
 
         volumes = [
           "local/config:/config",

--- a/packages/otel-collector/Makefile
+++ b/packages/otel-collector/Makefile
@@ -20,5 +20,5 @@ run:
 		-p 4317:4317 \
 		-p 13133:13133 \
 		-v ./otel-collector.local.yaml:/etc/otel-collector-config.yaml \
-		otel/opentelemetry-collector-contrib:0.130.0 \
+		e2bdev/opentelemetry-collector-contrib:0.135.0-with-hugepages-metrics \
 		--config /etc/otel-collector-config.yaml


### PR DESCRIPTION
Changes are currently present in our [forked repository](https://github.com/e2b-dev/opentelemetry-collector-contrib/pull/1) until the official repository adapts it.

<img width="1765" height="431" alt="image" src="https://github.com/user-attachments/assets/4d7128ca-3179-4bbf-a441-56deacd2a66e" />
