### PR TITLE
Remove template build spammy logs

### DIFF
--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -245,8 +245,6 @@ func (c *TemplatesBuildCache) Get(ctx context.Context, buildID uuid.UUID, templa
 		return item.Value(), nil
 	}
 
-	zap.L().Debug("Template build info found in cache", logger.WithBuildID(buildID.String()))
-
 	return item.Value(), nil
 }
 

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -107,8 +107,6 @@ func (c *PollBuildStatus) poll(ctx context.Context) {
 
 			return
 		case <-ticker.C:
-			c.logger.Debug("Checking template build status")
-
 			buildCompleted, err := c.checkBuildStatus(ctx)
 			if err != nil {
 				c.logger.Error("Build status polling received unrecoverable error", zap.Error(err))


### PR DESCRIPTION
Remove template build spammy logs. There is no need to log the same info twice. Also, the template SDK requests the build status every 200ms, so the log message that returns the state from the cache is spammed extensively.