### PR TITLE
Improve error message for invalid template when registering build

### DIFF
--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -130,7 +130,7 @@ func RegisterBuild(
 			telemetry.ReportCriticalError(ctx, "invalid alias", err)
 			return nil, &api.APIError{
 				Err:       err,
-				ClientMsg: fmt.Sprintf("Invalid alias: %s", alias),
+				ClientMsg: fmt.Sprintf("Invalid alias: %s", *data.Alias),
 				Code:      http.StatusBadRequest,
 			}
 		}


### PR DESCRIPTION
When starting a build with an invalid alias you would get:

`Error requesting template build: [400] bad request: Invalid alias: `

because `alias` is always an empty string if validation fails. Now, we return the original env ID. This makes the error handling also consistent with the other places where `id.CleanEnvID` is used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses the original input alias in the invalid-alias error message in `register_build.go` instead of the cleaned (often empty) value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec6f8841d7ca8d002affa867e7673690d464a04a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->