### PR TITLE
Pass timestamp from orchestrator

### DIFF
--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/oapi-codegen/runtime"
@@ -148,6 +149,9 @@ type PostInitJSONBody struct {
 
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
+
+	// Timestamp The current timestamp in RFC3339 format
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 }
 
 // PostFilesMultipartRequestBody defines body for PostFiles for multipart/form-data ContentType.

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/txn2/txeh"
+	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
 	"github.com/e2b-dev/infra/packages/envd/internal/logs"
@@ -53,6 +54,15 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 
 		if initRequest.HyperloopIP != nil {
 			go a.SetupHyperloop(*initRequest.HyperloopIP)
+		}
+
+		if initRequest.Timestamp != nil {
+			logger.Debug().Msgf("Setting sandbox start time to: %v", *initRequest.Timestamp)
+			ts := unix.NsecToTimespec(initRequest.Timestamp.UnixNano())
+			err = unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+			if err != nil {
+				logger.Error().Msgf("Failed to set system time: %v", err)
+			}
 		}
 	}
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -32,6 +32,15 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if initRequest.Timestamp != nil {
+			logger.Debug().Msgf("Setting sandbox start time to: %v", *initRequest.Timestamp)
+			ts := unix.NsecToTimespec(initRequest.Timestamp.UnixNano())
+			err = unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+			if err != nil {
+				logger.Error().Msgf("Failed to set system time: %v", err)
+			}
+		}
+
 		if initRequest.EnvVars != nil {
 			logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(*initRequest.EnvVars)))
 
@@ -54,15 +63,6 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 
 		if initRequest.HyperloopIP != nil {
 			go a.SetupHyperloop(*initRequest.HyperloopIP)
-		}
-
-		if initRequest.Timestamp != nil {
-			logger.Debug().Msgf("Setting sandbox start time to: %v", *initRequest.Timestamp)
-			ts := unix.NsecToTimespec(initRequest.Timestamp.UnixNano())
-			err = unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
-			if err != nil {
-				logger.Error().Msgf("Failed to set system time: %v", err)
-			}
 		}
 	}
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -25,7 +26,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		var initRequest PostInitJSONBody
 
 		err := json.NewDecoder(r.Body).Decode(&initRequest)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			logger.Error().Msgf("Failed to decode request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
 

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.3.3"
+	Version = "0.3.4"
 
 	commitSHA string
 

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -49,6 +49,10 @@ paths:
                 accessToken:
                   type: string
                   description: Access token for secure access to envd service
+                timestamp:
+                  type: string
+                  format: date-time
+                  description: The current timestamp in RFC3339 format
       responses:
         "204":
           description: Env vars set, the time and metadata is synced with the host

--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -53,6 +53,7 @@ type PostInitJSONBody struct {
 	EnvVars     *map[string]string `json:"envVars"`
 	AccessToken *string            `json:"accessToken,omitempty"`
 	HyperloopIP *string            `json:"hyperloopIP,omitempty"`
+	Timestamp   *time.Time         `json:"timestamp,omitempty"`
 }
 
 func (s *Sandbox) initEnvd(ctx context.Context, envVars map[string]string, accessToken *string) error {
@@ -61,10 +62,12 @@ func (s *Sandbox) initEnvd(ctx context.Context, envVars map[string]string, acces
 
 	hyperloopIP := s.Slot.HyperloopIPString()
 	address := fmt.Sprintf("http://%s:%d/init", s.Slot.HostIPString(), consts.DefaultEnvdServerPort)
+	now := time.Now()
 	jsonBody := &PostInitJSONBody{
 		EnvVars:     &envVars,
 		HyperloopIP: &hyperloopIP,
 		AccessToken: accessToken,
+		Timestamp:   &now,
 	}
 
 	body, err := json.Marshal(jsonBody)

--- a/tests/integration/internal/envd/api/models.gen.go
+++ b/tests/integration/internal/envd/api/models.gen.go
@@ -4,6 +4,8 @@
 package api
 
 import (
+	"time"
+
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
@@ -142,6 +144,9 @@ type PostInitJSONBody struct {
 
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
+
+	// Timestamp The current timestamp in RFC3339 format
+	Timestamp *time.Time `json:"timestamp,omitempty"`
 }
 
 // PostFilesMultipartRequestBody defines body for PostFiles for multipart/form-data ContentType.


### PR DESCRIPTION
# Description

Sometimes the time isn't synced, pass the time directly from orchestrator. It will then be kept synchronized by chrony 

Some extra logs during debugging
```
[2025-09-29 12:37:31.929Z] DEBUG { logger: 'envd', message: 'Setting system time. Current time: 2025-09-29 12:37:31.929714537 +0000 UTC m=+30.861367653', operation_id: '4' }
[2025-09-29 12:37:31.929Z] DEBUG { logger: 'envd', message: 'Setting sandbox start time to: 2025-09-29 12:37:32.159826264 +0000 UTC', operation_id: '4' }
[2025-09-29 12:37:32.159Z] DEBUG { logger: 'envd', message: 'Setting system time set inside sandbox. Current time: 2025-09-29 12:37:32.159839457 +0000 UTC m=+30.861521162', operation_id: '4' }
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass current time from orchestrator to envd via PostInit to sync sandbox clock; update spec, generated code, and version.
> 
> - **API/Spec**:
>   - Add optional `timestamp` (RFC3339 `date-time`) to `POST /init` in `packages/envd/spec/envd.yaml`.
>   - Regenerate models to include `PostInitJSONBody.Timestamp` in `packages/envd/internal/api/api.gen.go` and tests' `tests/integration/internal/envd/api/models.gen.go`.
> - **envd**:
>   - In `internal/api/init.go`, if `timestamp` is provided, set system time using `unix.ClockSettime`.
>   - Improve JSON decode EOF check using `errors.Is`.
> - **Orchestrator**:
>   - In `internal/sandbox/envd.go`, include current time in `/init` request (`PostInitJSONBody.Timestamp = time.Now()`).
> - **Misc**:
>   - Bump `Version` to `0.3.4` in `packages/envd/main.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5248c47bdc8824456bf45454b2bf0d6da6d66077. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->