### PR TITLE
Move docker reverse proxy to api node pool

### DIFF
--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -138,7 +138,7 @@ resource "nomad_job" "docker_reverse_proxy" {
   jobspec = templatefile("${path.module}/jobs/docker-reverse-proxy.hcl",
     {
       gcp_zone                      = var.gcp_zone
-      node_pool                     = var.builder_node_pool
+      node_pool                     = var.api_node_pool
       image_name                    = docker_image.docker_reverse_proxy_image.repo_digest
       postgres_connection_string    = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
       google_service_account_secret = var.docker_reverse_proxy_service_account_key


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `docker_reverse_proxy` Nomad job to use `var.api_node_pool` instead of `var.builder_node_pool`.
> 
> - **Infra (Nomad/Terraform)**:
>   - `iac/provider-gcp/nomad/main.tf`
>     - `docker_reverse_proxy` job: set `node_pool` to `var.api_node_pool` (from `var.builder_node_pool`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25ec1bbc8eb790b6278642efbb0337983996026f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->