### PR TITLE
Fix issue when trying to evict already dead sandbox

### DIFF
--- a/packages/api/internal/orchestrator/evictor/evict.go
+++ b/packages/api/internal/orchestrator/evictor/evict.go
@@ -31,7 +31,7 @@ func (e *Evictor) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(50 * time.Millisecond):
-			for _, item := range e.store.Items(nil, sandbox.WithOnlyExpired(true)) {
+			for _, item := range e.store.Items(nil, sandbox.WithOnlyExpired(true), sandbox.WithState(sandbox.StateRunning)) {
 				go func() {
 					stateAction := sandbox.StateActionKill
 					if item.AutoPause {


### PR DESCRIPTION
Introduced here 
https://github.com/e2b-dev/infra/pull/1271/files#diff-c3b47920c0d51252cf38682a367cc2985fbbf9489afe841ba6e0a6b11cab4bba
<img width="432" height="306" alt="image" src="https://github.com/user-attachments/assets/a94ef9a9-a4ed-402f-a66a-0878664f3ff9" />

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts eviction to expired sandboxes that are `running` to avoid acting on already dead ones.
> 
> - **Evictor (`packages/api/internal/orchestrator/evictor/evict.go`)**:
>   - Filters `store.Items` with `sandbox.WithState(sandbox.StateRunning)` alongside `sandbox.WithOnlyExpired(true)` to evict only expired, running sandboxes.
>   - Eviction logic and scheduling cadence remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37ed515178d481d92520e80f9ebef4a5bdbda9ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->