### PR TITLE
Envd - Keep polling even after first success

### DIFF
--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -149,8 +149,6 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 			if mmdsOpts.Address != "" {
 				mmdsChan <- mmdsOpts
 			}
-
-			return
 		}
 	}
 }


### PR DESCRIPTION
The polling function exits after the first success, so any changes done in the future won't be taken into account.

I am thinking if we shouldn't remove this completely and only use our server, where we can actively push changes (currently we are doing it via `/init`)