### PR TITLE
Add dns resolution logs and handle error correctly

### DIFF
--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -127,7 +127,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 				nodeIP, err = catalogResolution(r.Context(), sandboxId, catalog, orchestrators)
 				if err != nil {
 					if !errors.Is(err, ErrNodeNotFound) {
-						logger.Warn("failed to resolve node ip with Redis resolution", zap.Error(err), zap.String("node_ip", nodeIP))
+						logger.Warn("failed to resolve node ip with Redis resolution", zap.Error(err))
 					}
 
 					if !useDnsResolution {
@@ -137,7 +137,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 					nodeIP, err = dnsResolution(sandboxId, logger)
 					if err != nil {
 						if !errors.Is(err, ErrNodeNotFound) {
-							logger.Warn("failed to resolve node ip with DNS resolution", zap.Error(err), zap.String("node_ip", nodeIP))
+							logger.Warn("failed to resolve node ip with DNS resolution", zap.Error(err))
 						}
 
 						return nil, reverseproxy.NewErrSandboxNotFound(sandboxId)
@@ -147,7 +147,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 				nodeIP, err = dnsResolution(sandboxId, logger)
 				if err != nil {
 					if !errors.Is(err, ErrNodeNotFound) {
-						logger.Warn("failed to resolve node ip with DNS resolution", zap.Error(err), zap.String("node_ip", nodeIP))
+						logger.Warn("failed to resolve node ip with DNS resolution", zap.Error(err))
 					}
 
 					return nil, reverseproxy.NewErrSandboxNotFound(sandboxId)

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -15,7 +15,6 @@ import (
 
 	orchestratorspool "github.com/e2b-dev/infra/packages/proxy/internal/edge/pool"
 	"github.com/e2b-dev/infra/packages/proxy/internal/edge/sandboxes"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	l "github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
@@ -44,7 +43,7 @@ var (
 	ErrNodeNotFound = errors.New("node not found")
 )
 
-func dnsResolution(sandboxId string, l *zap.Logger) (string, error) {
+func dnsResolution(sandboxId string, logger *zap.Logger) (string, error) {
 	var err error
 
 	msg := new(dns.Msg)
@@ -58,7 +57,7 @@ func dnsResolution(sandboxId string, l *zap.Logger) (string, error) {
 		// the api server wasn't found, maybe the API server is rolling and the DNS server is not updated yet
 		if dnsErr != nil || len(resp.Answer) == 0 {
 			err = dnsErr
-			l.Warn("host for sandbox not found", zap.Error(err), logger.WithSandboxID(sandboxId), zap.Int("retry", i+1))
+			logger.Warn("host for sandbox not found", zap.Error(err), l.WithSandboxID(sandboxId), zap.Int("retry", i+1))
 
 			// Jitter
 			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -15,6 +15,7 @@ import (
 
 	orchestratorspool "github.com/e2b-dev/infra/packages/proxy/internal/edge/pool"
 	"github.com/e2b-dev/infra/packages/proxy/internal/edge/sandboxes"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	l "github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
@@ -57,7 +58,7 @@ func dnsResolution(sandboxId string, l *zap.Logger) (string, error) {
 		// the api server wasn't found, maybe the API server is rolling and the DNS server is not updated yet
 		if dnsErr != nil || len(resp.Answer) == 0 {
 			err = dnsErr
-			l.Warn(fmt.Sprintf("host for sandbox %s not found: %s", sandboxId, err), zap.Error(err), zap.Int("retry", i+1))
+			l.Warn("host for sandbox not found", zap.Error(err), logger.WithSandboxID(sandboxId), zap.Int("retry", i+1))
 
 			// Jitter
 			time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)

--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/template"
 )
@@ -60,13 +61,13 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 
 		var notFoundErr *SandboxNotFoundError
 		if errors.As(err, &notFoundErr) {
-			zap.L().Warn("sandbox not found", zap.String("host", r.Host))
+			zap.L().Warn("sandbox not found", zap.String("host", r.Host), logger.WithSandboxID(notFoundErr.SandboxId))
 
 			err := template.
 				NewSandboxNotFoundError(notFoundErr.SandboxId, r.Host).
 				HandleError(w, r)
 			if err != nil {
-				zap.L().Error("failed to handle sandbox not found error", zap.Error(err))
+				zap.L().Error("failed to handle sandbox not found error", zap.Error(err), logger.WithSandboxID(notFoundErr.SandboxId))
 				http.Error(w, "Failed to handle sandbox not found error", http.StatusInternalServerError)
 
 				return


### PR DESCRIPTION
Add dns resolution logs, handle error correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve DNS resolution error handling and switch to structured logging with sandbox IDs for DNS and not-found cases.
> 
> - **Client Proxy (`packages/client-proxy/internal/proxy/proxy.go`)**:
>   - **DNS resolution**: Switch warn logs to structured logging with `logger.WithSandboxID(sandboxId)`; propagate underlying DNS error (`fmt.Errorf("failed to resolve sandbox: %w")`) instead of returning `ErrNodeNotFound` on final failure.
> - **Shared Proxy (`packages/shared/pkg/proxy/handler.go`)**:
>   - **Not-found handling**: Include `logger.WithSandboxID(notFoundErr.SandboxId)` in warn and error logs; minor import added for logger.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d6792afc2070350dca52540a054c2a0da5c4239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->