### PR TITLE
Fix Docker build with go 1.24.7

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make
 

--- a/packages/client-proxy/Dockerfile
+++ b/packages/client-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make
 

--- a/packages/docker-reverse-proxy/Dockerfile
+++ b/packages/docker-reverse-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.20 AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache make
 


### PR DESCRIPTION
Fix Docker build with go 1.24.7. Version `alpine3.20` contains Golang 1.24.3.