### PR TITLE
Edge - Fix defer callback

### DIFF
--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -129,7 +129,9 @@ func (s *NodePassThroughServer) handler(srv any, serverStream grpc.ServerStream)
 	}
 
 	if callback != nil {
-		defer callback(err)
+		defer func() {
+			callback(err)
+		}()
 	}
 
 	// Explicitly *do not close* s2cErrChan and c2sErrChan, otherwise the select below will not terminate.


### PR DESCRIPTION
We want to capture the error at the end, no at that moment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wraps the deferred `callback` in a closure so it receives the final `err` at function exit in `packages/client-proxy/internal/edge-pass-through/proxy.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e809be70c5db6760cf04f2533b1cc75af5976827. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->