### PR TITLE
Add the nolintlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ linters:
     - govet
     - iface
     - importas
+    - nolintlint
     - staticcheck
     - testifylint
     - thelper

--- a/packages/api/internal/cache/auth/cache.go
+++ b/packages/api/internal/cache/auth/cache.go
@@ -66,7 +66,7 @@ func (c *TeamAuthCache) GetOrSet(ctx context.Context, key string, dataCallback D
 
 	templateInfo = item.Value()
 	if time.Since(templateInfo.lastRefresh) > refreshInterval {
-		go templateInfo.once.Do(key, func() (interface{}, error) { // nolint:contextcheck // TODO: fix this later
+		go templateInfo.once.Do(key, func() (interface{}, error) { //nolint:contextcheck // TODO: fix this later
 			c.Refresh(key, dataCallback)
 			return nil, err
 		})

--- a/packages/api/internal/dns/server.go
+++ b/packages/api/internal/dns/server.go
@@ -233,7 +233,7 @@ func (d *DNS) Start(ctx context.Context, address string, port string) {
 
 		// Close should be a noop if it's already been called,
 		// and it caches the error.
-		_ = d.Close(shutdownCtx) // nolint:contextcheck // TODO: fix this later
+		_ = d.Close(shutdownCtx) //nolint:contextcheck // TODO: fix this later
 	}()
 }
 

--- a/packages/api/internal/edge/pool.go
+++ b/packages/api/internal/edge/pool.go
@@ -161,7 +161,7 @@ func (d poolSynchronizationStore) PoolInsert(ctx context.Context, cluster querie
 
 	zap.L().Info("Initializing newly discovered cluster", l.WithClusterID(cluster.ID))
 
-	c, err := NewCluster( // nolint:contextcheck // TODO: fix this later
+	c, err := NewCluster( //nolint:contextcheck // TODO: fix this later
 		d.pool.tel,
 		cluster.Endpoint,
 		cluster.EndpointTls,

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -153,7 +153,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client) *APIStore {
 
 	authCache := authcache.NewTeamAuthCache()
 	templateCache := templatecache.NewTemplateCache(sqlcDB)
-	templateSpawnCounter := utils.NewTemplateSpawnCounter(time.Minute, dbClient) // nolint:contextcheck // TODO: fix this later
+	templateSpawnCounter := utils.NewTemplateSpawnCounter(time.Minute, dbClient) //nolint:contextcheck // TODO: fix this later
 
 	accessTokenGenerator, err := sandbox.NewEnvdAccessTokenGenerator()
 	if err != nil {

--- a/packages/api/internal/utils/error.go
+++ b/packages/api/internal/utils/error.go
@@ -98,7 +98,7 @@ func MultiErrorHandler(me openapi3.MultiError) error {
 
 	// Recreate logic from oapi-codegen/gin-middleware to handle the error
 	// Source: https://github.com/oapi-codegen/gin-middleware/blob/main/oapi_validate.go
-	switch e := err.(type) { // nolint:errorlint  // we copied this and don't want it to change
+	switch e := err.(type) { //nolint:errorlint  // we copied this and don't want it to change
 	case *openapi3filter.RequestError:
 		// We've got a bad request
 		// Split up the verbose error by lines and return the first one

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -77,7 +77,7 @@ func NewGinServer(ctx context.Context, tel *telemetry.Client, logger *zap.Logger
 			"/templates/:templateID/builds/:buildID/status",
 		),
 		customMiddleware.IncludeRoutes(
-			metricsMiddleware.Middleware(tel.MeterProvider, serviceName), // nolint:contextcheck // TODO: fix this later
+			metricsMiddleware.Middleware(tel.MeterProvider, serviceName), //nolint:contextcheck // TODO: fix this later
 			"/sandboxes",
 			"/sandboxes/:sandboxID",
 			"/sandboxes/:sandboxID/pause",

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -362,7 +362,7 @@ func run() int {
 		// close all resources that needs to be closed gracefully
 		for _, c := range closers {
 			zap.L().Info(fmt.Sprintf("Closing %T", c))
-			if err := c.Close(closeCtx); err != nil { // nolint:contextcheck // TODO: fix this later
+			if err := c.Close(closeCtx); err != nil { //nolint:contextcheck // TODO: fix this later
 				zap.L().Error("error during shutdown", zap.Error(err))
 			}
 		}

--- a/packages/db/scripts/migrator.go
+++ b/packages/db/scripts/migrator.go
@@ -42,7 +42,7 @@ func main() {
 	// Create a session locking
 	sessionLocker, err := lock.NewPostgresSessionLocker()
 	if err != nil {
-		log.Fatalf("failed to create session locker: %v", err) // nolint:gocritic // no harm in exiting after defer here
+		log.Fatalf("failed to create session locker: %v", err) //nolint:gocritic // no harm in exiting after defer here
 	}
 
 	goose.SetTableName(trackingTable)

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -50,7 +50,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	go func() { // nolint:contextcheck // TODO: fix this later
+	go func() { //nolint:contextcheck // TODO: fix this later
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		host.PollForMMDSOpts(ctx, a.mmdsChan, a.envVars)

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -46,7 +46,7 @@ type Handler struct {
 
 	cancel context.CancelFunc
 
-	outCtx    context.Context // nolint:containedctx // todo: refactor so this can be removed
+	outCtx    context.Context //nolint:containedctx // todo: refactor so this can be removed
 	outCancel context.CancelFunc
 
 	stdin io.WriteCloser

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -79,7 +79,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 		procCtx, cancelProc = context.WithTimeout(procCtx, timeout)
 	}
 
-	proc, err := handler.New( // nolint:contextcheck // TODO: fix this later
+	proc, err := handler.New( //nolint:contextcheck // TODO: fix this later
 		procCtx,
 		u,
 		req.Msg,

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -189,7 +189,7 @@ func main() {
 				},
 			})
 		} else {
-			log.Fatalf("error getting user: %v", err) // nolint:gocritic // probably fine to bail if we're done?
+			log.Fatalf("error getting user: %v", err) //nolint:gocritic // probably fine to bail if we're done?
 		}
 	}
 
@@ -205,6 +205,6 @@ func main() {
 
 	err := s.ListenAndServe()
 	if err != nil {
-		log.Fatalf("error starting server: %v", err) // nolint:gocritic // probably fine to bail if we're done?
+		log.Fatalf("error starting server: %v", err)
 	}
 }

--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	err := buildTemplate(ctx, *kernelVersion, *fcVersion, *templateID, *buildID)
 	if err != nil {
-		log.Fatalf("error building template: %v", err) // nolint:gocritic // probably fine to bail if we're done?
+		log.Fatalf("error building template: %v", err) //nolint:gocritic // probably fine to bail if we're done?
 	}
 }
 
@@ -131,7 +131,7 @@ func buildTemplate(
 		}
 	}()
 
-	artifactRegistry, err := artifactsregistry.GetArtifactsRegistryProvider() // nolint:contextcheck // TODO: fix this later
+	artifactRegistry, err := artifactsregistry.GetArtifactsRegistryProvider() //nolint:contextcheck // TODO: fix this later
 	if err != nil {
 		return fmt.Errorf("error getting artifacts registry provider: %w", err)
 	}

--- a/packages/orchestrator/cmd/mock-nbd/mock.go
+++ b/packages/orchestrator/cmd/mock-nbd/mock.go
@@ -154,7 +154,7 @@ func MockNbd(ctx context.Context, device *DeviceWithClose, index int, devicePool
 	go func() {
 		<-ctx.Done()
 
-		mnt.Close(context.Background()) // nolint:contextcheck // TODO: fix this later
+		mnt.Close(context.Background()) //nolint:contextcheck // TODO: fix this later
 	}()
 
 	_, err = mnt.Open(ctx)

--- a/packages/orchestrator/internal/events/sandbox_events_service.go
+++ b/packages/orchestrator/internal/events/sandbox_events_service.go
@@ -58,7 +58,7 @@ func (es *SandboxEventsService) HandleEvent(ctx context.Context, event event.San
 	}
 
 	go es.handlePubSubEvent(ctx, event)
-	go es.handleClickhouseBatcherEvent(event) // nolint:contextcheck // TODO: fix this later
+	go es.handleClickhouseBatcherEvent(event) //nolint:contextcheck // TODO: fix this later
 }
 
 func (es *SandboxEventsService) handlePubSubEvent(ctx context.Context, event event.SandboxEvent) {

--- a/packages/orchestrator/internal/metrics/sandboxes.go
+++ b/packages/orchestrator/internal/metrics/sandboxes.go
@@ -166,7 +166,7 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 					continue
 				}
 
-				wg.Go(func() error { // nolint:contextcheck // TODO: fix this later
+				wg.Go(func() error { //nolint:contextcheck // TODO: fix this later
 					// Make sure the sandbox doesn't change while we are getting metrics (the slot could be assigned to another sandbox)
 					sbxMetrics, err := sbx.Checks.GetMetrics(timeoutGetMetrics)
 					if err != nil {

--- a/packages/orchestrator/internal/sandbox/block/chunk.go
+++ b/packages/orchestrator/internal/sandbox/block/chunk.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Chunker struct {
-	ctx context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx context.Context //nolint:containedctx // todo: refactor so this can be removed
 
 	base    storage.ReaderAtCtx
 	cache   *Cache

--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -28,7 +28,7 @@ type deleteDiff struct {
 type DiffStore struct {
 	cachePath string
 	cache     *ttlcache.Cache[DiffStoreKey, Diff]
-	ctx       context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx       context.Context //nolint:containedctx // todo: refactor so this can be removed
 	close     chan struct{}
 
 	// pdSizes is used to keep track of the diff sizes

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -22,7 +22,7 @@ const (
 type Checks struct {
 	sandbox *Sandbox
 
-	ctx       context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx       context.Context //nolint:containedctx // todo: refactor so this can be removed
 	cancelCtx context.CancelCauseFunc
 
 	healthy atomic.Bool

--- a/packages/orchestrator/internal/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/internal/sandbox/nbd/dispatch.go
@@ -52,7 +52,7 @@ type Response struct {
 }
 
 type Dispatch struct {
-	ctx              context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx              context.Context //nolint:containedctx // todo: refactor so this can be removed
 	fp               io.ReadWriteCloser
 	responseHeader   []byte
 	writeLock        sync.Mutex

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct.go
@@ -32,7 +32,7 @@ const (
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd")
 
 type DirectPathMount struct {
-	ctx      context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx      context.Context //nolint:containedctx // todo: refactor so this can be removed
 	cancelfn context.CancelFunc
 
 	devicePool *DevicePool
@@ -102,7 +102,7 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 			}
 			server.Close()
 
-			dispatch := NewDispatch(d.ctx, serverc, d.Backend) // nolint:contextcheck // TODO: fix this later
+			dispatch := NewDispatch(d.ctx, serverc, d.Backend) //nolint:contextcheck // TODO: fix this later
 			// Start reading commands on the socket and dispatching them to our provider
 			d.handlersWg.Add(1)
 			go func() {

--- a/packages/orchestrator/internal/sandbox/nbd/pool.go
+++ b/packages/orchestrator/internal/sandbox/nbd/pool.go
@@ -50,7 +50,7 @@ type (
 //
 // Use `sudo modprobe nbd nbds_max=4096` to set the max number of devices to 4096, which is a good default for now.
 type DevicePool struct {
-	ctx  context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx  context.Context //nolint:containedctx // todo: refactor so this can be removed
 	exit chan error
 
 	// We use the bitset to speedup the free device lookup.
@@ -256,7 +256,7 @@ func (d *DevicePool) GetDevice(ctx context.Context) (DeviceSlot, error) {
 	}
 
 	slot := <-d.slots
-	d.slotCounter.Add(d.ctx, -1) // nolint:contextcheck // TODO: fix this later
+	d.slotCounter.Add(d.ctx, -1) //nolint:contextcheck // TODO: fix this later
 
 	return slot, nil
 }

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -17,7 +17,7 @@ const (
 )
 
 type Pool struct {
-	ctx    context.Context // nolint:containedctx // todo: refactor so this can be removed
+	ctx    context.Context //nolint:containedctx // todo: refactor so this can be removed
 	cancel context.CancelFunc
 
 	newSlots          chan *Slot
@@ -153,7 +153,7 @@ func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 
 	select {
 	case p.reusedSlots <- slot:
-		p.reusedSlotCounter.Add(context.Background(), 1) // nolint:contextcheck // TODO: fix this later
+		p.reusedSlotCounter.Add(context.Background(), 1) //nolint:contextcheck // TODO: fix this later
 	default:
 		err := p.cleanup(slot)
 		if err != nil {

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -538,7 +538,7 @@ func ResumeSandbox(
 		return nil, fmt.Errorf("failed to wait for sandbox start: %w", err)
 	}
 
-	go sbx.Checks.Start() // nolint:contextcheck // TODO: fix this later
+	go sbx.Checks.Start() //nolint:contextcheck // TODO: fix this later
 
 	go func() {
 		ctx, span := tracer.Start(context.WithoutCancel(ctx), "sandbox-exit-wait", trace.WithNewRoot())

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -296,7 +296,7 @@ func (s *server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	s.sandboxes.Remove(in.SandboxId)
 
 	// Check health metrics before stopping the sandbox
-	sbx.Checks.Healthcheck(true) // nolint:contextcheck // TODO: fix this later
+	sbx.Checks.Healthcheck(true) //nolint:contextcheck // TODO: fix this later
 
 	// Start the cleanup in a goroutine—the initial kill request should be send as the first thing in stop, and at this point you cannot route to the sandbox anymore.
 	// We don't wait for the whole cleanup to finish here.

--- a/packages/orchestrator/internal/template/server/main.go
+++ b/packages/orchestrator/internal/template/server/main.go
@@ -59,7 +59,7 @@ func New(
 ) (*ServerStore, error) {
 	logger.Info("Initializing template manager")
 
-	artifactsregistry, err := artifactsregistry.GetArtifactsRegistryProvider() // nolint:contextcheck // TODO: fix this later
+	artifactsregistry, err := artifactsregistry.GetArtifactsRegistryProvider() //nolint:contextcheck // TODO: fix this later
 	if err != nil {
 		return nil, fmt.Errorf("error getting artifacts registry provider: %w", err)
 	}

--- a/packages/shared/pkg/logger/exporter.go
+++ b/packages/shared/pkg/logger/exporter.go
@@ -13,7 +13,7 @@ import (
 )
 
 type HTTPWriter struct {
-	ctx        context.Context // nolint:containedctx // todo: fix the interface so this can be removed
+	ctx        context.Context //nolint:containedctx // todo: fix the interface so this can be removed
 	url        string
 	httpClient *http.Client
 	wg         sync.WaitGroup

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -20,7 +20,7 @@ var _ StorageProvider = (*FileSystemStorageProvider)(nil)
 
 type FileSystemStorageObjectProvider struct {
 	path string
-	ctx  context.Context // nolint:containedctx // todo: fix the interface so this can be removed
+	ctx  context.Context //nolint:containedctx // todo: fix the interface so this can be removed
 }
 
 var _ StorageObjectProvider = (*FileSystemStorageObjectProvider)(nil)

--- a/tests/integration/internal/tests/envd/localhost_bind_test.go
+++ b/tests/integration/internal/tests/envd/localhost_bind_test.go
@@ -55,7 +55,7 @@ func TestBindLocalhost(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			sbx := utils.SetupSandboxWithCleanup(t, client, utils.WithTimeout(300)) // nolint:contextcheck // TODO: fix this later
+			sbx := utils.SetupSandboxWithCleanup(t, client, utils.WithTimeout(300)) //nolint:contextcheck // TODO: fix this later
 			envdClient := setup.GetEnvdClient(t, ctx)
 
 			port := 3210

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -48,7 +48,7 @@ func main() {
 
 	err = seed(database, data)
 	if err != nil {
-		log.Fatalf("Failed to execute seed: %v", err) // nolint:gocritic // no harm in exiting after defer here
+		log.Fatalf("Failed to execute seed: %v", err) //nolint:gocritic // no harm in exiting after defer here
 	}
 
 	fmt.Println("Seed completed successfully.")


### PR DESCRIPTION
This linter removes `//nolint` directives when they're no longer useful. This also removes the space in `// nolint:` to make it more consistent with other directives like `//go:build` and `//go:generate`

https://github.com/ashanbrown/nolintlint