### PR TITLE
fix: template build panic handling

### DIFF
--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -32,6 +33,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
 const progressDelay = 5 * time.Second
@@ -131,6 +133,13 @@ func (b *Builder) Build(ctx context.Context, template storage.TemplateFiles, con
 		} else {
 			logger.Info(fmt.Sprintf("Build finished, took %s",
 				time.Since(startTime).Truncate(time.Second).String()))
+		}
+	}()
+
+	defer func() {
+		if r := recover(); r != nil {
+			telemetry.ReportCriticalError(ctx, "recovered from panic in template build", nil, attribute.String("panic", fmt.Sprintf("%v", r)), telemetry.WithTemplateID(config.TemplateID), telemetry.WithBuildID(template.BuildID))
+			e = errors.New("fatal error occurred during template build, please contact us")
 		}
 	}()
 

--- a/packages/orchestrator/internal/template/server/create_template.go
+++ b/packages/orchestrator/internal/template/server/create_template.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -98,7 +99,8 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 
 		defer func() {
 			if r := recover(); r != nil {
-				zap.L().Error("recovered from panic in template build", zap.Any("panic", r), logger.WithTemplateID(cfg.TemplateID), logger.WithBuildID(cfg.BuildID))
+				telemetry.ReportCriticalError(ctx, "recovered from panic in template build handler", nil, attribute.String("panic", fmt.Sprintf("%v", r)), telemetry.WithTemplateID(cfg.TemplateID), telemetry.WithBuildID(cfg.BuildID))
+				buildInfo.SetFail(builderrors.UnwrapUserError(errors.New("fatal error occurred, please contact us")))
 			}
 		}()
 


### PR DESCRIPTION
Fix template build panic handling to properly fail the build and report the error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Recover from panics during template builds, report them via telemetry with context, and mark the build as failed with a user-facing error.
> 
> - **Template Build (orchestrator)**:
>   - **Builder** (`internal/template/build/builder.go`): Add panic recovery that reports a critical error via telemetry (with `panic` attribute, `templateID`, `buildID`) and returns a generic build error.
>   - **Server** (`internal/template/server/create_template.go`): Replace panic log in background build with telemetry reporting and explicitly fail the build with a user-facing error.
> - **Telemetry**:
>   - Import and use `otel/attribute` and shared `telemetry` package for structured error reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97b59f0515452f616df589fce1bc7380678c6e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->