### PR TITLE
Remove load balancer infra for logs collector

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -105,9 +105,6 @@ module "cluster" {
   loki_node_pool         = var.loki_node_pool
   orchestrator_node_pool = var.orchestrator_node_pool
 
-  logs_health_proxy_port = var.logs_health_proxy_port
-  logs_proxy_port        = var.logs_proxy_port
-
   edge_api_port                = var.edge_api_port
   edge_proxy_port              = var.edge_proxy_port
   api_port                     = var.api_port
@@ -201,10 +198,6 @@ module "nomad" {
   edge_api_secret = random_password.edge_api_secret.result
 
   domain_name = var.domain_name
-
-  # Telemetry
-  logs_health_proxy_port = var.logs_health_proxy_port
-  logs_proxy_port        = var.logs_proxy_port
 
   # Logs
   loki_node_pool           = var.loki_node_pool

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -106,9 +106,7 @@ module "network" {
   build_instance_group  = google_compute_instance_group_manager.build_pool.instance_group
   server_instance_group = google_compute_instance_group_manager.server_pool.instance_group
 
-  nomad_port             = var.nomad_port
-  logs_proxy_port        = var.logs_proxy_port
-  logs_health_proxy_port = var.logs_health_proxy_port
+  nomad_port = var.nomad_port
 
   cluster_tag_name = var.cluster_tag_name
 

--- a/iac/provider-gcp/nomad-cluster/network/outputs.tf
+++ b/iac/provider-gcp/nomad-cluster/network/outputs.tf
@@ -1,3 +1,0 @@
-output "logs_proxy_ip" {
-  value = google_compute_global_address.orch_logs_ip.address
-}

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -63,21 +63,6 @@ variable "client_proxy_port" {
   })
 }
 
-variable "logs_proxy_port" {
-  type = object({
-    name = string
-    port = number
-  })
-}
-
-variable "logs_health_proxy_port" {
-  type = object({
-    name        = string
-    port        = number
-    health_path = string
-  })
-}
-
 variable "nomad_port" {
   type = number
 }

--- a/iac/provider-gcp/nomad-cluster/nodepool-client.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-client.tf
@@ -74,16 +74,6 @@ resource "google_compute_region_instance_group_manager" "client_pool" {
     instance_template = google_compute_instance_template.client.id
   }
 
-  named_port {
-    name = var.logs_health_proxy_port.name
-    port = var.logs_health_proxy_port.port
-  }
-
-  named_port {
-    name = var.logs_proxy_port.name
-    port = var.logs_proxy_port.port
-  }
-
   auto_healing_policies {
     health_check      = google_compute_health_check.client_nomad_check.id
     initial_delay_sec = 600

--- a/iac/provider-gcp/nomad-cluster/outputs.tf
+++ b/iac/provider-gcp/nomad-cluster/outputs.tf
@@ -1,7 +1,3 @@
-output "logs_proxy_ip" {
-  value = module.network.logs_proxy_ip
-}
-
 output "shared_chunk_cache_path" {
   value = var.filestore_cache_enabled ? "${local.nfs_mount_path}/${local.nfs_mount_subdir}" : ""
 }

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -155,22 +155,6 @@ variable "network_name" {
   default = "default"
 }
 
-variable "logs_proxy_port" {
-  type = object({
-    name = string
-    port = number
-  })
-}
-
-variable "logs_health_proxy_port" {
-  type = object({
-    name        = string
-    port        = number
-    health_path = string
-  })
-}
-
-
 variable "google_service_account_email" {
   type = string
 }

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -179,6 +179,10 @@ variable "logs_proxy_port" {
     name = string
     port = number
   })
+  default = {
+    name = "logs"
+    port = 30006
+  }
 }
 
 variable "logs_health_proxy_port" {
@@ -187,6 +191,11 @@ variable "logs_health_proxy_port" {
     port        = number
     health_path = string
   })
+  default = {
+    name        = "logs-health"
+    port        = 44313
+    health_path = "/health"
+  }
 }
 
 variable "analytics_collector_host_secret_name" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -177,30 +177,6 @@ variable "edge_proxy_port" {
   }
 }
 
-variable "logs_proxy_port" {
-  type = object({
-    name = string
-    port = number
-  })
-  default = {
-    name = "logs"
-    port = 30006
-  }
-}
-
-variable "logs_health_proxy_port" {
-  type = object({
-    name        = string
-    port        = number
-    health_path = string
-  })
-  default = {
-    name        = "logs-health"
-    port        = 44313
-    health_path = "/health"
-  }
-}
-
 variable "loki_cluster_size" {
   type    = number
   default = 0


### PR DESCRIPTION
When https://github.com/e2b-dev/infra/commit/6662158659124c04517abbde37c5aa14263be42a is deployed, we no longer need an infrastructure provisioning load balancer for the logs collector.