### PR TITLE
Fix compilation and linting issue

### DIFF
--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -140,7 +140,7 @@ func newOtelCore(ctx context.Context, opts opts) (zapcore.Core, error) {
 		return nil, fmt.Errorf("failed to create logs exporter: %w", err)
 	}
 
-	loggerProvider := telemetry.NewLogProvider(ctx, logsExporter, resource)
+	loggerProvider := telemetry.NewLogProvider(logsExporter, resource)
 	otelCore := logger.GetOTELCore(loggerProvider, serviceName)
 	return otelCore, nil
 }

--- a/packages/orchestrator/internal/sandbox/template/mask_template.go
+++ b/packages/orchestrator/internal/sandbox/template/mask_template.go
@@ -38,7 +38,7 @@ func NewMaskTemplate(
 	return t
 }
 
-func (c *MaskTemplate) Close(ctx context.Context) error {
+func (c *MaskTemplate) Close(_ context.Context) error {
 	if c.memfile != nil {
 		return (*c.memfile).Close()
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust telemetry logger provider call to new signature and mark unused context in MaskTemplate.Close to satisfy lint/compile.
> 
> - **Orchestrator**:
>   - **Telemetry**: Update `telemetry.NewLogProvider` call in `packages/orchestrator/cmd/clean-nfs-cache/main.go` to new signature `NewLogProvider(logsExporter, resource)` and wire into OTEL core setup.
>   - **Sandbox Template**: Mark unused parameter in `MaskTemplate.Close(_ context.Context)` in `packages/orchestrator/internal/sandbox/template/mask_template.go` to silence lint warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c4315d3f14b71772c5e877f2eb52839c4b2e12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->