### PR TITLE
Improve logging in NFS clean cache

### DIFF
--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -94,7 +94,7 @@ func cleanNFSCache(ctx context.Context) error {
 		})
 
 		var results results
-		timeit(fmt.Sprintf("deleting bottom %d files\n", opts.filesToDeletePerLoop), func() {
+		timeit(fmt.Sprintf("deleting bottom %d files", opts.filesToDeletePerLoop), func() {
 			results, err = deleteOldestFiles(cache, files, opts, &diskInfo, areWeDone, opts.filesToDeletePerLoop)
 			zap.L().Info("deleted files",
 				zap.Int64("count", results.deletedFiles),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace printf-style output with structured zap logging, initialize a global logger, and add small correctness/robustness improvements.
> 
> - **orchestrator/clean-nfs-cache (`packages/orchestrator/cmd/clean-nfs-cache/main.go`)**:
>   - **Structured logging**:
>     - Initialize global `zap` logger via `logger.NewLogger` with `serviceName`, `env.IsDebug`, and console output; replace globals and sync on exit.
>     - Replace `fmt` prints with structured logs for startup, disk usage, file fetch progress, deletions, and summary.
>     - Convert `timeit` to emit `zap.Debug` with `duration`.
>   - **Behavior/robustness**:
>     - `standardDeviation` returns `0` when input slice is empty.
>     - `getFiles` returns `nil` on cache error, logs final progress, and uses structured progress logs every 100 items.
>     - Minor log message adjustments (e.g., "deleting bottom %d files").
>   - **Main flow**:
>     - Use context-scoped logger; on failure, log with `zap.L().Error` before exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5791bfd96a005c81a3bdb3ea7ee7f0009bf4ed72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->