### PR TITLE
Update stanza in edge

### DIFF
--- a/iac/provider-gcp/nomad/jobs/edge.hcl
+++ b/iac/provider-gcp/nomad/jobs/edge.hcl
@@ -71,10 +71,10 @@ job "client-proxy" {
 %{ if update_stanza }
     # An update stanza to enable rolling updates of the service
     update {
-      # The number of extra instances to run during the update
+      # The number of instances that can be updated at the same time
       max_parallel     = ${update_max_parallel}
-      # Allows to spawn new version of the service before killing the old one
-      canary           = 1
+      # Number of extra instances that can be spawn before killing the old one
+      canary           = ${update_max_parallel}
       # Time to wait for the canary to be healthy
       min_healthy_time = "10s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust Nomad update strategy to make canary count match `update_max_parallel` and clarify related comments.
> 
> - **IaC (Nomad `edge.hcl`)**:
>   - **Update strategy**: Set `canary = ${update_max_parallel}` (was `1`) to allow multiple instances to update concurrently.
>   - **Comments**: Clarify that `max_parallel` is the number of instances updated simultaneously and that `canary` denotes extra instances spawned before killing old ones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34b24ead34258d07ca68aa275e5cbdbc8ef59ca5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->