### PR TITLE
Handle non running already paused sandbox

### DIFF
--- a/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
@@ -80,4 +80,20 @@ func TestSandboxPause(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, pauseResp.StatusCode())
 	})
+
+	t.Run("pause already paused sandbox", func(t *testing.T) {
+		// Create a sandbox with auto-pause disabled
+		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(true))
+		sbxId := sbx.SandboxID
+
+		// Pause the sandbox
+		resp, err := c.PostSandboxesSandboxIDPauseWithResponse(t.Context(), sbxId, setup.WithAPIKey())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNoContent, resp.StatusCode())
+
+		// Set timeout to 0 to force sandbox to be stopped
+		resp, err = c.PostSandboxesSandboxIDPauseWithResponse(t.Context(), sbxId, setup.WithAPIKey())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusConflict, resp.StatusCode())
+	})
 }

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
@@ -82,8 +82,7 @@ func TestSandboxPause(t *testing.T) {
 	})
 
 	t.Run("pause already paused sandbox", func(t *testing.T) {
-		// Create a sandbox with auto-pause disabled
-		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(true))
+		sbx := utils.SetupSandboxWithCleanup(t, c)
 		sbxId := sbx.SandboxID
 
 		// Pause the sandbox

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go
@@ -91,7 +91,7 @@ func TestSandboxPause(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusNoContent, resp.StatusCode())
 
-		// Set timeout to 0 to force sandbox to be stopped
+		// Try to pause the sandbox again
 		resp, err = c.PostSandboxesSandboxIDPauseWithResponse(t.Context(), sbxId, setup.WithAPIKey())
 		require.NoError(t, err)
 		require.Equal(t, http.StatusConflict, resp.StatusCode())


### PR DESCRIPTION
If we don't find the sandbox we should still check if the sandbox isn't already paused as we did before #1159 ([diff](https://github.com/e2b-dev/infra/pull/1159/files#diff-386acd384222ddabf0b05d4ee11c6e4b594228bb87be66dad56e8881dd321a08))


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors pause handler to check snapshots when sandbox isn’t running, returning 409 if already paused or 404 if no snapshot, and adds an integration test for the already-paused case.
> 
> - **Backend**:
>   - **Pause handling**: In `packages/api/internal/handlers/sandbox_pause.go`, centralizes non-running logic via `pauseHandleNotRunningSandbox(...)`.
>     - When `GetSandbox` fails or `RemoveSandbox` returns `ErrSandboxNotFound`, checks `GetLastSnapshot(...)` to determine response:
>       - Returns `409 Conflict` if snapshot exists (already paused).
>       - Returns `404 Not Found` if no snapshot.
>       - Returns `500 Internal Server Error` on DB errors.
> - **Tests**:
>   - Adds integration test `pause already paused sandbox` in `tests/integration/internal/tests/api/sandboxes/sandbox_pause_test.go` asserting `409 Conflict` on second pause.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit defa2ef7d039477023834bc494b72f97e28323fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->