### PR TITLE
Enable the if-return revive rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -101,7 +101,6 @@ linters:
         - { disabled: true, name: function-length }
         - { disabled: true, name: function-result-limit }
         - { disabled: true, name: get-return }
-        - { disabled: true, name: if-return }
         - { disabled: true, name: import-alias-naming }
         - { disabled: true, name: import-shadowing }
         - { disabled: true, name: line-length-limit }

--- a/packages/orchestrator/internal/sandbox/template_build.go
+++ b/packages/orchestrator/internal/sandbox/template_build.go
@@ -195,11 +195,7 @@ func (t *TemplateBuild) Upload(ctx context.Context, metadataPath string, fcSnapf
 	})
 
 	eg.Go(func() error {
-		if err := t.uploadMetadata(ctx, metadataPath); err != nil {
-			return err
-		}
-
-		return nil
+		return t.uploadMetadata(ctx, metadataPath)
 	})
 
 	done := make(chan error)


### PR DESCRIPTION
https://revive.run/r#if-return

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the revive `if-return` rule and simplifies `uploadMetadata` goroutine return in `template_build.go`.
> 
> - **Linting**:
>   - Enable revive rule `if-return` by removing its disable entry in `.golangci.yml`.
> - **Orchestrator**:
>   - Simplify `eg.Go` block in `packages/orchestrator/internal/sandbox/template_build.go` to `return t.uploadMetadata(ctx, metadataPath)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe7b6a3844bcd92af2ab8cf45d9266702e485908. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->