### PR TITLE
Support overriding orchestrator paths

### DIFF
--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg"
 )
 
 const (
@@ -17,7 +20,7 @@ const (
 	fallbackDiffSize = 100 << ToMBShift
 )
 
-const DefaultCachePath = "/orchestrator/build"
+var DefaultCachePath = filepath.Join(pkg.OrchestratorBasePath, "build")
 
 type deleteDiff struct {
 	size      int64

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -30,14 +30,15 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/sandboxtools"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/storage/cache"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
+	"github.com/e2b-dev/infra/packages/shared/pkg"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-const (
-	templatesDirectory = "/orchestrator/build-templates"
+var templatesDirectory = filepath.Join(pkg.OrchestratorBasePath, "build-templates")
 
+const (
 	rootfsBuildFileName = "rootfs.filesystem.build"
 	rootfsProvisionLink = "rootfs.filesystem.build.provision"
 

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -61,14 +61,19 @@ const (
 	defaultProxyPort = 5007
 
 	version = "0.1.0"
-
-	fileLockName = "/orchestrator.lock"
 )
 
 var (
-	forceStop = env.GetEnv("FORCE_STOP", "false") == "true"
-	commitSHA string
+	forceStop    = env.GetEnv("FORCE_STOP", "false") == "true"
+	commitSHA    string
+	fileLockName = "/orchestrator.lock"
 )
+
+func init() {
+	if value := os.Getenv("ORCHESTRATOR_LOCK_PATH"); value != "" {
+		fileLockName = value
+	}
+}
 
 func main() {
 	port := flag.Uint("port", defaultPort, "orchestrator server port")

--- a/packages/shared/pkg/config.go
+++ b/packages/shared/pkg/config.go
@@ -1,0 +1,11 @@
+package pkg
+
+import "os"
+
+var OrchestratorBasePath = "/orchestrator"
+
+func init() {
+	if value := os.Getenv("ORCHESTRATOR_BASE_PATH"); value != "" {
+		OrchestratorBasePath = value
+	}
+}

--- a/packages/shared/pkg/storage/sandbox.go
+++ b/packages/shared/pkg/storage/sandbox.go
@@ -5,12 +5,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 )
 
-const (
-	sandboxCacheDir = "/orchestrator/sandbox"
-)
+var sandboxCacheDir = filepath.Join(pkg.OrchestratorBasePath, "sandbox")
 
 type SandboxFiles struct {
 	TemplateCacheFiles

--- a/packages/shared/pkg/storage/template_cache.go
+++ b/packages/shared/pkg/storage/template_cache.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg"
 )
 
-const (
-	templateCacheDir = "/orchestrator/template"
-)
+var templateCacheDir = filepath.Join(pkg.OrchestratorBasePath, "template")
 
 type TemplateCacheFiles struct {
 	TemplateFiles


### PR DESCRIPTION
running the orchestrator against /orchestrator and writing the pid file to / isn't great for local dev.

- `ORCHESTRATOR_LOCK_PATH` (defaults to "/orchestrator.lock")
- `ORCHESTRATOR_BASE_PATH` (defaults to "/orchestrator")