### PR TITLE
Include vault metrics in otel collector

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -139,6 +139,7 @@ processors:
           - "orchestrator.*"
           - "template.*"
           - "api.*"
+          - "vault.*"
           - "client_proxy.*"
           - "Click*"
           - "otelcol.*"


### PR DESCRIPTION
This allows the vault otel metrics to actually be exported to Grafana

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `vault.*` to `filter/otlp` metric include list so Vault metrics are exported to Grafana.
> 
> - **Config**:
>   - Update `iac/provider-gcp/nomad/configs/otel-collector.yaml`:
>     - In `processors.filter/otlp.metrics.include.metric_names`, add `"vault.*"` to allow Vault metrics through the collector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c351327aa2f4ee5eaa376d874f9c5dffdfb48e2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->