### PR TITLE
Add flake.nix and flake.lock for reproducible dev env

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,163 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758791193,
+        "narHash": "sha256-F8WmEwFoHsnix7rt290R0rFXNJiMbClMZyIC/e+HYf0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "25e53aa156d47bad5082ff7618f5feb1f5e02d01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-1_0": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-1_6": {
+      "locked": {
+        "lastModified": 1735651292,
+        "narHash": "sha256-YLbzcBtYo1/FEzFsB3AnM16qFc6fWPMIoOuSoDwvg9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0da3c44a9460a26d2025ec3ed2ec60a895eb1114",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1758690382,
+        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1756381814,
+        "narHash": "sha256-tzo7YvAsGlzo4WiIHT0ooR59VHu+aKRQdHk7sIyoia4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "aca2499b79170038df0dbaec8bf2f689b506ad32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "terraform": "terraform"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "terraform": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-1_0": "nixpkgs-1_0",
+        "nixpkgs-1_6": "nixpkgs-1_6",
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1757559327,
+        "narHash": "sha256-PMiwO7mTITstDukabZjOIjyZD73eoI3Z3hTtBdMXvLI=",
+        "owner": "stackbuilders",
+        "repo": "nixpkgs-terraform",
+        "rev": "3edb1b3a5cd54dde28619f6fff90b8d20abbbd4a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stackbuilders",
+        "repo": "nixpkgs-terraform",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,56 @@
+{
+  description = "E2B Development environment";
+
+  # flake inputs
+  inputs.flake-utils.url      = "github:numtide/flake-utils";
+  inputs.nixpkgs.url          = "github:nixos/nixpkgs/nixos-25.05";
+  inputs.nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.terraform.url        = "github:stackbuilders/nixpkgs-terraform";
+
+  outputs = { self, flake-utils, nixpkgs, nixpkgs-unstable, terraform }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs         = import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+        unstablePkgs = import nixpkgs-unstable {
+          inherit system;
+          config.allowUnfree = true;
+        };
+
+        # E2B CLI wrapper
+        e2b-cli = pkgs.writeShellScriptBin "e2b" ''
+          exec ${pkgs.nodejs}/bin/npx @e2b/cli@latest "$@"
+        '';
+
+        # assemble notifier bits
+        fileNotifier = with pkgs; lib.optional stdenv.isLinux libnotify
+           ++ lib.optional stdenv.isLinux inotify-tools
+           ++ lib.optional stdenv.isDarwin terminal-notifier
+           ++ lib.optionals stdenv.isDarwin (
+                with darwin.apple_sdk.frameworks; [
+                  CoreFoundation
+                  CoreServices
+                ]
+              );
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            bashInteractive
+            git
+            packer
+            terraform.packages.${system}."1.5"
+            google-cloud-sdk
+            go
+            docker
+            cloudflared
+            postgresql
+            nodejs
+            nodePackages.npm
+            e2b-cli
+          ] ++ fileNotifier;
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary
- Introduces Nix flake for reproducible dev shells and builds.
- `flake.lock` pins exact inputs to avoid “works on my machine.”

## What’s included
- `flake.nix`: defines dev shell, build/run outputs, and inputs.
- `flake.lock`: lockfile generated by Nix.

## Why
- One-command setup for contributors.
- Identical toolchain on macOS/Linux/CI.

## Install Nix if needed: https://nixos.org/download

## How to use
```bash
nix develop
```

##  Consider using with `direnv`
Using direnv with a Nix flake makes your dev shell automatic and per-repo. When you cd into the project, direnv reads .envrc (e.g., use flake) and transparently loads the pinned tools and env from your flake; leaving the directory unloads them, so you don’t leak PATH changes or variables into other projects. It also watches files (like flake.nix/flake.lock) and reloads on changes, and uses an explicit allowlist (direnv allow) so nothing runs without your consent. Learn more at https://direnv.net

## Notes
- If flakes are not enabled:
  ```
  echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
  ```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `flake.nix` and `flake.lock` to define a reproducible dev shell with pinned toolchain and an `e2b` CLI wrapper.
> 
> - **Dev Environment (Nix flake)**:
>   - Adds `flake.nix` defining `devShell` with pinned tools: `terraform` ("1.5"), `google-cloud-sdk`, `go`, `docker`, `cloudflared`, `postgresql`, `nodejs`/`npm`, `git`, `packer`, `bashInteractive`.
>   - Introduces `e2b` CLI wrapper using `npx @e2b/cli@latest`.
>   - Includes OS-specific notifier deps: Linux (`libnotify`, `inotify-tools`), macOS (`terminal-notifier`, Apple frameworks `CoreFoundation`, `CoreServices`).
>   - Pins inputs via `flake.lock`: `nixpkgs` (25.05), `nixos-unstable`, `flake-utils`, `nixpkgs-terraform`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fefb8f93d8a2694c501f7723d664a6066eba757b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->