### PR TITLE
Run http logs exporter only once and async

### DIFF
--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -88,7 +88,7 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 			w.mmdsLock.Unlock()
 
 			w.startOnce.Do(func() {
-				w.start(ctx)
+				go w.start(ctx)
 			})
 		}
 	}

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	Version = "0.3.4"
+	Version = "0.3.5"
 
 	commitSHA string
 


### PR DESCRIPTION
Fixes issue where updates of `mmdsChan` are silenced forever as we start http logger exporter sync that forever blocks the loop.  This was actually causing logger MMDs not to be updated after the sandbox resumed.

Related to https://github.com/e2b-dev/infra/pull/1243, as this is the reason why older sandboxes started before the introduction of the hyperloop server are still sending logs to the old IP address after the sandbox was paused and resumed later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Start HTTP logs exporter asynchronously to prevent blocking MMDS updates and bump version to 0.3.5.
> 
> - **Logs**:
>   - `packages/envd/internal/logs/exporter/exporter.go`: Run `start(ctx)` in a goroutine on first MMDS update to avoid blocking the listener and allow ongoing MMDS updates.
> - **Version**:
>   - `packages/envd/main.go`: Bump `Version` to `0.3.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9ac4b0769c06c96bd3bf5d83b593a08b70e50e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->