### PR TITLE
Decrease the test reruns to 1

### DIFF
--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -51,9 +51,9 @@ test/%:
 		*.go:*) \
 			BASE=$${TEST_PATH%%:*}; \
 			TEST_FN=$${TEST_PATH#*:}; \
-			go tool gotestsum --rerun-fails=2 --packages="$$BASE" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 -run "$${TEST_FN}" ;; \
-		*.go) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
-		*) go tool gotestsum --rerun-fails=2 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
+			go tool gotestsum --rerun-fails=1 --packages="$$BASE" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 -run "$${TEST_FN}" ;; \
+		*.go) go tool gotestsum --rerun-fails=1 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
+		*) go tool gotestsum --rerun-fails=1 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 ;; \
 	esac
 
 .PHONY: connect-orchestrator

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_internet_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_internet_test.go
@@ -98,7 +98,7 @@ func TestInternetAccessResumedSbx(t *testing.T) {
 			require.Equal(t, http.StatusCreated, respResume.StatusCode(), "Expected status code 200 OK, got %d", respResume.StatusCode())
 
 			envdClient := setup.GetEnvdClient(t, ctx)
-			err = utils.ExecCommand(t, ctx, resp.JSON201, envdClient, "curl", "--connect-timeout", "3", "--max-time", "5", "-Is", "https://www.google.com")
+			err = utils.ExecCommand(t, ctx, resp.JSON201, envdClient, "curl", "--connect-timeout", "3", "--max-time", "5", "-Is", "https://www.gstatic.com/generate_204")
 			if tc.internetAccess {
 				require.NoError(t, err, "Expected curl command to succeed when internet access is allowed")
 			} else {

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_internet_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_internet_test.go
@@ -44,7 +44,7 @@ func TestInternetAccess(t *testing.T) {
 
 			envdClient := setup.GetEnvdClient(t, ctx)
 
-			err = utils.ExecCommand(t, ctx, resp.JSON201, envdClient, "curl", "--connect-timeout", "3", "--max-time", "5", "-Is", "https://www.google.com")
+			err = utils.ExecCommand(t, ctx, resp.JSON201, envdClient, "curl", "--connect-timeout", "3", "--max-time", "5", "-Is", "https://www.gstatic.com/generate_204")
 			if tc.internetAccess {
 				require.NoError(t, err, "Expected curl command to succeed when internet access is allowed")
 			} else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lower test reruns from 2→1 and replace google.com curl probe with gstatic generate_204 in sandbox internet tests.
> 
> - **Integration Tests**:
>   - **Makefile (`tests/integration/Makefile`)**: Reduce `gotestsum` `--rerun-fails` from `2` to `1` across all test path cases.
>   - **Sandbox internet checks (`tests/integration/internal/tests/api/sandboxes/sandbox_internet_test.go`)**:
>     - Replace curl target from `https://www.google.com` to `https://www.gstatic.com/generate_204` in both initial and resumed sandbox tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 881d013bbaf8b2a08a6ff50de7c124a98c14f3ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->