### PR TITLE
Forbid the `new` function from being used

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - errchkjson
     - exhaustive
     - exhaustruct
-    - forbidigo  # enable this when we're committed to avoiding os.Getenv
     - funcorder
     - funlen
     - gochecknoglobals
@@ -70,11 +69,12 @@ linters:
     # disabled intentionally
 
   settings:
-    # enable this when we're committed to avoiding os.Getenv
-    #    forbidigo:
-    #      forbid:
-    #        - pattern: os\.Getenv
-    #          msg: Add your field to the configuration model instead.
+    forbidigo:
+      forbid:
+        - pattern: "^new$"
+          msg: "Use &Type{} instead."
+#        - pattern: os\.Getenv
+#          msg: "Add your field to the configuration model instead."
 
     gocritic:
       disabled-checks:

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -45,13 +45,13 @@ var (
 func dnsResolution(sandboxId string, logger *zap.Logger) (string, error) {
 	var err error
 
-	msg := new(dns.Msg)
+	var msg dns.Msg
 	msg.SetQuestion(fmt.Sprintf("%s.", sandboxId), dns.TypeA)
 
 	var node string
 	for i := range maxRetries {
 		// send the query to the server
-		resp, _, dnsErr := dnsClient.Exchange(msg, dnsServer)
+		resp, _, dnsErr := dnsClient.Exchange(&msg, dnsServer)
 
 		// the api server wasn't found, maybe the API server is rolling and the DNS server is not updated yet
 		if dnsErr != nil || len(resp.Answer) == 0 {

--- a/packages/client-proxy/internal/service-discovery/dns-service-discovery.go
+++ b/packages/client-proxy/internal/service-discovery/dns-service-discovery.go
@@ -88,11 +88,11 @@ func (sd *DnsServiceDiscovery) sync(ctx context.Context) {
 		return
 	default:
 		for _, host := range sd.hosts {
-			msg := new(dns.Msg)
+			var msg dns.Msg
 			msg.SetQuestion(dns.Fqdn(host), dns.TypeA)
 
 			for range dnsMaxRetries {
-				response, _, err := dnsClient.Exchange(msg, sd.resolver)
+				response, _, err := dnsClient.Exchange(&msg, sd.resolver)
 				if err != nil {
 					sd.logger.Error("DNS service discovery failed", zap.Error(err))
 					time.Sleep(dnsRetryWait)

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -53,7 +53,7 @@ func (opts *MMDSOpts) AddOptsToJSON(jsonLogs []byte) ([]byte, error) {
 }
 
 func getMMDSToken(ctx context.Context, client *http.Client) (string, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://"+mmdsDefaultAddress+"/latest/api/token", new(bytes.Buffer))
+	request, err := http.NewRequestWithContext(ctx, http.MethodPut, "http://"+mmdsDefaultAddress+"/latest/api/token", &bytes.Buffer{})
 	if err != nil {
 		return "", err
 	}
@@ -81,7 +81,7 @@ func getMMDSToken(ctx context.Context, client *http.Client) (string, error) {
 }
 
 func getMMDSOpts(ctx context.Context, client *http.Client, token string) (*MMDSOpts, error) {
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+mmdsDefaultAddress, new(bytes.Buffer))
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+mmdsDefaultAddress, &bytes.Buffer{})
 	if err != nil {
 		return nil, err
 	}

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -187,7 +187,7 @@ func httpGet(t *testing.T, proxyURL string) (*http.Response, error) {
 		return nil, err
 	}
 
-	rsp, err := new(http.Client).Do(req)
+	rsp, err := (&http.Client{}).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/shared/pkg/proxy/template/template.go
+++ b/packages/shared/pkg/proxy/template/template.go
@@ -21,9 +21,9 @@ type TemplatedError[T jsonErrorMessage] struct {
 }
 
 func (e *TemplatedError[T]) buildHtml() ([]byte, error) {
-	html := new(bytes.Buffer)
+	var html bytes.Buffer
 
-	err := e.template.Execute(html, e.vars)
+	err := e.template.Execute(&html, e.vars)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // Test constants
@@ -415,7 +417,7 @@ func TestMultipartUploader_PartialFailures_Recovery(t *testing.T) {
 			partNumStr := strings.Split(strings.Split(r.URL.RawQuery, "partNumber=")[1], "&")[0]
 
 			// Track attempts per part
-			val, _ := partAttempts.LoadOrStore(partNumStr, new(int32))
+			val, _ := partAttempts.LoadOrStore(partNumStr, utils.ToPtr(int32(0)))
 			attempts := val.(*int32)
 			currentAttempts := atomic.AddInt32(attempts, 1)
 
@@ -677,7 +679,7 @@ func TestMultipartUploader_ConcurrentRetries_RaceCondition(t *testing.T) {
 			partNumStr := strings.Split(strings.Split(r.URL.RawQuery, "partNumber=")[1], "&")[0]
 
 			// Track retry attempts per part with race-safe operations
-			val, _ := retryAttempts.LoadOrStore(partNumStr, new(int32))
+			val, _ := retryAttempts.LoadOrStore(partNumStr, utils.ToPtr(int32(0)))
 			attempts := val.(*int32)
 			currentAttempt := atomic.AddInt32(attempts, 1)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables a lint rule forbidding `new` and refactors code/tests to use composite literals or address-of variables instead.
> 
> - **Linting**:
>   - **.golangci.yml**: Enable `forbidigo` with rule forbidding `^new$` (message: "Use &Type{} instead.").
> - **Refactors (replace `new` usage)**:
>   - `packages/client-proxy/internal/proxy/proxy.go`: Use `var msg dns.Msg` and pass `&msg` to `dnsClient.Exchange`.
>   - `packages/client-proxy/internal/service-discovery/dns-service-discovery.go`: Same `dns.Msg` refactor and `&msg` usage.
>   - `packages/envd/internal/host/mmds.go`: Use `&bytes.Buffer{}` in `http.NewRequestWithContext`.
>   - `packages/shared/pkg/proxy/template/template.go`: Use `bytes.Buffer` value and pass `&html` to `template.Execute`.
>   - `packages/shared/pkg/proxy/proxy_test.go`: Use `&http.Client{}` instead of `new(http.Client)`.
>   - `packages/shared/pkg/storage/gcp_multipart_test.go`: Use `utils.ToPtr(int32(0))` instead of `new(int32)` when storing in `sync.Map`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7d417215a7deb60a6015985e0f8544e5a55e7d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->