### PR TITLE
Enable revive's 'useless-break' rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,7 +119,6 @@ linters:
         - { disabled: true, name: unused-parameter }  # todo: enable this
         - { disabled: true, name: unused-receiver }
         - { disabled: true, name: use-errors-new }  # todo: enable this
-        - { disabled: true, name: useless-break }  # todo: enable this
         - { disabled: true, name: var-declaration }
         - { disabled: true, name: var-naming }
 
@@ -136,3 +135,7 @@ linters:
 
 run:
   go: 1.24.7
+
+issues:
+  max-issues-per-linter: 50
+  max-same-issues: 50

--- a/packages/api/internal/orchestrator/nodemanager/status.go
+++ b/packages/api/internal/orchestrator/nodemanager/status.go
@@ -34,10 +34,8 @@ func (n *Node) Status() api.NodeStatus {
 	case connectivity.Connecting:
 		return api.NodeStatusConnecting
 	default:
-		break
+		return n.status
 	}
-
-	return n.status
 }
 
 func (n *Node) setStatus(status api.NodeStatus) {

--- a/packages/envd/internal/services/process/input.go
+++ b/packages/envd/internal/services/process/input.go
@@ -77,7 +77,6 @@ func (s *Service) streamInputHandler(ctx context.Context, stream *connect.Client
 				return nil, err
 			}
 		case *rpc.StreamInputRequest_Keepalive:
-			break
 		default:
 			return nil, connect.NewError(connect.CodeUnimplemented, fmt.Errorf("invalid event type %T", req.GetEvent()))
 		}

--- a/packages/orchestrator/internal/sandbox/rootfs/direct.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/direct.go
@@ -71,7 +71,6 @@ func (o *DirectProvider) ExportDiff(
 
 	select {
 	case <-o.finishedOperations:
-		break
 	case <-ctx.Done():
 		return nil, fmt.Errorf("timeout waiting for overlay device to be released")
 	}

--- a/packages/orchestrator/internal/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/nbd.go
@@ -89,7 +89,6 @@ func (o *NBDProvider) ExportDiff(
 
 	select {
 	case <-o.finishedOperations:
-		break
 	case <-childCtx.Done():
 		return nil, fmt.Errorf("timeout waiting for overlay device to be released")
 	}

--- a/packages/orchestrator/internal/sandbox/snapshot.go
+++ b/packages/orchestrator/internal/sandbox/snapshot.go
@@ -28,7 +28,6 @@ func (s *Snapshot) Upload(
 	var memfilePath *string
 	switch r := s.MemfileDiff.(type) {
 	case *build.NoDiff:
-		break
 	default:
 		memfileLocalPath, err := r.CachePath()
 		if err != nil {
@@ -41,7 +40,6 @@ func (s *Snapshot) Upload(
 	var rootfsPath *string
 	switch r := s.RootfsDiff.(type) {
 	case *build.NoDiff:
-		break
 	default:
 		rootfsLocalPath, err := r.CachePath()
 		if err != nil {

--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -158,14 +158,12 @@ func (c *Cache) AddSnapshot(
 ) error {
 	switch memfileDiff.(type) {
 	case *build.NoDiff:
-		break
 	default:
 		c.buildStore.Add(memfileDiff)
 	}
 
 	switch rootfsDiff.(type) {
 	case *build.NoDiff:
-		break
 	default:
 		c.buildStore.Add(rootfsDiff)
 	}


### PR DESCRIPTION
https://revive.run/r#useless-break


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the revive useless-break rule, removes redundant break statements across several packages, and sets golangci-lint issue limits.
> 
> - **Linting**:
>   - Enable revive `useless-break` by removing its disable entry in `.golangci.yml`.
>   - Add `issues` limits: `max-issues-per-linter: 50`, `max-same-issues: 50`.
> - **Code cleanup (remove useless breaks)**:
>   - `packages/api/internal/orchestrator/nodemanager/status.go`: return directly from `switch default` in `Status()`.
>   - `packages/envd/internal/services/process/input.go`: drop `break` in `Keepalive` event handler.
>   - `packages/orchestrator/internal/sandbox/rootfs/{direct.go,nbd.go}`: remove `break` in `select` on `finishedOperations`.
>   - `packages/orchestrator/internal/sandbox/{snapshot.go,template/cache.go}`: remove `break` in type `switch` cases for `*build.NoDiff`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a48ebc47c51436bc0cad241f70926b6516df7bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->