### PR TITLE
Refactor network pool to avoid embedded context

### DIFF
--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -17,7 +17,6 @@ const (
 )
 
 type Pool struct {
-	ctx    context.Context //nolint:containedctx // todo: refactor so this can be removed
 	cancel context.CancelFunc
 
 	newSlots          chan *Slot
@@ -55,7 +54,6 @@ func NewPool(ctx context.Context, meterProvider metric.MeterProvider, newSlotsPo
 		reusedSlots:       reusedSlots,
 		newSlotCounter:    newSlotCounter,
 		reusedSlotCounter: reusedSlotsCounter,
-		ctx:               ctx,
 		cancel:            cancel,
 		slotStorage:       slotStorage,
 	}
@@ -72,8 +70,8 @@ func NewPool(ctx context.Context, meterProvider metric.MeterProvider, newSlotsPo
 	return pool, nil
 }
 
-func (p *Pool) createNetworkSlot() (*Slot, error) {
-	ips, err := p.slotStorage.Acquire(p.ctx)
+func (p *Pool) createNetworkSlot(ctx context.Context) (*Slot, error) {
+	ips, err := p.slotStorage.Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create network: %w", err)
 	}
@@ -98,7 +96,7 @@ func (p *Pool) populate(ctx context.Context) error {
 			// Do not return an error here, this is expected on close
 			return nil
 		default:
-			slot, err := p.createNetworkSlot()
+			slot, err := p.createNetworkSlot(ctx)
 			if err != nil {
 				zap.L().Error("[network slot pool]: failed to create network", zap.Error(err))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Eliminates embedded context from `Pool`, passing `ctx` explicitly to `createNetworkSlot` and its callers.
> 
> - **Network Pool (`packages/orchestrator/internal/sandbox/network/pool.go`)**:
>   - Remove embedded `ctx` from `Pool` and its initialization.
>   - Change `createNetworkSlot` to `createNetworkSlot(ctx context.Context)` and use passed `ctx` for `slotStorage.Acquire`.
>   - Update `populate` to call `createNetworkSlot(ctx)` and keep counters/channel operations unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0155f290277d3cd8ab2f393ff06a0c2046af6a4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->