### PR TITLE
Gather env vars just-in-time rather than on init()

### DIFF
--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -20,7 +20,9 @@ const (
 	fallbackDiffSize = 100 << ToMBShift
 )
 
-var DefaultCachePath = filepath.Join(pkg.OrchestratorBasePath, "build")
+func DefaultCachePath() string {
+	return filepath.Join(pkg.OrchestratorBasePath(), "build")
+}
 
 type deleteDiff struct {
 	size      int64

--- a/packages/orchestrator/internal/sandbox/fc/client.go
+++ b/packages/orchestrator/internal/sandbox/fc/client.go
@@ -171,11 +171,7 @@ func (c *apiClient) setBootSource(ctx context.Context, kernelArgs string, kernel
 	}
 
 	_, err := c.client.Operations.PutGuestBootSource(&bootSourceConfig)
-	if err != nil {
-		return fmt.Errorf("error setting fc boot source config: %w", err)
-	}
-
-	return nil
+	return err
 }
 
 func (c *apiClient) setRootfsDrive(ctx context.Context, rootfsPath string) error {

--- a/packages/orchestrator/internal/sandbox/fc/config.go
+++ b/packages/orchestrator/internal/sandbox/fc/config.go
@@ -1,21 +1,44 @@
 package fc
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
 
 const (
-	HostKernelsDir = "/fc-kernels"
-
-	SandboxDir        = "/fc-vm"
 	SandboxKernelFile = "vmlinux.bin"
 
-	FirecrackerVersionsDir = "/fc-versions"
-	FirecrackerBinaryName  = "firecracker"
+	FirecrackerBinaryName = "firecracker"
 
 	envsDisk     = "/mnt/disks/fc-envs/v1"
 	buildDirName = "builds"
 
 	SandboxRootfsFile = "rootfs.ext4"
 )
+
+func SandboxDir() string {
+	if value := os.Getenv("SANDBOX_DIR"); value != "" {
+		return value
+	}
+
+	return "/fc-vm"
+}
+
+func HostKernelsDir() string {
+	if value := os.Getenv("HOST_KERNELS_DIR"); value != "" {
+		return value
+	}
+
+	return "/fc-kernels"
+}
+
+func FirecrackerVersionsDir() string {
+	if value := os.Getenv("FIRECRACKER_VERSIONS_DIR"); value != "" {
+		return value
+	}
+
+	return "/fc-versions"
+}
 
 type FirecrackerVersions struct {
 	KernelVersion      string
@@ -27,11 +50,11 @@ func (t FirecrackerVersions) SandboxKernelDir() string {
 }
 
 func (t FirecrackerVersions) HostKernelPath() string {
-	return filepath.Join(HostKernelsDir, t.KernelVersion, SandboxKernelFile)
+	return filepath.Join(HostKernelsDir(), t.KernelVersion, SandboxKernelFile)
 }
 
 func (t FirecrackerVersions) FirecrackerPath() string {
-	return filepath.Join(FirecrackerVersionsDir, t.FirecrackerVersion, FirecrackerBinaryName)
+	return filepath.Join(FirecrackerVersionsDir(), t.FirecrackerVersion, FirecrackerBinaryName)
 }
 
 type RootfsPaths struct {

--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -278,7 +278,7 @@ func (p *Process) Create(
 	if err != nil {
 		fcStopErr := p.Stop(ctx)
 
-		return errors.Join(fmt.Errorf("error setting fc boot source config: %w", err), fcStopErr)
+		return errors.Join(fmt.Errorf("error setting fc boot source %q): %w", p.kernelPath, err), fcStopErr)
 	}
 	telemetry.ReportEvent(ctx, "set fc boot source config")
 

--- a/packages/orchestrator/internal/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/internal/sandbox/fc/script_builder.go
@@ -83,7 +83,7 @@ func (sb *StartScriptBuilder) buildArgs(
 ) startScriptArgs {
 	return startScriptArgs{
 		// General
-		SandboxDir: SandboxDir,
+		SandboxDir: SandboxDir(),
 
 		// Kernel
 		HostKernelPath:    versions.HostKernelPath(),

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -7,8 +7,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
-var localNamespaceStorageSwitch = os.Getenv("USE_LOCAL_NAMESPACE_STORAGE")
-
 type Storage interface {
 	Acquire(ctx context.Context) (*Slot, error)
 	Release(s *Slot) error
@@ -16,7 +14,7 @@ type Storage interface {
 
 // NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
 func NewStorage(slotsSize int, nodeID string) (Storage, error) {
-	if env.IsDevelopment() || localNamespaceStorageSwitch == "true" {
+	if env.IsDevelopment() || os.Getenv("USE_LOCAL_NAMESPACE_STORAGE") == "true" {
 		return NewStorageLocal(slotsSize)
 	}
 

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -726,7 +726,7 @@ func pauseProcessMemory(
 	defer span.End()
 
 	memfileDiffFile, err := build.NewLocalDiffFile(
-		build.DefaultCachePath,
+		build.DefaultCachePath(),
 		buildId.String(),
 		build.Memfile,
 	)
@@ -790,7 +790,7 @@ func pauseProcessRootfs(
 	ctx, span := tracer.Start(ctx, "process-rootfs")
 	defer span.End()
 
-	rootfsDiffFile, err := build.NewLocalDiffFile(build.DefaultCachePath, buildId.String(), build.Rootfs)
+	rootfsDiffFile, err := build.NewLocalDiffFile(build.DefaultCachePath(), buildId.String(), build.Rootfs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create rootfs diff: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -75,14 +75,14 @@ func NewCache(
 	})
 
 	// Delete the old build cache directory content.
-	err := cleanDir(build.DefaultCachePath)
+	err := cleanDir(build.DefaultCachePath())
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("failed to remove old build cache directory: %w", err)
 	}
 
 	buildStore, err := build.NewDiffStore(
 		ctx,
-		build.DefaultCachePath,
+		build.DefaultCachePath(),
 		buildCacheTTL,
 		buildCacheDelayEviction,
 		buildCacheMaxUsedPercentage,

--- a/packages/orchestrator/internal/template/build/core/envd/envd.go
+++ b/packages/orchestrator/internal/template/build/core/envd/envd.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetEnvdVersion(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, storage.HostEnvdPath, "-version")
+	cmd := exec.CommandContext(ctx, storage.HostEnvdPath(), "-version")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("error while getting envd version: %w", err)
@@ -20,5 +20,5 @@ func GetEnvdVersion(ctx context.Context) (string, error) {
 }
 
 func GetEnvdHash() (string, error) {
-	return utils.GetFileHash(storage.HostEnvdPath)
+	return utils.GetFileHash(storage.HostEnvdPath())
 }

--- a/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
@@ -71,11 +71,7 @@ func Mount(ctx context.Context, rootfsPath string, mountPoint string) error {
 	mountStderrWriter := telemetry.NewEventWriter(ctx, "stderr")
 	cmd.Stderr = mountStderrWriter
 
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("error mounting ext4 filesystem: %w", err)
-	}
-
-	return nil
+	return cmd.Run()
 }
 
 func Unmount(ctx context.Context, rootfsPath string) error {
@@ -221,7 +217,7 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (string, e
 		exitCode := cmd.ProcessState.ExitCode()
 
 		if exitCode > accExitCode {
-			return string(out), fmt.Errorf("error running e2fsck: %w", err)
+			return string(out), fmt.Errorf("error running e2fsck [exit %d]\n%s", exitCode, out)
 		}
 	}
 

--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -116,7 +116,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 	logger.Info("Creating file system and pulling Docker image")
 	ext4Size, err := oci.ToExt4(ctx, logger, img, rootfsPath, maxRootfsSize, r.template.RootfsBlockSize())
 	if err != nil {
-		return containerregistry.Config{}, fmt.Errorf("error creating ext4 filesystem: %w", err)
+		return containerregistry.Config{}, fmt.Errorf("error converting oci to ext4: %w", err)
 	}
 	telemetry.ReportEvent(childCtx, "created rootfs ext4 file")
 
@@ -209,7 +209,7 @@ ff02::2	ip6-allrouters
 127.0.1.1	%s
 `, hostname)
 
-	envdFileData, err := os.ReadFile(storage.HostEnvdPath)
+	envdFileData, err := os.ReadFile(storage.HostEnvdPath())
 	if err != nil {
 		return nil, fmt.Errorf("error reading envd file: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -151,7 +151,7 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 		lb.proxy,
 		sbx.Runtime.SandboxID,
 		"root",
-		storage.HostEnvdPath,
+		storage.HostEnvdPath(),
 		tmpEnvdPath,
 	)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -36,7 +36,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-var templatesDirectory = filepath.Join(pkg.OrchestratorBasePath, "build-templates")
+func templatesDirectory() string {
+	return filepath.Join(pkg.OrchestratorBasePath(), "build-templates")
+}
 
 const (
 	rootfsBuildFileName = "rootfs.filesystem.build"
@@ -159,7 +161,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 	baseMetadata metadata.Template,
 	hash string,
 ) (metadata.Template, error) {
-	templateBuildDir := filepath.Join(templatesDirectory, bb.Template.BuildID)
+	templateBuildDir := filepath.Join(templatesDirectory(), bb.Template.BuildID)
 	err := os.MkdirAll(templateBuildDir, 0o777)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("error creating template build directory: %w", err)

--- a/packages/shared/pkg/config.go
+++ b/packages/shared/pkg/config.go
@@ -2,10 +2,10 @@ package pkg
 
 import "os"
 
-var OrchestratorBasePath = "/orchestrator"
-
-func init() {
+func OrchestratorBasePath() string {
 	if value := os.Getenv("ORCHESTRATOR_BASE_PATH"); value != "" {
-		OrchestratorBasePath = value
+		return value
 	}
+
+	return "/orchestrator"
 }

--- a/packages/shared/pkg/storage/sandbox.go
+++ b/packages/shared/pkg/storage/sandbox.go
@@ -9,7 +9,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 )
 
-var sandboxCacheDir = filepath.Join(pkg.OrchestratorBasePath, "sandbox")
+func sandboxCacheDir() string {
+	return filepath.Join(pkg.OrchestratorBasePath(), "sandbox")
+}
 
 type SandboxFiles struct {
 	TemplateCacheFiles
@@ -41,7 +43,7 @@ func (c TemplateCacheFiles) NewSandboxFilesWithStaticID(sandboxID string, static
 }
 
 func (s *SandboxFiles) SandboxCacheRootfsPath() string {
-	return filepath.Join(sandboxCacheDir, fmt.Sprintf("rootfs-%s-%s.cow", s.SandboxID, s.randomID))
+	return filepath.Join(sandboxCacheDir(), fmt.Sprintf("rootfs-%s-%s.cow", s.SandboxID, s.randomID))
 }
 
 func (s *SandboxFiles) SandboxFirecrackerSocketPath() string {
@@ -53,5 +55,5 @@ func (s *SandboxFiles) SandboxUffdSocketPath() string {
 }
 
 func (s *SandboxFiles) SandboxCacheRootfsLinkPath() string {
-	return filepath.Join(sandboxCacheDir, fmt.Sprintf("rootfs-%s-%s.link", s.SandboxID, s.randomID))
+	return filepath.Join(sandboxCacheDir(), fmt.Sprintf("rootfs-%s-%s.link", s.SandboxID, s.randomID))
 }

--- a/packages/shared/pkg/storage/template.go
+++ b/packages/shared/pkg/storage/template.go
@@ -2,10 +2,10 @@ package storage
 
 import (
 	"fmt"
+	"os"
 )
 
 const (
-	HostEnvdPath  = "/fc-envd/envd"
 	GuestEnvdPath = "/usr/bin/envd"
 
 	MemfileName  = "memfile"
@@ -15,6 +15,14 @@ const (
 
 	HeaderSuffix = ".header"
 )
+
+func HostEnvdPath() string {
+	if value := os.Getenv("HOST_ENVD_PATH"); value != "" {
+		return value
+	}
+
+	return "/fc-envd/envd"
+}
 
 type TemplateFiles struct {
 	BuildID            string `json:"build_id"`

--- a/packages/shared/pkg/storage/template_cache.go
+++ b/packages/shared/pkg/storage/template_cache.go
@@ -10,7 +10,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg"
 )
 
-var templateCacheDir = filepath.Join(pkg.OrchestratorBasePath, "template")
+func templateCacheDir() string {
+	return filepath.Join(pkg.OrchestratorBasePath(), "template")
+}
 
 type TemplateCacheFiles struct {
 	TemplateFiles
@@ -47,5 +49,5 @@ func (c TemplateCacheFiles) CacheMetadataPath() string {
 }
 
 func (c TemplateCacheFiles) cacheDir() string {
-	return filepath.Join(templateCacheDir, c.BuildID, "cache", c.CacheIdentifier)
+	return filepath.Join(templateCacheDir(), c.BuildID, "cache", c.CacheIdentifier)
 }

--- a/packages/shared/pkg/storage/temporary_memfile.go
+++ b/packages/shared/pkg/storage/temporary_memfile.go
@@ -14,11 +14,15 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
-const (
-	// snapshotCacheDir is a tmpfs directory mounted on the host.
-	// This is used for speed optimization as the final diff is copied to the persistent storage.
-	snapshotCacheDir = "/mnt/snapshot-cache"
-)
+// snapshotCacheDir is a tmpfs directory mounted on the host.
+// This is used for speed optimization as the final diff is copied to the persistent storage.
+func snapshotCacheDir() string {
+	if value := os.Getenv("SNAPSHOT_CACHE_DIR"); value != "" {
+		return value
+	}
+
+	return "/mnt/snapshot-cache"
+}
 
 var maxParallelMemfileSnapshotting = utils.Must(env.GetEnvAsInt("MAX_PARALLEL_MEMFILE_SNAPSHOTTING", 8))
 
@@ -65,5 +69,5 @@ func (f *TemporaryMemfile) Close() error {
 func cacheMemfileFullSnapshotPath(buildID string, randomID string) string {
 	name := fmt.Sprintf("%s-%s-%s.full", buildID, MemfileName, randomID)
 
-	return filepath.Join(snapshotCacheDir, name)
+	return filepath.Join(snapshotCacheDir(), name)
 }


### PR DESCRIPTION
This helps with testing, and shouldn't slow down the application meaningfully.