### PR TITLE
Update the time comparison in periodic tests

### DIFF
--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -96,8 +96,8 @@ try {
   console.log("local date - end of request", localDateEnd);
   console.log("sandbox date", dateUnix);
 
-  // check if date is sandbox within 1 second of local
-  if ((dateUnix - localDateStart > 1) || (localDateEnd - dateUnix) > 1) {
+  // check if the diff between sandbox time and local time is less than 1 second (taking into consideration the request latency)
+  if (dateUnix < localDateStart - 1 || dateUnix > localDateEnd + 1) {
     throw new Error("❌ Date is not synchronized");
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the time sync test to compare sandbox time against local request start/end with a 1s tolerance and adds clearer timing logs.
> 
> - **Tests**:
>   - **`tests/periodic-test/time-is-synchronized/index.ts`**:
>     - Use `localDateStart` and `localDateEnd` around the command run to bound latency.
>     - Change comparison to ensure sandbox `dateUnix` is within `[localDateStart - 1, localDateEnd + 1]`.
>     - Add concise logs for start/end local times and sandbox time; remove older single-timestamp logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 009bdcd94c08e3624ef01597e90f5a597804e29e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->