### PR TITLE
Add tracing to consul client

### DIFF
--- a/packages/orchestrator/go.mod
+++ b/packages/orchestrator/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/vishvananda/netlink v1.3.1-0.20240922070040-084abd93d350
 	github.com/vishvananda/netns v0.0.5
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
@@ -232,7 +233,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.0 // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.13.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -80,7 +80,7 @@ func (p *Pool) createNetworkSlot() (*Slot, error) {
 
 	err = ips.CreateNetwork()
 	if err != nil {
-		releaseErr := p.slotStorage.Release(ips)
+		releaseErr := p.slotStorage.Release(p.ctx, ips)
 		err = errors.Join(err, releaseErr)
 
 		return nil, fmt.Errorf("failed to create network: %w", err)
@@ -172,7 +172,7 @@ func (p *Pool) cleanup(slot *Slot) error {
 		errs = append(errs, fmt.Errorf("cannot remove network when releasing slot '%d': %w", slot.Idx, err))
 	}
 
-	err = p.slotStorage.Release(slot)
+	err = p.slotStorage.Release(p.ctx, slot)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("failed to release slot '%d': %w", slot.Idx, err))
 	}

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -9,7 +9,7 @@ import (
 
 type Storage interface {
 	Acquire(ctx context.Context) (*Slot, error)
-	Release(s *Slot) error
+	Release(ctx context.Context, s *Slot) error
 }
 
 // NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -97,7 +97,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 	}
 }
 
-func (s *StorageLocal) Release(ips *Slot) error {
+func (s *StorageLocal) Release(_ context.Context, ips *Slot) error {
 	s.acquiredNsMu.Lock()
 	defer s.acquiredNsMu.Unlock()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds OpenTelemetry HTTP instrumentation to the Consul client and threads context through storage Acquire/Release, updating implementations and callers.
> 
> - **Networking / Storage**:
>   - **Tracing**: Instrument Consul client with `otelhttp` by setting `config.HttpClient.Transport` in `storage_kv.go`.
>   - **Context propagation**:
>     - Update `Storage` interface to `Release(ctx, s *Slot)` and implement in `storage_kv.go` and `storage_local.go`.
>     - Pass `ctx` to Consul KV ops via `WriteOptions.WithContext(ctx)` and `QueryOptions.WithContext(ctx)`.
>     - Update `pool.go` to call `Release(p.ctx, ...)` in error paths and cleanup.
> - **Dependencies**:
>   - Promote `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0` to direct dependency in `go.mod`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c39ab9991667cc6026a89a0fef6a183dfffcf73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->