### PR TITLE
Auto assign reviewer from same office, if not internal, then use CODEOWNERS 

### DIFF
--- a/.github/actions/auto-request-same-site/script.js
+++ b/.github/actions/auto-request-same-site/script.js
@@ -1,0 +1,76 @@
+const { Octokit } = require("@octokit/rest");
+const fs = require("fs");
+
+const token = process.env.APP_TOKEN;         // GitHub App installation token
+const org   = process.env.ORG;
+const sf    = process.env.SF_TEAM_SLUG;
+const prg   = process.env.PRG_TEAM_SLUG;
+const n     = parseInt(process.env.REVIEWERS_TO_REQUEST || "1", 10);
+
+const gh = new Octokit({ auth: token });
+const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+
+function prNumber() {
+  const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+  return ev.pull_request?.number || null;
+}
+
+async function getPR(num) {
+  const { data } = await gh.pulls.get({ owner, repo, pull_number: num });
+  return data;
+}
+
+async function getUserTeams(login) {
+  const data = await gh.graphql(
+    `query($org:String!, $login:String!){
+      organization(login:$org){
+        teams(first:100, userLogins: [$login]){ nodes { slug } }
+      }
+    }`,
+    { org, login }
+  );
+  return (data.organization?.teams?.nodes || []).map(t => t.slug);
+}
+
+async function listTeamMembers(teamSlug) {
+  const res = await gh.teams.listMembersInOrg({ org, team_slug: teamSlug, per_page: 100 });
+  return res.data.map(u => u.login);
+}
+
+function pickRandom(arr, k) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, Math.max(0, Math.min(k, a.length)));
+}
+
+(async () => {
+  const num = prNumber();
+  if (!num) { console.log("No PR number; exiting."); return; }
+
+  const pr = await getPR(num);
+  const author = pr.user.login;
+
+  const teams = await getUserTeams(author);
+  const site = teams.includes(sf) ? sf : teams.includes(prg) ? prg : null;
+  if (!site) { console.log("Author not in eng-sf or eng-prg; skipping."); return; }
+
+  // Individuals (default)
+  const members = (await listTeamMembers(site)).filter(u => u !== author);
+  const already = new Set(pr.requested_reviewers.map(r => r.login));
+  const candidates = members.filter(m => !already.has(m));
+  const reviewers = pickRandom(candidates, n);
+
+  if (reviewers.length) {
+    await gh.pulls.requestReviewers({ owner, repo, pull_number: num, reviewers });
+    console.log(`Requested ${reviewers.join(", ")} from ${site}`);
+  } else {
+    console.log(`No candidates to request from ${site}.`);
+  }
+
+  // Or request the whole team:
+  // await gh.pulls.requestReviewers({ owner, repo, pull_number: num, team_reviewers: [site] });
+  // console.log(`Requested team ${site}`);
+})().catch(e => { console.error(e); process.exit(1); });

--- a/.github/actions/auto-request-same-site/script.js
+++ b/.github/actions/auto-request-same-site/script.js
@@ -1,25 +1,27 @@
 const { Octokit } = require("@octokit/rest");
 const fs = require("fs");
 
-const token = process.env.APP_TOKEN;         // GitHub App installation token
+const token = process.env.APP_TOKEN; // GitHub App installation token
 const org   = process.env.ORG;
 const sf    = process.env.SF_TEAM_SLUG;
 const prg   = process.env.PRG_TEAM_SLUG;
 const n     = parseInt(process.env.REVIEWERS_TO_REQUEST || "1", 10);
+const TEAM_MODE = (process.env.TEAM_MODE || "false").toLowerCase() === "true";
 
 const gh = new Octokit({ auth: token });
 const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
 
-function prNumber() {
-  const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+// ---- helpers ----
+function getEvent() {
+  return JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+}
+function prNumber(ev) {
   return ev.pull_request?.number || null;
 }
-
 async function getPR(num) {
   const { data } = await gh.pulls.get({ owner, repo, pull_number: num });
   return data;
 }
-
 async function getUserTeams(login) {
   const data = await gh.graphql(
     `query($org:String!, $login:String!){
@@ -31,12 +33,10 @@ async function getUserTeams(login) {
   );
   return (data.organization?.teams?.nodes || []).map(t => t.slug);
 }
-
 async function listTeamMembers(teamSlug) {
   const res = await gh.teams.listMembersInOrg({ org, team_slug: teamSlug, per_page: 100 });
   return res.data.map(u => u.login);
 }
-
 function pickRandom(arr, k) {
   const a = [...arr];
   for (let i = a.length - 1; i > 0; i--) {
@@ -46,21 +46,110 @@ function pickRandom(arr, k) {
   return a.slice(0, Math.max(0, Math.min(k, a.length)));
 }
 
+// Read CODEOWNERS (from usual locations) and parse the global "*" owners.
+// Returns { users: [logins], teams: [teamSlugs] }
+async function readDefaultCodeownersOwners(baseRef) {
+  const paths = [".github/CODEOWNERS", "CODEOWNERS"];
+  let text = "";
+  for (const path of paths) {
+    try {
+      const { data } = await gh.repos.getContent({ owner, repo, path, ref: baseRef });
+      if (Array.isArray(data)) continue; // directory
+      text = Buffer.from(data.content, "base64").toString("utf8");
+      break;
+    } catch { /* try next */ }
+  }
+  if (!text) return { users: [], teams: [] };
+
+  // find last matching "*" rule (later rules take precedence)
+  const lines = text.split(/\r?\n/);
+  let starOwners = null;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const parts = line.split(/\s+/);
+    if (parts[0] === "*") starOwners = parts.slice(1);
+  }
+  if (!starOwners) return { users: [], teams: [] };
+
+  const users = [];
+  const teams = [];
+  for (const ownerRef of starOwners) {
+    if (!ownerRef.startsWith("@")) continue;
+    const clean = ownerRef.slice(1); // remove leading '@'
+    const slash = clean.indexOf("/");
+    if (slash > -1) {
+      // looks like org/team
+      const maybeOrg = clean.slice(0, slash);
+      const teamSlug = clean.slice(slash + 1);
+      if (maybeOrg.toLowerCase() === org.toLowerCase()) teams.push(teamSlug);
+      // if CODEOWNERS references another org's team, we ignore
+    } else {
+      users.push(clean);
+    }
+  }
+  return { users, teams };
+}
+
 (async () => {
-  const num = prNumber();
+  const ev = getEvent();
+  const num = prNumber(ev);
   if (!num) { console.log("No PR number; exiting."); return; }
 
+  const baseRef = ev.pull_request?.base?.ref || "main";
   const pr = await getPR(num);
   const author = pr.user.login;
 
+  // Determine author site
   const teams = await getUserTeams(author);
   const site = teams.includes(sf) ? sf : teams.includes(prg) ? prg : null;
-  if (!site) { console.log("Author not in eng-sf or eng-prg; skipping."); return; }
 
-  // Individuals (default)
-  const members = (await listTeamMembers(site)).filter(u => u !== author);
-  const already = new Set(pr.requested_reviewers.map(r => r.login));
-  const candidates = members.filter(m => !already.has(m));
+  // If author is not in eng-sf or eng-prg => do nothing (keep CODEOWNERS defaults)
+  if (!site) {
+    console.log("Author not in eng-sf or eng-prg; keeping CODEOWNERS reviewers.");
+    return;
+  }
+
+  // Author IS internal: remove global CODEOWNERS defaults, then assign same-site reviewers
+  const defaults = await readDefaultCodeownersOwners(baseRef);
+  console.log("CODEOWNERS * defaults:", defaults);
+
+  // Find currently requested users & teams
+  const { data: req } = await gh.pulls.listRequestedReviewers({ owner, repo, pull_number: num });
+  const currentUsers = new Set(req.users.map(u => u.login));
+  const currentTeams = new Set(req.teams.map(t => t.slug));
+
+  // Compute removal sets based on CODEOWNERS defaults
+  const toRemoveUsers = defaults.users.filter(u => currentUsers.has(u));
+  const toRemoveTeams = defaults.teams.filter(t => currentTeams.has(t));
+
+  if (toRemoveUsers.length || toRemoveTeams.length) {
+    await gh.pulls.removeRequestedReviewers({
+      owner, repo, pull_number: num,
+      reviewers: toRemoveUsers,
+      team_reviewers: toRemoveTeams
+    });
+    console.log(
+      "Removed CODEOWNERS defaults:",
+      toRemoveUsers.length ? `users=[${toRemoveUsers.join(", ")}]` : "users=[]",
+      toRemoveTeams.length ? `teams=[${toRemoveTeams.join(", ")}]` : "teams=[]"
+    );
+  } else {
+    console.log("No CODEOWNERS defaults currently requested (nothing to remove).");
+  }
+
+  // Now request same-site reviewers
+  if (TEAM_MODE) {
+    await gh.pulls.requestReviewers({ owner, repo, pull_number: num, team_reviewers: [site] });
+    console.log(`Requested team ${site}`);
+    return;
+  }
+
+  const siteMembers = (await listTeamMembers(site)).filter(u => u !== author);
+  // refresh requested reviewers after potential removals
+  const { data: req2 } = await gh.pulls.listRequestedReviewers({ owner, repo, pull_number: num });
+  const already = new Set(req2.users.map(u => u.login));
+  const candidates = siteMembers.filter(m => !already.has(m));
   const reviewers = pickRandom(candidates, n);
 
   if (reviewers.length) {
@@ -69,8 +158,4 @@ function pickRandom(arr, k) {
   } else {
     console.log(`No candidates to request from ${site}.`);
   }
-
-  // Or request the whole team:
-  // await gh.pulls.requestReviewers({ owner, repo, pull_number: num, team_reviewers: [site] });
-  // console.log(`Requested team ${site}`);
 })().catch(e => { console.error(e); process.exit(1); });

--- a/.github/workflows/auto-request-same-site.yml
+++ b/.github/workflows/auto-request-same-site.yml
@@ -1,13 +1,3 @@
-name: Auto-request same-site reviewers
-
-on:
-  # Works for PRs from branches AND forks (runs in base-repo context)
-  pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize, edited]
-
-# We’ll use a GitHub App installation token; the default GITHUB_TOKEN isn’t needed
-permissions: {}
-
 jobs:
   assign:
     runs-on: ubuntu-latest
@@ -19,7 +9,9 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: e2b-dev
-          # repositories: infra-stable  # optionally narrow
+
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -37,6 +29,6 @@ jobs:
           ORG: e2b-dev
           SF_TEAM_SLUG: eng-sf
           PRG_TEAM_SLUG: eng-prg
-          REVIEWERS_TO_REQUEST: "1"     # change to "2" if you want two people
-          TEAM_MODE: "false"            # set to "true" to request the whole team instead of individuals
+          REVIEWERS_TO_REQUEST: "1"
+          TEAM_MODE: "false"
         run: node .github/actions/auto-request-same-site/script.js

--- a/.github/workflows/auto-request-same-site.yml
+++ b/.github/workflows/auto-request-same-site.yml
@@ -1,0 +1,37 @@
+name: Auto-request same-site reviewers
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, edited]
+
+permissions: {}
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub App installation token
+        id: app
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: e2b-dev
+
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+
+      - run: npm init -y && npm i @octokit/rest
+
+      # No checkout needed since we don't run repo code,
+      # but if you want the file *in* the repo, do checkout + run it:
+      - uses: actions/checkout@v4
+
+      - name: Request reviewers (same-site)
+        env:
+          APP_TOKEN: ${{ steps.app.outputs.token }}
+          ORG: e2b-dev
+          SF_TEAM_SLUG: eng-sf
+          PRG_TEAM_SLUG: eng-prg
+          REVIEWERS_TO_REQUEST: "1"
+        run: node .github/actions/auto-request-same-site/script.js

--- a/.github/workflows/auto-request-same-site.yml
+++ b/.github/workflows/auto-request-same-site.yml
@@ -1,9 +1,11 @@
 name: Auto-request same-site reviewers
 
 on:
+  # Works for PRs from branches AND forks (runs in base-repo context)
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize, edited]
 
+# We’ll use a GitHub App installation token; the default GITHUB_TOKEN isn’t needed
 permissions: {}
 
 jobs:
@@ -17,21 +19,24 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: e2b-dev
+          # repositories: infra-stable  # optionally narrow
 
-      - uses: actions/setup-node@v4
-        with: { node-version: 20 }
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
 
-      - run: npm init -y && npm i @octokit/rest
+      - name: Install deps
+        run: |
+          npm init -y
+          npm i @octokit/rest
 
-      # No checkout needed since we don't run repo code,
-      # but if you want the file *in* the repo, do checkout + run it:
-      - uses: actions/checkout@v4
-
-      - name: Request reviewers (same-site)
+      - name: Run same-site override
         env:
           APP_TOKEN: ${{ steps.app.outputs.token }}
           ORG: e2b-dev
           SF_TEAM_SLUG: eng-sf
           PRG_TEAM_SLUG: eng-prg
-          REVIEWERS_TO_REQUEST: "1"
+          REVIEWERS_TO_REQUEST: "1"     # change to "2" if you want two people
+          TEAM_MODE: "false"            # set to "true" to request the whole team instead of individuals
         run: node .github/actions/auto-request-same-site/script.js


### PR DESCRIPTION
This PR adds a workflow to auto-assign reviewers.
 - If the PR author is in eng-sf or eng-prg, the default CODEOWNERS reviewers are removed and a same-site reviewer is requested instead.
 - If the author is outside those teams, the normal CODEOWNERS reviewers stay in place.

This keeps external PRs covered by defaults, while internal PRs get faster, same-site reviews.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a workflow and script to replace global CODEOWNERS reviewers with same-site reviewers for internal authors, leaving external authors unchanged.
> 
> - **CI**:
>   - Adds workflow `/.github/workflows/auto-request-same-site.yml` that authenticates via GitHub App, sets up Node, installs `@octokit/rest`, and runs a reviewer assignment script.
> - **Script**: `/.github/actions/auto-request-same-site/script.js`
>   - Determines PR author’s team (`eng-sf` or `eng-prg`) and, if internal, removes global `CODEOWNERS` `*` requested reviewers, then requests same-site reviewers.
>   - Parses `CODEOWNERS` via repo API to extract global owners; supports team mode or random selection of `n` individual reviewers (excluding author and already requested).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 924c9ab25f3ec873d0d1f1afd349e3ad40d35be8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->