### PR TITLE
Run lazy clock sync for longer running sandboxes

### DIFF
--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.3.1"
+	Version = "0.3.2"
 
 	commitSHA string
 

--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -270,6 +270,8 @@ echo "System Init"`), Mode: 0o777},
 		map[string]string{
 			// Enable envd service autostart
 			"etc/systemd/system/multi-user.target.wants/envd.service": "etc/systemd/system/envd.service",
+			// Enable chrony service autostart
+			"etc/systemd/system/multi-user.target.wants/chrony.service": "etc/systemd/system/chrony.service",
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
We experienced issues due to the missing wall clock sync and virtualized CPUs' sandbox time drifts for sandboxes that run for multiple hours. Adding the Chrony service with a lazy sync interval should keep the clock synced for longer-running sandboxes.