### PR TITLE
Update Terraform Google provider to latest 6.X version

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -1,33 +1,36 @@
 terraform {
   required_version = ">= 1.5.0, < 1.6.0"
+
   backend "gcs" {
     prefix = "terraform/orchestration/state"
   }
+
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"
       version = "3.0.2"
     }
+
     google = {
       source  = "hashicorp/google"
-      version = "6.28.0"
+      version = "6.49.3"
     }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "6.28.0"
-    }
+
     cloudflare = {
       source  = "cloudflare/cloudflare"
       version = "4.19.0"
     }
+
     nomad = {
       source  = "hashicorp/nomad"
       version = "2.1.0"
     }
+
     random = {
       source  = "hashicorp/random"
       version = "3.5.1"
     }
+
     grafana = {
       source  = "grafana/grafana"
       version = "3.18.3"
@@ -43,12 +46,6 @@ provider "docker" {
     username = "oauth2accesstoken"
     password = data.google_client_config.default.access_token
   }
-}
-
-provider "google-beta" {
-  project = var.gcp_project_id
-  region  = var.gcp_region
-  zone    = var.gcp_zone
 }
 
 provider "google" {

--- a/iac/provider-gcp/nomad-cluster-disk-image/main.tf
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.31.0"
+      version = "6.49.3"
     }
   }
 }

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -324,7 +324,6 @@ resource "google_compute_target_https_proxy" "default" {
 }
 
 resource "google_compute_global_forwarding_rule" "https" {
-  provider              = google-beta
   name                  = "${var.prefix}forwarding-rule-https"
   target                = google_compute_target_https_proxy.default.self_link
   load_balancing_scheme = "EXTERNAL_MANAGED"
@@ -333,7 +332,6 @@ resource "google_compute_global_forwarding_rule" "https" {
 }
 
 resource "google_compute_backend_service" "default" {
-  provider = google-beta
   for_each = local.backends
 
   name = "${var.prefix}backend-${each.key}"
@@ -367,7 +365,6 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  provider = google-beta
   for_each = local.health_checked_backends
   name     = "${var.prefix}hc-${each.key}"
 
@@ -417,7 +414,6 @@ resource "google_compute_health_check" "default" {
 
 
 resource "google_compute_security_policy" "default" {
-  provider = google-beta
   for_each = local.health_checked_backends
   name     = "${var.prefix}${each.key}"
 
@@ -628,7 +624,6 @@ resource "google_compute_firewall" "orch_firewall_egress" {
 # Security policy
 resource "google_compute_security_policy_rule" "api-throttling-api-key" {
   security_policy = google_compute_security_policy.default["api"].name
-  provider        = google-beta
   action          = "throttle"
   priority        = "300"
   match {
@@ -658,7 +653,6 @@ resource "google_compute_security_policy_rule" "api-throttling-api-key" {
 
 resource "google_compute_security_policy_rule" "api-throttling-ip" {
   security_policy = google_compute_security_policy.default["api"].name
-  provider        = google-beta
   action          = "throttle"
   priority        = "500"
   match {
@@ -689,7 +683,6 @@ resource "google_compute_security_policy_rule" "api-throttling-ip" {
 
 resource "google_compute_security_policy_rule" "sandbox-throttling-host" {
   security_policy = google_compute_security_policy.default["session"].name
-  provider        = google-beta
   description     = "WS envd connection requests per sandbox"
 
   action   = "throttle"
@@ -718,7 +711,6 @@ resource "google_compute_security_policy_rule" "sandbox-throttling-host" {
 
 resource "google_compute_security_policy_rule" "sandbox-throttling-ip" {
   security_policy = google_compute_security_policy.default["session"].name
-  provider        = google-beta
   action          = "throttle"
   priority        = "500"
   match {
@@ -749,7 +741,6 @@ resource "google_compute_security_policy_rule" "sandbox-throttling-ip" {
 
 resource "google_compute_security_policy_rule" "disable-consul" {
   security_policy = google_compute_security_policy.default["consul"].name
-  provider        = google-beta
   action          = "deny(403)"
   priority        = "1"
   description     = "Disable all requests to Consul"
@@ -762,8 +753,7 @@ resource "google_compute_security_policy_rule" "disable-consul" {
 }
 
 resource "google_compute_security_policy" "disable-bots-log-collector" {
-  name     = "disable-bots-log-collector"
-  provider = google-beta
+  name = "disable-bots-log-collector"
 
   rule {
     action   = "allow"

--- a/iac/provider-gcp/nomad-cluster/nodepool-client.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-client.tf
@@ -44,8 +44,7 @@ resource "google_compute_health_check" "client_nomad_check" {
 }
 
 resource "google_compute_region_autoscaler" "client" {
-  count    = var.client_cluster_size < var.client_cluster_size_max ? 1 : 0
-  provider = google-beta
+  count = var.client_cluster_size < var.client_cluster_size_max ? 1 : 0
 
   name   = "${local.client_pool_name}-client-autoscaler"
   region = var.gcp_region


### PR DESCRIPTION
- We no longer need google beta provider
- Newer version support interesting features such as secrets delete protection