### PR TITLE
Fix incorrect copy . . handling

### DIFF
--- a/packages/orchestrator/internal/template/build/commands/copy.go
+++ b/packages/orchestrator/internal/template/build/commands/copy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/sandboxtools"
@@ -67,7 +68,8 @@ elif [ -f "$entry" ]; then
 elif [ -d "$entry" ]; then
  # It's a directory – move all its contents into the destination folder
  mkdir -p "$targetPath"
- mv "$entry"/* "$targetPath/"
+ # Move all contents including hidden files
+ find "$entry" -mindepth 1 -maxdepth 1 -exec mv {} "$targetPath/" \;
 else
  echo "Error: entry is neither file nor directory"
  exit 1
@@ -87,7 +89,7 @@ fi
 // because the /tmp is mounted as a tmpfs and deleted on restart.
 func (c *Copy) Execute(
 	ctx context.Context,
-	_ *zap.Logger,
+	logger *zap.Logger,
 	proxy *proxy.SandboxProxy,
 	sandboxID string,
 	_ string,
@@ -141,7 +143,8 @@ func (c *Copy) Execute(
 		return metadata.Context{}, fmt.Errorf("failed to copy layer tar data to sandbox: %w", err)
 	}
 
-	sbxUnpackPath := filepath.Join("/tmp", step.GetFilesHash())
+	// Create nested unpack directory to allow multiple files in the root be correctly detected
+	sbxUnpackPath := filepath.Join("/tmp", step.GetFilesHash(), "unpack")
 
 	// 3) Extract the tar file in the sandbox's /tmp directory
 	err = sandboxtools.RunCommand(
@@ -169,9 +172,12 @@ func (c *Copy) Execute(
 		return metadata.Context{}, fmt.Errorf("failed to execute copy script template: %w", err)
 	}
 
-	err = sandboxtools.RunCommand(
+	err = sandboxtools.RunCommandWithLogger(
 		ctx,
 		proxy,
+		logger,
+		zapcore.DebugLevel,
+		"unpack",
 		sandboxID,
 		moveScript.String(),
 		cmdMetadata,


### PR DESCRIPTION
Fix incorrect copy . . handling. 

When the `COPY . .` instruction was used, all files were in the unpacked directory. Because the copy is detected by `ls -A | head -n 1` and the parent folder was `tmp`, invalid decision was done and incorrect folder was copied. Adding a nested folder should fix it as the parent folder will have only one folder, the unpack one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes COPY handling by unpacking into a nested dir, correctly moving hidden files, and adding debug-logged execution.
> 
> - **Build/Copy Command**:
>   - Unpack into nested `/tmp/<hash>/unpack` to correctly handle `COPY . .` root detection.
>   - Move directory contents via `find ... -exec mv` to include hidden files.
> - **Logging**:
>   - Use `RunCommandWithLogger` with provided `logger` at `zapcore.DebugLevel` for the unpack/move step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43310cd6abc0990017c1541f268a297423734e42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->