### PR TITLE
Update the time for each request

### DIFF
--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -25,12 +25,36 @@ const (
 
 // doRequestWithInfiniteRetries does a request with infinite retries until the context is done.
 // The parent context should have a deadline or a timeout.
-func doRequestWithInfiniteRetries(ctx context.Context, method, address string, requestBody []byte, accessToken *string, envdInitRequestTimeout time.Duration, sandboxID, envdVersion string) (*http.Response, int64, error) {
+func doRequestWithInfiniteRetries(
+	ctx context.Context,
+	method,
+	address string,
+	accessToken *string,
+	envdInitRequestTimeout time.Duration,
+	envVars map[string]string,
+	sandboxID,
+	envdVersion,
+	hyperloopIP string,
+) (*http.Response, int64, error) {
 	requestCount := int64(0)
 	for {
+		now := time.Now()
+
+		jsonBody := &PostInitJSONBody{
+			EnvVars:     &envVars,
+			HyperloopIP: &hyperloopIP,
+			AccessToken: accessToken,
+			Timestamp:   &now,
+		}
+
+		body, err := json.Marshal(jsonBody)
+		if err != nil {
+			return nil, requestCount, err
+		}
+
 		requestCount++
 		reqCtx, cancel := context.WithTimeout(ctx, envdInitRequestTimeout)
-		request, err := http.NewRequestWithContext(reqCtx, method, address, bytes.NewReader(requestBody))
+		request, err := http.NewRequestWithContext(reqCtx, method, address, bytes.NewReader(body))
 		if err != nil {
 			cancel()
 			return nil, requestCount, err
@@ -76,20 +100,18 @@ func (s *Sandbox) initEnvd(ctx context.Context) error {
 
 	hyperloopIP := s.Slot.HyperloopIPString()
 	address := fmt.Sprintf("http://%s:%d/init", s.Slot.HostIPString(), consts.DefaultEnvdServerPort)
-	now := time.Now()
-	jsonBody := &PostInitJSONBody{
-		EnvVars:     &s.Config.Envd.Vars,
-		HyperloopIP: &hyperloopIP,
-		AccessToken: s.Config.Envd.AccessToken,
-		Timestamp:   &now,
-	}
 
-	body, err := json.Marshal(jsonBody)
-	if err != nil {
-		return err
-	}
-
-	response, count, err := doRequestWithInfiniteRetries(ctx, "POST", address, body, s.Config.Envd.AccessToken, s.internalConfig.EnvdInitRequestTimeout, s.Runtime.SandboxID, s.Config.Envd.Version)
+	response, count, err := doRequestWithInfiniteRetries(
+		ctx,
+		http.MethodPost,
+		address,
+		s.Config.Envd.AccessToken,
+		s.internalConfig.EnvdInitRequestTimeout,
+		s.Config.Envd.Vars,
+		s.Runtime.SandboxID,
+		s.Config.Envd.Version,
+		hyperloopIP,
+	)
 	if err != nil {
 		envdInitCalls.Add(ctx, count, metric.WithAttributes(attributesFail...))
 		return fmt.Errorf("failed to init envd: %w", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes envd init request body construction in the retry function, adding a per-attempt timestamp and updating the call site accordingly.
> 
> - **Orchestrator Sandbox (`packages/orchestrator/internal/sandbox/envd.go`)**:
>   - **`doRequestWithInfiniteRetries`**: Refactored signature to accept `envVars` and `hyperloopIP`; constructs JSON body internally with `envVars`, `hyperloopIP`, `accessToken`, and a per-attempt `timestamp`.
>   - **`initEnvd`**: Updated to use the new API (no local JSON marshalling); uses `http.MethodPost` and passes `envVars` and `hyperloopIP` to the retry function.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4606480db748c61916643c122086c13a58670e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->