### PR TITLE
Convert any to native types

### DIFF
--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -20,6 +20,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/models/envbuild"
+	sharedUtils "github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const templateInfoExpiration = 5 * time.Minute
@@ -193,7 +194,8 @@ func (c *TemplatesBuildCache) SetStatus(buildID uuid.UUID, status envbuild.Statu
 		logger.WithBuildID(buildID.String()),
 		zap.String("to_status", status.String()),
 		zap.String("from_status", item.BuildStatus.String()),
-		zap.Any("reason", reason),
+		zap.String("reason", reason.Message),
+		zap.String("step", sharedUtils.Sprintp(reason.Step)),
 	)
 
 	_ = c.cache.Set(

--- a/packages/api/internal/orchestrator/nodemanager/node.go
+++ b/packages/api/internal/orchestrator/nodemanager/node.go
@@ -73,7 +73,7 @@ func New(
 
 	nodeStatus, ok := OrchestratorToApiNodeStateMapper[nodeInfo.ServiceStatus]
 	if !ok {
-		zap.L().Error("Unknown service info status", zap.Any("status", nodeInfo.ServiceStatus), logger.WithNodeID(nodeInfo.NodeId))
+		zap.L().Error("Unknown service info status", zap.String("status", nodeInfo.ServiceStatus.String()), logger.WithNodeID(nodeInfo.NodeId))
 		nodeStatus = api.NodeStatusUnhealthy
 	}
 
@@ -111,7 +111,7 @@ func New(
 func NewClusterNode(ctx context.Context, client *grpclient.GRPCClient, clusterID uuid.UUID, i *edge.ClusterInstance) (*Node, error) {
 	nodeStatus, ok := OrchestratorToApiNodeStateMapper[i.GetStatus()]
 	if !ok {
-		zap.L().Error("Unknown service info status", zap.Any("status", i.GetStatus()), logger.WithNodeID(i.NodeID))
+		zap.L().Error("Unknown service info status", zap.String("status", i.GetStatus().String()), logger.WithNodeID(i.NodeID))
 		nodeStatus = api.NodeStatusUnhealthy
 	}
 

--- a/packages/api/internal/orchestrator/nodemanager/status.go
+++ b/packages/api/internal/orchestrator/nodemanager/status.go
@@ -53,7 +53,7 @@ func (n *Node) setStatus(status api.NodeStatus) {
 func (n *Node) SendStatusChange(ctx context.Context, s api.NodeStatus) error {
 	nodeStatus, ok := ApiNodeToOrchestratorStateMapper[s]
 	if !ok {
-		zap.L().Error("Unknown service info status", zap.Any("status", s), logger.WithNodeID(n.ID))
+		zap.L().Error("Unknown service info status", zap.String("status", string(s)), logger.WithNodeID(n.ID))
 		return fmt.Errorf("unknown service info status: %s", s)
 	}
 

--- a/packages/api/internal/orchestrator/nodemanager/sync.go
+++ b/packages/api/internal/orchestrator/nodemanager/sync.go
@@ -27,7 +27,7 @@ func (n *Node) Sync(ctx context.Context, instanceCache *instance.MemoryStore) {
 		// update node status (if changed)
 		nodeStatus, ok := OrchestratorToApiNodeStateMapper[nodeInfo.ServiceStatus]
 		if !ok {
-			zap.L().Error("Unknown service info status", zap.Any("status", nodeInfo.ServiceStatus), logger.WithNodeID(n.ID))
+			zap.L().Error("Unknown service info status", zap.String("status", nodeInfo.ServiceStatus.String()), logger.WithNodeID(n.ID))
 			nodeStatus = api.NodeStatusUnhealthy
 		}
 

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -159,7 +159,7 @@ func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 	}
 
 	// debug log the status
-	c.logger.Debug("setting status pointer", zap.Any("status", status))
+	c.logger.Debug("setting status pointer", zap.String("status", status.Status.String()))
 
 	c.status = status
 	return nil
@@ -190,7 +190,7 @@ func (c *PollBuildStatus) dispatchBasedOnStatus(ctx context.Context, status *tem
 		}
 		return true, nil
 	default:
-		c.logger.Debug("skipping status", zap.Any("status", status))
+		c.logger.Debug("skipping status", zap.String("status", status.Status.String()))
 		return false, nil
 	}
 }
@@ -210,7 +210,7 @@ func (c *PollBuildStatus) checkBuildStatus(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	c.logger.Debug("dispatching based on status", zap.Any("status", c.status))
+	c.logger.Debug("dispatching based on status", zap.String("status", c.status.Status.String()))
 
 	buildCompleted, err := c.dispatchBasedOnStatus(ctx, c.status)
 	if err != nil {

--- a/packages/client-proxy/internal/edge/pool/orchestrator.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator.go
@@ -156,7 +156,7 @@ func getMappedStatus(s e2bgrpcorchestratorinfo.ServiceInfoStatus) OrchestratorSt
 		return OrchestratorStatusUnhealthy
 	}
 
-	zap.L().Error("Unknown service info status", zap.Any("status", s))
+	zap.L().Error("Unknown service info status", zap.String("status", s.String()))
 	return OrchestratorStatusUnhealthy
 }
 

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -91,7 +91,7 @@ func New(
 		return nil
 	})
 	if err != nil {
-		zap.L().Error("Error registering sandbox count metric", zap.Any("metric_name", telemetry.OrchestratorSandboxCountMeterName), zap.Error(err))
+		zap.L().Error("Error registering sandbox count metric", zap.String("metric_name", string(telemetry.OrchestratorSandboxCountMeterName)), zap.Error(err))
 	}
 
 	orchestrator.RegisterSandboxServiceServer(cfg.GRPC.GRPCServer(), srv.server)

--- a/packages/orchestrator/internal/template/cache/build_cache.go
+++ b/packages/orchestrator/internal/template/cache/build_cache.go
@@ -104,7 +104,7 @@ func NewBuildCache(meterProvider metric.MeterProvider) *BuildCache {
 		return nil
 	})
 	if err != nil {
-		zap.L().Error("error creating counter", zap.Error(err), zap.Any("counter_name", telemetry.BuildCounterMeterName))
+		zap.L().Error("error creating counter", zap.Error(err), zap.String("counter_name", string(telemetry.BuildCounterMeterName)))
 	}
 
 	go cache.Start()


### PR DESCRIPTION
# Description

Some of the "status" fields were actually structs containing logs, which increased the size of the metadata and caused logs to be dropped.

Minimized the amount of using `zap.Any`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit b1207cc1ec180b64c2ae3d613f7c57f8a4b2edef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->