### PR TITLE
Improve template alias error messages

### DIFF
--- a/packages/db/dberrors/dberrors.go
+++ b/packages/db/dberrors/dberrors.go
@@ -1,0 +1,10 @@
+package dberrors
+
+import (
+	"database/sql"
+	"errors"
+)
+
+func IsNotFoundError(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
+}

--- a/packages/db/queries/get_templatealias_by_alias.sql
+++ b/packages/db/queries/get_templatealias_by_alias.sql
@@ -1,4 +1,5 @@
 -- name: GetTemplateAliasByAlias :one
-SELECT ea.*
+SELECT ea.*, e.team_id, e.public
 FROM "public"."env_aliases" ea
+JOIN "public"."envs" e ON ea.env_id = e.id
 WHERE ea.alias = $1;

--- a/packages/db/queries/get_templatealias_by_alias.sql.go
+++ b/packages/db/queries/get_templatealias_by_alias.sql.go
@@ -7,17 +7,34 @@ package queries
 
 import (
 	"context"
+
+	"github.com/google/uuid"
 )
 
 const getTemplateAliasByAlias = `-- name: GetTemplateAliasByAlias :one
-SELECT ea.alias, ea.is_renamable, ea.env_id
+SELECT ea.alias, ea.is_renamable, ea.env_id, e.team_id, e.public
 FROM "public"."env_aliases" ea
+JOIN "public"."envs" e ON ea.env_id = e.id
 WHERE ea.alias = $1
 `
 
-func (q *Queries) GetTemplateAliasByAlias(ctx context.Context, alias string) (EnvAlias, error) {
+type GetTemplateAliasByAliasRow struct {
+	Alias       string
+	IsRenamable bool
+	EnvID       string
+	TeamID      uuid.UUID
+	Public      bool
+}
+
+func (q *Queries) GetTemplateAliasByAlias(ctx context.Context, alias string) (GetTemplateAliasByAliasRow, error) {
 	row := q.db.QueryRow(ctx, getTemplateAliasByAlias, alias)
-	var i EnvAlias
-	err := row.Scan(&i.Alias, &i.IsRenamable, &i.EnvID)
+	var i GetTemplateAliasByAliasRow
+	err := row.Scan(
+		&i.Alias,
+		&i.IsRenamable,
+		&i.EnvID,
+		&i.TeamID,
+		&i.Public,
+	)
 	return i, err
 }


### PR DESCRIPTION
Improve template alias error messages. Includes refactoring of the old endpoints and removal of isNew flag. This should put the authorization logic closer to the request handlers and remove unnecessary logic from the code depth.