### PR TITLE
IGNORE THIS JUST A TEST

### DIFF
--- a/packages/orchestrator/internal/cfg/model.go
+++ b/packages/orchestrator/internal/cfg/model.go
@@ -13,7 +13,6 @@ type Config struct {
 	GRPCPort                   uint16   `env:"GRPC_PORT"                    envDefault:"5008"`
 	LaunchDarklyAPIKey         string   `env:"LAUNCH_DARKLY_API_KEY"`
 	OrchestratorBasePath       string   `env:"ORCHESTRATOR_BASE_PATH"       envDefault:"/orchestrator"`
-	OrchestratorLockPath       string   `env:"ORCHESTRATOR_LOCK_PATH"       envDefault:"/orchestrator.lock"`
 	ProxyPort                  uint16   `env:"PROXY_PORT"                   envDefault:"5007"`
 	RedisClusterURL            string   `env:"REDIS_CLUSTER_URL"`
 	RedisURL                   string   `env:"REDIS_URL"`


### PR DESCRIPTION
IGNORE THIS JUST A TEST

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the lock-file crash/restart guard from orchestrator startup and drops the `Config.OrchestratorLockPath` field.
> 
> - **Orchestrator**:
>   - Remove lock-file startup guard logic from `packages/orchestrator/main.go` (no longer creates/checks `/orchestrator.lock`).
>   - Drop `Config.OrchestratorLockPath` and its env `ORCHESTRATOR_LOCK_PATH` from `packages/orchestrator/internal/cfg/model.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d9a28344d2f7118a35bec7295a78b1a6dfa98e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->