### PR TITLE
Run pull request jobs on all pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,8 +10,6 @@ concurrency:
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   lint:


### PR DESCRIPTION
If we open a pull request to another pull request, we'd still like to know if it's going to break the build before merging. For example, [#1168](https://github.com/e2b-dev/infra/pull/1168) points at [#1167](https://github.com/e2b-dev/infra/pull/1167) as an option for resolving a comment. It's not clear that we want to go this way, so it makes sense to open it as a PR so we can talk about it. However, I'd like to know that it actually works before merging it.