### PR TITLE
Add launch darkly to template manager

### DIFF
--- a/iac/provider-gcp/nomad/jobs/template-manager.hcl
+++ b/iac/provider-gcp/nomad/jobs/template-manager.hcl
@@ -80,6 +80,9 @@ job "template-manager-system" {
 %{ if !update_stanza }
         FORCE_STOP                    = "true"
 %{ endif }
+%{ if launch_darkly_api_key != "" }
+        LAUNCH_DARKLY_API_KEY         = "${launch_darkly_api_key}"
+%{ endif }
       }
 
       config {

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -508,6 +508,7 @@ resource "nomad_job" "template_manager" {
     allow_sandbox_internet          = var.allow_sandbox_internet
     clickhouse_connection_string    = local.clickhouse_connection_string
     dockerhub_remote_repository_url = var.dockerhub_remote_repository_url
+    launch_darkly_api_key           = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
 
     # For now we DISABLE the shared chunk cache in the template manager
     shared_chunk_cache_path = ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wires LaunchDarkly API key from Secret Manager into the template-manager Nomad job and exposes it as an env var (conditionally).
> 
> - **Nomad (template-manager)**:
>   - **Env var**: Add `LAUNCH_DARKLY_API_KEY` (only set when non-empty) to `jobs/template-manager.hcl`.
>   - **Template var**: Plumb `launch_darkly_api_key` into the job via `main.tf` using Secret Manager data.
>   - **Template fix**: Close the `update_stanza` conditional after setting `FORCE_STOP`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9334bf48a38d51e4469ba9a113db26943d60418c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->