### PR TITLE
Progress deadline and service update for ingress

### DIFF
--- a/iac/provider-gcp/nomad/jobs/ingress.hcl
+++ b/iac/provider-gcp/nomad/jobs/ingress.hcl
@@ -24,7 +24,18 @@ job "ingress" {
 # https://developer.hashicorp.com/nomad/docs/job-specification/update
 %{ if update_stanza }
     update {
-      max_parallel = 1    # Update only 1 node at a time
+      # The number of instances that can be updated at the same time
+      max_parallel     = 1
+      # Number of extra instances that can be spawn before killing the old one
+      canary           = 1
+      # Time to wait for the canary to be healthy
+      min_healthy_time = "10s"
+      # Time to wait for the canary to be healthy, if not it will be marked as failed
+      healthy_deadline = "30s"
+      # Whether to promote the canary if the rest of the group is not healthy
+      auto_promote     = true
+      # Deadline for the update to be completed
+      progress_deadline = "24h"
     }
 %{ endif }
 
@@ -49,7 +60,6 @@ job "ingress" {
       %{ if update_stanza }
         kill_timeout = "24h"
       %{ endif }
-
       kill_signal  = "SIGTERM"
 
       config {


### PR DESCRIPTION
Fixing the issue caused by previous tests with the system service that does not allow updates with the following settings.
We want to extend the progress deadline to 24 hours and set the maximum parallel and canary settings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures the ingress job’s Nomad update stanza with canary deployment, health timings, and a 24h progress deadline.
> 
> - **Nomad job update strategy** (`iac/provider-gcp/nomad/jobs/ingress.hcl`):
>   - Expand `update` stanza:
>     - `max_parallel = 1`, `canary = 1`
>     - `min_healthy_time = "10s"`, `healthy_deadline = "30s"`
>     - `auto_promote = true`, `progress_deadline = "24h"`
>   - Keep task behavior under `update_stanza` with `kill_timeout = "24h"`; retain `kill_signal = "SIGTERM"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88d850dc4919c2bb0cd79eef0f1df23026c1c8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->