### PR TITLE
Enable journal and metadata csum ext4 flags

### DIFF
--- a/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
@@ -41,8 +41,8 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 	cmd := exec.CommandContext(ctx,
 		"mkfs.ext4",
 		// Matches the final ext4 features used by tar2ext4 tool
-		// But enables resize_inode, sparse_super (default, required for resize_inode)
-		"-O", `^has_journal,^dir_index,^64bit,^dir_nlink,^metadata_csum,ext_attr,sparse_super2,filetype,extent,flex_bg,large_file,huge_file,extra_isize`,
+		// But enables resize_inode, sparse_super (default, required for resize_inode), has_journal (default), metadata_csum (default)
+		"-O", `^dir_index,^64bit,^dir_nlink,ext_attr,sparse_super2,filetype,extent,flex_bg,large_file,huge_file,extra_isize`,
 		"-b", strconv.FormatInt(blockSize, 10),
 		"-m", strconv.FormatInt(reservedBlocksPercentage, 10),
 		"-i", strconv.FormatInt(inodesRatio, 10),

--- a/packages/orchestrator/internal/template/build/storage/cache/cache.go
+++ b/packages/orchestrator/internal/template/build/storage/cache/cache.go
@@ -14,7 +14,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-const hashingVersion = "v1"
+const hashingVersion = "v2"
 
 const minimalCachedTemplateVersion = 2
 


### PR DESCRIPTION
Enable journal and metadata csum. This change is to keep the filesystem state clean and prevent any accidental data loss. Invalidates the build caches to force rebuilds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables ext4 journaling and metadata checksums and bumps cache hashing to v2 to force rebuilds.
> 
> - **Filesystem**:
>   - Update `packages/orchestrator/internal/template/build/core/filesystem/ext4.go` to enable `has_journal` and `metadata_csum` in `mkfs.ext4` options (remove their exclusions).
> - **Build Cache**:
>   - Bump `hashingVersion` to `v2` in `packages/orchestrator/internal/template/build/storage/cache/cache.go` to invalidate existing caches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 337b5f7a0c92030ff03c26b4769cdbef99a27003. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->