### PR TITLE
Expose some counters to nbd and network pools

### DIFF
--- a/packages/orchestrator/benchmark_test.go
+++ b/packages/orchestrator/benchmark_test.go
@@ -128,7 +128,7 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 	sbxlogger.SetSandboxLoggerInternal(logger)
 	// sbxlogger.SetSandboxLoggerExternal(logger)
 
-	networkPool, err := network.NewPool(noop.MeterProvider{}, 8, 8, clientID, networkConfig)
+	networkPool, err := network.NewPool(8, 8, clientID, networkConfig)
 	require.NoError(b, err)
 	go func() {
 		networkPool.Populate(b.Context())
@@ -139,7 +139,7 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 		assert.NoError(b, err)
 	}()
 
-	devicePool, err := nbd.NewDevicePool(noop.MeterProvider{})
+	devicePool, err := nbd.NewDevicePool()
 	require.NoError(b, err, "do you have the nbd kernel module installed?")
 	go func() {
 		devicePool.Populate(b.Context())

--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -116,7 +116,7 @@ func buildTemplate(
 		return fmt.Errorf("could not create storage provider: %w", err)
 	}
 
-	devicePool, err := nbd.NewDevicePool(noop.MeterProvider{})
+	devicePool, err := nbd.NewDevicePool()
 	if err != nil {
 		return fmt.Errorf("could not create device pool: %w", err)
 	}
@@ -130,7 +130,7 @@ func buildTemplate(
 		}
 	}()
 
-	networkPool, err := network.NewPool(noop.MeterProvider{}, 8, 8, clientID, networkConfig)
+	networkPool, err := network.NewPool(8, 8, clientID, networkConfig)
 	if err != nil {
 		return fmt.Errorf("could not create network pool: %w", err)
 	}

--- a/packages/orchestrator/cmd/mock-nbd/mock.go
+++ b/packages/orchestrator/cmd/mock-nbd/mock.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pojntfx/go-nbd/pkg/backend"
-	"go.opentelemetry.io/otel/metric/noop"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
@@ -87,7 +86,7 @@ func main() {
 
 	done := make(chan os.Signal, 1)
 	signal.Notify(done, os.Interrupt)
-	devicePool, err := nbd.NewDevicePool(noop.MeterProvider{})
+	devicePool, err := nbd.NewDevicePool()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create device pool: %v\n", err)
 		return

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -7,15 +7,43 @@ import (
 	"sync"
 
 	"github.com/caarlos0/env/v11"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const (
 	NewSlotsPoolSize    = 32
 	ReusedSlotsPoolSize = 100
+)
+
+var (
+	meter = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network")
+
+	newSlotsAvailableCounter = utils.Must(meter.Int64UpDownCounter("orchestrator.network.slots_pool.new",
+		metric.WithDescription("Number of new network slots ready to be used."),
+		metric.WithUnit("{slot"),
+	))
+	reusableSlotsAvailableCounter = utils.Must(meter.Int64UpDownCounter("orchestrator.network.slots_pool.reused",
+		metric.WithDescription("Number of reused network slots ready to be used."),
+		metric.WithUnit("{slot}"),
+	))
+	acquiredSlots = utils.Must(meter.Int64Counter("orchestrator.network.slots_pool.acquired",
+		metric.WithDescription("Number of network slots acquired."),
+		metric.WithUnit("{slot}"),
+	))
+	returnedSlotCounter = utils.Must(meter.Int64Counter("orchestrator.network.slots_pool.returned",
+		metric.WithDescription("Number of network slots returned."),
+		metric.WithUnit("{slot}"),
+	))
+	releasedSlotCounter = utils.Must(meter.Int64Counter("orchestrator.network.slots_pool.released",
+		metric.WithDescription("Number of network slots released."),
+		metric.WithUnit("{slot}"),
+	))
 )
 
 type Config struct {
@@ -36,31 +64,17 @@ type Pool struct {
 	done     chan struct{}
 	doneOnce sync.Once
 
-	newSlots          chan *Slot
-	reusedSlots       chan *Slot
-	newSlotCounter    metric.Int64UpDownCounter
-	reusedSlotCounter metric.Int64UpDownCounter
+	newSlots    chan *Slot
+	reusedSlots chan *Slot
 
 	slotStorage Storage
 }
 
 var ErrClosed = errors.New("cannot read from a closed pool")
 
-func NewPool(meterProvider metric.MeterProvider, newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string, config Config) (*Pool, error) {
+func NewPool(newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string, config Config) (*Pool, error) {
 	newSlots := make(chan *Slot, newSlotsPoolSize-1)
 	reusedSlots := make(chan *Slot, reusedSlotsPoolSize)
-
-	meter := meterProvider.Meter("orchestrator.network.pool")
-
-	newSlotCounter, err := telemetry.GetUpDownCounter(meter, telemetry.NewNetworkSlotSPoolCounterMeterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create new slot counter: %w", err)
-	}
-
-	reusedSlotsCounter, err := telemetry.GetUpDownCounter(meter, telemetry.ReusedNetworkSlotSPoolCounterMeterName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create reused slot counter: %w", err)
-	}
 
 	slotStorage, err := NewStorage(vrtSlotsSize, nodeID, config)
 	if err != nil {
@@ -68,13 +82,11 @@ func NewPool(meterProvider metric.MeterProvider, newSlotsPoolSize, reusedSlotsPo
 	}
 
 	pool := &Pool{
-		config:            config,
-		done:              make(chan struct{}),
-		newSlots:          newSlots,
-		reusedSlots:       reusedSlots,
-		newSlotCounter:    newSlotCounter,
-		reusedSlotCounter: reusedSlotsCounter,
-		slotStorage:       slotStorage,
+		config:      config,
+		done:        make(chan struct{}),
+		newSlots:    newSlots,
+		reusedSlots: reusedSlots,
+		slotStorage: slotStorage,
 	}
 
 	return pool, nil
@@ -114,7 +126,7 @@ func (p *Pool) Populate(ctx context.Context) {
 				continue
 			}
 
-			p.newSlotCounter.Add(ctx, 1)
+			newSlotsAvailableCounter.Add(ctx, 1)
 			p.newSlots <- slot
 		}
 	}
@@ -127,7 +139,8 @@ func (p *Pool) Get(ctx context.Context, allowInternet bool) (*Slot, error) {
 	case <-p.done:
 		return nil, ErrClosed
 	case s := <-p.reusedSlots:
-		p.reusedSlotCounter.Add(ctx, -1)
+		reusableSlotsAvailableCounter.Add(ctx, -1)
+		acquiredSlots.Add(ctx, 1, metric.WithAttributes(attribute.String("pool", "reused")))
 		telemetry.ReportEvent(ctx, "reused network slot")
 
 		slot = s
@@ -138,7 +151,8 @@ func (p *Pool) Get(ctx context.Context, allowInternet bool) (*Slot, error) {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case s := <-p.newSlots:
-			p.newSlotCounter.Add(ctx, -1)
+			newSlotsAvailableCounter.Add(ctx, -1)
+			acquiredSlots.Add(ctx, 1, metric.WithAttributes(attribute.String("pool", "new")))
 			telemetry.ReportEvent(ctx, "new network slot")
 
 			slot = s
@@ -165,7 +179,7 @@ func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 	err := slot.ResetInternet(ctx)
 	if err != nil {
 		// Cleanup the slot if resetting internet fails
-		if cerr := p.cleanup(slot); cerr != nil {
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
 			return fmt.Errorf("reset internet: %w; cleanup: %w", err, cerr)
 		}
 
@@ -178,9 +192,10 @@ func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 	case <-p.done:
 		return ErrClosed
 	case p.reusedSlots <- slot:
-		p.reusedSlotCounter.Add(ctx, 1)
+		returnedSlotCounter.Add(ctx, 1)
+		reusableSlotsAvailableCounter.Add(ctx, 1)
 	default:
-		err := p.cleanup(slot)
+		err := p.cleanup(ctx, slot)
 		if err != nil {
 			return fmt.Errorf("failed to return slot '%d': %w", slot.Idx, err)
 		}
@@ -189,7 +204,7 @@ func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 	return nil
 }
 
-func (p *Pool) cleanup(slot *Slot) error {
+func (p *Pool) cleanup(ctx context.Context, slot *Slot) error {
 	var errs []error
 
 	err := slot.RemoveNetwork()
@@ -202,10 +217,12 @@ func (p *Pool) cleanup(slot *Slot) error {
 		errs = append(errs, fmt.Errorf("failed to release slot '%d': %w", slot.Idx, err))
 	}
 
+	releasedSlotCounter.Add(ctx, 1)
+
 	return errors.Join(errs...)
 }
 
-func (p *Pool) Close(_ context.Context) error {
+func (p *Pool) Close(ctx context.Context) error {
 	zap.L().Info("Closing network pool")
 
 	p.doneOnce.Do(func() {
@@ -215,7 +232,7 @@ func (p *Pool) Close(_ context.Context) error {
 	var errs []error
 
 	for slot := range p.newSlots {
-		err := p.cleanup(slot)
+		err := p.cleanup(ctx, slot)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
 		}
@@ -224,7 +241,7 @@ func (p *Pool) Close(_ context.Context) error {
 	close(p.reusedSlots)
 
 	for slot := range p.reusedSlots {
-		err := p.cleanup(slot)
+		err := p.cleanup(ctx, slot)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
 		}

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -326,7 +326,7 @@ func run(config cfg.Config) (success bool) {
 	closers = append(closers, closer{"sandbox proxy", sandboxProxy.Close})
 
 	// device pool
-	devicePool, err := nbd.NewDevicePool(tel.MeterProvider)
+	devicePool, err := nbd.NewDevicePool()
 	if err != nil {
 		zap.L().Fatal("failed to create device pool", zap.Error(err))
 	}
@@ -337,7 +337,7 @@ func run(config cfg.Config) (success bool) {
 	closers = append(closers, closer{"device pool", devicePool.Close})
 
 	// network pool
-	networkPool, err := network.NewPool(tel.MeterProvider, network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, nodeID, config.NetworkConfig)
+	networkPool, err := network.NewPool(network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, nodeID, config.NetworkConfig)
 	if err != nil {
 		zap.L().Fatal("failed to create network pool", zap.Error(err))
 	}

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -34,10 +34,7 @@ const (
 )
 
 const (
-	SandboxCountMeterName                  UpDownCounterType = "api.env.instance.running"
-	NewNetworkSlotSPoolCounterMeterName    UpDownCounterType = "orchestrator.network.slots_pool.new"
-	ReusedNetworkSlotSPoolCounterMeterName UpDownCounterType = "orchestrator.network.slots_pool.reused"
-	NBDkSlotSReadyPoolCounterMeterName     UpDownCounterType = "orchestrator.nbd.slots_pool.read"
+	SandboxCountMeterName UpDownCounterType = "api.env.instance.running"
 )
 
 const (
@@ -120,17 +117,11 @@ var observableCounterUnits = map[ObservableCounterType]string{
 }
 
 var upDownCounterDesc = map[UpDownCounterType]string{
-	SandboxCountMeterName:                  "Counter of started instances.",
-	ReusedNetworkSlotSPoolCounterMeterName: "Number of reused network slots ready to be used.",
-	NewNetworkSlotSPoolCounterMeterName:    "Number of new network slots ready to be used.",
-	NBDkSlotSReadyPoolCounterMeterName:     "Number of nbd slots ready to be used.",
+	SandboxCountMeterName: "Counter of started instances.",
 }
 
 var upDownCounterUnits = map[UpDownCounterType]string{
-	SandboxCountMeterName:                  "{sandbox}",
-	ReusedNetworkSlotSPoolCounterMeterName: "{slot}",
-	NewNetworkSlotSPoolCounterMeterName:    "{slot}",
-	NBDkSlotSReadyPoolCounterMeterName:     "{slot}",
+	SandboxCountMeterName: "{sandbox}",
 }
 
 var observableUpDownCounterDesc = map[ObservableUpDownCounterType]string{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds OTEL metrics for nbd/network pools and simplifies APIs by removing MeterProvider parameters, updating call sites accordingly.
> 
> - **Telemetry/metrics**:
>   - **NBD pool (`internal/sandbox/nbd/pool.go`)**:
>     - Add OTEL counters: `slots_pool.ready` (up/down), `slots_pool.acquired`, `slots_pool.released`.
>     - Track acquisitions, releases, and ready count; change `release` to accept `ctx`.
>   - **Network pool (`internal/sandbox/network/pool.go`)**:
>     - Add OTEL counters: `slots_pool.new`/`reused` (up/down), `slots_pool.acquired` (with `pool` attr), `slots_pool.returned`, `slots_pool.released`.
>     - Use new counters in `Populate`, `Get`, `Return`, `cleanup`, `Close`; `cleanup`/`Close` now accept `ctx`.
>   - **Shared telemetry (`shared/pkg/telemetry/meters.go`)**:
>     - Remove pool-specific UpDownCounter names now defined locally in pools.
> - **API changes**:
>   - `nbd.NewDevicePool()` no longer takes a `MeterProvider`.
>   - `network.NewPool(newSize, reusedSize, nodeID, config)` no longer takes a `MeterProvider`.
>   - Update all call sites (benchmarks, CLI, orchestrator main, mock-nbd) to new signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc3aa2087c569b05ab04a52cc3f1dfcdd4797aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->