### PR TITLE
Expose only the stateless data from the sandbox store

### DIFF
--- a/packages/api/internal/cache/instance/instance.go
+++ b/packages/api/internal/cache/instance/instance.go
@@ -1,23 +1,19 @@
 package instance
 
 import (
-	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
-	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const (
-	InstanceExpiration = time.Second * 15
+	SandboxExpiration = time.Second * 15
 	// Should we auto pause the instance by default instead of killing it,
-	InstanceAutoPauseDefault = false
+	AutoPauseDefault = false
 )
 
 type State string
@@ -57,8 +53,8 @@ func NewSandbox(
 	envdAccessToken *string,
 	allowInternetAccess *bool,
 	baseTemplateID string,
-) Data {
-	return Data{
+) Sandbox {
+	return Sandbox{
 		SandboxID:  sandboxID,
 		TemplateID: templateID,
 		ClientID:   clientID,
@@ -87,7 +83,7 @@ func NewSandbox(
 	}
 }
 
-type Data struct {
+type Sandbox struct {
 	SandboxID  string
 	TemplateID string
 	ClientID   string
@@ -116,52 +112,52 @@ type Data struct {
 	State State
 }
 
-type InstanceInfo struct {
-	_data Data
+type memorySandbox struct {
+	_data Sandbox
 
 	transition *utils.ErrorOnce
 	mu         sync.RWMutex
 }
 
-func NewInstanceInfo(data Data) *InstanceInfo {
-	return &InstanceInfo{
+func newMemorySandbox(data Sandbox) *memorySandbox {
+	return &memorySandbox{
 		_data: data,
 	}
 }
 
-func (i Data) LoggerMetadata() sbxlogger.SandboxMetadata {
+func (s Sandbox) LoggerMetadata() sbxlogger.SandboxMetadata {
 	return sbxlogger.SandboxMetadata{
-		SandboxID:  i.SandboxID,
-		TemplateID: i.TemplateID,
-		TeamID:     i.TeamID.String(),
+		SandboxID:  s.SandboxID,
+		TemplateID: s.TemplateID,
+		TeamID:     s.TeamID.String(),
 	}
 }
 
-func (i Data) IsExpired() bool {
-	return time.Now().After(i.EndTime)
+func (s Sandbox) IsExpired() bool {
+	return time.Now().After(s.EndTime)
 }
 
-func (i *InstanceInfo) SetExpired() {
+func (i *memorySandbox) SetExpired() {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
 	i.setExpired()
 }
 
-func (i *InstanceInfo) setExpired() {
+func (i *memorySandbox) setExpired() {
 	if !i._data.IsExpired() {
 		i._data.EndTime = time.Now()
 	}
 }
 
-func (i *InstanceInfo) Data() Data {
+func (i *memorySandbox) Data() Sandbox {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
 	return i._data
 }
 
-func (i *InstanceInfo) State() State {
+func (i *memorySandbox) State() State {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
@@ -169,93 +165,16 @@ func (i *InstanceInfo) State() State {
 }
 
 // SandboxID returns the sandbox ID, safe to use without lock, it's immutable
-func (i *InstanceInfo) SandboxID() string {
+func (i *memorySandbox) SandboxID() string {
 	return i._data.SandboxID
 }
 
 // TeamID returns the team ID, safe to use without lock, it's immutable
-func (i *InstanceInfo) TeamID() uuid.UUID {
+func (i *memorySandbox) TeamID() uuid.UUID {
 	return i._data.TeamID
 }
 
-func (i *InstanceInfo) startRemoving(ctx context.Context, stateAction StateAction) (alreadyDone bool, callback func(error), err error) {
-	newState := StateKilling
-	if stateAction == StateActionPause {
-		newState = StatePausing
-	}
-
-	i.mu.Lock()
-	transition := i.transition
-	if transition != nil {
-		currentState := i._data.State
-		i.mu.Unlock()
-
-		if currentState != newState && !allowed[currentState][newState] {
-			return false, nil, fmt.Errorf("invalid state transition, already in transition from %s", currentState)
-		}
-
-		zap.L().Debug("State transition already in progress to the same state, waiting", logger.WithSandboxID(i.SandboxID()), zap.String("state", string(newState)))
-		err = transition.WaitWithContext(ctx)
-		if err != nil {
-			return false, nil, fmt.Errorf("sandbox is in failed state: %w", err)
-		}
-
-		// If the transition is to the same state just wait
-		switch {
-		case currentState == newState:
-			return true, func(err error) {}, nil
-		case allowed[currentState][newState]:
-			return i.startRemoving(ctx, stateAction)
-		default:
-			return false, nil, fmt.Errorf("unexpected state transition")
-		}
-	}
-
-	defer i.mu.Unlock()
-	if i._data.State == newState {
-		zap.L().Debug("Already in the same state", logger.WithSandboxID(i.SandboxID()), zap.String("state", string(newState)))
-		return true, func(error) {}, nil
-	}
-
-	if _, ok := allowed[i._data.State][newState]; !ok {
-		return false, nil, fmt.Errorf("invalid state transition from %s to %s", i._data.State, newState)
-	}
-
-	i.setExpired()
-	i._data.State = newState
-	i.transition = utils.NewErrorOnce()
-
-	callback = func(err error) {
-		zap.L().Debug("Transition complete", logger.WithSandboxID(i.SandboxID()), zap.String("state", string(newState)), zap.Error(err))
-		i.mu.Lock()
-		defer i.mu.Unlock()
-
-		setErr := i.transition.SetError(err)
-		if err != nil {
-			// Keep the transition in place so the error stays
-			zap.L().Error("Failed to set transition result", logger.WithSandboxID(i.SandboxID()), zap.Error(setErr))
-			return
-		}
-
-		// The transition is completed and the next transition can be started
-		i.transition = nil
-	}
-
-	return false, callback, nil
-}
-
-func (i *InstanceInfo) WaitForStateChange(ctx context.Context) error {
-	i.mu.RLock()
-	transition := i.transition
-	i.mu.RUnlock()
-	if transition == nil {
-		return nil
-	}
-
-	return transition.WaitWithContext(ctx)
-}
-
-func (i *InstanceInfo) ExtendEndTime(newEndTime time.Time, allowShorter bool) bool {
+func (i *memorySandbox) extendEndTime(newEndTime time.Time, allowShorter bool) bool {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 

--- a/packages/api/internal/cache/instance/operations.go
+++ b/packages/api/internal/cache/instance/operations.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 type StateAction string
@@ -20,8 +21,8 @@ const (
 	StateActionKill  StateAction = "kill"
 )
 
-// Add the instance to the cache
-func (c *MemoryStore) Add(ctx context.Context, sandbox Data, newlyCreated bool) {
+// Add the sandbox to the cache
+func (ms *MemoryStore) Add(ctx context.Context, sandbox Sandbox, newlyCreated bool) {
 	sbxlogger.I(sandbox).Debug("Adding sandbox to cache",
 		zap.Bool("newly_created", newlyCreated),
 		zap.Time("start_time", sandbox.StartTime),
@@ -34,31 +35,31 @@ func (c *MemoryStore) Add(ctx context.Context, sandbox Data, newlyCreated bool) 
 		sandbox.EndTime = sandbox.StartTime.Add(sandbox.MaxInstanceLength)
 	}
 
-	added := c.items.SetIfAbsent(sandbox.SandboxID, NewInstanceInfo(sandbox))
+	added := ms.items.SetIfAbsent(sandbox.SandboxID, newMemorySandbox(sandbox))
 	if !added {
 		zap.L().Warn("Sandbox already exists in cache", logger.WithSandboxID(sandbox.SandboxID))
 		return
 	}
 
-	for _, callback := range c.insertCallbacks {
+	for _, callback := range ms.insertCallbacks {
 		callback(ctx, sandbox, newlyCreated)
 	}
 
-	for _, callback := range c.insertAsyncCallbacks {
+	for _, callback := range ms.insertAsyncCallbacks {
 		go callback(context.WithoutCancel(ctx), sandbox, newlyCreated)
 	}
 	// Release the reservation if it exists
-	c.reservations.release(sandbox.SandboxID)
+	ms.reservations.release(sandbox.SandboxID)
 }
 
-// Exists Check if the instance exists in the cache or is being evicted.
-func (c *MemoryStore) Exists(sandboxID string) bool {
-	return c.items.Has(sandboxID)
+// Exists Check if the sandbox exists in the cache or is being evicted.
+func (ms *MemoryStore) Exists(sandboxID string) bool {
+	return ms.items.Has(sandboxID)
 }
 
 // Get the item from the cache.
-func (c *MemoryStore) Get(sandboxID string) (*InstanceInfo, error) {
-	item, ok := c.items.Get(sandboxID)
+func (ms *MemoryStore) get(sandboxID string) (*memorySandbox, error) {
+	item, ok := ms.items.Get(sandboxID)
 	if !ok {
 		return nil, fmt.Errorf("sandbox \"%s\" doesn't exist", sandboxID)
 	}
@@ -66,29 +67,29 @@ func (c *MemoryStore) Get(sandboxID string) (*InstanceInfo, error) {
 	return item, nil
 }
 
-// GetData the item from the cache.
-func (c *MemoryStore) GetData(sandboxID string, includeEvicting bool) (Data, error) {
-	item, ok := c.items.Get(sandboxID)
+// Get the item from the cache.
+func (ms *MemoryStore) Get(sandboxID string, includeEvicting bool) (Sandbox, error) {
+	item, ok := ms.items.Get(sandboxID)
 	if !ok {
-		return Data{}, fmt.Errorf("sandbox \"%s\" doesn't exist", sandboxID)
+		return Sandbox{}, fmt.Errorf("sandbox \"%s\" doesn't exist", sandboxID)
 	}
 
 	data := item.Data()
 
 	if data.IsExpired() && !includeEvicting {
-		return Data{}, fmt.Errorf("sandbox \"%s\" is being evicted", sandboxID)
+		return Sandbox{}, fmt.Errorf("sandbox \"%s\" is being evicted", sandboxID)
 	}
 
 	return data, nil
 }
 
-func (c *MemoryStore) Remove(sandboxID string) {
-	c.items.Remove(sandboxID)
+func (ms *MemoryStore) Remove(sandboxID string) {
+	ms.items.Remove(sandboxID)
 }
 
-func (c *MemoryStore) Items(teamID *uuid.UUID) []Data {
-	items := make([]Data, 0)
-	for _, item := range c.items.Items() {
+func (ms *MemoryStore) Items(teamID *uuid.UUID) []Sandbox {
+	items := make([]Sandbox, 0)
+	for _, item := range ms.items.Items() {
 		data := item.Data()
 		if data.IsExpired() {
 			continue
@@ -104,9 +105,9 @@ func (c *MemoryStore) Items(teamID *uuid.UUID) []Data {
 	return items
 }
 
-func (c *MemoryStore) ItemsToEvict() []Data {
-	items := make([]Data, 0)
-	for _, item := range c.items.Items() {
+func (ms *MemoryStore) ItemsToEvict() []Sandbox {
+	items := make([]Sandbox, 0)
+	for _, item := range ms.items.Items() {
 		data := item.Data()
 		if !data.IsExpired() {
 			continue
@@ -122,9 +123,9 @@ func (c *MemoryStore) ItemsToEvict() []Data {
 	return items
 }
 
-func (c *MemoryStore) ItemsByState(teamID *uuid.UUID, states []State) map[State][]Data {
-	items := make(map[State][]Data)
-	for _, item := range c.items.Items() {
+func (ms *MemoryStore) ItemsByState(teamID *uuid.UUID, states []State) map[State][]Sandbox {
+	items := make(map[State][]Sandbox)
+	for _, item := range ms.items.Items() {
 		data := item.Data()
 		if teamID != nil && data.TeamID != *teamID {
 			continue
@@ -132,7 +133,7 @@ func (c *MemoryStore) ItemsByState(teamID *uuid.UUID, states []State) map[State]
 
 		if slices.Contains(states, data.State) {
 			if _, ok := items[data.State]; !ok {
-				items[data.State] = []Data{}
+				items[data.State] = []Sandbox{}
 			}
 
 			items[data.State] = append(items[data.State], data)
@@ -142,24 +143,109 @@ func (c *MemoryStore) ItemsByState(teamID *uuid.UUID, states []State) map[State]
 	return items
 }
 
-func (c *MemoryStore) Len(teamID *uuid.UUID) int {
-	return len(c.Items(teamID))
+func (ms *MemoryStore) Len(teamID *uuid.UUID) int {
+	return len(ms.Items(teamID))
 }
 
-func (c *MemoryStore) ExtendEndTime(sandboxID string, newEndTime time.Time, allowShorter bool) (bool, error) {
-	item, ok := c.items.Get(sandboxID)
+func (ms *MemoryStore) ExtendEndTime(sandboxID string, newEndTime time.Time, allowShorter bool) (bool, error) {
+	item, ok := ms.items.Get(sandboxID)
 	if !ok {
 		return false, fmt.Errorf("sandbox \"%s\" doesn't exist", sandboxID)
 	}
 
-	return item.ExtendEndTime(newEndTime, allowShorter), nil
+	return item.extendEndTime(newEndTime, allowShorter), nil
 }
 
-func (c *MemoryStore) StartRemoving(ctx context.Context, sandboxID string, stateAction StateAction) (alreadyDone bool, callback func(error), err error) {
-	sbx, err := c.Get(sandboxID)
+func (ms *MemoryStore) StartRemoving(ctx context.Context, sandboxID string, stateAction StateAction) (alreadyDone bool, callback func(error), err error) {
+	sbx, err := ms.get(sandboxID)
 	if err != nil {
 		return false, nil, err
 	}
 
-	return sbx.startRemoving(ctx, stateAction)
+	return startRemoving(ctx, sbx, stateAction)
+}
+
+func startRemoving(ctx context.Context, sbx *memorySandbox, stateAction StateAction) (alreadyDone bool, callback func(error), err error) {
+	newState := StateKilling
+	if stateAction == StateActionPause {
+		newState = StatePausing
+	}
+
+	sbx.mu.Lock()
+	transition := sbx.transition
+	if transition != nil {
+		currentState := sbx._data.State
+		sbx.mu.Unlock()
+
+		if currentState != newState && !allowed[currentState][newState] {
+			return false, nil, fmt.Errorf("invalid state transition, already in transition from %s", currentState)
+		}
+
+		zap.L().Debug("State transition already in progress to the same state, waiting", logger.WithSandboxID(sbx.SandboxID()), zap.String("state", string(newState)))
+		err = transition.WaitWithContext(ctx)
+		if err != nil {
+			return false, nil, fmt.Errorf("sandbox is in failed state: %w", err)
+		}
+
+		// If the transition is to the same state just wait
+		switch {
+		case currentState == newState:
+			return true, func(err error) {}, nil
+		case allowed[currentState][newState]:
+			return startRemoving(ctx, sbx, stateAction)
+		default:
+			return false, nil, fmt.Errorf("unexpected state transition")
+		}
+	}
+
+	defer sbx.mu.Unlock()
+	if sbx._data.State == newState {
+		zap.L().Debug("Already in the same state", logger.WithSandboxID(sbx.SandboxID()), zap.String("state", string(newState)))
+		return true, func(error) {}, nil
+	}
+
+	if _, ok := allowed[sbx._data.State][newState]; !ok {
+		return false, nil, fmt.Errorf("invalid state transition from %s to %s", sbx._data.State, newState)
+	}
+
+	sbx.setExpired()
+	sbx._data.State = newState
+	sbx.transition = utils.NewErrorOnce()
+
+	callback = func(err error) {
+		zap.L().Debug("Transition complete", logger.WithSandboxID(sbx.SandboxID()), zap.String("state", string(newState)), zap.Error(err))
+		sbx.mu.Lock()
+		defer sbx.mu.Unlock()
+
+		setErr := sbx.transition.SetError(err)
+		if err != nil {
+			// Keep the transition in place so the error stays
+			zap.L().Error("Failed to set transition result", logger.WithSandboxID(sbx.SandboxID()), zap.Error(setErr))
+			return
+		}
+
+		// The transition is completed and the next transition can be started
+		sbx.transition = nil
+	}
+
+	return false, callback, nil
+}
+
+func (ms *MemoryStore) WaitForStateChange(ctx context.Context, sandboxID string) error {
+	sbx, err := ms.get(sandboxID)
+	if err != nil {
+		return fmt.Errorf("failed to get sandbox: %w", err)
+	}
+	return waitForStateChange(ctx, sbx)
+}
+
+func waitForStateChange(ctx context.Context, sbx *memorySandbox) error {
+	sbx.mu.RLock()
+	transition := sbx.transition
+	sbx.mu.RUnlock()
+	if transition == nil {
+		return nil
+	}
+
+	return transition.WaitWithContext(ctx)
 }

--- a/packages/api/internal/cache/instance/reservation_test.go
+++ b/packages/api/internal/cache/instance/reservation_test.go
@@ -17,20 +17,20 @@ const (
 
 var teamID = uuid.New()
 
-func newInstanceCache() *MemoryStore {
+func newMemoryStore() *MemoryStore {
 	cache := NewStore(nil, nil)
 	return cache
 }
 
 func TestReservation(t *testing.T) {
-	cache := newInstanceCache()
+	cache := newMemoryStore()
 
 	_, err := cache.Reserve(sandboxID, teamID, 1)
 	assert.NoError(t, err)
 }
 
 func TestReservation_Exceeded(t *testing.T) {
-	cache := newInstanceCache()
+	cache := newMemoryStore()
 
 	_, err := cache.Reserve(sandboxID, teamID, 0)
 	require.Error(t, err)
@@ -38,7 +38,7 @@ func TestReservation_Exceeded(t *testing.T) {
 }
 
 func TestReservation_SameSandbox(t *testing.T) {
-	cache := newInstanceCache()
+	cache := newMemoryStore()
 
 	_, err := cache.Reserve(sandboxID, teamID, 10)
 	require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestReservation_SameSandbox(t *testing.T) {
 }
 
 func TestReservation_Release(t *testing.T) {
-	cache := newInstanceCache()
+	cache := newMemoryStore()
 
 	release, err := cache.Reserve(sandboxID, teamID, 1)
 	require.NoError(t, err)
@@ -60,9 +60,9 @@ func TestReservation_Release(t *testing.T) {
 }
 
 func TestReservation_ResumeAlreadyRunningSandbox(t *testing.T) {
-	cache := newInstanceCache()
+	cache := newMemoryStore()
 
-	data := Data{
+	data := Sandbox{
 		ClientID:   consts.ClientID,
 		SandboxID:  sandboxID,
 		TemplateID: "test",

--- a/packages/api/internal/cache/instance/store.go
+++ b/packages/api/internal/cache/instance/store.go
@@ -8,12 +8,12 @@ import (
 )
 
 type (
-	InsertCallback func(ctx context.Context, sbx Data, created bool)
+	InsertCallback func(ctx context.Context, sbx Sandbox, created bool)
 )
 
 type MemoryStore struct {
 	reservations *ReservationCache
-	items        cmap.ConcurrentMap[string, *InstanceInfo]
+	items        cmap.ConcurrentMap[string, *memorySandbox]
 
 	// If the callback isn't very simple, consider running it in a goroutine to prevent blocking the main flow
 	insertCallbacks      []InsertCallback
@@ -27,7 +27,7 @@ func NewStore(
 	insertAsyncCallbacks []InsertCallback,
 ) *MemoryStore {
 	instanceCache := &MemoryStore{
-		items: cmap.New[*InstanceInfo](),
+		items: cmap.New[*memorySandbox](),
 
 		insertCallbacks:      insertCallbacks,
 		insertAsyncCallbacks: insertAsyncCallbacks,

--- a/packages/api/internal/cache/instance/sync.go
+++ b/packages/api/internal/cache/instance/sync.go
@@ -6,20 +6,20 @@ import (
 )
 
 // TODO: this should be removed once we have a better way to handle node sync
-// Don't remove instances that were started in the grace period on node sync
+// Don't remove sandboxes that were started in the grace period on node sync
 // This is to prevent remove instances that are still being started
 const syncSandboxRemoveGracePeriod = 10 * time.Second
 
-func (c *MemoryStore) Sync(ctx context.Context, instances []Data, nodeID string) {
-	instanceMap := make(map[string]Data)
+func (ms *MemoryStore) Sync(ctx context.Context, sandboxes []Sandbox, nodeID string) {
+	sandboxMap := make(map[string]Sandbox)
 
 	// Use a map for faster lookup
-	for _, instance := range instances {
-		instanceMap[instance.SandboxID] = instance
+	for _, sandbox := range sandboxes {
+		sandboxMap[sandbox.SandboxID] = sandbox
 	}
 
-	// Remove instances that are not in Orchestrator anymore
-	for _, item := range c.items.Items() {
+	// Remove sandboxes that are not in Orchestrator anymore
+	for _, item := range ms.items.Items() {
 		data := item.Data()
 		if data.IsExpired() {
 			continue
@@ -33,18 +33,18 @@ func (c *MemoryStore) Sync(ctx context.Context, instances []Data, nodeID string)
 			continue
 		}
 
-		_, found := instanceMap[data.SandboxID]
+		_, found := sandboxMap[data.SandboxID]
 		if !found {
 			item.SetExpired()
 		}
 	}
 
-	// Add instances that are not in the cache with the default TTL
-	for _, instance := range instances {
-		if c.Exists(instance.SandboxID) {
+	// Add sandboxes that are not in the cache with the default TTL
+	for _, sandbox := range sandboxes {
+		if ms.Exists(sandbox.SandboxID) {
 			continue
 		}
 
-		c.Add(ctx, instance, false)
+		ms.Add(ctx, sandbox, false)
 	}
 }

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -120,7 +120,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		envVars = *body.EnvVars
 	}
 
-	timeout := instance.InstanceExpiration
+	timeout := instance.SandboxExpiration
 	if body.Timeout != nil {
 		timeout = time.Duration(*body.Timeout) * time.Second
 
@@ -130,7 +130,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		}
 	}
 
-	autoPause := instance.InstanceAutoPauseDefault
+	autoPause := instance.AutoPauseDefault
 	if body.AutoPause != nil {
 		autoPause = *body.AutoPause
 	}

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -42,7 +42,7 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 	}
 
 	// Try to get the running sandbox first
-	sbx, err := a.orchestrator.GetSandboxData(sandboxId, true)
+	sbx, err := a.orchestrator.GetSandbox(sandboxId, true)
 	if err == nil {
 		// Check if sandbox belongs to the team
 		if sbx.TeamID != team.ID {

--- a/packages/api/internal/handlers/sandbox_kill.go
+++ b/packages/api/internal/handlers/sandbox_kill.go
@@ -87,7 +87,7 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 
 	killedOrRemoved := false
 
-	sbx, err := a.orchestrator.GetSandboxData(sandboxID, true)
+	sbx, err := a.orchestrator.GetSandbox(sandboxID, true)
 	if err == nil {
 		if sbx.TeamID != teamID {
 			a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox \"%s\"", sandboxID))

--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -31,7 +31,7 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 	traceID := span.SpanContext().TraceID().String()
 	c.Set("traceID", traceID)
 
-	sbx, err := a.orchestrator.GetSandboxData(sandboxID, true)
+	sbx, err := a.orchestrator.GetSandbox(sandboxID, true)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("sandbox \"%s\" doesn't exist or you don't have access to it", sandboxID))
 		return

--- a/packages/api/internal/handlers/sandbox_refresh.go
+++ b/packages/api/internal/handlers/sandbox_refresh.go
@@ -32,13 +32,13 @@ func (a *APIStore) PostSandboxesSandboxIDRefreshes(
 	}
 
 	if body.Duration == nil {
-		duration = instance.InstanceExpiration
+		duration = instance.SandboxExpiration
 	} else {
 		duration = time.Duration(*body.Duration) * time.Second
 	}
 
-	if duration < instance.InstanceExpiration {
-		duration = instance.InstanceExpiration
+	if duration < instance.SandboxExpiration {
+		duration = instance.SandboxExpiration
 	}
 
 	apiErr := a.orchestrator.KeepAliveFor(ctx, sandboxID, duration, false)

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -43,7 +43,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		return
 	}
 
-	timeout := instance.InstanceExpiration
+	timeout := instance.SandboxExpiration
 	if body.Timeout != nil {
 		timeout = time.Duration(*body.Timeout) * time.Second
 
@@ -55,13 +55,12 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	}
 
 	sandboxID = utils.ShortID(sandboxID)
-	sbxCache, err := a.orchestrator.GetSandbox(sandboxID)
+	sandboxData, err := a.orchestrator.GetSandbox(sandboxID, true)
 	if err == nil {
-		data := sbxCache.Data()
-		switch data.State {
+		switch sandboxData.State {
 		case instance.StatePausing:
 			zap.L().Debug("Waiting for sandbox to pause", logger.WithSandboxID(sandboxID))
-			err = sbxCache.WaitForStateChange(ctx)
+			err = a.orchestrator.WaitForStateChange(ctx, sandboxID)
 			if err != nil {
 				a.sendAPIStoreError(c, http.StatusInternalServerError, "Error waiting for sandbox to pause")
 				return
@@ -74,14 +73,14 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 			zap.L().Debug("Sandbox is already running",
 				logger.WithSandboxID(sandboxID),
-				zap.Time("end_time", data.EndTime),
-				zap.Time("start_time", data.StartTime),
-				zap.String("node_id", data.NodeID),
+				zap.Time("end_time", sandboxData.EndTime),
+				zap.Time("start_time", sandboxData.StartTime),
+				zap.String("node_id", sandboxData.NodeID),
 			)
 
 			return
 		default:
-			zap.L().Error("Sandbox is in an unknown state", logger.WithSandboxID(sandboxID), zap.String("state", string(data.State)))
+			zap.L().Error("Sandbox is in an unknown state", logger.WithSandboxID(sandboxID), zap.String("state", string(sandboxData.State)))
 			a.sendAPIStoreError(c, http.StatusInternalServerError, "Sandbox is in an unknown state")
 			return
 		}

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -56,7 +56,7 @@ func (a *APIStore) getPausedSandboxes(ctx context.Context, teamID uuid.UUID, run
 	return sandboxes, nil
 }
 
-func getRunningSandboxes(runningSandboxes []instance.Data, metadataFilter *map[string]string) []utils.PaginatedSandbox {
+func getRunningSandboxes(runningSandboxes []instance.Sandbox, metadataFilter *map[string]string) []utils.PaginatedSandbox {
 	// Running Sandbox IDs
 	runningSandboxList := instanceInfoToPaginatedSandboxes(runningSandboxes)
 
@@ -264,7 +264,7 @@ func snapshotsToPaginatedSandboxes(snapshots []queries.GetSnapshotsWithCursorRow
 	return sandboxes
 }
 
-func instanceInfoToPaginatedSandboxes(runningSandboxes []instance.Data) []utils.PaginatedSandbox {
+func instanceInfoToPaginatedSandboxes(runningSandboxes []instance.Sandbox) []utils.PaginatedSandbox {
 	sandboxes := make([]utils.PaginatedSandbox, 0)
 
 	// Add running sandboxes to results

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -36,7 +36,7 @@ func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
 			return
 		case <-ticker.C:
 			sandboxes := o.sandboxStore.Items(nil)
-			longRunningSandboxes := make([]instance.Data, 0, len(sandboxes))
+			longRunningSandboxes := make([]instance.Sandbox, 0, len(sandboxes))
 			for _, sandbox := range sandboxes {
 				if time.Since(sandbox.StartTime) > oldSandboxThreshold {
 					longRunningSandboxes = append(longRunningSandboxes, sandbox)
@@ -49,7 +49,7 @@ func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
 }
 
 // sendAnalyticsForLongRunningSandboxes sends long-running instances event to analytics
-func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyticscollector.Analytics, instances []instance.Data) {
+func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyticscollector.Analytics, instances []instance.Sandbox) {
 	if len(instances) == 0 {
 		zap.L().Debug("No long-running instances to report to analytics")
 		return
@@ -77,7 +77,7 @@ func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyt
 	}
 }
 
-func (o *Orchestrator) analyticsRemove(ctx context.Context, sandbox instance.Data, stateAction instance.StateAction) {
+func (o *Orchestrator) analyticsRemove(ctx context.Context, sandbox instance.Sandbox, stateAction instance.StateAction) {
 	ctx, cancel := context.WithTimeout(ctx, reportTimeout)
 	defer cancel()
 
@@ -109,7 +109,7 @@ func (o *Orchestrator) analyticsRemove(ctx context.Context, sandbox instance.Dat
 	}
 }
 
-func (o *Orchestrator) analyticsInsert(ctx context.Context, sandbox instance.Data, created bool) {
+func (o *Orchestrator) analyticsInsert(ctx context.Context, sandbox instance.Sandbox, created bool) {
 	ctx, cancel := context.WithTimeout(ctx, reportTimeout)
 	defer cancel()
 
@@ -132,7 +132,7 @@ func (o *Orchestrator) analyticsInsert(ctx context.Context, sandbox instance.Dat
 	}
 }
 
-func (o *Orchestrator) countersInsert(ctx context.Context, sandbox instance.Data, newlyCreated bool) {
+func (o *Orchestrator) countersInsert(ctx context.Context, sandbox instance.Sandbox, newlyCreated bool) {
 	attributes := []attribute.KeyValue{
 		telemetry.WithTeamID(sandbox.TeamID.String()),
 	}
@@ -144,7 +144,7 @@ func (o *Orchestrator) countersInsert(ctx context.Context, sandbox instance.Data
 	o.sandboxCounter.Add(ctx, 1, metric.WithAttributes(attributes...))
 }
 
-func (o *Orchestrator) countersRemove(ctx context.Context, sandbox instance.Data, _ instance.StateAction) {
+func (o *Orchestrator) countersRemove(ctx context.Context, sandbox instance.Sandbox, _ instance.StateAction) {
 	attributes := []attribute.KeyValue{
 		telemetry.WithTeamID(sandbox.TeamID.String()),
 	}

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -19,12 +19,8 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/api/internal/orchest
 // cacheSyncTime is the time to sync the cache with the actual instances in Orchestrator.
 const cacheSyncTime = 20 * time.Second
 
-func (o *Orchestrator) GetSandbox(sandboxID string) (*instance.InstanceInfo, error) {
-	return o.sandboxStore.Get(sandboxID)
-}
-
-func (o *Orchestrator) GetSandboxData(sandboxID string, includeEvicting bool) (instance.Data, error) {
-	return o.sandboxStore.GetData(sandboxID, includeEvicting)
+func (o *Orchestrator) GetSandbox(sandboxID string, includeEvicting bool) (instance.Sandbox, error) {
+	return o.sandboxStore.Get(sandboxID, includeEvicting)
 }
 
 // keepInSync the cache with the actual instances in Orchestrator to handle instances that died.

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -12,7 +12,7 @@ import (
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 )
 
-func (o *Orchestrator) RemoveSandbox(ctx context.Context, sbx instance.Data, stateAction instance.StateAction) error {
+func (o *Orchestrator) RemoveSandbox(ctx context.Context, sbx instance.Sandbox, stateAction instance.StateAction) error {
 	ctx, span := tracer.Start(ctx, "remove-sandbox")
 	defer span.End()
 
@@ -65,7 +65,7 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, sbx instance.Data, sta
 	return nil
 }
 
-func (o *Orchestrator) removeSandboxFromNode(ctx context.Context, sandbox instance.Data, stateAction instance.StateAction) error {
+func (o *Orchestrator) removeSandboxFromNode(ctx context.Context, sandbox instance.Sandbox, stateAction instance.StateAction) error {
 	ctx, span := tracer.Start(ctx, "remove-sandbox-from-node")
 	defer span.End()
 

--- a/packages/api/internal/orchestrator/evictor/evict.go
+++ b/packages/api/internal/orchestrator/evictor/evict.go
@@ -12,12 +12,12 @@ import (
 
 type Evictor struct {
 	store         *instance.MemoryStore
-	removeSandbox func(ctx context.Context, sandbox instance.Data, stateAction instance.StateAction) error
+	removeSandbox func(ctx context.Context, sandbox instance.Sandbox, stateAction instance.StateAction) error
 }
 
 func New(
 	store *instance.MemoryStore,
-	removeSandbox func(ctx context.Context, sandbox instance.Data, stateAction instance.StateAction) error,
+	removeSandbox func(ctx context.Context, sandbox instance.Sandbox, stateAction instance.StateAction) error,
 ) *Evictor {
 	return &Evictor{
 		store:         store,

--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (o *Orchestrator) KeepAliveFor(ctx context.Context, sandboxID string, duration time.Duration, allowShorter bool) *api.APIError {
-	data, err := o.GetSandboxData(sandboxID, false)
+	data, err := o.GetSandbox(sandboxID, false)
 	if err != nil {
 		return &api.APIError{Code: http.StatusNotFound, ClientMsg: fmt.Sprintf("Sandbox '%s' is not running anymore", sandboxID), Err: err}
 	}

--- a/packages/api/internal/orchestrator/lifecycle.go
+++ b/packages/api/internal/orchestrator/lifecycle.go
@@ -9,11 +9,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-func (o *Orchestrator) observeTeamSandbox(ctx context.Context, sandbox instance.Data, created bool) {
+func (o *Orchestrator) observeTeamSandbox(ctx context.Context, sandbox instance.Sandbox, created bool) {
 	o.teamMetricsObserver.Add(ctx, sandbox.TeamID, created)
 }
 
-func (o *Orchestrator) addToNode(ctx context.Context, sandbox instance.Data, _ bool) {
+func (o *Orchestrator) addToNode(ctx context.Context, sandbox instance.Sandbox, _ bool) {
 	node := o.GetNode(sandbox.ClusterID, sandbox.NodeID)
 	if node == nil {
 		zap.L().Error("failed to get node", logger.WithNodeID(sandbox.NodeID))

--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GetSandboxes returns all instances for a given node.
-func (o *Orchestrator) GetSandboxes(ctx context.Context, teamID *uuid.UUID, states []instance.State) map[instance.State][]instance.Data {
+func (o *Orchestrator) GetSandboxes(ctx context.Context, teamID *uuid.UUID, states []instance.State) map[instance.State][]instance.Sandbox {
 	_, childSpan := tracer.Start(ctx, "get-sandboxes")
 	defer childSpan.End()
 

--- a/packages/api/internal/orchestrator/nodemanager/metrics.go
+++ b/packages/api/internal/orchestrator/nodemanager/metrics.go
@@ -86,7 +86,7 @@ func (n *Node) Metrics() Metrics {
 	return result
 }
 
-func (n *Node) AddSandbox(sandbox instance.Data) {
+func (n *Node) AddSandbox(sandbox instance.Sandbox) {
 	n.metricsMu.Lock()
 	defer n.metricsMu.Unlock()
 
@@ -94,7 +94,7 @@ func (n *Node) AddSandbox(sandbox instance.Data) {
 	n.metrics.RamUsage += sandbox.RamMB
 }
 
-func (n *Node) RemoveSandbox(sandbox instance.Data) {
+func (n *Node) RemoveSandbox(sandbox instance.Sandbox) {
 	n.metricsMu.Lock()
 	defer n.metricsMu.Unlock()
 

--- a/packages/api/internal/orchestrator/nodemanager/sandboxes.go
+++ b/packages/api/internal/orchestrator/nodemanager/sandboxes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
-func (n *Node) GetSandboxes(ctx context.Context) ([]instance.Data, error) {
+func (n *Node) GetSandboxes(ctx context.Context) ([]instance.Sandbox, error) {
 	childCtx, childSpan := tracer.Start(ctx, "get-sandboxes-from-orchestrator")
 	defer childSpan.End()
 
@@ -27,7 +27,7 @@ func (n *Node) GetSandboxes(ctx context.Context) ([]instance.Data, error) {
 
 	sandboxes := res.GetSandboxes()
 
-	sandboxesInfo := make([]instance.Data, 0, len(sandboxes))
+	sandboxesInfo := make([]instance.Sandbox, 0, len(sandboxes))
 
 	for _, sbx := range sandboxes {
 		config := sbx.GetConfig()

--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -25,7 +25,7 @@ func (PauseQueueExhaustedError) Error() string {
 	return "The pause queue is exhausted"
 }
 
-func (o *Orchestrator) pauseSandbox(ctx context.Context, node *nodemanager.Node, sbx instance.Data) (err error) {
+func (o *Orchestrator) pauseSandbox(ctx context.Context, node *nodemanager.Node, sbx instance.Sandbox) (err error) {
 	ctx, span := tracer.Start(ctx, "pause-sandbox")
 	defer span.End()
 
@@ -87,7 +87,7 @@ func (o *Orchestrator) pauseSandbox(ctx context.Context, node *nodemanager.Node,
 	return nil
 }
 
-func snapshotInstance(ctx context.Context, orch *Orchestrator, node *nodemanager.Node, sbx instance.Data, templateID, buildID string) error {
+func snapshotInstance(ctx context.Context, orch *Orchestrator, node *nodemanager.Node, sbx instance.Sandbox, templateID, buildID string) error {
 	childCtx, childSpan := tracer.Start(ctx, "snapshot-instance")
 	defer childSpan.End()
 
@@ -120,4 +120,8 @@ func snapshotInstance(ctx context.Context, orch *Orchestrator, node *nodemanager
 	}
 
 	return fmt.Errorf("failed to pause sandbox '%s': %w", sbx.SandboxID, err)
+}
+
+func (o *Orchestrator) WaitForStateChange(ctx context.Context, sandboxID string) error {
+	return o.sandboxStore.WaitForStateChange(ctx, sandboxID)
 }

--- a/packages/api/internal/orchestrator/placement/placement_benchmark_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_benchmark_test.go
@@ -122,7 +122,7 @@ func (n *SimulatedNode) placeSandbox(sandbox *LiveSandbox) bool {
 		return false
 	}
 
-	n.AddSandbox(instance.Data{
+	n.AddSandbox(instance.Sandbox{
 		VCpu:  sandbox.RequestedCPU,
 		RamMB: sandbox.RequestedMemory,
 	})
@@ -153,7 +153,7 @@ func (n *SimulatedNode) removeSandbox(sandboxID string) {
 	metrics := n.Metrics()
 
 	if sandbox, exists := n.sandboxes[sandboxID]; exists {
-		n.RemoveSandbox(instance.Data{
+		n.RemoveSandbox(instance.Sandbox{
 			VCpu:  sandbox.RequestedCPU,
 			RamMB: sandbox.RequestedMemory,
 		})


### PR DESCRIPTION
Refactor to expose only stateless data and adapt naming for clarity.