### PR TITLE
Expose docker reverse proxy

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -64,7 +64,11 @@ locals {
         request_path = var.docker_reverse_proxy_port.health_path
         port         = var.docker_reverse_proxy_port.port
       }
-      groups = [{ group = var.build_instance_group }]
+      # TODO: (2025-10-01) - this should be only api instance group, but keeping this here for a migration period (at least until 2025-10-15)
+      groups = [
+        { group = var.api_instance_group },
+        { group = var.build_instance_group },
+      ]
     }
     nomad = {
       protocol                        = "HTTP"

--- a/iac/provider-gcp/nomad-cluster/nodepool-api.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-api.tf
@@ -66,6 +66,11 @@ resource "google_compute_instance_group_manager" "api_pool" {
     port = var.api_port.port
   }
 
+  named_port {
+    name = var.docker_reverse_proxy_port.name
+    port = var.docker_reverse_proxy_port.port
+  }
+
   dynamic "named_port" {
     for_each = local.api_additional_ports
     content {

--- a/iac/provider-gcp/nomad-cluster/nodepool-build.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-build.tf
@@ -50,6 +50,7 @@ resource "google_compute_instance_group_manager" "build_pool" {
     instance_template = google_compute_instance_template.build.id
   }
 
+  # TODO: (2025-10-01) - keep this here for a migration period (at least until 2025-10-15)
   named_port {
     name = var.docker_reverse_proxy_port.name
     port = var.docker_reverse_proxy_port.port


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds docker reverse proxy named port to the API node pool and updates the LB backend to target both API and build instance groups.
> 
> - **Network / Load Balancer**:
>   - Update `backends.docker-reverse-proxy.groups` in `iac/provider-gcp/nomad-cluster/network/main.tf` to include both `var.api_instance_group` and `var.build_instance_group`.
> - **Node Pools**:
>   - API: Add `named_port` for `var.docker_reverse_proxy_port` in `iac/provider-gcp/nomad-cluster/nodepool-api.tf`.
>   - Build: Keep `named_port` for `var.docker_reverse_proxy_port` in `iac/provider-gcp/nomad-cluster/nodepool-build.tf` (no functional change).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c33da90c52050a32224fb60fb11bbfabba004089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->