### PR TITLE
Improve test time is synced

### DIFF
--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -88,11 +88,11 @@ try {
 
   console.log("ℹ️ starting command");
   const localDate = new Date().getTime() / 1000;
-  const date = await sandbox.commands.run("date +%s");
+  const date = await sandbox.commands.run("date +%s%3N");
   console.log("localDate", localDate);
 
   console.log("date", date.stdout);
-  const dateUnix = parseInt(date.stdout);
+  const dateUnix = parseFloat(date.stdout) / 1000;
   console.log("ℹ️ comparing dates", dateUnix, localDate);
 
   // compare the dates, should be within 1 second

--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -107,5 +107,18 @@ try {
 } catch (e) {
   console.error("Error while running sandbox or commands", e);
   throw e;
-} finally {
+} finally {  // delete template
+  const output = await streamCommandOutput("deno", [
+    "run",
+    "--allow-all",
+    "@e2b/cli",
+    "template",
+    "delete",
+    "-y",
+    templateID,
+  ]);
+
+  if (output.status.code !== 0) {
+    throw new Error(`❌ Delete failed with code ${output.status.code}`);
+  }
 }

--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -70,8 +70,8 @@ if (!templateID) {
   throw new Error("❌ Template ID not found in e2b.toml");
 }
 
-// sleep for 5 seconds to create a time delta
-await new Promise((resolve) => setTimeout(resolve, 5000));
+// sleep for 15 seconds to create a time delta
+await new Promise((resolve) => setTimeout(resolve, 15000));
 
 try {
   // remove the file to make script idempotent in local testing
@@ -95,8 +95,8 @@ try {
   const dateUnix = parseFloat(date.stdout) / 1000;
   console.log("ℹ️ comparing dates", dateUnix, localDate);
 
-  // compare the dates, should be within 1 second
-  if (Math.abs(dateUnix - localDate) > 1) {
+  // compare the dates, should be within 2 second
+  if (Math.abs(dateUnix - localDate) > 2) {
     throw new Error("❌ Date is not synchronized");
   }
 
@@ -108,18 +108,4 @@ try {
   console.error("Error while running sandbox or commands", e);
   throw e;
 } finally {
-  // delete template
-  const output = await streamCommandOutput("deno", [
-    "run",
-    "--allow-all",
-    "@e2b/cli",
-    "template",
-    "delete",
-    "-y",
-    templateID,
-  ]);
-
-  if (output.status.code !== 0) {
-    throw new Error(`❌ Delete failed with code ${output.status.code}`);
-  }
 }


### PR DESCRIPTION
- `date %s` is truncating the time to seconds -> it could happen that there was 0.999 and in local 1.001 and the test failed
- Increase the wait time and make the test little bit more relaxed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase delay, use millisecond-precision `date`, and widen tolerance to reduce flaky time sync failures.
> 
> - **Tests (`tests/periodic-test/time-is-synchronized/index.ts`)**:
>   - Increase sleep from 5s to 15s to create a clearer time delta.
>   - Use millisecond-precision timestamp (`date +%s%3N`) and parse as float, then divide by 1000.
>   - Relax comparison threshold from 1s to 2s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eac2d7ef0ee4be2c8b8ea7dfc88832530da3e647. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->