### PR TITLE
Use catalog repository primary and dns lookup as fallback

### DIFF
--- a/iac/provider-gcp/nomad/jobs/edge.hcl
+++ b/iac/provider-gcp/nomad/jobs/edge.hcl
@@ -122,8 +122,8 @@ job "client-proxy" {
 
         ENVIRONMENT = "${environment}"
 
-        // use legacy dns resolution for orchestrator services
-        USE_PROXY_CATALOG_RESOLUTION = "false"
+        USE_CATALOG_RESOLUTION = "true"
+        USE_DNS_RESOLUTION     = "true"
 
         OTEL_COLLECTOR_GRPC_ENDPOINT  = "${otel_collector_grpc_endpoint}"
         LOGS_COLLECTOR_ADDRESS        = "${logs_collector_address}"


### PR DESCRIPTION
Followup after https://github.com/e2b-dev/infra/pull/1298 that will use Redis sandbox routing first and use DNS as optional fallback. This is done during the migration period, when we have both routing sources in operation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `client-proxy` Nomad job to use catalog-based service resolution with DNS fallback by updating env flags.
> 
> - **Edge Nomad job (`iac/provider-gcp/nomad/jobs/edge.hcl`)**:
>   - Enable catalog and DNS resolution via env flags:
>     - Add `USE_CATALOG_RESOLUTION="true"` and `USE_DNS_RESOLUTION="true"`.
>     - Remove legacy `USE_PROXY_CATALOG_RESOLUTION` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6178816bd3c208df081073db0957489e41715889. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->