### PR TITLE
PoC: Use of ingress controller for Nomad cluster

### DIFF
--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -92,15 +92,15 @@ module "network" {
 
   gcp_project_id = var.gcp_project_id
 
-  api_port                  = var.api_port
-  docker_reverse_proxy_port = var.docker_reverse_proxy_port
-  network_name              = var.network_name
-  domain_name               = var.domain_name
-  additional_domains        = var.additional_domains
+  // api_port                  = var.api_port
+  // docker_reverse_proxy_port = var.docker_reverse_proxy_port
+  network_name       = var.network_name
+  domain_name        = var.domain_name
+  additional_domains = var.additional_domains
 
-  client_instance_group    = google_compute_region_instance_group_manager.client_pool.instance_group
-  client_proxy_port        = var.edge_proxy_port
-  client_proxy_health_port = var.edge_api_port
+  client_instance_group = google_compute_region_instance_group_manager.client_pool.instance_group
+  //client_proxy_port        = var.edge_proxy_port
+  //client_proxy_health_port = var.edge_api_port
 
   api_instance_group    = google_compute_instance_group_manager.api_pool.instance_group
   build_instance_group  = google_compute_instance_group_manager.build_pool.instance_group
@@ -115,14 +115,23 @@ module "network" {
   labels = var.labels
   prefix = var.prefix
 
-  additional_api_path_rules = [
-    for service in var.additional_api_services : {
-      paths      = service.paths
-      service_id = service.service_id
-    }
-  ]
+  //additional_api_path_rules = [
+  //  for service in var.additional_api_services : {
+  //    paths      = service.paths
+  //    service_id = service.service_id
+  //  }
+  //]
 
-  additional_ports = [for service in var.additional_api_services : service.api_node_group_port]
+  //additional_ports = [for service in var.additional_api_services : service.api_node_group_port]
+
+
+  ingress = {
+    port_name        = "ingress"
+    port             = 8800
+    health_port_name = "ingress-health"
+    health_port      = 8900
+    health_path      = "/ping"
+  }
 }
 
 module "filestore" {

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -32,34 +32,14 @@ variable "cloudflare_api_token_secret_name" {
   type = string
 }
 
-variable "api_port" {
+variable "ingress" {
   type = object({
-    name        = string
-    port        = number
-    health_path = string
-  })
-}
+    port_name = string
+    port      = number
 
-variable "docker_reverse_proxy_port" {
-  type = object({
-    name        = string
-    port        = number
-    health_path = string
-  })
-}
-
-variable "client_proxy_health_port" {
-  type = object({
-    name = string
-    port = number
-    path = string
-  })
-}
-
-variable "client_proxy_port" {
-  type = object({
-    name = string
-    port = number
+    health_port_name = string
+    health_port      = number
+    health_path      = string
   })
 }
 
@@ -103,6 +83,7 @@ variable "labels" {
   type        = map(string)
 }
 
+/*
 variable "additional_api_path_rules" {
   description = "Additional path rules to add to the load balancer routing."
   type = list(object({
@@ -115,3 +96,35 @@ variable "additional_ports" {
   description = "Additional ports to expose on the load balancer."
   type        = list(number)
 }
+
+variable "api_port" {
+  type = object({
+    name        = string
+    port        = number
+    health_path = string
+  })
+}
+
+variable "docker_reverse_proxy_port" {
+  type = object({
+    name        = string
+    port        = number
+    health_path = string
+  })
+}
+
+variable "client_proxy_health_port" {
+  type = object({
+    name = string
+    port = number
+    path = string
+  })
+}
+
+variable "client_proxy_port" {
+  type = object({
+    name = string
+    port = number
+  })
+}
+*/

--- a/iac/provider-gcp/nomad-cluster/nodepool-api.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-api.tf
@@ -52,26 +52,13 @@ resource "google_compute_instance_group_manager" "api_pool" {
   }
 
   named_port {
-    name = var.edge_api_port.name
-    port = var.edge_api_port.port
+    name = "ingress"
+    port = 8800
   }
 
   named_port {
-    name = var.edge_proxy_port.name
-    port = var.edge_proxy_port.port
-  }
-
-  named_port {
-    name = var.api_port.name
-    port = var.api_port.port
-  }
-
-  dynamic "named_port" {
-    for_each = local.api_additional_ports
-    content {
-      name = "${var.prefix}${named_port.value.name}"
-      port = named_port.value.port
-    }
+    name = "ingress-health"
+    port = 8900
   }
 
   auto_healing_policies {

--- a/iac/provider-gcp/nomad-cluster/nodepool-build.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-build.tf
@@ -50,11 +50,6 @@ resource "google_compute_instance_group_manager" "build_pool" {
     instance_template = google_compute_instance_template.build.id
   }
 
-  named_port {
-    name = var.docker_reverse_proxy_port.name
-    port = var.docker_reverse_proxy_port.port
-  }
-
   auto_healing_policies {
     health_check      = google_compute_health_check.build_nomad_check.id
     initial_delay_sec = 600

--- a/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
@@ -44,11 +44,6 @@ resource "google_compute_instance_group_manager" "clickhouse_pool" {
     instance_template = google_compute_instance_template.clickhouse.id
   }
 
-  named_port {
-    name = var.clickhouse_health_port.name
-    port = var.clickhouse_health_port.port
-  }
-
   auto_healing_policies {
     health_check      = google_compute_health_check.clickhouse_nomad_check.id
     initial_delay_sec = 600

--- a/iac/provider-gcp/nomad/jobs/api.hcl
+++ b/iac/provider-gcp/nomad/jobs/api.hcl
@@ -37,6 +37,12 @@ job "api" {
       port = "${port_number}"
       task = "start"
 
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.api.rule=Host(`api.e2b-jirka.dev`)",
+        "traefik.http.routers.api.priority=10"
+      ]
+
       check {
         type     = "http"
         name     = "health"
@@ -47,7 +53,6 @@ job "api" {
       }
     }
 
-%{ if update_stanza }
     # An update stanza to enable rolling updates of the service
     update {
       # The number of extra instances to run during the update
@@ -61,7 +66,6 @@ job "api" {
       # Whether to promote the canary if the rest of the group is not healthy
       auto_promote     = true
     }
-%{ endif }
 
     task "start" {
       driver       = "docker"
@@ -109,7 +113,6 @@ job "api" {
       }
 
       config {
-        network_mode = "host"
         image        = "${api_docker_image}"
         ports        = ["${port_name}"]
         args         = [

--- a/iac/provider-gcp/nomad/jobs/docker-reverse-proxy.hcl
+++ b/iac/provider-gcp/nomad/jobs/docker-reverse-proxy.hcl
@@ -24,6 +24,12 @@ job "docker-reverse-proxy" {
       name = "docker-reverse-proxy"
       port = "${port_name}"
 
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.docker_reverse_proxy.rule=Host(`docker.e2b-jirka.dev`)",
+        "traefik.http.routers.docker_reverse_proxy.priority=12"
+      ]
+
       check {
         type     = "http"
         name     = "health"
@@ -53,10 +59,9 @@ job "docker-reverse-proxy" {
       }
 
       config {
-        network_mode = "host"
-        image        = "${image_name}"
-        ports        = ["${port_name}"]
-        args = [
+        image = "${image_name}"
+        ports = ["${port_name}"]
+        args  = [
           "--port", "${port_number}",
         ]
       }

--- a/iac/provider-gcp/nomad/jobs/ingress.hcl
+++ b/iac/provider-gcp/nomad/jobs/ingress.hcl
@@ -22,11 +22,19 @@ job "ingress" {
     }
 %{ endif }
 
-    // todo: health check
     service {
-      port     = "ingress"
-      name     = "ingress"
-      provider = "nomad"
+      port = "ingress"
+      name = "ingress"
+      task = "ingress"
+
+      check {
+        type     = "http"
+        name     = "health"
+        path     = "/ping"
+        interval = "3s"
+        timeout  = "3s"
+        port     = "${control_port}"
+      }
     }
 
     task "ingress" {
@@ -55,7 +63,7 @@ job "ingress" {
 
           "--accesslog=true",
           "--ping=true",
-          "--ping.entryPoint=web",
+          "--ping.entryPoint=traefik",
           "--metrics=true",
           "--metrics.prometheus=true",
           "--metrics.prometheus.entryPoint=traefik",

--- a/iac/provider-gcp/nomad/jobs/ingress.hcl
+++ b/iac/provider-gcp/nomad/jobs/ingress.hcl
@@ -1,0 +1,83 @@
+job "ingress" {
+  datacenters = ["${gcp_zone}"]
+  node_pool   = "${node_pool}"
+  type        = "system"
+  priority    = 90
+
+  group "ingress" {
+    network {
+      port "ingress" {
+        static = "${ingress_port}"
+      }
+
+      port "control" {
+        static = "${control_port}"
+      }
+    }
+
+# https://developer.hashicorp.com/nomad/docs/job-specification/update
+%{ if update_stanza }
+    update {
+      max_parallel = 1    # Update only 1 node at a time
+    }
+%{ endif }
+
+    // todo: health check
+    service {
+      port     = "ingress"
+      name     = "ingress"
+      provider = "nomad"
+    }
+
+    task "ingress" {
+      driver = "docker"
+
+      # If we need more than 30s we will need to update the max_kill_timeout in nomad
+      # https://developer.hashicorp.com/nomad/docs/configuration/client#max_kill_timeout
+      %{ if update_stanza }
+        kill_timeout = "24h"
+      %{ endif }
+
+      kill_signal  = "SIGTERM"
+
+      config {
+        network_mode = "host"
+        image        = "traefik:v3.5"
+        ports        = ["control", "ingress"]
+        args = [
+          # Entry-points that are set internally by Traefik
+          "--entrypoints.web.address=:${ingress_port}",
+          "--entrypoints.traefik.address=:${control_port}",
+
+          # Traefik internals (logging, metrics, ...)
+          "--api.dashboard=true",
+          "--api.insecure=false",
+
+          "--accesslog=true",
+          "--ping=true",
+          "--ping.entryPoint=web",
+          "--metrics=true",
+          "--metrics.prometheus=true",
+          "--metrics.prometheus.entryPoint=traefik",
+
+          # Traefik Nomad provider
+          "--providers.nomad=true",
+          "--providers.nomad.endpoint.address=${nomad_endpoint}",
+          "--providers.nomad.endpoint.token=${nomad_token}",
+
+          # Traefik Consul provider
+          "--providers.consulcatalog=true",
+          "--providers.consulcatalog.exposedByDefault=false",
+          "--providers.consulcatalog.endpoint.address=${consul_endpoint}",
+          "--providers.consulcatalog.endpoint.token=${consul_token}",
+        ]
+      }
+
+      resources {
+        memory_max = ${memory_mb * 1.5}
+        memory     = ${memory_mb}
+        cpu        = ${cpu_count * 1000}
+      }
+    }
+  }
+}

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -68,6 +68,26 @@ resource "docker_image" "db_migrator_image" {
   platform      = "linux/amd64/v8"
 }
 
+resource "nomad_job" "ingress" {
+  jobspec = templatefile("${path.module}/jobs/ingress.hcl",
+    {
+      update_stanza = var.api_machine_count > 1
+      cpu_count     = var.api_resources_cpu_count
+      memory_mb     = var.api_resources_memory_mb
+      node_pool     = var.api_node_pool
+      gcp_zone      = var.gcp_zone
+
+      ingress_port = 8800
+      control_port = 8900
+
+      nomad_endpoint = "http://localhost:4646"
+      nomad_token    = var.nomad_acl_token_secret
+
+      consul_token    = var.consul_acl_token_secret
+      consul_endpoint = "http://localhost:8500"
+  })
+}
+
 resource "nomad_job" "api" {
   jobspec = templatefile("${path.module}/jobs/api.hcl", {
     update_stanza = var.api_machine_count > 1

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -72,8 +72,8 @@ resource "nomad_job" "ingress" {
   jobspec = templatefile("${path.module}/jobs/ingress.hcl",
     {
       update_stanza = var.api_machine_count > 1
-      cpu_count     = var.api_resources_cpu_count
-      memory_mb     = var.api_resources_memory_mb
+      cpu_count     = 1
+      memory_mb     = 512
       node_pool     = var.api_node_pool
       gcp_zone      = var.gcp_zone
 


### PR DESCRIPTION
Docs related to Traefik and cooperation with Nomad (https://doc.traefik.io/traefik/reference/install-configuration/providers/hashicorp/nomad/).

Why?
- Currently, we are mapping port numbers and port names back and forth to propagate them from the Nomad job to the VM instances and the backend user by the load balancer.
- Simplify load balancer setup as it will expose just one port for ingress, which will make configuration easier for different cloud providers.
-  To expose the job to the load balancer, we currently need to define it as a host network. At the same time, if we need to perform a blue/green deployment, we require multiple nodes to ensure it is done safely. With ingress, we can have various APIs/client proxies, etc, on the same host during deployment.
- When deploying internal services, the process of propagating additional VM ports, firewall, and load balancer configuration can easily cause misconfiguration errors, and it's not developer-friendly. With ingress, we can deploy the service to the cluster and define Traefik labels to route the new service as needed.
- For future migrations, this can really help us to customize it as needed with custom temporal routing done in our own Traefik/Nginx instead of a load balancer that does not have access to business logic.

Points that need some care:
- Nomad and Consul still need to be attached manually to LB, because otherwise, we would create a circular dependency.
- We have some load balancer filtering and security rules, which can be transferred too; we need to investigate more around the catch-all hostname, as now we cannot distinguish between (api|docker|edge). and *. as both requests are routed to the same backend. We can work around that.