### PR TITLE
Change preallocated hugepages for build

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -141,6 +141,9 @@ module "cluster" {
   filestore_cache_tier        = var.filestore_cache_tier
   filestore_cache_capacity_gb = var.filestore_cache_capacity_gb
 
+  build_base_hugepages_percentage        = var.build_base_hugepages_percentage
+  orchestrator_base_hugepages_percentage = var.orchestrator_base_hugepages_percentage
+
   labels = var.labels
   prefix = var.prefix
 

--- a/iac/provider-gcp/nomad-cluster/nodepool-build.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-build.tf
@@ -21,6 +21,7 @@ locals {
     NFS_MOUNT_OPTS               = local.nfs_mount_opts
     USE_FILESTORE_CACHE          = var.filestore_cache_enabled
     NODE_POOL                    = var.build_node_pool
+    BASE_HUGEPAGES_PERCENTAGE    = var.build_base_hugepages_percentage
   })
 }
 

--- a/iac/provider-gcp/nomad-cluster/nodepool-client.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-client.tf
@@ -21,6 +21,7 @@ locals {
     NFS_MOUNT_OPTS               = local.nfs_mount_opts
     USE_FILESTORE_CACHE          = var.filestore_cache_enabled
     NODE_POOL                    = var.orchestrator_node_pool
+    BASE_HUGEPAGES_PERCENTAGE    = var.orchestrator_base_hugepages_percentage
   })
 }
 

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -218,7 +218,7 @@ echo "- Huge page size: $hugepage_size_in_mib MiB"
 hugepages=$(($hugepages_ram / $hugepage_size_in_mib))
 
 # This percentage will be permanently allocated for huge pages and in monitoring it will be shown as used.
-base_hugepages_percentage=80
+base_hugepages_percentage=${BASE_HUGEPAGES_PERCENTAGE}
 base_hugepages=$(($hugepages * $base_hugepages_percentage / 100))
 base_hugepages=$(remove_decimal $base_hugepages)
 echo "- Allocating $base_hugepages huge pages ($base_hugepages_percentage%) for base usage"

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -315,3 +315,13 @@ variable "orchestrator_node_pool" {
   description = "The name of the Nomad pool."
   type        = string
 }
+
+variable "build_base_hugepages_percentage" {
+  description = "The percentage of memory to use for preallocated hugepages."
+  type        = number
+}
+
+variable "orchestrator_base_hugepages_percentage" {
+  description = "The percentage of memory to use for preallocated hugepages."
+  type        = number
+}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -434,3 +434,15 @@ variable "min_cpu_platform" {
   type    = string
   default = "Intel Skylake"
 }
+
+variable "build_base_hugepages_percentage" {
+  description = "The percentage of memory to use for preallocated hugepages."
+  type        = number
+  default     = 60
+}
+
+variable "orchestrator_base_hugepages_percentage" {
+  description = "The percentage of memory to use for preallocated hugepages."
+  type        = number
+  default     = 80
+}


### PR DESCRIPTION
Change preallocated hugepages for build nodes from 80 to 60%. This change is required because on the build nodes, you need a lot of memory to pause the sandbox.