### PR TITLE
Sandbox Store- Explicitly require the state

### DIFF
--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -86,7 +86,7 @@ func (a *APIStore) GetSandboxes(c *gin.Context, params api.GetSandboxesParams) {
 		return
 	}
 
-	sandboxes := a.orchestrator.GetSandboxes(ctx, team.ID, sandbox.WithState(sandbox.StateRunning))
+	sandboxes := a.orchestrator.GetSandboxes(ctx, team.ID, []sandbox.State{sandbox.StateRunning})
 	runningSandboxes := getRunningSandboxes(sandboxes, metadataFilter)
 
 	// Sort sandboxes by start time descending
@@ -144,7 +144,7 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 		return
 	}
 
-	allSandboxes := a.orchestrator.GetSandboxes(ctx, team.ID, sandbox.WithStates(sandbox.StateRunning, sandbox.StatePausing))
+	allSandboxes := a.orchestrator.GetSandboxes(ctx, team.ID, []sandbox.State{sandbox.StateRunning, sandbox.StatePausing})
 	runningSandboxes := sharedUtils.Filter(allSandboxes, func(sbx sandbox.Sandbox) bool {
 		return sbx.State == sandbox.StateRunning
 	})

--- a/packages/api/internal/metrics/team.go
+++ b/packages/api/internal/metrics/team.go
@@ -77,7 +77,7 @@ func (so *TeamObserver) Start(cache sandbox.Store) (err error) {
 	// Register callbacks for team sandbox metrics
 	so.registration, err = so.meter.RegisterCallback(
 		func(ctx context.Context, obs metric.Observer) error {
-			sbxs := cache.Items(nil)
+			sbxs := cache.Items(nil, []sandbox.State{sandbox.StateRunning})
 			sbxsPerTeam := make(map[string]int64)
 			for _, sbx := range sbxs {
 				teamID := sbx.TeamID.String()

--- a/packages/api/internal/orchestrator/admin.go
+++ b/packages/api/internal/orchestrator/admin.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
@@ -38,7 +39,7 @@ func (o *Orchestrator) AdminNodes() []*api.Node {
 		}
 	}
 
-	for _, sbx := range o.sandboxStore.Items(nil) {
+	for _, sbx := range o.sandboxStore.Items(nil, []sandbox.State{sandbox.StateRunning}) {
 		n, ok := apiNodes[sbx.NodeID]
 		if !ok {
 			zap.L().Error("node for sandbox wasn't found", logger.WithNodeID(sbx.NodeID), logger.WithSandboxID(sbx.SandboxID))
@@ -83,7 +84,7 @@ func (o *Orchestrator) AdminNodeDetail(clusterID uuid.UUID, nodeIDOrNomadNodeSho
 		Metrics:         metrics,
 	}
 
-	for _, sbx := range o.sandboxStore.Items(nil) {
+	for _, sbx := range o.sandboxStore.Items(nil, []sandbox.State{sandbox.StateRunning}) {
 		if sbx.NodeID == n.ID && sbx.ClusterID == n.ClusterID {
 			var metadata *api.SandboxMetadata
 			if sbx.Metadata != nil {

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -35,7 +35,7 @@ func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
 			zap.L().Info("Stopping node analytics reporting due to context cancellation")
 			return
 		case <-ticker.C:
-			sandboxes := o.sandboxStore.Items(nil, sandbox.WithState(sandbox.StateRunning))
+			sandboxes := o.sandboxStore.Items(nil, []sandbox.State{sandbox.StateRunning})
 			longRunningSandboxes := make([]sandbox.Sandbox, 0, len(sandboxes))
 			for _, sandbox := range sandboxes {
 				if time.Since(sandbox.StartTime) > oldSandboxThreshold {

--- a/packages/api/internal/orchestrator/evictor/evict.go
+++ b/packages/api/internal/orchestrator/evictor/evict.go
@@ -31,7 +31,7 @@ func (e *Evictor) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(50 * time.Millisecond):
-			for _, item := range e.store.Items(nil, sandbox.WithOnlyExpired(true), sandbox.WithState(sandbox.StateRunning)) {
+			for _, item := range e.store.Items(nil, []sandbox.State{sandbox.StateRunning}, sandbox.WithOnlyExpired(true)) {
 				go func() {
 					stateAction := sandbox.StateActionKill
 					if item.AutoPause {

--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -10,9 +10,9 @@ import (
 )
 
 // GetSandboxes returns all instances for a given node.
-func (o *Orchestrator) GetSandboxes(ctx context.Context, teamID uuid.UUID, options ...sandbox.ItemsOption) []sandbox.Sandbox {
+func (o *Orchestrator) GetSandboxes(ctx context.Context, teamID uuid.UUID, states []sandbox.State, options ...sandbox.ItemsOption) []sandbox.Sandbox {
 	_, childSpan := tracer.Start(ctx, "get-sandboxes")
 	defer childSpan.End()
 
-	return o.sandboxStore.Items(&teamID, options...)
+	return o.sandboxStore.Items(&teamID, states, options...)
 }

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -198,7 +198,7 @@ func (o *Orchestrator) startStatusLogging(ctx context.Context) {
 			}
 
 			zap.L().Info("API internal status",
-				zap.Int("sandboxes_count", len(o.sandboxStore.Items(nil))),
+				zap.Int("sandboxes_count", len(o.sandboxStore.Items(nil, []sandbox.State{sandbox.StateRunning}))),
 				zap.Int("nodes_count", o.nodes.Count()),
 				zap.Any("nodes", connectedNodes),
 			)

--- a/packages/api/internal/sandbox/store.go
+++ b/packages/api/internal/sandbox/store.go
@@ -12,14 +12,11 @@ type (
 )
 
 type ItemsFilter struct {
-	States      []State
 	OnlyExpired bool
 }
 
 func NewItemsFilter() *ItemsFilter {
-	// Defaults to prevent accidental full scans
 	return &ItemsFilter{
-		States:      nil,
 		OnlyExpired: false,
 	}
 }
@@ -30,28 +27,11 @@ type Store interface {
 	Get(sandboxID string, includeEvicting bool) (Sandbox, error)
 	Remove(sandboxID string)
 
-	Items(teamID *uuid.UUID, options ...ItemsOption) []Sandbox
+	Items(teamID *uuid.UUID, states []State, options ...ItemsOption) []Sandbox
 
 	Update(sandboxID string, updateFunc func(sandbox Sandbox) (Sandbox, error)) (Sandbox, error)
 	StartRemoving(ctx context.Context, sandboxID string, stateAction StateAction) (alreadyDone bool, callback func(error), err error)
 	WaitForStateChange(ctx context.Context, sandboxID string) error
-}
-
-func WithState(state State) ItemsOption {
-	return func(f *ItemsFilter) {
-		f.States = []State{state}
-	}
-}
-
-func WithStates(states ...State) ItemsOption {
-	return func(f *ItemsFilter) {
-		if len(states) == 0 {
-			f.States = nil
-			return
-		}
-
-		f.States = states
-	}
 }
 
 func WithOnlyExpired(isExpired bool) ItemsOption {

--- a/packages/api/internal/sandbox/store/memory/filters.go
+++ b/packages/api/internal/sandbox/store/memory/filters.go
@@ -1,16 +1,11 @@
 package memory
 
 import (
-	"slices"
-
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 )
 
 // applyFilter checks if a sandbox matches the filter criteria
 func applyFilter(sbx sandbox.Sandbox, filter *sandbox.ItemsFilter) bool {
-	if filter.States != nil && !slices.Contains(filter.States, sbx.State) {
-		return false
-	}
 	if filter.OnlyExpired && !sbx.IsExpired() {
 		return false
 	}

--- a/packages/api/internal/sandbox/store/memory/filters_test.go
+++ b/packages/api/internal/sandbox/store/memory/filters_test.go
@@ -1,0 +1,94 @@
+package memory
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+)
+
+func createFilterTestSandbox(state sandbox.State, endTime time.Time) sandbox.Sandbox {
+	return sandbox.Sandbox{
+		SandboxID:         "test-sandbox-id",
+		TemplateID:        "test-template",
+		ClientID:          "test-client",
+		ExecutionID:       "test-execution",
+		TeamID:            uuid.New(),
+		BuildID:           uuid.New(),
+		ClusterID:         uuid.New(),
+		MaxInstanceLength: time.Hour,
+		StartTime:         time.Now().Add(-30 * time.Minute),
+		EndTime:           endTime,
+		State:             state,
+		AutoPause:         false,
+	}
+}
+
+// TestApplyFilter_ExpiredFiltering tests the expiration filter logic used by the evictor
+func TestApplyFilter_ExpiredFiltering(t *testing.T) {
+	tests := []struct {
+		name          string
+		onlyExpired   bool
+		endTime       time.Time
+		expectedMatch bool
+		description   string
+	}{
+		{
+			name:          "no filter - not expired",
+			onlyExpired:   false,
+			endTime:       time.Now().Add(time.Hour),
+			expectedMatch: true,
+			description:   "Should match when no filter is applied",
+		},
+		{
+			name:          "no filter - expired",
+			onlyExpired:   false,
+			endTime:       time.Now().Add(-time.Hour),
+			expectedMatch: true,
+			description:   "Should match when no filter is applied, even if expired",
+		},
+		{
+			name:          "expired filter - not expired",
+			onlyExpired:   true,
+			endTime:       time.Now().Add(time.Hour),
+			expectedMatch: false,
+			description:   "Should NOT match when filtering for expired but sandbox is active",
+		},
+		{
+			name:          "expired filter - expired",
+			onlyExpired:   true,
+			endTime:       time.Now().Add(-time.Hour),
+			expectedMatch: true,
+			description:   "Should match when filtering for expired and sandbox is expired",
+		},
+		{
+			name:          "expired filter - just expired",
+			onlyExpired:   true,
+			endTime:       time.Now().Add(-time.Nanosecond),
+			expectedMatch: true,
+			description:   "Should match when expired by even a nanosecond",
+		},
+		{
+			name:          "expired filter - about to expire",
+			onlyExpired:   true,
+			endTime:       time.Now().Add(time.Millisecond),
+			expectedMatch: false,
+			description:   "Should NOT match when still has time left",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := sandbox.NewItemsFilter()
+			sandbox.WithOnlyExpired(tt.onlyExpired)(filter)
+
+			sbx := createFilterTestSandbox(sandbox.StateRunning, tt.endTime)
+			result := applyFilter(sbx, filter)
+
+			assert.Equal(t, tt.expectedMatch, result, tt.description)
+		})
+	}
+}

--- a/packages/api/internal/sandbox/store/memory/operations.go
+++ b/packages/api/internal/sandbox/store/memory/operations.go
@@ -94,7 +94,7 @@ func (s *Store) Items(teamID *uuid.UUID, states []sandbox.State, options ...sand
 			continue
 		}
 
-		if !slices.Contains(states, data.State) {
+		if states != nil && !slices.Contains(states, data.State) {
 			continue
 		}
 


### PR DESCRIPTION
There was issue in admin endpoints - it was missing the state as it was unintentionally omitted. It's fine there, but we want to prevent this in future

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require explicit sandbox state filters in store/list APIs and update orchestrator, handlers, admin, metrics, analytics, evictor, and logging; remove state from ItemsFilter and add expiration filter tests.
> 
> - **Core**:
>   - Refactor `sandbox.Store.Items` to `Items(teamID, states, ...options)` and remove state from `ItemsFilter` (delete `WithState/WithStates`).
>   - Update memory store to filter by provided `[]sandbox.State` and keep `OnlyExpired` logic.
> - **Orchestrator**:
>   - Change `GetSandboxes(ctx, teamID, states, ...)` signature and pass through to store.
>   - Use explicit states in admin node listing and details, analytics long-running scan, evictor loop, and periodic status logging (count only `StateRunning`).
> - **Handlers/API**:
>   - Use explicit states when listing sandboxes (running; running+pausing in V2).
> - **Metrics**:
>   - Team observer reads items with `StateRunning` only.
> - **Tests**:
>   - Add `filters_test.go` to validate expiration filtering behavior.
> - **Misc**:
>   - Minor log message tweak in transition path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 282cb76abc00b9a79da836c77c83fda45dbf3fbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->