### PR TITLE
Refactor the Create/Resume functions to avoid globals/reduce args

### DIFF
--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -155,8 +155,12 @@ func buildTemplate(
 	if err != nil {
 		zap.L().Fatal("failed to create build metrics", zap.Error(err))
 	}
+
+	sandboxFactory := sandbox.NewFactory(networkPool, devicePool, featureFlags, true)
+
 	builder := build.NewBuilder(
 		logger,
+		sandboxFactory,
 		persistenceTemplate,
 		persistenceBuild,
 		artifactRegistry,

--- a/packages/orchestrator/internal/config/config.go
+++ b/packages/orchestrator/internal/config/config.go
@@ -1,5 +1,0 @@
-package config
-
-import "github.com/e2b-dev/infra/packages/shared/pkg/env"
-
-var AllowSandboxInternet = env.GetEnv("ALLOW_SANDBOX_INTERNET", "true") != "false"

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	globalconfig "github.com/e2b-dev/infra/packages/orchestrator/internal/config"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/fc"
@@ -23,6 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/uffd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -116,12 +116,32 @@ type networkSlotRes struct {
 	err  error
 }
 
-// CreateSandbox creates the sandbox.
-// IMPORTANT: You must Close() the sandbox after you are done with it.
-func CreateSandbox(
-	ctx context.Context,
+type Factory struct {
+	networkPool  *network.Pool
+	devicePool   *nbd.DevicePool
+	featureFlags *featureflags.Client
+
+	defaultAllowInternetAccess bool
+}
+
+func NewFactory(
 	networkPool *network.Pool,
 	devicePool *nbd.DevicePool,
+	featureFlags *featureflags.Client,
+	defaultAllowInternetAccess bool,
+) *Factory {
+	return &Factory{
+		networkPool:                networkPool,
+		devicePool:                 devicePool,
+		featureFlags:               featureFlags,
+		defaultAllowInternetAccess: defaultAllowInternetAccess,
+	}
+}
+
+// CreateSandbox creates the sandbox.
+// IMPORTANT: You must Close() the sandbox after you are done with it.
+func (f *Factory) CreateSandbox(
+	ctx context.Context,
 	config Config,
 	runtime RuntimeMetadata,
 	fcVersions fc.FirecrackerVersions,
@@ -146,12 +166,12 @@ func CreateSandbox(
 		}
 	}()
 
-	allowInternet := globalconfig.AllowSandboxInternet
+	allowInternet := f.defaultAllowInternetAccess
 	if config.AllowInternetAccess != nil {
 		allowInternet = *config.AllowInternetAccess
 	}
 
-	ipsCh := getNetworkSlotAsync(ctx, networkPool, cleanup, allowInternet)
+	ipsCh := getNetworkSlotAsync(ctx, f.networkPool, cleanup, allowInternet)
 	defer func() {
 		// Ensure the slot is received from chan so the slot is cleaned up properly in cleanup
 		<-ipsCh
@@ -177,7 +197,7 @@ func CreateSandbox(
 		rootfsProvider, err = rootfs.NewNBDProvider(
 			rootFS,
 			sandboxFiles.SandboxCacheRootfsPath(),
-			devicePool,
+			f.devicePool,
 		)
 	} else {
 		rootfsProvider, err = rootfs.NewDirectProvider(
@@ -302,17 +322,14 @@ func CreateSandbox(
 
 // ResumeSandbox resumes the sandbox from already saved template or snapshot.
 // IMPORTANT: You must Close() the sandbox after you are done with it.
-func ResumeSandbox(
+func (f *Factory) ResumeSandbox(
 	ctx context.Context,
-	networkPool *network.Pool,
 	t template.Template,
 	config Config,
 	runtime RuntimeMetadata,
 	traceID string,
 	startedAt time.Time,
 	endAt time.Time,
-	devicePool *nbd.DevicePool,
-	useClickhouseMetrics bool,
 	apiConfigToStore *orchestrator.SandboxConfig,
 ) (s *Sandbox, e error) {
 	ctx, span := tracer.Start(ctx, "resume-sandbox")
@@ -341,12 +358,12 @@ func ResumeSandbox(
 		}
 	}()
 
-	allowInternet := globalconfig.AllowSandboxInternet
+	allowInternet := f.defaultAllowInternetAccess
 	if config.AllowInternetAccess != nil {
 		allowInternet = *config.AllowInternetAccess
 	}
 
-	ipsCh := getNetworkSlotAsync(ctx, networkPool, cleanup, allowInternet)
+	ipsCh := getNetworkSlotAsync(ctx, f.networkPool, cleanup, allowInternet)
 	defer func() {
 		// Ensure the slot is received from chan so the slot is cleaned up properly in cleanup
 		<-ipsCh
@@ -374,7 +391,7 @@ func ResumeSandbox(
 	rootfsOverlay, err := rootfs.NewNBDProvider(
 		readonlyRootfs,
 		sandboxFiles.SandboxCacheRootfsPath(),
-		devicePool,
+		f.devicePool,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create rootfs overlay: %w", err)
@@ -521,6 +538,11 @@ func ResumeSandbox(
 		APIStoredConfig: apiConfigToStore,
 
 		exit: exit,
+	}
+
+	useClickhouseMetrics, flagErr := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlagName)
+	if flagErr != nil {
+		zap.L().Error("soft failing during metrics write feature flag receive", zap.Error(flagErr))
 	}
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -27,6 +27,7 @@ import (
 type server struct {
 	orchestrator.UnimplementedSandboxServiceServer
 
+	sandboxFactory    *sandbox.Factory
 	info              *service.ServiceInfo
 	sandboxes         *smap.Map[*sandbox.Sandbox]
 	proxy             *proxy.SandboxProxy
@@ -56,22 +57,21 @@ type ServiceConfig struct {
 	TemplateCache    *template.Cache
 	Info             *service.ServiceInfo
 	Proxy            *proxy.SandboxProxy
+	SandboxFactory   *sandbox.Factory
 	Sandboxes        *smap.Map[*sandbox.Sandbox]
 	Persistence      storage.StorageProvider
 	FeatureFlags     *featureflags.Client
 	SbxEventsService events.EventsService[event.SandboxEvent]
 }
 
-func New(
-	ctx context.Context,
-	cfg ServiceConfig,
-) (*Service, error) {
+func New(cfg ServiceConfig) *Service {
 	srv := &Service{
 		info:        cfg.Info,
 		proxy:       cfg.Proxy,
 		persistence: cfg.Persistence,
 	}
 	srv.server = &server{
+		sandboxFactory:    cfg.SandboxFactory,
 		info:              cfg.Info,
 		proxy:             srv.proxy,
 		sandboxes:         cfg.Sandboxes,
@@ -96,5 +96,5 @@ func New(
 
 	orchestrator.RegisterSandboxServiceServer(cfg.GRPC.GRPCServer(), srv.server)
 
-	return srv, nil
+	return srv
 }

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -42,6 +42,7 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/interna
 type Builder struct {
 	logger *zap.Logger
 
+	sandboxFactory   *sandbox.Factory
 	templateStorage  storage.StorageProvider
 	buildStorage     storage.StorageProvider
 	devicePool       *nbd.DevicePool
@@ -55,6 +56,7 @@ type Builder struct {
 
 func NewBuilder(
 	logger *zap.Logger,
+	sandboxFactory *sandbox.Factory,
 	templateStorage storage.StorageProvider,
 	buildStorage storage.StorageProvider,
 	artifactRegistry artifactsregistry.ArtifactsRegistry,
@@ -76,6 +78,7 @@ func NewBuilder(
 		sandboxes:        sandboxes,
 		templateCache:    templateCache,
 		metrics:          buildMetrics,
+		sandboxFactory:   sandboxFactory,
 	}
 }
 
@@ -212,6 +215,7 @@ func runBuild(
 		layerExecutor,
 		index,
 		builder.metrics,
+		builder.sandboxFactory,
 	)
 
 	commandExecutor := commands.NewCommandExecutor(
@@ -222,6 +226,7 @@ func runBuild(
 
 	stepBuilders := steps.CreateStepPhases(
 		bc,
+		builder.sandboxFactory,
 		builder.logger,
 		builder.proxy,
 		layerExecutor,
@@ -232,6 +237,7 @@ func runBuild(
 
 	postProcessingBuilder := finalize.New(
 		bc,
+		builder.sandboxFactory,
 		builder.templateStorage,
 		builder.proxy,
 		layerExecutor,

--- a/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
@@ -15,14 +15,15 @@ import (
 
 // ResumeSandbox creates sandboxes for resuming existing templates
 type ResumeSandbox struct {
-	config  sandbox.Config
-	timeout time.Duration
+	config         sandbox.Config
+	sandboxFactory *sandbox.Factory
+	timeout        time.Duration
 }
 
 var _ SandboxCreator = (*ResumeSandbox)(nil)
 
-func NewResumeSandbox(config sandbox.Config, timeout time.Duration) *ResumeSandbox {
-	return &ResumeSandbox{config: config, timeout: timeout}
+func NewResumeSandbox(config sandbox.Config, sandboxFactory *sandbox.Factory, timeout time.Duration) *ResumeSandbox {
+	return &ResumeSandbox{config: config, sandboxFactory: sandboxFactory, timeout: timeout}
 }
 
 func (rs *ResumeSandbox) Sandbox(
@@ -30,9 +31,8 @@ func (rs *ResumeSandbox) Sandbox(
 	layerExecutor *LayerExecutor,
 	template sbxtemplate.Template,
 ) (*sandbox.Sandbox, error) {
-	sbx, err := sandbox.ResumeSandbox(
+	sbx, err := rs.sandboxFactory.ResumeSandbox(
 		ctx,
-		layerExecutor.networkPool,
 		template,
 		rs.config,
 		sandbox.RuntimeMetadata{
@@ -43,8 +43,6 @@ func (rs *ResumeSandbox) Sandbox(
 		uuid.New().String(),
 		time.Now(),
 		time.Now().Add(rs.timeout),
-		layerExecutor.devicePool,
-		false,
 		nil,
 	)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/phases/base/provision.go
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.go
@@ -74,10 +74,8 @@ func (bb *BaseBuilder) provisionSandbox(
 	logsWriter := &writer.PrefixFilteredWriter{Writer: zapWriter, PrefixFilter: logExternalPrefix}
 	defer logsWriter.Close()
 
-	sbx, err := sandbox.CreateSandbox(
+	sbx, err := bb.sandboxFactory.CreateSandbox(
 		ctx,
-		bb.networkPool,
-		bb.devicePool,
 		sandboxConfig,
 		sandboxRuntime,
 		fcVersions,

--- a/packages/orchestrator/internal/template/build/phases/steps/factory.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/factory.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
+	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/buildcontext"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/commands"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/layer"
@@ -14,6 +15,7 @@ import (
 
 func CreateStepPhases(
 	bc buildcontext.BuildContext,
+	sandboxFactory *sandbox.Factory,
 	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	layerExecutor *layer.LayerExecutor,
@@ -27,6 +29,7 @@ func CreateStepPhases(
 		steps = append(steps,
 			New(
 				bc,
+				sandboxFactory,
 				logger,
 				proxy,
 				layerExecutor,

--- a/packages/orchestrator/internal/template/server/main.go
+++ b/packages/orchestrator/internal/template/server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/cache"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
@@ -75,8 +76,17 @@ func New(
 	if err != nil {
 		return nil, fmt.Errorf("failed to create build metrics: %w", err)
 	}
+
+	featureFlags, err := featureflags.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create feature flags client: %w", err)
+	}
+
+	sandboxFactory := sandbox.NewFactory(networkPool, devicePool, featureFlags, true)
+
 	builder := build.NewBuilder(
 		logger,
+		sandboxFactory,
 		templatePersistence,
 		buildPersistance,
 		artifactsregistry,

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -361,25 +361,22 @@ func run(port, proxyPort, hyperloopPort uint) (success bool) {
 		zap.L().Fatal("failed to create sandbox observer", zap.Error(err))
 	}
 
-	_, err = server.New(
-		ctx,
-		server.ServiceConfig{
-			GRPC:             grpcSrv,
-			Tel:              tel,
-			NetworkPool:      networkPool,
-			DevicePool:       devicePool,
-			TemplateCache:    templateCache,
-			Info:             serviceInfo,
-			Proxy:            sandboxProxy,
-			Sandboxes:        sandboxes,
-			Persistence:      persistence,
-			FeatureFlags:     featureFlags,
-			SbxEventsService: sbxEventsService,
-		},
-	)
-	if err != nil {
-		zap.L().Fatal("failed to create server", zap.Error(err))
-	}
+	sandboxFactory := sandbox.NewFactory(networkPool, devicePool, featureFlags, env.GetEnv("ALLOW_SANDBOX_INTERNET", "true") != "false")
+
+	server.New(server.ServiceConfig{
+		SandboxFactory:   sandboxFactory,
+		GRPC:             grpcSrv,
+		Tel:              tel,
+		NetworkPool:      networkPool,
+		DevicePool:       devicePool,
+		TemplateCache:    templateCache,
+		Info:             serviceInfo,
+		Proxy:            sandboxProxy,
+		Sandboxes:        sandboxes,
+		Persistence:      persistence,
+		FeatureFlags:     featureFlags,
+		SbxEventsService: sbxEventsService,
+	})
 
 	tmplSbxLoggerExternal := sbxlogger.NewLogger(
 		ctx,


### PR DESCRIPTION
This PR  creates a `Factory` struct, which does a few things:

- moves `networkPool` and `devicePool` to a central place, so they don't need to be passed into `CreateSandbox` and `ResumeSandbox` on every  invocation.
- moves the query for `MetricsWriteFlagName` into the Factory, simplifying the arguments.
- move the check of the `ALLOW_SANDBOX_INTERNET` env var into the `main` function, and out of the global scope.