### PR TITLE
Clickhouse - Dont save backup locally

### DIFF
--- a/iac/provider-gcp/nomad/jobs/clickhouse-backup.hcl
+++ b/iac/provider-gcp/nomad/jobs/clickhouse-backup.hcl
@@ -35,7 +35,7 @@ job "clickhouse-backup" {
 
         entrypoint = ["/bin/sh", "-c"]
         args = [
-          "clickhouse-backup create_remote --tables='default.*' auto_backup_$(date +%F_%H-%M)"
+          "clickhouse-backup create_remote --delete-local --tables='default.*' auto_backup_$(date +%F_%H-%M)"
         ]
       }
 


### PR DESCRIPTION
Currently all backups are forever stored locally on disk