### PR TITLE
Fix flaky sandbox metrics test

### DIFF
--- a/tests/integration/internal/tests/api/metrics/sandbox_list_metrics_test.go
+++ b/tests/integration/internal/tests/api/metrics/sandbox_list_metrics_test.go
@@ -31,7 +31,7 @@ func TestSandboxListMetrics(t *testing.T) {
 
 		require.NotNil(t, response.JSON200)
 		require.NotNil(t, response.JSON200.Sandboxes)
-		if len(response.JSON200.Sandboxes) == 0 {
+		if len(response.JSON200.Sandboxes) < 2 {
 			return false
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make the integration test wait until metrics for both sandboxes are returned (len < 2) before proceeding to reduce flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ef60f280a27097ce3c8531f0e29760ec55915c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->