### PR TITLE
Envd prevent unnecessary jumps

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -84,6 +84,8 @@ func (a *API) SetData(logger zerolog.Logger, data PostInitJSONBody) error {
 			if err != nil {
 				logger.Error().Msgf("Failed to set system time: %v", err)
 			}
+		} else {
+			logger.Debug().Msgf("Timestamp %v is not far enough in the past or future, not setting system time", *data.Timestamp)
 		}
 	}
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -75,6 +75,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 
 func (a *API) SetData(logger zerolog.Logger, data PostInitJSONBody) error {
 	if data.Timestamp != nil {
+		// Check if the time is before maxTimeInPast or after maxTimeInFuture
 		if data.Timestamp.Before(time.Now().Add(-maxTimeInPast)) ||
 			data.Timestamp.After(time.Now().Add(maxTimeInFuture)) {
 			logger.Debug().Msgf("Setting sandbox start time to: %v", *data.Timestamp)

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -45,7 +45,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		defer a.initLock.Unlock()
 
 		// Update data only if the request is newer or if there's no timestamp at all
-		if initRequest.Timestamp != nil || a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano()) {
+		if initRequest.Timestamp == nil || a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano()) {
 			// Check if the time is before maxTimeInPast or after maxTimeInFuture
 			validTime := initRequest.Timestamp == nil ||
 				initRequest.Timestamp.Before(time.Now().Add(-maxTimeInPast)) ||


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only set system time during init when timestamp deviates beyond small thresholds; otherwise skip and log.
> 
> - **Backend (`packages/envd/internal/api/init.go`)**:
>   - **Time setting logic**: Introduce `maxTimeInPast` (50ms) and `maxTimeInFuture` (5s) thresholds and only call `unix.ClockSettime` when `data.Timestamp` is outside this window.
>   - Adds debug logging when the timestamp is within the window and the system time update is skipped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 189d0be1da22a3382e9a72cba501be2bc52d2094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->