### PR TITLE
Fix concurrent hosts file write during sbx start

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -52,7 +52,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if initRequest.HyperloopIP != nil {
-			a.SetupHyperloop(*initRequest.HyperloopIP)
+			go a.SetupHyperloop(*initRequest.HyperloopIP)
 		}
 	}
 
@@ -69,6 +69,9 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) SetupHyperloop(address string) {
+	a.hyperloopLock.Lock()
+	defer a.hyperloopLock.Unlock()
+
 	hosts, err := txeh.NewHosts(&txeh.HostsConfig{ReadFilePath: "/etc/hosts", WriteFilePath: "/etc/hosts"})
 	if err != nil {
 		a.logger.Error().Msgf("Failed to create hosts: %v", err)

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/rs/zerolog"
 
@@ -11,11 +12,12 @@ import (
 )
 
 type API struct {
-	isNotFC     bool
-	logger      *zerolog.Logger
-	accessToken *string
-	envVars     *utils.Map[string, string]
-	mmdsChan    chan *host.MMDSOpts
+	isNotFC       bool
+	logger        *zerolog.Logger
+	accessToken   *string
+	envVars       *utils.Map[string, string]
+	mmdsChan      chan *host.MMDSOpts
+	hyperloopLock *sync.Mutex
 }
 
 func New(l *zerolog.Logger, envVars *utils.Map[string, string], mmdsChan chan *host.MMDSOpts, isNotFC bool) *API {

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -17,7 +17,7 @@ type API struct {
 	accessToken   *string
 	envVars       *utils.Map[string, string]
 	mmdsChan      chan *host.MMDSOpts
-	hyperloopLock *sync.Mutex
+	hyperloopLock sync.Mutex
 }
 
 func New(l *zerolog.Logger, envVars *utils.Map[string, string], mmdsChan chan *host.MMDSOpts, isNotFC bool) *API {

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.3.2"
+	Version = "0.3.3"
 
 	commitSHA string
 


### PR DESCRIPTION
Fixes the issue causing concurrent writing to the hosts file, as it sometimes occurs when we call init multiple times.