### PR TITLE
Enable the nlreturn linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,6 @@ linters:
     - mnd
     - nestif
     - nilnil
-    - nlreturn
     - noinlineerr
     - nonamedreturns
     - nosprintfhostport

--- a/packages/api/internal/cache/auth/cache.go
+++ b/packages/api/internal/cache/auth/cache.go
@@ -60,6 +60,7 @@ func (c *TeamAuthCache) GetOrSet(ctx context.Context, key string, dataCallback D
 	if time.Since(templateInfo.lastRefresh) > refreshInterval {
 		go templateInfo.once.Do(key, func() (any, error) { //nolint:contextcheck // TODO: fix this later
 			c.Refresh(key, dataCallback)
+
 			return nil, err
 		})
 	}

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -38,5 +38,6 @@ type Config struct {
 func Parse() (Config, error) {
 	var config Config
 	err := env.Parse(&config)
+
 	return config, err
 }

--- a/packages/api/internal/db/apikeys.go
+++ b/packages/api/internal/db/apikeys.go
@@ -51,5 +51,6 @@ func GetTeamAuth(ctx context.Context, db *sqlcdb.Client, apiKey string) (*types.
 	}
 
 	team := types.NewTeam(&result.Team, &result.TeamLimit)
+
 	return team, nil
 }

--- a/packages/api/internal/db/user.go
+++ b/packages/api/internal/db/user.go
@@ -35,5 +35,6 @@ func GetTeamByIDAndUserIDAuth(ctx context.Context, db *sqlcdb.Client, teamID str
 	}
 
 	team := types.NewTeam(&result.Team, &result.TeamLimit)
+
 	return team, nil
 }

--- a/packages/api/internal/edge/cluster.go
+++ b/packages/api/internal/edge/cluster.go
@@ -56,9 +56,11 @@ func NewCluster(tel *telemetry.Client, endpoint string, endpointTLS bool, secret
 			c.RequestEditors,
 			func(_ context.Context, req *http.Request) error {
 				req.Header.Set(consts.EdgeApiAuthHeader, secret)
+
 				return nil
 			},
 		)
+
 		return nil
 	}
 
@@ -102,6 +104,7 @@ func NewCluster(tel *telemetry.Client, endpoint string, endpointTLS bool, secret
 func (c *Cluster) Close() error {
 	c.synchronization.Close()
 	err := c.grpcClient.Close()
+
 	return err
 }
 

--- a/packages/api/internal/edge/cluster_instances.go
+++ b/packages/api/internal/edge/cluster_instances.go
@@ -50,6 +50,7 @@ func (c *Cluster) syncInstance(ctx context.Context, instance *ClusterInstance) {
 	err = utils.UnwrapGRPCError(err)
 	if err != nil {
 		zap.L().Error("Failed to get instance info", zap.Error(err), l.WithClusterID(c.ID), l.WithNodeID(instance.NodeID), l.WithServiceInstanceID(instance.ServiceInstanceID))
+
 		return
 	}
 
@@ -63,12 +64,14 @@ func (c *Cluster) syncInstance(ctx context.Context, instance *ClusterInstance) {
 func (n *ClusterInstance) GetStatus() infogrpc.ServiceInfoStatus {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
+
 	return n.status
 }
 
 func (n *ClusterInstance) hasRole(r infogrpc.ServiceInfoRole) bool {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
+
 	return slices.Contains(n.roles, r)
 }
 
@@ -126,6 +129,7 @@ func (d clusterSynchronizationStore) PoolList(_ context.Context) []*ClusterInsta
 
 func (d clusterSynchronizationStore) PoolExists(_ context.Context, s api.ClusterOrchestratorNode) bool {
 	_, found := d.cluster.instances.Get(s.NodeID)
+
 	return found
 }
 

--- a/packages/api/internal/edge/pool.go
+++ b/packages/api/internal/edge/pool.go
@@ -142,11 +142,13 @@ func (d poolSynchronizationStore) PoolList(_ context.Context) []*Cluster {
 	for _, item := range d.pool.clusters.Items() {
 		items = append(items, item)
 	}
+
 	return items
 }
 
 func (d poolSynchronizationStore) PoolExists(_ context.Context, cluster queries.Cluster) bool {
 	_, found := d.pool.clusters.Get(cluster.ID.String())
+
 	return found
 }
 
@@ -165,6 +167,7 @@ func (d poolSynchronizationStore) PoolInsert(_ context.Context, cluster queries.
 	)
 	if err != nil {
 		zap.L().Error("Initializing cluster failed", zap.Error(err), l.WithClusterID(c.ID))
+
 		return
 	}
 

--- a/packages/api/internal/handlers/accesstoken.go
+++ b/packages/api/internal/handlers/accesstoken.go
@@ -91,6 +91,7 @@ func (a *APIStore) DeleteAccessTokensAccessTokenID(c *gin.Context, accessTokenID
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		c.String(http.StatusNotFound, "id not found")
+
 		return
 	} else if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when deleting access token: %s", err))

--- a/packages/api/internal/handlers/admin.go
+++ b/packages/api/internal/handlers/admin.go
@@ -24,11 +24,13 @@ func (a *APIStore) GetNodesNodeID(c *gin.Context, nodeID api.NodeID, params api.
 	if err != nil {
 		if errors.Is(err, orchestrator.ErrNodeNotFound) {
 			c.Status(http.StatusNotFound)
+
 			return
 		}
 
 		telemetry.ReportCriticalError(c.Request.Context(), "error when getting node details", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting node details")
+
 		return
 	}
 
@@ -51,6 +53,7 @@ func (a *APIStore) PostNodesNodeID(c *gin.Context, nodeId api.NodeID) {
 	node := a.orchestrator.GetNodeByIDOrNomadShortID(clusterID, nodeId)
 	if node == nil {
 		c.Status(http.StatusNotFound)
+
 		return
 	}
 
@@ -59,6 +62,7 @@ func (a *APIStore) PostNodesNodeID(c *gin.Context, nodeId api.NodeID) {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when sending status change: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when sending status change", err)
+
 		return
 	}
 

--- a/packages/api/internal/handlers/apikey.go
+++ b/packages/api/internal/handlers/apikey.go
@@ -26,6 +26,7 @@ func (a *APIStore) PatchApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
+
 		return
 	}
 
@@ -34,6 +35,7 @@ func (a *APIStore) PatchApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing API key ID: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when parsing API key ID", err)
+
 		return
 	}
 
@@ -48,11 +50,13 @@ func (a *APIStore) PatchApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		c.String(http.StatusNotFound, "id not found")
+
 		return
 	} else if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when updating team API key name: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when updating team API key name", err)
+
 		return
 	}
 
@@ -107,6 +111,7 @@ func (a *APIStore) DeleteApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing API key ID: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when parsing API key ID", err)
+
 		return
 	}
 
@@ -120,10 +125,12 @@ func (a *APIStore) DeleteApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when deleting API key: %s", err))
 
 		telemetry.ReportCriticalError(ctx, "error when deleting API key", err)
+
 		return
 	}
 	if len(ids) == 0 {
 		c.String(http.StatusNotFound, "id not found")
+
 		return
 	}
 

--- a/packages/api/internal/handlers/sandbox.go
+++ b/packages/api/internal/handlers/sandbox.go
@@ -65,6 +65,7 @@ func (a *APIStore) startSandbox(
 	)
 	if instanceErr != nil {
 		telemetry.ReportError(ctx, "error when creating instance", instanceErr.Err)
+
 		return nil, instanceErr
 	}
 

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -82,6 +82,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	if checkErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when getting template", checkErr.Err)
 		a.sendAPIStoreError(c, checkErr.Code, checkErr.ClientMsg)
+
 		return
 	}
 	templateSpan.End()
@@ -131,6 +132,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 
 		if timeout > time.Duration(teamInfo.Limits.MaxLengthHours)*time.Hour {
 			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Timeout cannot be greater than %d hours", teamInfo.Limits.MaxLengthHours))
+
 			return
 		}
 	}
@@ -146,6 +148,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		if tokenErr != nil {
 			zap.L().Error("Secure envd access token error", zap.Error(tokenErr.Err), logger.WithSandboxID(sandboxID), logger.WithBuildID(build.ID.String()))
 			a.sendAPIStoreError(c, tokenErr.Code, tokenErr.ClientMsg)
+
 			return
 		}
 
@@ -175,6 +178,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	if createErr != nil {
 		zap.L().Error("Failed to create sandbox", zap.Error(createErr.Err))
 		a.sendAPIStoreError(c, createErr.Code, createErr.ClientMsg)
+
 		return
 	}
 
@@ -223,6 +227,7 @@ func setTemplateNameMetric(c *gin.Context, aliases []string) {
 	for _, alias := range aliases {
 		if _, exists := mostUsedTemplates[alias]; exists {
 			c.Set(metricTemplateAlias, alias)
+
 			return
 		}
 	}
@@ -235,5 +240,6 @@ func firstAlias(aliases []string) string {
 	if len(aliases) == 0 {
 		return ""
 	}
+
 	return aliases[0]
 }

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -87,6 +87,7 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 		}
 
 		c.JSON(http.StatusOK, sandbox)
+
 		return
 	}
 

--- a/packages/api/internal/handlers/sandbox_kill.go
+++ b/packages/api/internal/handlers/sandbox_kill.go
@@ -91,6 +91,7 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	if err == nil {
 		if sbx.TeamID != teamID {
 			a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox \"%s\"", sandboxID))
+
 			return
 		}
 
@@ -102,10 +103,12 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 			zap.L().Debug("Sandbox not found", logger.WithSandboxID(sandboxID))
 		case errors.Is(err, orchestrator.ErrSandboxOperationFailed):
 			a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error killing sandbox: %s", err))
+
 			return
 		default:
 			telemetry.ReportError(ctx, "error killing sandbox", err)
 			a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error killing sandbox: %s", err))
+
 			return
 		}
 	} else {
@@ -119,6 +122,7 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	case deleteSnapshotErr != nil:
 		telemetry.ReportError(ctx, "error deleting sandbox", deleteSnapshotErr)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error deleting sandbox: %s", deleteSnapshotErr))
+
 		return
 	default:
 		killedOrRemoved = true

--- a/packages/api/internal/handlers/sandbox_logs.go
+++ b/packages/api/internal/handlers/sandbox_logs.go
@@ -32,6 +32,7 @@ func (a *APIStore) GetSandboxesSandboxIDLogs(c *gin.Context, sandboxID string, p
 	sbxLogs, err := a.getClusterSandboxLogs(ctx, sandboxID, team.ID.String(), utils.WithClusterFallback(team.ClusterID), params.Limit, params.Start)
 	if err != nil {
 		a.sendAPIStoreError(c, int(err.Code), err.Message)
+
 		return
 	}
 
@@ -42,6 +43,7 @@ func (a *APIStore) getClusterSandboxLogs(ctx context.Context, sandboxID string, 
 	cluster, ok := a.clustersPool.GetClusterById(clusterID)
 	if !ok {
 		telemetry.ReportCriticalError(ctx, "error getting cluster by ID", fmt.Errorf("cluster with ID '%s' not found", clusterID))
+
 		return nil, &api.Error{
 			Code:    http.StatusInternalServerError,
 			Message: fmt.Sprintf("Error getting cluster '%s'", clusterID),
@@ -57,6 +59,7 @@ func (a *APIStore) getClusterSandboxLogs(ctx context.Context, sandboxID string, 
 	)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when returning logs for sandbox", err)
+
 		return nil, &api.Error{
 			Code:    http.StatusInternalServerError,
 			Message: fmt.Sprintf("Error returning logs for sandbox '%s'", sandboxID),
@@ -65,6 +68,7 @@ func (a *APIStore) getClusterSandboxLogs(ctx context.Context, sandboxID string, 
 
 	if res.JSON200 == nil {
 		telemetry.ReportCriticalError(ctx, "error when returning logs for sandbox", fmt.Errorf("unexpected response for sandbox '%s': %s", sandboxID, string(res.Body)))
+
 		return nil, &api.Error{
 			Code:    http.StatusInternalServerError,
 			Message: fmt.Sprintf("Error returning logs for sandbox '%s'", sandboxID),

--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -39,12 +39,14 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 		// This is here just to have the possibility to turn off ClickHouse metrics reading
 
 		c.JSON(http.StatusOK, []api.SandboxMetric{})
+
 		return
 	}
 
 	start, end, err := getSandboxStartEndTime(ctx, a.clickhouseStore, team.ID.String(), sandboxID, params)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("error when getting metrics time range: %s", err))
+
 		return
 	}
 
@@ -52,6 +54,7 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 	if err != nil {
 		telemetry.ReportError(ctx, "error validating dates", err, telemetry.WithTeamID(team.ID.String()))
 		a.sendAPIStoreError(c, http.StatusBadRequest, err.Error())
+
 		return
 	}
 
@@ -67,6 +70,7 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 		)
 
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("error querying sandbox metrics: %s", err))
+
 		return
 	}
 
@@ -139,5 +143,6 @@ func getSandboxStartEndTime(ctx context.Context, clickhouseStore clickhouse.Clic
 			end = sbxEnd
 		}
 	}
+
 	return start, end, nil
 }

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -63,10 +63,12 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 			err = a.orchestrator.WaitForStateChange(ctx, sandboxID)
 			if err != nil {
 				a.sendAPIStoreError(c, http.StatusInternalServerError, "Error waiting for sandbox to pause")
+
 				return
 			}
 		case sandbox.StateKilling:
 			a.sendAPIStoreError(c, http.StatusNotFound, "Sandbox can't be resumed, no snapshot found")
+
 			return
 		case sandbox.StateRunning:
 			a.sendAPIStoreError(c, http.StatusConflict, fmt.Sprintf("Sandbox %s is already running", sandboxID))
@@ -82,6 +84,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		default:
 			zap.L().Error("Sandbox is in an unknown state", logger.WithSandboxID(sandboxID), zap.String("state", string(sandboxData.State)))
 			a.sendAPIStoreError(c, http.StatusInternalServerError, "Sandbox is in an unknown state")
+
 			return
 		}
 	}
@@ -91,11 +94,13 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		if errors.Is(err, sql.ErrNoRows) {
 			zap.L().Debug("Snapshot not found", logger.WithSandboxID(sandboxID))
 			a.sendAPIStoreError(c, http.StatusNotFound, "Sandbox can't be resumed, no snapshot found")
+
 			return
 		}
 
 		zap.L().Error("Error getting last snapshot", logger.WithSandboxID(sandboxID), zap.Error(err))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting snapshot")
+
 		return
 	}
 
@@ -125,6 +130,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		if tokenErr != nil {
 			zap.L().Error("Secure envd access token error", zap.Error(tokenErr.Err), logger.WithTemplateID(build.EnvID), logger.WithBuildID(build.ID.String()), logger.WithSandboxID(sandboxID))
 			a.sendAPIStoreError(c, tokenErr.Code, tokenErr.ClientMsg)
+
 			return
 		}
 

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -54,6 +54,7 @@ func (a *APIStore) getPausedSandboxes(ctx context.Context, teamID uuid.UUID, run
 	}
 
 	sandboxes := snapshotsToPaginatedSandboxes(snapshots)
+
 	return sandboxes, nil
 }
 

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -191,6 +191,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, config cfg.Config) 
 				if orch.NodeCount() != 0 {
 					zap.L().Info("Nodes are ready, setting API as healthy")
 					a.Healthy = true
+
 					return
 				}
 			}
@@ -340,6 +341,7 @@ func getJWTClaims(secrets []string, token string) (*supabaseClaims, error) {
 		if err != nil {
 			// This error is ignored because we will try to parse the token with the next secret.
 			errs = append(errs, fmt.Errorf("failed to parse supabase token: %w", err))
+
 			continue
 		}
 

--- a/packages/api/internal/handlers/team_metrics.go
+++ b/packages/api/internal/handlers/team_metrics.go
@@ -43,6 +43,7 @@ func (a *APIStore) GetTeamsTeamIDMetrics(c *gin.Context, teamID string, params a
 		// This is here just to have the possibility to turn off ClickHouse metrics reading
 
 		c.JSON(http.StatusOK, []api.TeamMetric{})
+
 		return
 	}
 
@@ -60,6 +61,7 @@ func (a *APIStore) GetTeamsTeamIDMetrics(c *gin.Context, teamID string, params a
 	if err != nil {
 		telemetry.ReportError(ctx, "error validating dates", err, telemetry.WithTeamID(team.ID.String()))
 		a.sendAPIStoreError(c, http.StatusBadRequest, err.Error())
+
 		return
 	}
 
@@ -69,6 +71,7 @@ func (a *APIStore) GetTeamsTeamIDMetrics(c *gin.Context, teamID string, params a
 	if err != nil {
 		telemetry.ReportError(ctx, "error fetching team metrics", err, telemetry.WithTeamID(team.ID.String()))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("error querying team metrics: %s", err))
+
 		return
 	}
 

--- a/packages/api/internal/handlers/team_metrics_max.go
+++ b/packages/api/internal/handlers/team_metrics_max.go
@@ -43,6 +43,7 @@ func (a *APIStore) GetTeamsTeamIDMetricsMax(c *gin.Context, teamID string, param
 		// This is here just to have the possibility to turn off ClickHouse metrics reading
 
 		c.JSON(http.StatusOK, api.MaxTeamMetric{})
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_build_status.go
+++ b/packages/api/internal/handlers/template_build_status.go
@@ -27,6 +27,7 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	if err != nil {
 		telemetry.ReportError(ctx, "error when parsing build id", err)
 		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid build id")
+
 		return
 	}
 
@@ -35,11 +36,13 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 		var notFoundErr templatecache.TemplateBuildInfoNotFoundError
 		if errors.As(err, &notFoundErr) {
 			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Build '%s' not found", buildUUID))
+
 			return
 		}
 
 		telemetry.ReportError(ctx, "error when getting template", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting template")
+
 		return
 	}
 
@@ -48,12 +51,14 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
 	if team.ID != buildInfo.TeamID {
 		telemetry.ReportError(ctx, "user doesn't have access to env", fmt.Errorf("user doesn't have access to env '%s'", templateID), telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to this sandbox template (%s)", templateID))
+
 		return
 	}
 
@@ -68,6 +73,7 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 		}
 
 		c.JSON(http.StatusOK, result)
+
 		return
 	}
 
@@ -85,6 +91,7 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	if err != nil {
 		telemetry.ReportError(ctx, "error when getting build client", err, telemetry.WithTemplateID(templateID), telemetry.WithBuildID(buildID))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting build client")
+
 		return
 	}
 
@@ -163,5 +170,6 @@ func apiToLogLevel(level *api.LogLevel) *logs.LogLevel {
 	}
 
 	value := logs.StringToLevel(string(*level))
+
 	return &value
 }

--- a/packages/api/internal/handlers/template_delete.go
+++ b/packages/api/internal/handlers/template_delete.go
@@ -63,6 +63,7 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_layer_files_upload.go
+++ b/packages/api/internal/handlers/template_layer_files_upload.go
@@ -20,6 +20,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Error when getting template: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when getting env", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -28,6 +29,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
@@ -35,6 +37,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	if team.ID != templateDB.TeamID {
 		telemetry.ReportCriticalError(ctx, "error when getting template", err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Error when getting template: %s", err))
+
 		return
 	}
 
@@ -42,6 +45,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when getting available build client", err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting available build client")
+
 		return
 	}
 
@@ -49,6 +53,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when requesting layer files upload", err, telemetry.WithTemplateID(templateID), attribute.String("hash", hash))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when requesting layer files upload")
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_request_build.go
+++ b/packages/api/internal/handlers/template_request_build.go
@@ -28,6 +28,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid request body: %s", err))
 		telemetry.ReportCriticalError(ctx, "invalid request body", err)
+
 		return
 	}
 
@@ -35,6 +36,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and limits", apiErr.Err)
+
 		return
 	}
 
@@ -47,6 +49,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 	if apiErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+
 		return
 	}
 
@@ -76,6 +79,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid request body: %s", err))
 		telemetry.ReportCriticalError(ctx, "invalid request body", err)
+
 		return
 	}
 
@@ -83,6 +87,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid template ID: %s", rawTemplateID))
 		telemetry.ReportCriticalError(c.Request.Context(), "invalid template ID", err)
+
 		return
 	}
 	span.SetAttributes(telemetry.WithTemplateID(templateID))
@@ -91,6 +96,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
@@ -100,15 +106,18 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 		if templateDB.TeamID != team.ID {
 			a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You do not have access to the template '%s'", templateID))
 			telemetry.ReportError(ctx, "template access forbidden", nil, telemetry.WithTemplateID(templateID), telemetry.WithTeamID(team.ID.String()))
+
 			return
 		}
 	case dberrors.IsNotFoundError(err):
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Template '%s' not found", templateID))
 		telemetry.ReportError(ctx, "template not found", err, telemetry.WithTemplateID(templateID))
+
 		return
 	default:
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when getting template: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when getting template", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -116,6 +125,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	if apiErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_request_build_v2.go
+++ b/packages/api/internal/handlers/template_request_build_v2.go
@@ -34,6 +34,7 @@ func (a *APIStore) PostV2Templates(c *gin.Context) {
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team, limits", apiErr.Err)
+
 		return
 	}
 
@@ -48,6 +49,7 @@ func (a *APIStore) PostV2Templates(c *gin.Context) {
 		if templateAlias.TeamID != team.ID {
 			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Alias `%s` is already taken", body.Alias))
 			telemetry.ReportError(ctx, "template alias is already taken", nil, telemetry.WithTemplateID(templateAlias.EnvID), telemetry.WithTeamID(team.ID.String()), attribute.String("alias", body.Alias))
+
 			return
 		}
 
@@ -58,6 +60,7 @@ func (a *APIStore) PostV2Templates(c *gin.Context) {
 	default:
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when getting template alias: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when getting template alias", err)
+
 		return
 	}
 	span.End()
@@ -66,6 +69,7 @@ func (a *APIStore) PostV2Templates(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting available build client")
 		telemetry.ReportCriticalError(ctx, "error when getting available build client", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -84,6 +88,7 @@ func (a *APIStore) PostV2Templates(c *gin.Context) {
 	if apiError != nil {
 		a.sendAPIStoreError(c, apiError.Code, apiError.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "build template register failed", apiError.Err)
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_start_build.go
+++ b/packages/api/internal/handlers/template_start_build.go
@@ -37,6 +37,7 @@ func (a *APIStore) CheckAndCancelConcurrentBuilds(ctx context.Context, templateI
 		All(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "Error when getting running builds", err)
+
 		return fmt.Errorf("error when getting running builds: %w", err)
 	}
 
@@ -56,6 +57,7 @@ func (a *APIStore) CheckAndCancelConcurrentBuilds(ctx context.Context, templateI
 		deleteJobErr := a.templateManager.DeleteBuilds(ctx, buildIDs)
 		if deleteJobErr != nil {
 			telemetry.ReportCriticalError(ctx, "error when canceling running build", deleteJobErr)
+
 			return fmt.Errorf("error when canceling running build: %w", deleteJobErr)
 		}
 		telemetry.ReportEvent(ctx, "canceled running builds")
@@ -106,6 +108,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 	for _, t := range teams {
 		if t.Team.ID == templateBuildDB.Env.TeamID {
 			team = t.Team
+
 			break
 		}
 	}
@@ -127,6 +130,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 	// Check and cancel concurrent builds
 	if err := a.CheckAndCancelConcurrentBuilds(ctx, templateID, buildUUID, apiutils.WithClusterFallback(team.ClusterID)); err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error during template build request")
+
 		return
 	}
 
@@ -137,6 +141,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 	if build.Status != envbuild.StatusWaiting.String() {
 		a.sendAPIStoreError(c, http.StatusBadRequest, "build is not in waiting state")
 		telemetry.ReportCriticalError(ctx, "build is not in waiting state", fmt.Errorf("build is not in waiting state: %s", build.Status), telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -176,6 +181,7 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "build failed", err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when starting template build: %s", err))
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_start_build_v2.go
+++ b/packages/api/internal/handlers/template_start_build_v2.go
@@ -64,6 +64,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Error when getting template: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when getting env", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -72,6 +73,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
@@ -91,6 +93,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	// Check and cancel concurrent builds
 	if err := a.CheckAndCancelConcurrentBuilds(ctx, templateID, buildUUID, apiutils.WithClusterFallback(team.ClusterID)); err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error during template build request")
+
 		return
 	}
 
@@ -101,6 +104,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if build.Status != envbuild.StatusWaiting.String() {
 		a.sendAPIStoreError(c, http.StatusBadRequest, "build is not in waiting state")
 		telemetry.ReportCriticalError(ctx, "build is not in waiting state", fmt.Errorf("build is not in waiting state: %s", build.Status), telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -112,6 +116,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when processing steps: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when processing steps", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -124,6 +129,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when updating build", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when updating build: %s", err))
+
 		return
 	}
 
@@ -131,6 +137,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing user agent: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when parsing user agent", err, telemetry.WithTemplateID(templateID))
+
 		return
 	}
 
@@ -167,6 +174,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "build failed", err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when starting template build: %s", err))
+
 		return
 	}
 

--- a/packages/api/internal/handlers/template_update.go
+++ b/packages/api/internal/handlers/template_update.go
@@ -69,6 +69,7 @@ func (a *APIStore) PatchTemplatesTemplateID(c *gin.Context, aliasOrTemplateID ap
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
@@ -90,6 +91,7 @@ func (a *APIStore) PatchTemplatesTemplateID(c *gin.Context, aliasOrTemplateID ap
 			telemetry.ReportError(ctx, "error when updating env", dbErr)
 
 			a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when updating env")
+
 			return
 		}
 	}

--- a/packages/api/internal/handlers/templates_list.go
+++ b/packages/api/internal/handlers/templates_list.go
@@ -19,6 +19,7 @@ func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)
+
 		return
 	}
 
@@ -26,6 +27,7 @@ func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 		if team.ID.String() != *params.TeamID {
 			a.sendAPIStoreError(c, http.StatusBadRequest, "Team ID param mismatch with the API key")
 			telemetry.ReportError(ctx, "team param mismatch with the API key", nil, telemetry.WithTeamID(team.ID.String()))
+
 			return
 		}
 	}
@@ -38,6 +40,7 @@ func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when getting templates")
 		telemetry.ReportCriticalError(ctx, "error when getting templates", err)
+
 		return
 	}
 

--- a/packages/api/internal/middleware/exclude.go
+++ b/packages/api/internal/middleware/exclude.go
@@ -36,6 +36,7 @@ func shouldInclude(path string, patterns []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/packages/api/internal/middleware/logging.go
+++ b/packages/api/internal/middleware/logging.go
@@ -56,6 +56,7 @@ func LoggingMiddleware(logger *zap.Logger, conf Config) gin.HandlerFunc {
 				}
 
 				track = false
+
 				break
 			}
 		}

--- a/packages/api/internal/middleware/otel/metrics/middleware.go
+++ b/packages/api/internal/middleware/otel/metrics/middleware.go
@@ -86,5 +86,6 @@ func attributesFromGinContext(ginCtx *gin.Context, filterPrefix string) []attrib
 			attrs = append(attrs, attribute.String(k, fmt.Sprintf("%v", val)))
 		}
 	}
+
 	return attrs
 }

--- a/packages/api/internal/middleware/otel/tracing/middleware.go
+++ b/packages/api/internal/middleware/otel/tracing/middleware.go
@@ -53,6 +53,7 @@ func Middleware(tracerProvider oteltrace.TracerProvider, service string) gin.Han
 	if cfg.Propagators == nil {
 		cfg.Propagators = otel.GetTextMapPropagator()
 	}
+
 	return func(c *gin.Context) {
 		c.Set(tracerKey, tracer)
 		ctx := c.Request.Context()

--- a/packages/api/internal/orchestrator/admin.go
+++ b/packages/api/internal/orchestrator/admin.go
@@ -43,6 +43,7 @@ func (o *Orchestrator) AdminNodes() []*api.Node {
 		n, ok := apiNodes[sbx.NodeID]
 		if !ok {
 			zap.L().Error("node for sandbox wasn't found", logger.WithNodeID(sbx.NodeID), logger.WithSandboxID(sbx.SandboxID))
+
 			continue
 		}
 

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -33,6 +33,7 @@ func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			zap.L().Info("Stopping node analytics reporting due to context cancellation")
+
 			return
 		case <-ticker.C:
 			sandboxes := o.sandboxStore.Items(nil, []sandbox.State{sandbox.StateRunning})
@@ -52,6 +53,7 @@ func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
 func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyticscollector.Analytics, instances []sandbox.Sandbox) {
 	if len(instances) == 0 {
 		zap.L().Debug("No long-running instances to report to analytics")
+
 		return
 	}
 

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -38,6 +38,7 @@ func (o *Orchestrator) keepInSync(ctx context.Context, instanceCache *memory.Sto
 		select {
 		case <-ctx.Done():
 			zap.L().Info("Stopping keepInSync")
+
 			return
 		case <-ticker.C:
 			o.syncNodes(ctx, instanceCache, skipSyncingWithNomad)
@@ -61,6 +62,7 @@ func (o *Orchestrator) syncNodes(ctx context.Context, instanceCache *memory.Stor
 		nomadSD, err := o.listNomadNodes(spanCtx)
 		if err != nil {
 			zap.L().Error("Error listing orchestrator nodes", zap.Error(err))
+
 			return
 		}
 
@@ -192,6 +194,7 @@ func (o *Orchestrator) syncNode(ctx context.Context, node *nodemanager.Node, dis
 	for _, activeNode := range discovered {
 		if node.NomadNodeShortID == activeNode.NomadNodeShortID {
 			found = true
+
 			break
 		}
 	}

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -28,6 +28,7 @@ func (o *Orchestrator) connectToNode(ctx context.Context, discovered nodemanager
 
 	// Update host metrics from service info
 	o.registerNode(orchestratorNode)
+
 	return nil
 }
 
@@ -38,6 +39,7 @@ func (o *Orchestrator) connectToClusterNode(ctx context.Context, cluster *edge.C
 	orchestratorNode, err := nodemanager.NewClusterNode(ctx, clusterGRPC.Client, cluster.ID, cluster.SandboxDomain, i)
 	if err != nil {
 		zap.L().Error("Failed to create node", zap.Error(err))
+
 		return
 	}
 
@@ -70,6 +72,7 @@ func (o *Orchestrator) GetClient(ctx context.Context, clusterID uuid.UUID, nodeI
 	}
 
 	client, ctx := n.GetClient(ctx)
+
 	return client, ctx, nil
 }
 
@@ -101,6 +104,7 @@ func (o *Orchestrator) listNomadNodes(ctx context.Context) ([]nodemanager.NomadS
 func (o *Orchestrator) GetNode(clusterID uuid.UUID, nodeID string) *nodemanager.Node {
 	scopedKey := o.scopedNodeID(clusterID, nodeID)
 	n, _ := o.nodes.Get(scopedKey)
+
 	return n
 }
 

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -98,6 +98,7 @@ func (o *Orchestrator) CreateSandbox(
 			}
 		default:
 			zap.L().Error("failed to reserve sandbox for team", logger.WithSandboxID(sandboxID), zap.Error(err))
+
 			return sandbox.Sandbox{}, &api.APIError{
 				Code:      http.StatusInternalServerError,
 				ClientMsg: fmt.Sprintf("Failed to create sandbox: %s", err),
@@ -246,5 +247,6 @@ func (o *Orchestrator) CreateSandbox(
 	)
 
 	o.sandboxStore.Add(ctx, sbx, true)
+
 	return sbx, nil
 }

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -24,22 +24,27 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, sbx sandbox.Sandbox, s
 			switch sbx.State {
 			case sandbox.StateKilling:
 				zap.L().Info("Sandbox is already killed", logger.WithSandboxID(sandboxID))
+
 				return nil
 			default: // It shouldn't happen the sandbox ended in paused state
 				zap.L().Error("Error killing sandbox", zap.Error(err), logger.WithSandboxID(sandboxID))
+
 				return ErrSandboxOperationFailed
 			}
 		case sandbox.StateActionPause:
 			switch sbx.State {
 			case sandbox.StateKilling:
 				zap.L().Info("Sandbox is already killed", logger.WithSandboxID(sandboxID))
+
 				return ErrSandboxNotFound
 			default:
 				zap.L().Error("Error pausing sandbox", zap.Error(err), logger.WithSandboxID(sandboxID))
+
 				return ErrSandboxOperationFailed
 			}
 		default:
 			zap.L().Error("Invalid state action", logger.WithSandboxID(sandboxID), zap.String("state_action", string(stateAction)))
+
 			return ErrSandboxOperationFailed
 		}
 	}
@@ -59,6 +64,7 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, sbx sandbox.Sandbox, s
 	err = o.removeSandboxFromNode(ctx, sbx, stateAction)
 	if err != nil {
 		zap.L().Error("Error pausing sandbox", zap.Error(err), logger.WithSandboxID(sbx.SandboxID))
+
 		return ErrSandboxOperationFailed
 	}
 
@@ -72,6 +78,7 @@ func (o *Orchestrator) removeSandboxFromNode(ctx context.Context, sbx sandbox.Sa
 	node := o.GetNode(sbx.ClusterID, sbx.NodeID)
 	if node == nil {
 		zap.L().Error("failed to get node", logger.WithNodeID(sbx.NodeID))
+
 		return fmt.Errorf("node '%s' not found", sbx.NodeID)
 	}
 
@@ -94,6 +101,7 @@ func (o *Orchestrator) removeSandboxFromNode(ctx context.Context, sbx sandbox.Sa
 		err = o.pauseSandbox(ctx, node, sbx)
 		if err != nil {
 			zap.L().Debug("failed to create snapshot", logger.WithSandboxID(sbx.SandboxID), zap.String("base_template_id", sbx.BaseTemplateID))
+
 			return fmt.Errorf("failed to auto pause sandbox '%s': %w", sbx.SandboxID, err)
 		}
 	case sandbox.StateActionKill:

--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -36,6 +36,7 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, sandboxID string, durat
 
 		zap.L().Debug("sandbox ttl updated", logger.WithSandboxID(sbx.SandboxID), zap.Time("end_time", newEndTime))
 		sbx.EndTime = newEndTime
+
 		return sbx, nil
 	}
 

--- a/packages/api/internal/orchestrator/metrics.go
+++ b/packages/api/internal/orchestrator/metrics.go
@@ -23,6 +23,7 @@ func (o *Orchestrator) setupMetrics(meterProvider metric.MeterProvider) error {
 				attribute.String("node.id", node.ID),
 			))
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -35,6 +36,7 @@ func (o *Orchestrator) setupMetrics(meterProvider metric.MeterProvider) error {
 				attribute.String("node.id", node.ID),
 			))
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/packages/api/internal/orchestrator/nodemanager/metadata.go
+++ b/packages/api/internal/orchestrator/nodemanager/metadata.go
@@ -29,6 +29,7 @@ func (n *Node) setMetadata(md NodeMetadata) {
 func (n *Node) Metadata() NodeMetadata {
 	n.mutex.RLock()
 	defer n.mutex.RUnlock()
+
 	return n.meta
 }
 

--- a/packages/api/internal/orchestrator/nodemanager/metrics.go
+++ b/packages/api/internal/orchestrator/nodemanager/metrics.go
@@ -83,6 +83,7 @@ func (n *Node) Metrics() Metrics {
 	}
 
 	copy(result.HostDisks, n.metrics.HostDisks)
+
 	return result
 }
 

--- a/packages/api/internal/orchestrator/nodemanager/node.go
+++ b/packages/api/internal/orchestrator/nodemanager/node.go
@@ -69,6 +69,7 @@ func New(
 	nodeInfo, err := client.Info.ServiceInfo(ctx, &emptypb.Empty{})
 	if err != nil {
 		_ = client.Close()
+
 		return nil, fmt.Errorf("failed to get node service info: %w", err)
 	}
 
@@ -150,6 +151,7 @@ func NewClusterNode(ctx context.Context, client *grpclient.GRPCClient, clusterID
 	nodeInfo, err := nodeClient.Info.ServiceInfo(ctx, &emptypb.Empty{})
 	if err != nil {
 		zap.L().Error("Failed to get node service info", zap.Error(err), logger.WithNodeID(n.ID))
+
 		return n, nil
 	}
 

--- a/packages/api/internal/orchestrator/nodemanager/status.go
+++ b/packages/api/internal/orchestrator/nodemanager/status.go
@@ -52,6 +52,7 @@ func (n *Node) SendStatusChange(ctx context.Context, s api.NodeStatus) error {
 	nodeStatus, ok := ApiNodeToOrchestratorStateMapper[s]
 	if !ok {
 		zap.L().Error("Unknown service info status", zap.String("status", string(s)), logger.WithNodeID(n.ID))
+
 		return fmt.Errorf("unknown service info status: %s", s)
 	}
 
@@ -59,6 +60,7 @@ func (n *Node) SendStatusChange(ctx context.Context, s api.NodeStatus) error {
 	_, err := client.Info.ServiceStatusOverride(ctx, &orchestratorinfo.ServiceStatusChangeRequest{ServiceStatus: nodeStatus})
 	if err != nil {
 		zap.L().Error("Failed to send status change", zap.Error(err))
+
 		return err
 	}
 

--- a/packages/api/internal/orchestrator/nodemanager/sync.go
+++ b/packages/api/internal/orchestrator/nodemanager/sync.go
@@ -21,6 +21,7 @@ func (n *Node) Sync(ctx context.Context, instanceCache *memory.Store) {
 		nodeInfo, err := client.Info.ServiceInfo(ctx, &emptypb.Empty{})
 		if err != nil {
 			zap.L().Error("Error getting node info", zap.Error(err), logger.WithNodeID(n.ID))
+
 			continue
 		}
 
@@ -45,24 +46,28 @@ func (n *Node) Sync(ctx context.Context, instanceCache *memory.Store) {
 		activeInstances, instancesErr := n.GetSandboxes(ctx)
 		if instancesErr != nil {
 			zap.L().Error("Error getting instances", zap.Error(instancesErr), logger.WithNodeID(n.ID))
+
 			continue
 		}
 
 		instanceCache.Sync(ctx, activeInstances, n.ID)
 
 		syncRetrySuccess = true
+
 		break
 	}
 
 	if !syncRetrySuccess {
 		zap.L().Error("Failed to sync node after max retries, temporarily marking as unhealthy", logger.WithNodeID(n.ID))
 		n.setStatus(api.NodeStatusUnhealthy)
+
 		return
 	}
 
 	builds, buildsErr := n.listCachedBuilds(ctx)
 	if buildsErr != nil {
 		zap.L().Error("Error listing cached builds", zap.Error(buildsErr), logger.WithNodeID(n.ID))
+
 		return
 	}
 

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -74,6 +74,7 @@ func New(
 	)
 	if err != nil {
 		zap.L().Error("Error initializing Analytics client", zap.Error(err))
+
 		return nil, err
 	}
 
@@ -90,12 +91,14 @@ func New(
 	sandboxCounter, err := telemetry.GetUpDownCounter(meter, telemetry.SandboxCountMeterName)
 	if err != nil {
 		zap.L().Error("error getting counter", zap.Error(err))
+
 		return nil, err
 	}
 
 	createdCounter, err := telemetry.GetCounter(meter, telemetry.SandboxCreateMeterName)
 	if err != nil {
 		zap.L().Error("error getting counter", zap.Error(err))
+
 		return nil, err
 	}
 
@@ -146,6 +149,7 @@ func New(
 	teamMetricsObserver, err := metrics.NewTeamObserver(ctx, sandboxStore)
 	if err != nil {
 		zap.L().Error("Failed to create team metrics observer", zap.Error(err))
+
 		return nil, fmt.Errorf("failed to create team metrics observer: %w", err)
 	}
 
@@ -158,6 +162,7 @@ func New(
 
 	if err := o.setupMetrics(tel.MeterProvider); err != nil {
 		zap.L().Error("Failed to setup metrics", zap.Error(err))
+
 		return nil, fmt.Errorf("failed to setup metrics: %w", err)
 	}
 
@@ -242,12 +247,14 @@ func (o *Orchestrator) getPlacementAlgorithm(ctx context.Context) placement.Algo
 	if err != nil {
 		zap.L().Error("Failed to evaluate placement algorithm feature flag, using least-busy",
 			zap.Error(err))
+
 		return o.leastBusyAlgorithm
 	}
 
 	if useBestOfK {
 		return o.bestOfKAlgorithm
 	}
+
 	return o.leastBusyAlgorithm
 }
 

--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -107,6 +107,7 @@ func snapshotInstance(ctx context.Context, orch *Orchestrator, node *nodemanager
 
 	if err == nil {
 		telemetry.ReportEvent(ctx, "Paused sandbox")
+
 		return nil
 	}
 

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -98,6 +98,7 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 		}
 
 		node.PlacementMetrics.Success(sbxRequest.GetSandbox().GetSandboxId())
+
 		return node, nil
 	}
 

--- a/packages/api/internal/orchestrator/placement/placement_benchmark_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_benchmark_test.go
@@ -107,6 +107,7 @@ func createSimulatedNodes(config BenchmarkConfig) []*SimulatedNode {
 		}
 		nodes[i] = simNode
 	}
+
 	return nodes
 }
 
@@ -119,6 +120,7 @@ func (n *SimulatedNode) placeSandbox(sbx *LiveSandbox) bool {
 	// Check capacity with overcommit
 	if metrics.CpuAllocated+uint32(sbx.RequestedCPU) > metrics.CpuCount*4 { // 4x overcommit
 		atomic.AddInt64(&n.rejectedPlacements, 1)
+
 		return false
 	}
 
@@ -246,6 +248,7 @@ func runBenchmark(b *testing.B, algorithm Algorithm, config BenchmarkConfig) *Be
 						// Remove from active list
 						activeSandboxes.Delete(key)
 					}
+
 					return true
 				})
 			case <-stopCleanup:

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K.go
@@ -93,6 +93,7 @@ func NewBestOfK(config BestOfKConfig) Algorithm {
 func (b *BestOfK) getConfig() BestOfKConfig {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
+
 	return b.config
 }
 

--- a/packages/api/internal/orchestrator/placement/placement_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_test.go
@@ -21,6 +21,7 @@ type mockAlgorithm struct {
 
 func (m *mockAlgorithm) excludeNode(err error) bool {
 	args := m.Called(err)
+
 	return args.Bool(0)
 }
 
@@ -29,6 +30,7 @@ func (m *mockAlgorithm) chooseNode(ctx context.Context, nodes []*nodemanager.Nod
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
+
 	return args.Get(0).(*nodemanager.Node), args.Error(1)
 }
 

--- a/packages/api/internal/sandbox/store/memory/filters.go
+++ b/packages/api/internal/sandbox/store/memory/filters.go
@@ -9,5 +9,6 @@ func applyFilter(sbx sandbox.Sandbox, filter *sandbox.ItemsFilter) bool {
 	if filter.OnlyExpired && !sbx.IsExpired() {
 		return false
 	}
+
 	return true
 }

--- a/packages/api/internal/sandbox/store/memory/operations.go
+++ b/packages/api/internal/sandbox/store/memory/operations.go
@@ -31,6 +31,7 @@ func (s *Store) Add(ctx context.Context, sandbox sandbox.Sandbox, newlyCreated b
 	added := s.items.SetIfAbsent(sandbox.SandboxID, newMemorySandbox(sandbox))
 	if !added {
 		zap.L().Warn("Sandbox already exists in cache", logger.WithSandboxID(sandbox.SandboxID))
+
 		return
 	}
 
@@ -116,6 +117,7 @@ func (s *Store) Update(sandboxID string, updateFunc func(sandbox.Sandbox) (sandb
 	}
 
 	item._data = sbx
+
 	return sbx, nil
 }
 
@@ -164,6 +166,7 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, stateAction sandbox.
 	defer sbx.mu.Unlock()
 	if sbx._data.State == newState {
 		zap.L().Debug("Already in the same state", logger.WithSandboxID(sbx.SandboxID()), zap.String("state", string(newState)))
+
 		return true, func(error) {}, nil
 	}
 
@@ -184,6 +187,7 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, stateAction sandbox.
 		if err != nil {
 			// Keep the transition in place so the error stays
 			zap.L().Error("Failed to set transition result", logger.WithSandboxID(sbx.SandboxID()), zap.Error(setErr))
+
 			return
 		}
 
@@ -199,6 +203,7 @@ func (s *Store) WaitForStateChange(ctx context.Context, sandboxID string) error 
 	if err != nil {
 		return fmt.Errorf("failed to get sandbox: %w", err)
 	}
+
 	return waitForStateChange(ctx, sbx)
 }
 

--- a/packages/api/internal/sandbox/store/memory/reservation_test.go
+++ b/packages/api/internal/sandbox/store/memory/reservation_test.go
@@ -20,6 +20,7 @@ var teamID = uuid.New()
 
 func newMemoryStore() *Store {
 	cache := NewStore(nil, nil)
+
 	return cache
 }
 

--- a/packages/api/internal/template-manager/build_client.go
+++ b/packages/api/internal/template-manager/build_client.go
@@ -24,6 +24,7 @@ func (bc *BuildClient) GetLogs(ctx context.Context, templateID, buildID string, 
 		l, err := provider.GetLogs(ctx, templateID, buildID, offset, level)
 		if err != nil {
 			telemetry.ReportEvent(ctx, "soft error when getting logs for template build", telemetry.WithTemplateID(templateID), telemetry.WithBuildID(buildID), attribute.String("provider", fmt.Sprintf("%T", provider)))
+
 			continue
 		}
 

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -145,6 +145,7 @@ func (tm *TemplateManager) CreateTemplate(
 		if err != nil {
 			return fmt.Errorf("failed to set build status: %w", err)
 		}
+
 		return nil
 	}
 
@@ -213,6 +214,7 @@ func convertTemplateSteps(steps *[]api.TemplateStep) []*templatemanagergrpc.Temp
 			Force:     step.Force,
 		}
 	}
+
 	return result
 }
 
@@ -233,6 +235,7 @@ func convertImageRegistry(registry *api.FromImageRegistry) (*templatemanagergrpc
 		if err != nil {
 			return nil, err
 		}
+
 		return &templatemanagergrpc.FromImageRegistry{
 			Type: &templatemanagergrpc.FromImageRegistry_Aws{
 				Aws: &templatemanagergrpc.AWSRegistry{
@@ -247,6 +250,7 @@ func convertImageRegistry(registry *api.FromImageRegistry) (*templatemanagergrpc
 		if err != nil {
 			return nil, err
 		}
+
 		return &templatemanagergrpc.FromImageRegistry{
 			Type: &templatemanagergrpc.FromImageRegistry_Gcp{
 				Gcp: &templatemanagergrpc.GCPRegistry{
@@ -259,6 +263,7 @@ func convertImageRegistry(registry *api.FromImageRegistry) (*templatemanagergrpc
 		if err != nil {
 			return nil, err
 		}
+
 		return &templatemanagergrpc.FromImageRegistry{
 			Type: &templatemanagergrpc.FromImageRegistry_General{
 				General: &templatemanagergrpc.GeneralRegistry{
@@ -312,5 +317,6 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 			FromImage: *fromImage,
 		}
 	}
+
 	return nil
 }

--- a/packages/api/internal/template-manager/logs/edge_provider.go
+++ b/packages/api/internal/template-manager/logs/edge_provider.go
@@ -22,6 +22,7 @@ func logToEdgeLevel(level *logs.LogLevel) *edgeapi.LogLevel {
 	}
 
 	value := edgeapi.LogLevel(logs.LevelToString(*level))
+
 	return &value
 }
 
@@ -35,6 +36,7 @@ func (c *ClusterPlacementProvider) GetLogs(ctx context.Context, templateID strin
 
 	if res.StatusCode() != 200 || res.JSON200 == nil {
 		zap.L().Error("failed to get build logs in template manager", zap.String("body", string(res.Body)))
+
 		return nil, errors.New("failed to get build logs in template manager")
 	}
 

--- a/packages/api/internal/template-manager/logs/template_manager_provider.go
+++ b/packages/api/internal/template-manager/logs/template_manager_provider.go
@@ -35,6 +35,7 @@ func (t *TemplateManagerProvider) GetLogs(ctx context.Context, templateID string
 	if err != nil {
 		telemetry.ReportError(ctx, "error when returning logs for template build", err)
 		zap.L().Error("error when returning logs for template build", zap.Error(err), logger.WithBuildID(buildID))
+
 		return nil, err
 	}
 

--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -103,6 +103,7 @@ func (tm *TemplateManager) BuildsStatusPeriodicalSync(ctx context.Context) {
 			if err != nil {
 				zap.L().Error("Error getting running builds for periodical sync", zap.Error(err))
 				dbxCtxCancel()
+
 				continue
 			}
 

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -70,6 +70,7 @@ func RegisterBuild(
 	totalConcurrentTemplateBuilds := data.Team.Limits.BuildConcurrency
 	if len(teamBuildsExcludingCurrent) >= int(totalConcurrentTemplateBuilds) {
 		telemetry.ReportError(ctx, "team has reached max concurrent template builds", nil, telemetry.WithTeamID(data.Team.ID.String()), attribute.Int64("total.concurrent_template_builds", totalConcurrentTemplateBuilds))
+
 		return nil, &api.APIError{
 			Code: http.StatusTooManyRequests,
 			ClientMsg: fmt.Sprintf(
@@ -83,6 +84,7 @@ func RegisterBuild(
 	buildID, err := uuid.NewRandom()
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when generating build id", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: "Failed to generate build id",
@@ -121,6 +123,7 @@ func RegisterBuild(
 	cpuCount, ramMB, apiError := team.LimitResources(data.Team.Limits, data.CpuCount, data.MemoryMB)
 	if apiError != nil {
 		telemetry.ReportCriticalError(ctx, "error when getting CPU and RAM", apiError.Err)
+
 		return nil, apiError
 	}
 
@@ -129,6 +132,7 @@ func RegisterBuild(
 		alias, err = id.CleanEnvID(*data.Alias)
 		if err != nil {
 			telemetry.ReportCriticalError(ctx, "invalid alias", err)
+
 			return nil, &api.APIError{
 				Err:       err,
 				ClientMsg: fmt.Sprintf("Invalid alias: %s", *data.Alias),
@@ -141,6 +145,7 @@ func RegisterBuild(
 	tx, err := db.Client.Tx(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when starting transaction", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when starting transaction: %s", err),
@@ -171,6 +176,7 @@ func RegisterBuild(
 		Exec(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
@@ -186,6 +192,7 @@ func RegisterBuild(
 	).SetStatus(envbuild.StatusFailed).SetFinishedAt(time.Now()).Exec(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when updating env", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when updating template: %s", err),
@@ -211,6 +218,7 @@ func RegisterBuild(
 		Save(ctx)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when inserting build", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when inserting build: %s", err),
@@ -228,6 +236,7 @@ func RegisterBuild(
 			All(ctx)
 		if err != nil {
 			telemetry.ReportCriticalError(ctx, "error when checking alias", err, attribute.String("alias", alias))
+
 			return nil, &api.APIError{
 				Err:       err,
 				ClientMsg: fmt.Sprintf("Error when querying alias '%s': %s", alias, err),
@@ -239,6 +248,7 @@ func RegisterBuild(
 		if len(envs) > 0 {
 			err := fmt.Errorf("alias '%s' is already used", alias)
 			telemetry.ReportCriticalError(ctx, "conflict of alias", err, attribute.String("alias", alias))
+
 			return nil, &api.APIError{
 				Err:       err,
 				ClientMsg: fmt.Sprintf("Alias '%s' is already used", alias),
@@ -250,6 +260,7 @@ func RegisterBuild(
 		if err != nil {
 			if !models.IsNotFound(err) {
 				telemetry.ReportCriticalError(ctx, "error when checking alias", err, attribute.String("alias", alias))
+
 				return nil, &api.APIError{
 					Err:       err,
 					ClientMsg: fmt.Sprintf("Error when querying for alias: %s", err),
@@ -260,6 +271,7 @@ func RegisterBuild(
 			count, err := tx.EnvAlias.Delete().Where(envalias.EnvID(data.TemplateID), envalias.IsRenamable(true)).Exec(ctx)
 			if err != nil {
 				telemetry.ReportCriticalError(ctx, "error when deleting template alias", err, attribute.String("alias", alias))
+
 				return nil, &api.APIError{
 					Err:       err,
 					ClientMsg: fmt.Sprintf("Error when deleting template alias: %s", err),
@@ -278,6 +290,7 @@ func RegisterBuild(
 				Exec(ctx)
 			if err != nil {
 				telemetry.ReportCriticalError(ctx, "error when inserting alias", err, attribute.String("alias", alias))
+
 				return nil, &api.APIError{
 					Err:       err,
 					ClientMsg: fmt.Sprintf("Error when inserting alias '%s': %s", alias, err),
@@ -288,6 +301,7 @@ func RegisterBuild(
 		} else if aliasDB.EnvID != data.TemplateID {
 			err := fmt.Errorf("alias '%s' already used", alias)
 			telemetry.ReportCriticalError(ctx, "alias already used", err, attribute.String("alias", alias))
+
 			return nil, &api.APIError{
 				Err:       err,
 				ClientMsg: fmt.Sprintf("Alias '%s' already used", alias),
@@ -302,6 +316,7 @@ func RegisterBuild(
 	err = tx.Commit()
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error when committing transaction", err)
+
 		return nil, &api.APIError{
 			Err:       err,
 			ClientMsg: fmt.Sprintf("Error when committing transaction: %s", err),

--- a/packages/api/internal/utils/counter.go
+++ b/packages/api/internal/utils/counter.go
@@ -34,6 +34,7 @@ func NewTemplateSpawnCounter(ctx context.Context, tickerDuration time.Duration, 
 	}
 
 	go counter.processUpdates(ctx)
+
 	return counter
 }
 
@@ -54,9 +55,11 @@ func (t *TemplateSpawnCounter) processUpdates(ctx context.Context) {
 			t.flushCounters(ctx)
 		case <-ctx.Done():
 			t.ticker.Stop()
+
 			return
 		case <-t.done:
 			t.ticker.Stop()
+
 			return
 		}
 	}

--- a/packages/api/internal/utils/db.go
+++ b/packages/api/internal/utils/db.go
@@ -36,5 +36,6 @@ func CheckMigrationVersion(connectionString string, expectedMigration int64) err
 	}
 
 	zap.L().Info("Database version", zap.Int64("version", version), zap.Int64("expected_migration", expectedMigration))
+
 	return nil
 }

--- a/packages/api/internal/utils/error.go
+++ b/packages/api/internal/utils/error.go
@@ -104,6 +104,7 @@ func MultiErrorHandler(me openapi3.MultiError) error {
 		// Split up the verbose error by lines and return the first one
 		// openapi errors seem to be multi-line with a decent message on the first
 		errorLines := strings.Split(e.Error(), "\n")
+
 		return fmt.Errorf("error in openapi3filter.RequestError: %s", errorLines[0])
 	case *openapi3filter.SecurityRequirementsError:
 		return processCustomErrors(e) // custom implementation
@@ -136,6 +137,7 @@ func processCustomErrors(e *openapi3filter.SecurityRequirementsError) error {
 		}
 
 		err = errW
+
 		break
 	}
 

--- a/packages/api/internal/utils/sandboxes_list.go
+++ b/packages/api/internal/utils/sandboxes_list.go
@@ -24,6 +24,7 @@ type PaginatedSandbox struct {
 
 func (p *PaginatedSandbox) GenerateCursor() string {
 	cursor := fmt.Sprintf("%s__%s", p.PaginationTimestamp.Format(time.RFC3339Nano), p.SandboxID)
+
 	return base64.URLEncoding.EncodeToString([]byte(cursor))
 }
 
@@ -99,6 +100,7 @@ func SortPaginatedSandboxesDesc(sandboxes []PaginatedSandbox) {
 		if !a.StartedAt.Equal(b.StartedAt) {
 			return b.StartedAt.Compare(a.StartedAt)
 		}
+
 		return strings.Compare(a.SandboxID, b.SandboxID)
 	})
 }
@@ -119,6 +121,7 @@ func FilterSandboxesOnMetadata(sandboxes []PaginatedSandbox, metadata *map[strin
 		for key, value := range *metadata {
 			if metadataValue, ok := (*sbx.Metadata)[key]; !ok || metadataValue != value {
 				matchesAll = false
+
 				break
 			}
 		}

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -293,6 +293,7 @@ func run() int {
 		// this will call os.Exit: defers won't run, but none
 		// need to yet. Change this if this is called later.
 		logger.Error("Error loading swagger spec", zap.Error(err))
+
 		return 1
 	}
 
@@ -330,6 +331,7 @@ func run() int {
 		}
 		if count == 0 {
 			logger.Info("no cleanup operations")
+
 			return
 		}
 		logger.Info("Running cleanup operations", zap.Int("count", count))

--- a/packages/clickhouse/pkg/batcher/batcher.go
+++ b/packages/clickhouse/pkg/batcher/batcher.go
@@ -125,6 +125,7 @@ func (b *Batcher[T]) Stop() error {
 	<-b.doneCh
 	b.ch = nil
 	b.doneCh = nil
+
 	return nil
 }
 
@@ -164,6 +165,7 @@ func processBatches[T any](f BatcherFunc[T], ch <-chan T, maxBatchedItemBatchSiz
 		case batchedItem, ok = <-ch:
 			if !ok {
 				call(f, batch, errorHandler)
+
 				return
 			}
 			batch = append(batch, batchedItem)
@@ -173,6 +175,7 @@ func processBatches[T any](f BatcherFunc[T], ch <-chan T, maxBatchedItemBatchSiz
 				// Flush what's left in the buffer if the batcher is stopped
 				if !ok {
 					call(f, batch, errorHandler)
+
 					return
 				}
 				batch = append(batch, batchedItem)
@@ -183,6 +186,7 @@ func processBatches[T any](f BatcherFunc[T], ch <-chan T, maxBatchedItemBatchSiz
 					case batchedItem, ok = <-ch:
 						if !ok {
 							call(f, batch, errorHandler)
+
 							return
 						}
 						batch = append(batch, batchedItem)

--- a/packages/clickhouse/pkg/batcher/batcher_test.go
+++ b/packages/clickhouse/pkg/batcher/batcher_test.go
@@ -80,6 +80,7 @@ func TestBatcherPushStop(t *testing.T) {
 	n := 0
 	b, err := NewBatcher[int](func(batch []int) error {
 		n += len(batch)
+
 		return nil
 	}, BatcherOptions{MaxDelay: time.Hour})
 	if err != nil {
@@ -127,6 +128,7 @@ func TestBatcherConcurrentPush(t *testing.T) {
 		for _, v := range batch {
 			atomic.AddUint32(&s, v)
 		}
+
 		return nil
 	}, BatcherOptions{})
 	if err != nil {
@@ -163,6 +165,7 @@ func TestBatcherQueueSize(t *testing.T) {
 	b, err := NewBatcher[int](func(batch []int) error {
 		<-ch
 		n += len(batch)
+
 		return nil
 	}, BatcherOptions{
 		MaxDelay:     time.Hour,
@@ -241,6 +244,7 @@ func testBatcherPushMaxDelay(t *testing.T, itemsCount int, maxDelay time.Duratio
 		lastTime = time.Now()
 		nn += len(batch)
 		n++
+
 		return nil
 	}, BatcherOptions{
 		MaxDelay:     maxDelay,
@@ -291,6 +295,7 @@ func testBatcherPushMaxBatchSize(t *testing.T, itemsCount, batchSize int) {
 		}
 		nn += len(batch)
 		n++
+
 		return nil
 	}, BatcherOptions{
 		MaxDelay:     time.Hour,

--- a/packages/clickhouse/pkg/batcher/product_usage_insert_batcher.go
+++ b/packages/clickhouse/pkg/batcher/product_usage_insert_batcher.go
@@ -89,6 +89,7 @@ func (b *ProductUsageInsertBatcher) Push(event clickhouse.ProductUsage) error {
 	if !success {
 		return ErrBatcherQueueFull
 	}
+
 	return nil
 }
 
@@ -106,5 +107,6 @@ func (b *ProductUsageInsertBatcher) Close(context.Context) error {
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
+
 	return nil
 }

--- a/packages/clickhouse/pkg/batcher/sandbox_events_insert_batcher.go
+++ b/packages/clickhouse/pkg/batcher/sandbox_events_insert_batcher.go
@@ -105,6 +105,7 @@ func (b *SandboxEventInsertBatcher) Push(event clickhouse.SandboxEvent) error {
 	if !success {
 		return ErrBatcherQueueFull
 	}
+
 	return nil
 }
 
@@ -122,5 +123,6 @@ func (b *SandboxEventInsertBatcher) Close(context.Context) error {
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
+
 	return nil
 }

--- a/packages/clickhouse/pkg/batcher/timer.go
+++ b/packages/clickhouse/pkg/batcher/timer.go
@@ -18,6 +18,7 @@ func acquireTimer(timeout time.Duration) *time.Timer {
 	if t.Reset(timeout) {
 		log.Printf("Active timer trapped into AcquireTimer() with timeout %s", timeout)
 	}
+
 	return t
 }
 

--- a/packages/client-proxy/internal/edge-pass-through/proxy.go
+++ b/packages/client-proxy/internal/edge-pass-through/proxy.go
@@ -153,6 +153,7 @@ func (s *NodePassThroughServer) handler(_ any, serverStream grpc.ServerStream) (
 				// to cancel the clientStream to the backend, let all of its goroutines be freed up by the CancelFunc and
 				// exit with an error to the stack
 				clientCancel()
+
 				return status.Errorf(codes.Internal, "failed proxying s2c: %v", s2cErr)
 			}
 		case c2sErr := <-c2sErrChan:
@@ -164,6 +165,7 @@ func (s *NodePassThroughServer) handler(_ any, serverStream grpc.ServerStream) (
 			if !errors.Is(c2sErr, io.EOF) {
 				return c2sErr
 			}
+
 			return nil
 		}
 	}
@@ -178,11 +180,13 @@ func (s *NodePassThroughServer) forwardClientToServer(src grpc.ClientStream, dst
 		md, err := src.Header()
 		if err != nil {
 			ret <- err
+
 			return
 		}
 
 		if err := dst.SendHeader(md); err != nil {
 			ret <- err
+
 			return
 		}
 
@@ -190,11 +194,13 @@ func (s *NodePassThroughServer) forwardClientToServer(src grpc.ClientStream, dst
 		for {
 			if err := src.RecvMsg(f); err != nil {
 				ret <- err // this can be io.EOF which is happy case
+
 				break
 			}
 
 			if err := dst.SendMsg(f); err != nil {
 				ret <- err
+
 				break
 			}
 		}
@@ -211,10 +217,12 @@ func (s *NodePassThroughServer) forwardServerToClient(src grpc.ServerStream, dst
 		for {
 			if err := src.RecvMsg(f); err != nil {
 				ret <- err // this can be io.EOF which is happy case
+
 				break
 			}
 			if err := dst.SendMsg(f); err != nil {
 				ret <- err
+
 				break
 			}
 		}

--- a/packages/client-proxy/internal/edge/handlers/healthy.go
+++ b/packages/client-proxy/internal/edge/handlers/healthy.go
@@ -15,6 +15,7 @@ func (a *APIStore) HealthCheck(c *gin.Context) {
 	if status == api.Healthy || status == api.Draining {
 		c.Status(http.StatusOK)
 		c.Writer.Write([]byte("healthy"))
+
 		return
 	}
 
@@ -27,6 +28,7 @@ func (a *APIStore) HealthCheckTraffic(c *gin.Context) {
 	if a.info.GetStatus() == api.Healthy {
 		c.Status(http.StatusOK)
 		c.Writer.Write([]byte("healthy"))
+
 		return
 	}
 
@@ -39,6 +41,7 @@ func (a *APIStore) HealthCheckMachine(c *gin.Context) {
 	if a.info.IsTerminating() {
 		c.Status(http.StatusServiceUnavailable)
 		c.Writer.Write([]byte("service is terminating"))
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/sandbox-catalog-create-entry.go
+++ b/packages/client-proxy/internal/edge/handlers/sandbox-catalog-create-entry.go
@@ -21,6 +21,7 @@ func (a *APIStore) V1SandboxCatalogCreate(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 		telemetry.ReportError(ctx, "error when parsing request", err)
+
 		return
 	}
 
@@ -31,6 +32,7 @@ func (a *APIStore) V1SandboxCatalogCreate(c *gin.Context) {
 	if !ok {
 		a.sendAPIStoreError(c, http.StatusBadRequest, "Orchestrator not found")
 		telemetry.ReportError(ctx, "orchestrator not found", nil)
+
 		return
 	}
 
@@ -49,6 +51,7 @@ func (a *APIStore) V1SandboxCatalogCreate(c *gin.Context) {
 		zap.L().Error("Error when storing sandbox in catalog", zap.Error(err))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when storing sandbox in catalog")
 		telemetry.ReportCriticalError(ctx, "error when storing sandbox in catalog", err)
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/sandbox-catalog-delete-entry.go
+++ b/packages/client-proxy/internal/edge/handlers/sandbox-catalog-delete-entry.go
@@ -19,6 +19,7 @@ func (a *APIStore) V1SandboxCatalogDelete(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
+
 		return
 	}
 
@@ -30,6 +31,7 @@ func (a *APIStore) V1SandboxCatalogDelete(c *gin.Context) {
 		zap.L().Error("Error when deleting sandbox from catalog", zap.Error(err))
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when deleting sandbox from catalog")
 		telemetry.ReportCriticalError(ctx, "error when deleting sandbox from catalog", err)
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/sandbox-logs.go
+++ b/packages/client-proxy/internal/edge/handlers/sandbox-logs.go
@@ -39,6 +39,7 @@ func (a *APIStore) V1SandboxLogs(c *gin.Context, sandboxID string, params api.V1
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when fetching sandbox logs")
 		telemetry.ReportCriticalError(ctx, "error when fetching sandbox logs", err)
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-node-drain.go
@@ -32,6 +32,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeDrain(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
+
 		return
 	}
 
@@ -39,6 +40,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeDrain(c *gin.Context) {
 	if body.ServiceInstanceID == a.info.ServiceInstanceID && body.ServiceType == api.ClusterNodeTypeEdge {
 		a.info.SetStatus(api.Draining)
 		c.Status(http.StatusOK)
+
 		return
 	}
 
@@ -49,6 +51,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeDrain(c *gin.Context) {
 	err = a.sendNodeRequest(reqTimeout, body.ServiceInstanceID, body.ServiceType, api.Draining)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, "Error when calling service discovery service")
+
 		return
 	}
 
@@ -86,6 +89,7 @@ func (a *APIStore) sendOrchestratorRequest(ctx context.Context, serviceInstanceI
 	)
 	if err != nil {
 		logger.Error("failed to request orchestrator status change", zap.Error(err))
+
 		return errors.New("failed to request orchestrator status change")
 	}
 
@@ -99,6 +103,7 @@ func (a *APIStore) sendEdgeRequest(ctx context.Context, serviceInstanceID string
 	e, err := a.edgePool.GetInstanceByID(serviceInstanceID)
 	if err != nil {
 		logger.Error("failed to get service instance from edge pool", zap.Error(err))
+
 		return errors.New("failed to get edge service instance")
 	}
 
@@ -116,6 +121,7 @@ func (a *APIStore) sendEdgeRequest(ctx context.Context, serviceInstanceID string
 
 	if err != nil {
 		logger.Error("failed to request edge service instance status change", zap.Error(err))
+
 		return errors.New("failed to request edge service instance status change")
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-node-kill.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-node-kill.go
@@ -22,6 +22,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeKill(c *gin.Context) {
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
+
 		return
 	}
 
@@ -29,6 +30,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeKill(c *gin.Context) {
 	if body.ServiceInstanceID == a.info.ServiceInstanceID && body.ServiceType == api.ClusterNodeTypeEdge {
 		a.info.SetStatus(api.Unhealthy)
 		c.Status(http.StatusOK)
+
 		return
 	}
 
@@ -39,6 +41,7 @@ func (a *APIStore) V1ServiceDiscoveryNodeKill(c *gin.Context) {
 	err = a.sendNodeRequest(reqTimeout, body.ServiceInstanceID, body.ServiceType, api.Unhealthy)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, "Error when calling service discovery node")
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/service-discovery-orchestrators.go
+++ b/packages/client-proxy/internal/edge/handlers/service-discovery-orchestrators.go
@@ -58,6 +58,7 @@ func getOrchestratorStatusResolved(s e2borchestrators.OrchestratorStatus) api.Cl
 		return api.Unhealthy
 	default:
 		zap.L().Error("Unknown orchestrator status", zap.String("status", string(s)))
+
 		return api.Unhealthy
 	}
 }

--- a/packages/client-proxy/internal/edge/handlers/store.go
+++ b/packages/client-proxy/internal/edge/handlers/store.go
@@ -65,6 +65,7 @@ func NewStore(
 		if env.IsDebug() {
 			zap.L().Info("Skipping orchestrator readiness check in debug mode")
 			store.info.SetStatus(api.Healthy)
+
 			return
 		}
 
@@ -73,6 +74,7 @@ func NewStore(
 		if config.SkipInitialOrchestratorReadinessCheck {
 			time.Sleep(10 * time.Second)
 			store.info.SetStatus(api.Healthy)
+
 			return
 		}
 
@@ -87,6 +89,7 @@ func NewStore(
 				if len(list) > 0 {
 					zap.L().Info("Marking API as healthy, at least one orchestrator is available")
 					store.info.SetStatus(api.Healthy)
+
 					return
 				}
 			}
@@ -124,6 +127,7 @@ func parseBody[B any](ctx context.Context, c *gin.Context) (body B, err error) {
 	if err != nil {
 		bodyErr := fmt.Errorf("error when parsing request: %w", err)
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
+
 		return body, bodyErr
 	}
 

--- a/packages/client-proxy/internal/edge/handlers/template-build-logs.go
+++ b/packages/client-proxy/internal/edge/handlers/template-build-logs.go
@@ -22,6 +22,7 @@ func apiLevelToLogLevel(level *api.LogLevel) *logs.LogLevel {
 	}
 
 	value := logs.StringToLevel(string(*level))
+
 	return &value
 }
 
@@ -43,6 +44,7 @@ func (a *APIStore) V1TemplateBuildLogs(c *gin.Context, buildID string, params ap
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when fetching template build logs")
 		telemetry.ReportCriticalError(ctx, "error when fetching template build logs", err)
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/http.go
+++ b/packages/client-proxy/internal/edge/http.go
@@ -70,6 +70,7 @@ func NewGinServer(logger *zap.Logger, store *handlers.APIStore, swagger *openapi
 		func(c *gin.Context) {
 			if skippedPaths.MatchString(c.Request.URL.Path) {
 				c.Next()
+
 				return
 			}
 
@@ -81,6 +82,7 @@ func NewGinServer(logger *zap.Logger, store *handlers.APIStore, swagger *openapi
 	)
 
 	api.RegisterHandlersWithOptions(handler, store, api.GinServerOptions{})
+
 	return handler
 }
 

--- a/packages/client-proxy/internal/edge/logger-provider/provider_loki.go
+++ b/packages/client-proxy/internal/edge/logger-provider/provider_loki.go
@@ -43,6 +43,7 @@ func (l *LokiQueryProvider) QueryBuildLogs(ctx context.Context, templateID strin
 	if err != nil {
 		telemetry.ReportError(ctx, "error when returning logs for template build", err)
 		zap.L().Error("error when returning logs for template build", zap.Error(err), logger.WithBuildID(buildID))
+
 		return make([]logs.LogEntry, 0), nil
 	}
 
@@ -50,6 +51,7 @@ func (l *LokiQueryProvider) QueryBuildLogs(ctx context.Context, templateID strin
 	if err != nil {
 		telemetry.ReportError(ctx, "error when mapping build logs", err)
 		zap.L().Error("error when mapping logs for template build", zap.Error(err), logger.WithBuildID(buildID))
+
 		return make([]logs.LogEntry, 0), nil
 	}
 
@@ -67,6 +69,7 @@ func (l *LokiQueryProvider) QuerySandboxLogs(ctx context.Context, teamID string,
 	if err != nil {
 		telemetry.ReportError(ctx, "error when returning logs for sandbox", err)
 		zap.L().Error("error when returning logs for sandbox", zap.Error(err), logger.WithSandboxID(sandboxID))
+
 		return make([]logs.LogEntry, 0), nil
 	}
 
@@ -74,6 +77,7 @@ func (l *LokiQueryProvider) QuerySandboxLogs(ctx context.Context, teamID string,
 	if err != nil {
 		telemetry.ReportError(ctx, "error when mapping sandbox logs", err)
 		zap.L().Error("error when mapping logs for sandbox", zap.Error(err), logger.WithSandboxID(sandboxID))
+
 		return make([]logs.LogEntry, 0), nil
 	}
 

--- a/packages/client-proxy/internal/edge/pool/edge-pool.go
+++ b/packages/client-proxy/internal/edge/pool/edge-pool.go
@@ -56,6 +56,7 @@ func NewEdgePool(logger *zap.Logger, discovery sd.ServiceDiscoveryAdapter, insta
 
 func (p *EdgePool) Close(context.Context) error {
 	p.synchronization.Close()
+
 	return nil
 }
 
@@ -102,12 +103,14 @@ func (e *edgeInstancesSyncStore) PoolList(context.Context) []*EdgeInstance {
 	for _, item := range e.pool.instances.Items() {
 		items = append(items, item)
 	}
+
 	return items
 }
 
 func (e *edgeInstancesSyncStore) PoolExists(_ context.Context, source sd.ServiceDiscoveryItem) bool {
 	host := e.getHost(source.NodeIP, source.NodePort)
 	_, found := e.pool.instances.Get(host)
+
 	return found
 }
 
@@ -122,6 +125,7 @@ func (e *edgeInstancesSyncStore) PoolInsert(ctx context.Context, source sd.Servi
 	o, err := NewEdgeInstance(host, e.pool.auth)
 	if err != nil {
 		zap.L().Error("failed to register new edge instance", zap.String("host", host), zap.Error(err))
+
 		return
 	}
 
@@ -133,6 +137,7 @@ func (e *edgeInstancesSyncStore) PoolInsert(ctx context.Context, source sd.Servi
 	err = o.sync(ctx)
 	if err != nil {
 		zap.L().Error("Failed to finish initial edge instance sync", zap.Error(err), l.WithNodeID(o.GetInfo().NodeID))
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/pool/edge.go
+++ b/packages/client-proxy/internal/edge/pool/edge.go
@@ -61,11 +61,13 @@ func (o *EdgeInstance) sync(ctx context.Context) error {
 		res, err := o.client.V1InfoWithResponse(ctx)
 		if err != nil {
 			zap.L().Error("failed to check edge instance status", l.WithNodeID(info.NodeID), zap.Error(err))
+
 			continue
 		}
 
 		if res.JSON200 == nil {
 			zap.L().Error("failed to check edge instance status", l.WithNodeID(info.NodeID), zap.Int("status", res.StatusCode()))
+
 			continue
 		}
 
@@ -92,6 +94,7 @@ func (o *EdgeInstance) GetClient() *api.ClientWithResponses {
 func (o *EdgeInstance) GetInfo() EdgeInstanceInfo {
 	o.mutex.RLock()
 	defer o.mutex.RUnlock()
+
 	return o.info
 }
 
@@ -108,9 +111,11 @@ func newEdgeApiClient(host string, auth authorization.AuthorizationService) (*ap
 			c.RequestEditors,
 			func(_ context.Context, req *http.Request) error {
 				req.Header.Set(consts.EdgeApiAuthHeader, auth.GetSecret())
+
 				return nil
 			},
 		)
+
 		return nil
 	}
 

--- a/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator-pool.go
@@ -89,6 +89,7 @@ func (p *OrchestratorsPool) statusLogSync() {
 		select {
 		case <-p.close:
 			p.logger.Info("Stopping orchestrators pool sync")
+
 			return
 		case <-ticker.C:
 			orchestrators := len(p.GetOrchestrators())
@@ -150,12 +151,14 @@ func (e *orchestratorInstancesSyncStore) PoolList(_ context.Context) []*Orchestr
 	for _, item := range e.pool.instances.Items() {
 		items = append(items, item)
 	}
+
 	return items
 }
 
 func (e *orchestratorInstancesSyncStore) PoolExists(_ context.Context, source sd.ServiceDiscoveryItem) bool {
 	host := e.getHost(source.NodeIP, source.NodePort)
 	_, found := e.pool.instances.Get(host)
+
 	return found
 }
 
@@ -164,6 +167,7 @@ func (e *orchestratorInstancesSyncStore) PoolInsert(ctx context.Context, source 
 	o, err := NewOrchestratorInstance(e.pool.tracerProvider, e.pool.metricProvider, source.NodeIP, source.NodePort)
 	if err != nil {
 		zap.L().Error("failed to register new orchestrator instance", zap.String("host", host), zap.Error(err))
+
 		return
 	}
 
@@ -175,6 +179,7 @@ func (e *orchestratorInstancesSyncStore) PoolInsert(ctx context.Context, source 
 	err = o.sync(ctx)
 	if err != nil {
 		zap.L().Error("Failed to finish initial orchestrator instance sync", zap.Error(err), l.WithNodeID(o.GetInfo().NodeID))
+
 		return
 	}
 

--- a/packages/client-proxy/internal/edge/pool/orchestrator.go
+++ b/packages/client-proxy/internal/edge/pool/orchestrator.go
@@ -86,6 +86,7 @@ func (o *OrchestratorInstance) sync(ctx context.Context) error {
 		status, err := o.client.Info.ServiceInfo(ctx, &emptypb.Empty{})
 		if err != nil {
 			zap.L().Error("failed to check orchestrator health", l.WithNodeID(freshInfo.NodeID), zap.Error(err))
+
 			continue
 		}
 
@@ -124,6 +125,7 @@ func (o *OrchestratorInstance) setInfo(i OrchestratorInstanceInfo) {
 func (o *OrchestratorInstance) GetInfo() OrchestratorInstanceInfo {
 	o.mutex.RLock()
 	defer o.mutex.RUnlock()
+
 	return o.info
 }
 
@@ -157,6 +159,7 @@ func getMappedStatus(s e2bgrpcorchestratorinfo.ServiceInfoStatus) OrchestratorSt
 	}
 
 	zap.L().Error("Unknown service info status", zap.String("status", s.String()))
+
 	return OrchestratorStatusUnhealthy
 }
 

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -96,6 +96,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 	_, err := telemetry.GetObservableUpDownCounter(
 		meter, telemetry.ClientProxyPoolConnectionsMeterCounterName, func(_ context.Context, observer metric.Int64Observer) error {
 			observer.Observe(proxy.CurrentServerConnections())
+
 			return nil
 		},
 	)
@@ -106,6 +107,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 	_, err = telemetry.GetObservableUpDownCounter(
 		meter, telemetry.ClientProxyPoolSizeMeterCounterName, func(_ context.Context, observer metric.Int64Observer) error {
 			observer.Observe(int64(proxy.CurrentPoolSize()))
+
 			return nil
 		},
 	)
@@ -116,6 +118,7 @@ func NewClientProxy(meterProvider metric.MeterProvider, serviceName string, port
 	_, err = telemetry.GetObservableUpDownCounter(
 		meter, telemetry.ClientProxyServerConnectionsMeterCounterName, func(_ context.Context, observer metric.Int64Observer) error {
 			observer.Observe(proxy.CurrentPoolConnections())
+
 			return nil
 		},
 	)

--- a/packages/client-proxy/internal/service-discovery/builder.go
+++ b/packages/client-proxy/internal/service-discovery/builder.go
@@ -50,6 +50,7 @@ func createDnsProvider(ctx context.Context, config cfg.ServiceDiscoveryConfig, p
 	if len(dnsHosts) == 0 {
 		return nil, ErrMissingDNSQuery
 	}
+
 	return NewDnsServiceDiscovery(ctx, logger, dnsHosts, dnsResolverAddress, port), nil
 }
 

--- a/packages/client-proxy/internal/service-discovery/dns-service-discovery.go
+++ b/packages/client-proxy/internal/service-discovery/dns-service-discovery.go
@@ -69,6 +69,7 @@ func (sd *DnsServiceDiscovery) keepInSync(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			sd.logger.Info("Stopping service discovery keep-in-sync")
+
 			return
 		case <-ticker.C:
 			sd.sync(ctx)
@@ -85,6 +86,7 @@ func (sd *DnsServiceDiscovery) sync(ctx context.Context) {
 	select {
 	case <-ctxTimeout.Done():
 		sd.logger.Error("Service discovery sync timed out")
+
 		return
 	default:
 		for _, host := range sd.hosts {
@@ -96,6 +98,7 @@ func (sd *DnsServiceDiscovery) sync(ctx context.Context) {
 				if err != nil {
 					sd.logger.Error("DNS service discovery failed", zap.Error(err))
 					time.Sleep(dnsRetryWait)
+
 					continue
 				}
 

--- a/packages/client-proxy/internal/service-discovery/k8s-service-discovery.go
+++ b/packages/client-proxy/internal/service-discovery/k8s-service-discovery.go
@@ -69,6 +69,7 @@ func (sd *K8sServiceDiscovery) keepInSync(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			sd.logger.Info("Stopping service discovery keep-in-sync")
+
 			return
 		case <-ticker.C:
 			sd.sync(ctx)
@@ -83,6 +84,7 @@ func (sd *K8sServiceDiscovery) sync(ctx context.Context) {
 	list, err := sd.client.CoreV1().Pods(sd.filterNamespace).List(reqCtx, metav1.ListOptions{LabelSelector: sd.filterLabels})
 	if err != nil {
 		sd.logger.Error("Failed to describe pods", zap.Error(err))
+
 		return
 	}
 

--- a/packages/client-proxy/internal/service-discovery/nomad-service-discovery.go
+++ b/packages/client-proxy/internal/service-discovery/nomad-service-discovery.go
@@ -69,6 +69,7 @@ func (sd *NomadServiceDiscovery) keepInSync(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			sd.logger.Info("Stopping service discovery keep-in-sync")
+
 			return
 		case <-ticker.C:
 			sd.sync(ctx)
@@ -91,6 +92,7 @@ func (sd *NomadServiceDiscovery) sync(ctx context.Context) {
 	results, _, err := sd.client.Allocations().List(options.WithContext(ctx))
 	if err != nil {
 		sd.logger.Error("Failed to list Nomad allocations in service discovery", zap.Error(err))
+
 		return
 	}
 
@@ -98,12 +100,14 @@ func (sd *NomadServiceDiscovery) sync(ctx context.Context) {
 	for _, v := range results {
 		if v.AllocatedResources == nil {
 			sd.logger.Warn("No allocated resources found", zap.String("job", v.JobID), zap.String("alloc", v.ID))
+
 			continue
 		}
 
 		nets := v.AllocatedResources.Shared.Networks
 		if len(nets) == 0 {
 			sd.logger.Warn("No allocation networks found", zap.String("job", v.JobID), zap.String("alloc", v.ID))
+
 			continue
 		}
 

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -108,12 +108,14 @@ func run() int {
 	edgeSD, err := servicediscovery.BuildServiceDiscoveryProvider(ctx, config.EdgeServiceDiscovery, config.EdgePort, logger)
 	if err != nil {
 		logger.Error("Failed to build edge discovery config", zap.Error(err))
+
 		return 1
 	}
 
 	orchestratorsSD, err := servicediscovery.BuildServiceDiscoveryProvider(ctx, config.OrchestratorServiceDiscovery, config.OrchestratorPort, logger)
 	if err != nil {
 		logger.Error("Failed to build orchestrator discovery config", zap.Error(err))
+
 		return 1
 	}
 
@@ -153,6 +155,7 @@ func run() int {
 	)
 	if err != nil {
 		logger.Error("Failed to create client proxy", zap.Error(err))
+
 		return 1
 	}
 
@@ -165,12 +168,14 @@ func run() int {
 	edgeApiStore, err := edge.NewEdgeAPIStore(ctx, logger, info, edges, orchestrators, catalog, config)
 	if err != nil {
 		logger.Error("failed to create edge api store", zap.Error(err))
+
 		return 1
 	}
 
 	edgeApiSwagger, err := api.GetSwagger()
 	if err != nil {
 		logger.Error("Failed to get swagger", zap.Error(err))
+
 		return 1
 	}
 
@@ -179,6 +184,7 @@ func run() int {
 	lis, err := lisCfg.Listen(ctx, "tcp", lisAddr)
 	if err != nil {
 		logger.Error("Failed to listen on edge port", zap.Uint16("port", config.EdgePort), zap.Error(err))
+
 		return 1
 	}
 

--- a/packages/db/client/client.go
+++ b/packages/db/client/client.go
@@ -61,6 +61,7 @@ func NewClient(ctx context.Context, options ...Option) (*Client, error) {
 
 func (db *Client) Close() error {
 	db.conn.Close()
+
 	return nil
 }
 
@@ -72,5 +73,6 @@ func (db *Client) WithTx(ctx context.Context) (*Client, pgx.Tx, error) {
 	}
 
 	client := &Client{Queries: db.Queries.WithTx(tx), conn: db.conn}
+
 	return client, tx, nil
 }

--- a/packages/docker-reverse-proxy/internal/auth/validate.go
+++ b/packages/docker-reverse-proxy/internal/auth/validate.go
@@ -52,6 +52,7 @@ func ValidateAccessToken(ctx context.Context, db *models.Client, accessToken str
 	exists, err := db.AccessToken.Query().Where(accesstoken.AccessTokenHash(hashedToken)).Exist(ctx)
 	if err != nil {
 		log.Printf("Error while checking access token: %s\n", err.Error())
+
 		return false
 	}
 

--- a/packages/docker-reverse-proxy/internal/cache/auth.go
+++ b/packages/docker-reverse-proxy/internal/cache/auth.go
@@ -61,5 +61,6 @@ func (c *AuthCache) Create(templateID, token string, expiresIn int) string {
 	c.cache.Set(userToken, data, authInfoExpiration)
 
 	log.Printf("Created new auth token for '%s' expiring in '%d'\n", templateID, expiresIn)
+
 	return jsonResponse
 }

--- a/packages/docker-reverse-proxy/internal/handlers/proxy.go
+++ b/packages/docker-reverse-proxy/internal/handlers/proxy.go
@@ -35,6 +35,7 @@ func (a *APIStore) Proxy(w http.ResponseWriter, req *http.Request) {
 	// Other methods than PATCH require the Authorization header
 	if strings.HasPrefix(path, constants.GCPArtifactUploadPrefix) {
 		a.ServeHTTP(w, req)
+
 		return
 	}
 
@@ -45,6 +46,7 @@ func (a *APIStore) Proxy(w http.ResponseWriter, req *http.Request) {
 		log.Printf("No matching route found for path: %s\n", path)
 
 		w.WriteHeader(http.StatusForbidden)
+
 		return
 	}
 

--- a/packages/docker-reverse-proxy/internal/handlers/token.go
+++ b/packages/docker-reverse-proxy/internal/handlers/token.go
@@ -34,6 +34,7 @@ func (a *APIStore) GetToken(w http.ResponseWriter, r *http.Request) error {
 	accessToken, err := auth.ExtractAccessToken(authHeader, "Basic ")
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
+
 		return fmt.Errorf("error while extracting access token: %w", err)
 	}
 

--- a/packages/docker-reverse-proxy/internal/utils/random.go
+++ b/packages/docker-reverse-proxy/internal/utils/random.go
@@ -11,5 +11,6 @@ func GenerateRandomString(length int) string {
 	if err != nil {
 		panic(err)
 	}
+
 	return base64.StdEncoding.EncodeToString(b)
 }

--- a/packages/docker-reverse-proxy/internal/utils/string.go
+++ b/packages/docker-reverse-proxy/internal/utils/string.go
@@ -4,5 +4,6 @@ func SubstringMax(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
+
 	return s[:maxLen] + "..."
 }

--- a/packages/docker-reverse-proxy/main.go
+++ b/packages/docker-reverse-proxy/main.go
@@ -36,6 +36,7 @@ func main() {
 		// Health check for nomad
 		if req.URL.Path == "/health" {
 			store.HealthCheck(w, req)
+
 			return
 		}
 
@@ -45,6 +46,7 @@ func main() {
 		// https://distribution.github.io/distribution/spec/api/#starting-an-upload
 		if req.Method == http.MethodPatch && strings.HasPrefix(path, constants.GCPArtifactUploadPrefix) {
 			store.ServeHTTP(w, req)
+
 			return
 		}
 
@@ -52,6 +54,7 @@ func main() {
 		// We are using Token validation, and not OAuth2, so we need to return 404 for the POST /v2/token endpoint
 		if req.URL.Path == "/v2/token" && req.Method == http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 
@@ -69,6 +72,7 @@ func main() {
 			if err != nil {
 				log.Printf("Error while getting token: %s\n", err)
 			}
+
 			return
 		}
 

--- a/packages/envd/internal/api/auth.go
+++ b/packages/envd/internal/api/auth.go
@@ -38,6 +38,7 @@ func (a *API) WithAuthorization(handler http.Handler) http.Handler {
 
 				err := fmt.Errorf("unauthorized access, please provide a valid access token or method signing if supported")
 				jsonError(w, http.StatusUnauthorized, err)
+
 				return
 			}
 		}
@@ -100,6 +101,7 @@ func (a *API) validateSigning(r *http.Request, signature *string, signatureExpir
 
 	if err != nil {
 		a.logger.Error().Err(err).Msg("error generating signing key")
+
 		return errors.New("invalid signature")
 	}
 

--- a/packages/envd/internal/api/download.go
+++ b/packages/envd/internal/api/download.go
@@ -31,6 +31,7 @@ func (a *API) GetFiles(w http.ResponseWriter, r *http.Request, params GetFilesPa
 	if err != nil {
 		a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("error during auth validation")
 		jsonError(w, http.StatusUnauthorized, err)
+
 		return
 	}
 
@@ -38,6 +39,7 @@ func (a *API) GetFiles(w http.ResponseWriter, r *http.Request, params GetFilesPa
 	if err != nil {
 		a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("no user specified")
 		jsonError(w, http.StatusBadRequest, err)
+
 		return
 	}
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -61,6 +61,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusBadRequest)
 				}
 				w.Write([]byte(err.Error()))
+
 				return
 			}
 		}
@@ -105,6 +106,7 @@ func (a *API) SetData(logger zerolog.Logger, data PostInitJSONBody) error {
 	if data.AccessToken != nil {
 		if a.accessToken != nil && *data.AccessToken != *a.accessToken {
 			logger.Error().Msg("Access token is already set and cannot be changed")
+
 			return ErrAccessTokenAlreadySet
 		}
 

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -58,6 +58,7 @@ func (a *API) GetMetrics(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		a.logger.Error().Err(err).Msg("Failed to get metrics")
 		w.WriteHeader(http.StatusInternalServerError)
+
 		return
 	}
 

--- a/packages/envd/internal/api/upload.go
+++ b/packages/envd/internal/api/upload.go
@@ -168,6 +168,7 @@ func (a *API) PostFiles(w http.ResponseWriter, r *http.Request, params PostFiles
 	if err != nil {
 		a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("error during auth validation")
 		jsonError(w, http.StatusUnauthorized, err)
+
 		return
 	}
 
@@ -175,6 +176,7 @@ func (a *API) PostFiles(w http.ResponseWriter, r *http.Request, params PostFiles
 	if err != nil {
 		a.logger.Error().Err(err).Str(string(logs.OperationIDKey), operationID).Msg("no user specified")
 		jsonError(w, http.StatusBadRequest, err)
+
 		return
 	}
 

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -119,17 +119,20 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 		select {
 		case <-ctx.Done():
 			fmt.Fprintf(os.Stderr, "context cancelled while waiting for mmds opts")
+
 			return
 		case <-ticker.C:
 			token, err := getMMDSToken(ctx, httpClient)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error getting mmds token: %v\n", err)
+
 				continue
 			}
 
 			mmdsOpts, err := getMMDSOpts(ctx, httpClient, token)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error getting mmds opts: %v\n", err)
+
 				continue
 			}
 

--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -189,6 +189,7 @@ func (f *Forwarder) stopPortForwarding(p *PortToForward) {
 
 	if err := syscall.Kill(-p.socat.Process.Pid, syscall.SIGKILL); err != nil {
 		logger.Error().Err(err).Msg("Failed to kill process group")
+
 		return
 	}
 

--- a/packages/envd/internal/services/filesystem/dir.go
+++ b/packages/envd/internal/services/filesystem/dir.go
@@ -166,6 +166,7 @@ func walkDir(requestedPath string, dirPath string, depth int) (entries []*rpc.En
 		entryInfo.Path = path
 
 		entries = append(entries, entryInfo)
+
 		return nil
 	})
 	if err != nil {

--- a/packages/envd/internal/services/filesystem/utils.go
+++ b/packages/envd/internal/services/filesystem/utils.go
@@ -55,6 +55,7 @@ func entryInfo(path string) (*rpc.EntryInfo, error) {
 		if os.IsNotExist(err) {
 			return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("file not found: %w", err))
 		}
+
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error getting file info: %w", err))
 	}
 

--- a/packages/envd/internal/services/filesystem/watch_sync.go
+++ b/packages/envd/internal/services/filesystem/watch_sync.go
@@ -40,6 +40,7 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 	if err != nil {
 		_ = w.Close()
 		cancel()
+
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error adding path %s to watcher: %w", watchPath, err))
 	}
 	fw := &FileWatcher{
@@ -57,14 +58,17 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 			case chErr, ok := <-w.Errors:
 				if !ok {
 					fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("watcher error channel closed"))
+
 					return
 				}
 
 				fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("watcher error: %w", chErr))
+
 				return
 			case e, ok := <-w.Events:
 				if !ok {
 					fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("watcher event channel closed"))
+
 					return
 				}
 
@@ -95,6 +99,7 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 					name, nameErr := filepath.Rel(watchPath, e.Name)
 					if nameErr != nil {
 						fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("error getting relative path: %w", nameErr))
+
 						return
 					}
 

--- a/packages/envd/internal/services/legacy/conversion.go
+++ b/packages/envd/internal/services/legacy/conversion.go
@@ -37,6 +37,7 @@ func addConverter[TIn, TOut any](fn func(TIn) TOut) {
 		}
 
 		c := fn(b)
+
 		return connect.NewResponse[TOut](&c), nil
 	}
 
@@ -47,6 +48,7 @@ func addConverter[TIn, TOut any](fn func(TIn) TOut) {
 		}
 
 		c := fn(b)
+
 		return &c
 	}
 }
@@ -144,6 +146,7 @@ func maybeConvertResponse(logger *zerolog.Logger, response connect.AnyResponse) 
 		logger.Warn().
 			Type("response", response).
 			Msg("cannot convert, expected protoreflect.ProtoMessage")
+
 		return response
 	}
 
@@ -153,6 +156,7 @@ func maybeConvertResponse(logger *zerolog.Logger, response connect.AnyResponse) 
 		logger.Error().
 			Type("response", response).
 			Msg("do not know how to convert")
+
 		return response
 	}
 
@@ -181,6 +185,7 @@ func convertStartEvent(e *filesystem.WatchDirResponse_StartEvent) *WatchDirRespo
 	if e == nil {
 		return nil
 	}
+
 	return &WatchDirResponse_StartEvent{}
 }
 
@@ -188,6 +193,7 @@ func convertFilesystemEvent(e *filesystem.FilesystemEvent) *FilesystemEvent {
 	if e == nil {
 		return nil
 	}
+
 	return &FilesystemEvent{
 		Name: e.GetName(),
 		Type: EventType(e.GetType()),
@@ -198,5 +204,6 @@ func convertKeepAlive(e *filesystem.WatchDirResponse_KeepAlive) *WatchDirRespons
 	if e == nil {
 		return nil
 	}
+
 	return &WatchDirResponse_KeepAlive{}
 }

--- a/packages/envd/internal/services/legacy/interceptor.go
+++ b/packages/envd/internal/services/legacy/interceptor.go
@@ -18,6 +18,7 @@ func shouldHideChanges(request http.Header, response http.Header) bool {
 	}
 
 	response.Set(notifyHeader, "true")
+
 	return true
 }
 

--- a/packages/envd/internal/services/legacy/interceptor_test.go
+++ b/packages/envd/internal/services/legacy/interceptor_test.go
@@ -65,6 +65,7 @@ func TestInterceptor(t *testing.T) {
 		req := connect.NewRequest[filesystem.ListDirRequest](&filesystem.ListDirRequest{Path: "/a/b/c"})
 		resp, err := client.ListDir(t.Context(), req)
 		require.NoError(t, err)
+
 		return resp.Header()
 	}
 
@@ -159,6 +160,7 @@ func (u userAgentInterceptor) WrapStreamingClient(clientFunc connect.StreamingCl
 	return func(ctx context.Context, s connect.Spec) connect.StreamingClientConn {
 		conn := clientFunc(ctx, s)
 		conn.RequestHeader().Set("user-agent", u.userAgent)
+
 		return conn
 	}
 }

--- a/packages/envd/internal/services/legacy/stream.go
+++ b/packages/envd/internal/services/legacy/stream.go
@@ -28,6 +28,7 @@ func (s streamConverter) RequestHeader() http.Header {
 
 func (s streamConverter) Send(a any) error {
 	a = maybeConvertValue(a)
+
 	return s.conn.Send(a)
 }
 

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -108,6 +108,7 @@ func New(
 	if defaults.EnvVars != nil {
 		defaults.EnvVars.Range(func(key string, value string) bool {
 			formattedVars = append(formattedVars, key+"="+value)
+
 			return true
 		})
 	}

--- a/packages/envd/internal/services/process/service.go
+++ b/packages/envd/internal/services/process/service.go
@@ -62,6 +62,7 @@ func (s *Service) getProcess(selector *rpc.ProcessSelector) (*handler.Handler, e
 
 			if *value.Tag == tag {
 				proc = value
+
 				return true
 			}
 

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -151,10 +151,12 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				})
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr)))
+
 					return
 				}
 			case <-ctx.Done():
 				cancel(ctx.Err())
+
 				return
 			case event, ok := <-data:
 				if !ok {
@@ -168,6 +170,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				})
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending data event: %w", streamErr)))
+
 					return
 				}
 

--- a/packages/envd/internal/utils/atomic.go
+++ b/packages/envd/internal/utils/atomic.go
@@ -22,5 +22,6 @@ func (a *AtomicMax) SetToGreater(newValue int64) bool {
 	}
 
 	a.val = newValue
+
 	return true
 }

--- a/packages/envd/internal/utils/map.go
+++ b/packages/envd/internal/utils/map.go
@@ -21,6 +21,7 @@ func (m *Map[K, V]) Load(key K) (value V, ok bool) {
 	if !ok {
 		return value, ok
 	}
+
 	return v.(V), ok
 }
 
@@ -29,11 +30,13 @@ func (m *Map[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
 	if !loaded {
 		return value, loaded
 	}
+
 	return v.(V), loaded
 }
 
 func (m *Map[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
 	a, loaded := m.m.LoadOrStore(key, value)
+
 	return a.(V), loaded
 }
 

--- a/packages/envd/internal/utils/multipart.go
+++ b/packages/envd/internal/utils/multipart.go
@@ -23,6 +23,7 @@ func (p *CustomPart) FileNameWithPath() (string, error) {
 	if !ok {
 		return "", errors.New("filename not found in Content-Disposition header")
 	}
+
 	return filename, nil
 }
 
@@ -32,6 +33,7 @@ func (p *CustomPart) parseContentDisposition() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return dispositionParams, nil
 }
 

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -114,6 +114,7 @@ func withCORS(h http.Handler) http.Handler {
 		),
 		MaxAge: int(maxAge.Seconds()),
 	})
+
 	return middleware.Handler(h)
 }
 
@@ -122,11 +123,13 @@ func main() {
 
 	if versionFlag {
 		fmt.Printf("%s\n", Version)
+
 		return
 	}
 
 	if commitFlag {
 		fmt.Printf("%s\n", commitSHA)
+
 		return
 	}
 

--- a/packages/local-dev/seed-local-database.go
+++ b/packages/local-dev/seed-local-database.go
@@ -155,6 +155,7 @@ func ignoreConstraints(err error) error {
 			return nil
 		}
 	}
+
 	return err
 }
 
@@ -184,6 +185,7 @@ func upsertTeam(ctx context.Context, database *db.DB) (*models.Team, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create team: %w", err)
 	}
+
 	return team, nil
 }
 
@@ -201,6 +203,7 @@ func upsertUser(ctx context.Context, database *db.DB) (*models.User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to upsert user: %w", err)
 	}
+
 	return user, nil
 }
 
@@ -224,5 +227,6 @@ func createTokenHash(prefix, accessToken string) (string, keys.MaskedIdentifier,
 	if err != nil {
 		return "", keys.MaskedIdentifier{}, fmt.Errorf("failed to mask key")
 	}
+
 	return accessTokenHash, accessTokenMask, nil
 }

--- a/packages/orchestrator/benchmark_test.go
+++ b/packages/orchestrator/benchmark_test.go
@@ -334,6 +334,7 @@ func (tc *testContainer) testOneItem(b *testing.B, buildID, kernelVersion, fcVer
 		err = sbx.Close(ctx)
 		require.NoError(b, err)
 		b.StartTimer()
+
 		return
 	}
 

--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -230,5 +230,6 @@ func buildTemplate(
 	}
 
 	fmt.Println("Build finished, closing...")
+
 	return nil
 }

--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -142,12 +142,14 @@ func newOtelCore(ctx context.Context, opts opts) (zapcore.Core, error) {
 
 	loggerProvider := telemetry.NewLogProvider(logsExporter, resource)
 	otelCore := logger.GetOTELCore(loggerProvider, serviceName)
+
 	return otelCore, nil
 }
 
 func printSummary(r results, opts opts) {
 	if r.deletedFiles == 0 {
 		zap.L().Info("no files deleted")
+
 		return
 	}
 
@@ -177,6 +179,7 @@ func standardDeviation(accessed []time.Duration) time.Duration {
 	}
 
 	sd = math.Sqrt(sd / float64(len(accessed)))
+
 	return time.Duration(sd)
 }
 
@@ -195,6 +198,7 @@ func minDuration(durations []time.Duration) time.Duration {
 func loop[T any](items []T, betterThan func(one, two T) bool) T {
 	if len(items) == 0 {
 		var t T
+
 		return t
 	}
 
@@ -237,6 +241,7 @@ func deleteOldestFiles(cache *pkg.ListingCache, files []pkg.File, opts opts, dis
 				zap.L().Error("failed to delete",
 					zap.String("path", file.Path),
 					zap.Error(err))
+
 				continue
 			}
 		}
@@ -308,6 +313,7 @@ func getFiles(cache *pkg.ListingCache, maxFiles int) ([]pkg.File, error) {
 	}
 
 	reportGetFilesProgress(len(usedFiles), dupeHits)
+
 	return items, nil
 }
 

--- a/packages/orchestrator/cmd/clean-nfs-cache/pkg/atime_linux.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/pkg/atime_linux.go
@@ -28,6 +28,7 @@ func GetFileMetadata(fullPath string) (File, error) {
 	if statx.Mask&unix.STATX_BTIME == unix.STATX_BTIME {
 		t.BTime = statxTimestampToTime(statx.Btime)
 	}
+
 	return t, nil
 }
 

--- a/packages/orchestrator/cmd/clean-nfs-cache/pkg/cache_test.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/pkg/cache_test.go
@@ -128,6 +128,7 @@ func buildItemsFromPaths(basePath string, input []string) []cacheEntry {
 			isDir: false,
 		})
 	}
+
 	return items
 }
 

--- a/packages/orchestrator/cmd/mock-nbd/mock.go
+++ b/packages/orchestrator/cmd/mock-nbd/mock.go
@@ -89,6 +89,7 @@ func main() {
 	devicePool, err := nbd.NewDevicePool()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create device pool: %v\n", err)
+
 		return
 	}
 	go func() {
@@ -99,6 +100,7 @@ func main() {
 		err = devicePool.Close(ctx)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to close device pool: %v\n", err)
+
 			return
 		}
 	}()

--- a/packages/orchestrator/internal/events/sandbox_events_service.go
+++ b/packages/orchestrator/internal/events/sandbox_events_service.go
@@ -54,6 +54,7 @@ func (es *SandboxEventsService) HandleEvent(ctx context.Context, event event.San
 	err := validateEvent(event)
 	if err != nil {
 		es.logger.Error("error validating sandbox event", zap.Error(err))
+
 		return
 	}
 
@@ -77,6 +78,7 @@ func (es *SandboxEventsService) handlePubSubEvent(ctx context.Context, event eve
 		shouldPublish, err := es.pubsub.ShouldPublish(ctx, webhooks.DeriveKey(event.SandboxTeamID))
 		if err != nil {
 			es.logger.Error("error checking if sandbox should publish", zap.Error(err))
+
 			return
 		}
 

--- a/packages/orchestrator/internal/factories/cmux.go
+++ b/packages/orchestrator/internal/factories/cmux.go
@@ -16,5 +16,6 @@ func NewCMUXServer(ctx context.Context, port uint16) (cmux.CMux, error) {
 	}
 
 	m := cmux.New(lis)
+
 	return m, nil
 }

--- a/packages/orchestrator/internal/factories/redis.go
+++ b/packages/orchestrator/internal/factories/redis.go
@@ -45,5 +45,6 @@ func CloseCleanly(client redis.UniversalClient) error {
 	if err := client.Close(); err != nil && !errors.Is(err, redis.ErrClosed) {
 		return err
 	}
+
 	return nil
 }

--- a/packages/orchestrator/internal/healthcheck/healthcheck.go
+++ b/packages/orchestrator/internal/healthcheck/healthcheck.go
@@ -31,6 +31,7 @@ func (h *Healthcheck) CreateHandler() http.Handler {
 	// Start /health HTTP server
 	routeMux := http.NewServeMux()
 	routeMux.HandleFunc("/health", h.healthHandler)
+
 	return routeMux
 }
 

--- a/packages/orchestrator/internal/hyperloopserver/handlers/logs.go
+++ b/packages/orchestrator/internal/hyperloopserver/handlers/logs.go
@@ -16,6 +16,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 	if err != nil {
 		h.sendAPIStoreError(c, http.StatusBadRequest, "Error when finding source sandbox")
 		h.logger.Error("error finding sandbox for source addr", zap.String("addr", c.Request.RemoteAddr), zap.Error(err))
+
 		return
 	}
 
@@ -25,6 +26,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 	if err := c.ShouldBindJSON(&payload); err != nil {
 		h.sendAPIStoreError(c, http.StatusBadRequest, "Invalid body for logs")
 		h.logger.Error("error when parsing sandbox logs request", zap.Error(err), logger.WithSandboxID(sbxID))
+
 		return
 	}
 
@@ -36,6 +38,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 	if err != nil {
 		h.sendAPIStoreError(c, http.StatusInternalServerError, "Error when parsing logs payload")
 		h.logger.Error("error when parsing logs payload", zap.Error(err), logger.WithSandboxID(sbxID))
+
 		return
 	}
 
@@ -43,6 +46,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 	if err != nil {
 		h.sendAPIStoreError(c, http.StatusInternalServerError, "Error when creating request to forwarding sandbox logs")
 		h.logger.Error("error when creating request to forwarding sandbox logs", zap.Error(err), logger.WithSandboxID(sbxID))
+
 		return
 	}
 
@@ -51,6 +55,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 	if err != nil {
 		h.sendAPIStoreError(c, http.StatusInternalServerError, "Error when forwarding sandbox logs")
 		h.logger.Error("error when forwarding sandbox logs", zap.Error(err), logger.WithSandboxID(sbxID))
+
 		return
 	}
 	defer response.Body.Close()

--- a/packages/orchestrator/internal/hyperloopserver/handlers/me.go
+++ b/packages/orchestrator/internal/hyperloopserver/handlers/me.go
@@ -14,6 +14,7 @@ func (h *APIStore) Me(c *gin.Context) {
 	if err != nil {
 		h.sendAPIStoreError(c, http.StatusBadRequest, "Error when finding source sandbox")
 		h.logger.Error("error finding sandbox for source addr", zap.String("addr", c.Request.RemoteAddr), zap.Error(err))
+
 		return
 	}
 

--- a/packages/orchestrator/internal/metrics/sandboxes.go
+++ b/packages/orchestrator/internal/metrics/sandboxes.go
@@ -68,6 +68,7 @@ func NewSandboxObserver(ctx context.Context, nodeID, serviceName, serviceCommit,
 		if kind == sdkmetric.InstrumentKindGauge {
 			return metricdata.DeltaTemporality
 		}
+
 		return metricdata.CumulativeTemporality
 	})
 
@@ -155,6 +156,7 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 				ok, err := utils.IsGTEVersion(sbx.Config.Envd.Version, minEnvdVersionForMetrics)
 				if err != nil {
 					zap.L().Error("Failed to check envd version", zap.Error(err), logger.WithSandboxID(sbx.Runtime.SandboxID))
+
 					continue
 				}
 				if !ok {
@@ -252,6 +254,7 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 							zap.Float32("cpu_threshold_percent", sbxCpuThresholdPct),
 						)
 					}
+
 					return nil
 				})
 			}

--- a/packages/orchestrator/internal/sandbox/block/cache.go
+++ b/packages/orchestrator/internal/sandbox/block/cache.go
@@ -107,6 +107,7 @@ func (m *Cache) ExportToDiff(out io.Writer) (*header.DiffMetadata, error) {
 		}
 		if isEmpty {
 			empty.Set(uint(blockIdx))
+
 			continue
 		}
 
@@ -242,6 +243,7 @@ func (m *Cache) dirtySortedKeys() []int64 {
 	var keys []int64
 	m.dirty.Range(func(key, _ any) bool {
 		keys = append(keys, key.(int64))
+
 		return true
 	})
 	sort.Slice(keys, func(i, j int) bool {

--- a/packages/orchestrator/internal/sandbox/block/chunk.go
+++ b/packages/orchestrator/internal/sandbox/block/chunk.go
@@ -84,6 +84,7 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64) ([]byte, error) 
 		timer.End(ctx, length,
 			attribute.String(result, resultTypeSuccess),
 			attribute.String(pullType, pullTypeLocal))
+
 		return b, nil
 	}
 
@@ -92,6 +93,7 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64) ([]byte, error) 
 			attribute.String(result, "failure"),
 			attribute.String(pullType, pullTypeLocal),
 			attribute.String(failureReason, failureTypeLocalRead))
+
 		return nil, fmt.Errorf("failed read from cache at offset %d: %w", off, err)
 	}
 
@@ -101,6 +103,7 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64) ([]byte, error) 
 			attribute.String(result, resultTypeFailure),
 			attribute.String(pullType, pullTypeRemote),
 			attribute.String(failureReason, failureTypeCacheFetch))
+
 		return nil, fmt.Errorf("failed to ensure data at %d-%d: %w", off, off+length, chunkErr)
 	}
 
@@ -110,12 +113,14 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64) ([]byte, error) 
 			attribute.String(result, resultTypeFailure),
 			attribute.String(pullType, pullTypeLocal),
 			attribute.String(failureReason, failureTypeLocalReadAgain))
+
 		return nil, fmt.Errorf("failed to read from cache after ensuring data at %d-%d: %w", off, off+length, cacheErr)
 	}
 
 	timer.End(ctx, length,
 		attribute.String(result, resultTypeSuccess),
 		attribute.String(pullType, pullTypeRemote))
+
 	return b, nil
 }
 
@@ -156,6 +161,7 @@ func (c *Chunker) fetchToCache(ctx context.Context, off, length int64) error {
 						attribute.String(result, resultTypeFailure),
 						attribute.String(failureReason, failureTypeRemoteRead),
 					)
+
 					return fmt.Errorf("failed to read chunk from base %d: %w", fetchOff, err)
 				}
 				fetchSW.End(ctx, int64(readBytes), attribute.String("result", resultTypeSuccess))
@@ -168,6 +174,7 @@ func (c *Chunker) fetchToCache(ctx context.Context, off, length int64) error {
 						attribute.String(result, resultTypeFailure),
 						attribute.String(failureReason, failureTypeLocalWrite),
 					)
+
 					return fmt.Errorf("failed to write chunk %d to cache: %w", fetchOff, cacheErr)
 				}
 

--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -156,6 +156,7 @@ func (s *DiffStore) startDiskSpaceEviction(
 			if err != nil {
 				zap.L().Error("failed to get disk usage", zap.Error(err))
 				timer.Reset(getDelay(false))
+
 				continue
 			}
 
@@ -170,6 +171,7 @@ func (s *DiffStore) startDiskSpaceEviction(
 				st, err := flags.IntFlag(ctx, featureflags.BuildCacheMaxUsagePercentage, featureflags.ServiceContext(string(s)))
 				if err != nil {
 					zap.L().Warn("failed to get build cache max usage percentage flag", zap.Error(err))
+
 					continue
 				}
 
@@ -180,6 +182,7 @@ func (s *DiffStore) startDiskSpaceEviction(
 
 			if percentage <= float64(threshold) {
 				timer.Reset(getDelay(false))
+
 				continue
 			}
 
@@ -187,6 +190,7 @@ func (s *DiffStore) startDiskSpaceEviction(
 			if err != nil {
 				zap.L().Error("failed to delete oldest item from cache", zap.Error(err))
 				timer.Reset(getDelay(false))
+
 				continue
 			}
 
@@ -204,6 +208,7 @@ func (s *DiffStore) getPendingDeletesSize() int64 {
 	for _, value := range s.pdSizes {
 		pendingSize += value.size
 	}
+
 	return pendingSize
 }
 
@@ -236,6 +241,7 @@ func (s *DiffStore) deleteOldestFromCache(ctx context.Context) (suc bool, e erro
 		s.scheduleDelete(ctx, item.Key(), sfSize)
 
 		success = true
+
 		return false
 	})
 
@@ -262,6 +268,7 @@ func (s *DiffStore) isBeingDeleted(key DiffStoreKey) bool {
 	defer s.pdMu.RUnlock()
 
 	_, f := s.pdSizes[key]
+
 	return f
 }
 

--- a/packages/orchestrator/internal/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/internal/sandbox/build/storage_diff.go
@@ -68,6 +68,7 @@ func (b *StorageDiff) Init(ctx context.Context) error {
 	if err != nil {
 		errMsg := fmt.Errorf("failed to get object size: %w", err)
 		b.chunker.SetError(errMsg)
+
 		return errMsg
 	}
 
@@ -75,6 +76,7 @@ func (b *StorageDiff) Init(ctx context.Context) error {
 	if err != nil {
 		errMsg := fmt.Errorf("failed to create chunker: %w", err)
 		b.chunker.SetError(errMsg)
+
 		return errMsg
 	}
 

--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -86,11 +86,13 @@ func (c *Checks) Healthcheck(ctx context.Context, alwaysReport bool) {
 	if !ok && c.healthy.CompareAndSwap(true, false) {
 		sbxlogger.E(c.sandbox).Healthcheck(sbxlogger.Fail)
 		sbxlogger.I(c.sandbox).Error("healthcheck failed", zap.Error(err))
+
 		return
 	}
 
 	if ok && c.healthy.CompareAndSwap(false, true) {
 		sbxlogger.E(c.sandbox).Healthcheck(sbxlogger.Success)
+
 		return
 	}
 

--- a/packages/orchestrator/internal/sandbox/cleanup.go
+++ b/packages/orchestrator/internal/sandbox/cleanup.go
@@ -30,6 +30,7 @@ func NewCleanup() *Cleanup {
 func (c *Cleanup) Add(f func(ctx context.Context) error) {
 	if c.hasRun.Load() == true {
 		zap.L().Error("Add called after cleanup has run, ignoring function")
+
 		return
 	}
 
@@ -42,6 +43,7 @@ func (c *Cleanup) Add(f func(ctx context.Context) error) {
 func (c *Cleanup) AddPriority(f func(ctx context.Context) error) {
 	if c.hasRun.Load() == true {
 		zap.L().Error("AddPriority called after cleanup has run, ignoring function")
+
 		return
 	}
 
@@ -55,6 +57,7 @@ func (c *Cleanup) Run(ctx context.Context) error {
 	c.once.Do(func() {
 		c.run(context.WithoutCancel(ctx))
 	})
+
 	return c.error
 }
 

--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -62,6 +62,7 @@ func doRequestWithInfiniteRetries(
 		request, err := http.NewRequestWithContext(reqCtx, method, address, bytes.NewReader(body))
 		if err != nil {
 			cancel()
+
 			return nil, requestCount, err
 		}
 
@@ -123,6 +124,7 @@ func (s *Sandbox) initEnvd(ctx context.Context) error {
 	)
 	if err != nil {
 		envdInitCalls.Add(ctx, count, metric.WithAttributes(attributesFail...))
+
 		return fmt.Errorf("failed to init envd: %w", err)
 	}
 
@@ -147,6 +149,7 @@ func (s *Sandbox) initEnvd(ctx context.Context) error {
 			zap.Int("status_code", response.StatusCode),
 			zap.String("response_body", utils.Truncate(string(body), 100)),
 		)
+
 		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
 

--- a/packages/orchestrator/internal/sandbox/fc/client.go
+++ b/packages/orchestrator/internal/sandbox/fc/client.go
@@ -171,6 +171,7 @@ func (c *apiClient) setBootSource(ctx context.Context, kernelArgs string, kernel
 	}
 
 	_, err := c.client.Operations.PutGuestBootSource(&bootSourceConfig)
+
 	return err
 }
 
@@ -257,6 +258,7 @@ func (c *apiClient) setMachineConfig(
 	if err != nil {
 		return fmt.Errorf("error setting fc machine config: %w", err)
 	}
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/fc/kernel_args.go
+++ b/packages/orchestrator/internal/sandbox/fc/kernel_args.go
@@ -18,5 +18,6 @@ func (ka KernelArgs) String() string {
 		}
 	}
 	sort.Strings(args) // optional: for consistent output
+
 	return strings.Join(args, " ")
 }

--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -323,6 +323,7 @@ func (p *Process) Create(
 	}
 
 	telemetry.ReportEvent(ctx, "started fc")
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/internal/sandbox/fc/script_builder.go
@@ -70,6 +70,7 @@ type StartScriptBuilder struct {
 func NewStartScriptBuilder(builderConfig cfg.BuilderConfig) *StartScriptBuilder {
 	templateV1 := txtTemplate.Must(txtTemplate.New("fc-start-v1").Parse(startScriptV1))
 	templateV2 := txtTemplate.Must(txtTemplate.New("fc-start-v2").Parse(startScriptV2))
+
 	return &StartScriptBuilder{
 		builderConfig: builderConfig,
 		templateV1:    templateV1,
@@ -155,6 +156,7 @@ func (sb *StartScriptBuilder) getRootfsPath(args startScriptArgs, rootfsPaths Ro
 	if rootfsPaths.TemplateVersion <= 1 {
 		rootfsPath = filepath.Join(args.DeprecatedSandboxRootfsDir, args.SandboxRootfsFile)
 	}
+
 	return rootfsPath
 }
 

--- a/packages/orchestrator/internal/sandbox/metrics.go
+++ b/packages/orchestrator/internal/sandbox/metrics.go
@@ -52,6 +52,7 @@ func (c *Checks) GetMetrics(ctx context.Context, timeout time.Duration) (*Metric
 
 	if response.StatusCode != http.StatusOK {
 		err = fmt.Errorf("unexpected status code: %d", response.StatusCode)
+
 		return nil, err
 	}
 

--- a/packages/orchestrator/internal/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/internal/sandbox/nbd/dispatch.go
@@ -73,6 +73,7 @@ func NewDispatch(fp io.ReadWriter, prov Provider) *Dispatch {
 	}
 
 	binary.BigEndian.PutUint32(d.responseHeader, NBDResponseMagic)
+
 	return d
 }
 
@@ -170,6 +171,7 @@ func (d *Dispatch) Handle(ctx context.Context) error {
 					rp += 28
 					if wp-rp < int(request.Length) {
 						rp -= 28
+
 						break process // We don't have enough data yet... Wait for next read
 					}
 					data := make([]byte, request.Length)
@@ -206,6 +208,7 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		d.pendingResponses.Add(1)
 	} else {
 		d.shuttingDownLock.Unlock()
+
 		return ErrShuttingDown
 	}
 	d.shuttingDownLock.Unlock()
@@ -255,6 +258,7 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 		d.pendingResponses.Add(1)
 	} else {
 		d.shuttingDownLock.Unlock()
+
 		return ErrShuttingDown
 	}
 	d.shuttingDownLock.Unlock()
@@ -292,6 +296,7 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 		}
 		d.pendingResponses.Done()
 	}()
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/nbd/pool.go
+++ b/packages/orchestrator/internal/sandbox/nbd/pool.go
@@ -137,6 +137,7 @@ func (d *DevicePool) Populate(ctx context.Context) {
 
 			failedCount++
 			time.Sleep(waitOnNBDError)
+
 			continue
 		}
 		failedCount = 0
@@ -259,6 +260,7 @@ func (d *DevicePool) GetDevice(ctx context.Context) (DeviceSlot, error) {
 	case slot := <-d.slots:
 		acquired.Add(ctx, 1)
 		slotCounter.Add(ctx, -1)
+
 		return slot, nil
 	}
 }
@@ -278,6 +280,7 @@ func (d *DevicePool) release(ctx context.Context, idx DeviceSlot) error {
 	d.mu.Unlock()
 
 	released.Add(ctx, 1)
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/network/firewall.go
+++ b/packages/orchestrator/internal/sandbox/network/firewall.go
@@ -80,6 +80,7 @@ func NewFirewall(tapIf string) (*Firewall, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error while configuring initial block set: %w", err)
 	}
+
 	return fw, nil
 }
 
@@ -181,6 +182,7 @@ func (fw *Firewall) AddBlockedIP(cidr string) error {
 	if err != nil {
 		return fmt.Errorf("flush add blocked IP changes: %w", err)
 	}
+
 	return nil
 }
 
@@ -203,6 +205,7 @@ func (fw *Firewall) AddAllowedIP(cidr string) error {
 	if err != nil {
 		return fmt.Errorf("flush add allowed IP changes: %w", err)
 	}
+
 	return nil
 }
 
@@ -227,6 +230,7 @@ func (fw *Firewall) ResetBlockedCustom() error {
 	if err := fw.blockSet.ClearAndAddElements(fw.conn, initData); err != nil {
 		return err
 	}
+
 	return fw.conn.Flush()
 }
 

--- a/packages/orchestrator/internal/sandbox/network/slot.go
+++ b/packages/orchestrator/internal/sandbox/network/slot.go
@@ -209,6 +209,7 @@ func (s *Slot) TapMask() int {
 
 func (s *Slot) TapMaskString() string {
 	mask := net.CIDRMask(s.TapMask(), 32)
+
 	return net.IP(mask).String()
 }
 
@@ -322,6 +323,7 @@ func getHostNetworkCIDR() *net.IPNet {
 	}
 
 	log.Println("Using host network cidr", "cidr", cidr)
+
 	return subnet
 }
 
@@ -334,6 +336,7 @@ func getVrtNetworkCIDR() *net.IPNet {
 	}
 
 	log.Printf("Using vrt network cidr %s", cidr)
+
 	return subnet
 }
 
@@ -349,5 +352,6 @@ func GetVrtSlotsSize() int {
 	totalSlots := (totalIPs / vrtAddressPerSlot) - vrtAddressPerSlot
 
 	log.Printf("Using network slot size: %d", totalSlots)
+
 	return totalSlots
 }

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -88,6 +88,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 			if !available {
 				s.foreignNs[slotName] = struct{}{}
 				zap.L().Debug("Skipping slot because not available", zap.String("slot", slotName))
+
 				continue
 			}
 
@@ -156,6 +157,7 @@ func getForeignNamespaces() ([]string, error) {
 
 func getSlotName(slotIdx int) string {
 	slotIdxStr := strconv.Itoa(slotIdx)
+
 	return fmt.Sprintf("ns-%s", slotIdxStr)
 }
 

--- a/packages/orchestrator/internal/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_memory.go
@@ -33,6 +33,7 @@ func (s *StorageMemory) Acquire(_ context.Context) (*Slot, error) {
 		key := getMemoryKey(slotIdx)
 		if !s.freeSlots[slotIdx] {
 			s.freeSlots[slotIdx] = true
+
 			return NewSlot(key, slotIdx, s.config)
 		}
 	}

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -615,6 +615,7 @@ func (s *Sandbox) Close(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to cleanup sandbox: %w", err)
 	}
+
 	return nil
 }
 
@@ -898,6 +899,7 @@ func getNetworkSlotAsync(
 		ips, err := networkPool.Get(ctx, allowInternet)
 		if err != nil {
 			r <- networkSlotRes{nil, fmt.Errorf("failed to get network slot: %w", err)}
+
 			return
 		}
 
@@ -1026,5 +1028,6 @@ func (f *Factory) GetEnvdInitRequestTimeout(ctx context.Context) time.Duration {
 	if err != nil {
 		zap.L().Warn("failed to get envd timeout from feature flag, using default", zap.Error(err))
 	}
+
 	return time.Duration(envdInitRequestTimeoutMs) * time.Millisecond
 }

--- a/packages/orchestrator/internal/sandbox/snapshot.go
+++ b/packages/orchestrator/internal/sandbox/snapshot.go
@@ -69,6 +69,7 @@ func (s *Snapshot) Upload(
 	if uploadErr != nil {
 		return fmt.Errorf("error uploading template build: %w", uploadErr)
 	}
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/sandbox/template/mask_template.go
+++ b/packages/orchestrator/internal/sandbox/template/mask_template.go
@@ -57,6 +57,7 @@ func (c *MaskTemplate) Memfile(ctx context.Context) (block.ReadonlyDevice, error
 	if c.memfile != nil {
 		return *c.memfile, nil
 	}
+
 	return c.template.Memfile(ctx)
 }
 

--- a/packages/orchestrator/internal/sandbox/template/storage_file.go
+++ b/packages/orchestrator/internal/sandbox/template/storage_file.go
@@ -34,6 +34,7 @@ func newStorageFile(
 	_, err = object.WriteTo(ctx, f)
 	if err != nil {
 		cleanupErr := os.Remove(path)
+
 		return nil, fmt.Errorf("NEW STORAGE failed to write to file: %w", errors.Join(err, cleanupErr))
 	}
 

--- a/packages/orchestrator/internal/sandbox/template/storage_template.go
+++ b/packages/orchestrator/internal/sandbox/template/storage_template.go
@@ -224,6 +224,7 @@ func (t *storageTemplate) Fetch(ctx context.Context, buildStore *build.DiffStore
 			logger.WithBuildID(t.files.BuildID),
 			zap.Error(err),
 		)
+
 		return
 	}
 }

--- a/packages/orchestrator/internal/sandbox/uffd/noop.go
+++ b/packages/orchestrator/internal/sandbox/uffd/noop.go
@@ -53,6 +53,7 @@ func (m *NoopMemory) Stop() error {
 func (m *NoopMemory) Ready() chan struct{} {
 	ch := make(chan struct{})
 	ch <- struct{}{}
+
 	return ch
 }
 

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -83,6 +83,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	acquired := s.startingSandboxes.TryAcquire(1)
 	if !acquired {
 		telemetry.ReportEvent(ctx, "too many starting sandboxes on node")
+
 		return nil, status.Errorf(codes.ResourceExhausted, "too many sandboxes starting on this node, please retry")
 	}
 	defer s.startingSandboxes.Release(1)
@@ -131,6 +132,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	if err != nil {
 		err := errors.Join(err, context.Cause(ctx))
 		telemetry.ReportCriticalError(ctx, "failed to create sandbox", err)
+
 		return nil, status.Errorf(codes.Internal, "failed to create sandbox: %s", err)
 	}
 

--- a/packages/orchestrator/internal/server/sandboxes_test.go
+++ b/packages/orchestrator/internal/server/sandboxes_test.go
@@ -76,6 +76,7 @@ func Test_server_List(t *testing.T) {
 			got, err := s.List(t.Context(), tt.args.in1)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("server.List() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {

--- a/packages/orchestrator/internal/service/service_info.go
+++ b/packages/orchestrator/internal/service/service_info.go
@@ -108,11 +108,13 @@ func convertDiskMetrics(disks []metrics.DiskInfo) []*orchestratorinfo.DiskMetric
 			TotalBytes:     disk.TotalBytes,
 		}
 	}
+
 	return result
 }
 
 func (s *Server) ServiceStatusOverride(_ context.Context, req *orchestratorinfo.ServiceStatusChangeRequest) (*emptypb.Empty, error) {
 	zap.L().Info("service status override request received", zap.String("status", req.GetServiceStatus().String()))
 	s.info.SetStatus(req.GetServiceStatus())
+
 	return &emptypb.Empty{}, nil
 }

--- a/packages/orchestrator/internal/template/build/buildlogger/log_entry_logger.go
+++ b/packages/orchestrator/internal/template/build/buildlogger/log_entry_logger.go
@@ -39,6 +39,7 @@ func (b *LogEntryLogger) Write(p []byte) (n int, err error) {
 			fields, err := logs.FlatJsonLogLineParser(string(line))
 			if err != nil {
 				zap.L().Error("error parsing log line", zap.Error(err), zap.ByteString("line", line))
+
 				continue
 			}
 
@@ -46,6 +47,7 @@ func (b *LogEntryLogger) Write(p []byte) (n int, err error) {
 			err = json.Unmarshal(line, &entry)
 			if err != nil {
 				zap.L().Error("failed to unmarshal log entry", zap.Error(err), zap.ByteString("line", line))
+
 				continue
 			}
 
@@ -63,6 +65,7 @@ func (b *LogEntryLogger) Write(p []byte) (n int, err error) {
 			})
 		}
 	}
+
 	return len(p), nil
 }
 
@@ -97,6 +100,7 @@ func (b *LogEntryLogger) Lines() []*template_manager.TemplateBuildLogEntry {
 	// Shallow copy of the slice (not the entries themselves)
 	copied := make([]*template_manager.TemplateBuildLogEntry, len(b.lines))
 	copy(copied, b.lines)
+
 	return copied
 }
 

--- a/packages/orchestrator/internal/template/build/commands/env.go
+++ b/packages/orchestrator/internal/template/build/commands/env.go
@@ -52,6 +52,7 @@ func (e *Env) Execute(
 	}
 
 	cmdMetadata.EnvVars = envVars
+
 	return cmdMetadata, nil
 }
 

--- a/packages/orchestrator/internal/template/build/commands/executor.go
+++ b/packages/orchestrator/internal/template/build/commands/executor.go
@@ -107,5 +107,6 @@ func (ce *CommandExecutor) Execute(
 	if err != nil {
 		return metadata.Context{}, err
 	}
+
 	return cmdMetadata, nil
 }

--- a/packages/orchestrator/internal/template/build/commands/user.go
+++ b/packages/orchestrator/internal/template/build/commands/user.go
@@ -166,5 +166,6 @@ func saveUserMeta(
 	)
 
 	cmdMetadata.User = user
+
 	return cmdMetadata, err
 }

--- a/packages/orchestrator/internal/template/build/commands/workdir.go
+++ b/packages/orchestrator/internal/template/build/commands/workdir.go
@@ -112,6 +112,7 @@ func saveWorkdirMeta(
 		func(stdout, stderr string) {
 			if stderr != "" {
 				outputErr = fmt.Errorf("error getting absolute path of workdir: %s", stderr)
+
 				return
 			}
 			workdir = strings.TrimSpace(stdout)
@@ -126,5 +127,6 @@ func saveWorkdirMeta(
 	}
 
 	cmdMetadata.WorkDir = &workdir
+
 	return cmdMetadata, nil
 }

--- a/packages/orchestrator/internal/template/build/core/envd/envd.go
+++ b/packages/orchestrator/internal/template/build/core/envd/envd.go
@@ -16,6 +16,7 @@ func GetEnvdVersion(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error while getting envd version: %w", err)
 	}
+
 	return strings.TrimSpace(string(out)), nil
 }
 

--- a/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/internal/template/build/core/filesystem/ext4.go
@@ -135,6 +135,7 @@ func Resize(ctx context.Context, rootfsPath string, targetSize int64) (int64, er
 	err := cmd.Run()
 	if err != nil {
 		LogMetadata(ctx, rootfsPath)
+
 		return 0, fmt.Errorf("error resizing rootfs file: %w", err)
 	}
 
@@ -160,6 +161,7 @@ func Shrink(ctx context.Context, rootfsPath string) (int64, error) {
 	err := cmd.Run()
 	if err != nil {
 		LogMetadata(ctx, rootfsPath)
+
 		return 0, fmt.Errorf("error shrinking rootfs file: %w", err)
 	}
 
@@ -182,6 +184,7 @@ func GetFreeSpace(ctx context.Context, rootfsPath string, blockSize int64) (int6
 	output := out.String()
 	if err != nil {
 		zap.L().Error("Error getting free space", zap.Error(err), zap.String("output", output))
+
 		return 0, fmt.Errorf("error statting ext4: %w", err)
 	}
 
@@ -197,6 +200,7 @@ func GetFreeSpace(ctx context.Context, rootfsPath string, blockSize int64) (int6
 	}
 
 	freeBytes := (freeBlocks - reservedBlocks) * blockSize
+
 	return freeBytes, nil
 }
 
@@ -251,6 +255,7 @@ func RemoveFile(ctx context.Context, rootfsPath string, filePath string) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		zap.L().Error("error removing file", zap.Error(err), zap.String("output", string(out)))
+
 		return fmt.Errorf("error removing file: %w", err)
 	}
 
@@ -320,6 +325,7 @@ func parseFreeBlocks(debugfsOutput string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse free blocks: %w", err)
 	}
+
 	return freeBlocks, nil
 }
 
@@ -334,5 +340,6 @@ func parseReservedBlocks(debugfsOutput string) (int64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("could not parse reserved blocks: %w", err)
 	}
+
 	return reservedBlocks, nil
 }

--- a/packages/orchestrator/internal/template/build/core/oci/auth/gcp.go
+++ b/packages/orchestrator/internal/template/build/core/oci/auth/gcp.go
@@ -25,5 +25,6 @@ func NewGCPAuthProvider(registry *templatemanager.GCPRegistry) *GCPAuthProvider 
 func (p *GCPAuthProvider) GetAuthOption(context.Context) (remote.Option, error) {
 	// Create authenticator using the service account JSON
 	authenticator := google.NewJSONKeyAuthenticator(p.registry.GetServiceAccountJson())
+
 	return remote.WithAuth(authenticator), nil
 }

--- a/packages/orchestrator/internal/template/build/core/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci.go
@@ -56,6 +56,7 @@ func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRep
 		}
 
 		telemetry.ReportEvent(ctx, "pulled public image")
+
 		return img, nil
 	}
 
@@ -79,6 +80,7 @@ func GetPublicImage(ctx context.Context, dockerhubRepository dockerhub.RemoteRep
 	}
 
 	telemetry.ReportEvent(ctx, "pulled public image")
+
 	return img, nil
 }
 
@@ -92,6 +94,7 @@ func GetImage(ctx context.Context, artifactRegistry artifactsregistry.ArtifactsR
 	}
 
 	telemetry.ReportEvent(childCtx, "pulled image")
+
 	return img, nil
 }
 
@@ -202,6 +205,7 @@ func ParseEnvs(envs []string) map[string]string {
 			envMap[key] = value
 		}
 	}
+
 	return envMap
 }
 
@@ -292,6 +296,7 @@ func copyFiles(ctx context.Context, src, dest string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("while copying files from %s to %s: %w: %s", src, dest, err, string(out))
 	}
+
 	return nil
 }
 
@@ -348,6 +353,7 @@ func createExport(ctx context.Context, logger *zap.Logger, srcImage containerreg
 			if err != nil {
 				return fmt.Errorf("failed to untar layer %d: %w", i, err)
 			}
+
 			return nil
 		})
 	}

--- a/packages/orchestrator/internal/template/build/core/oci/oci_test.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci_test.go
@@ -101,6 +101,7 @@ func authHandler(handler http.Handler, username, password string) http.Handler {
 		// Allow certain endpoints without auth (like /v2/)
 		if r.URL.Path == "/v2/" || r.URL.Path == "/v2" {
 			handler.ServeHTTP(w, r)
+
 			return
 		}
 
@@ -110,6 +111,7 @@ func authHandler(handler http.Handler, username, password string) http.Handler {
 			// Send WWW-Authenticate challenge
 			w.Header().Set("WWW-Authenticate", `Basic realm="Registry"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+
 			return
 		}
 
@@ -118,6 +120,7 @@ func authHandler(handler http.Handler, username, password string) http.Handler {
 		if !ok || user != username || pass != password {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Registry"`)
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+
 			return
 		}
 

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -251,6 +251,7 @@ func (lb *LayerExecutor) PauseAndUpload(
 		}
 
 		userLogger.Debug(fmt.Sprintf("Saved: %s", meta.Template.BuildID))
+
 		return nil
 	})
 

--- a/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
+++ b/packages/orchestrator/internal/template/build/layer/resume_sandbox.go
@@ -47,5 +47,6 @@ func (rs *ResumeSandbox) Sandbox(
 	if err != nil {
 		return nil, fmt.Errorf("resume sandbox: %w", err)
 	}
+
 	return sbx, nil
 }

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -244,6 +244,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 			zap.String("result", ext4Check),
 			zap.Error(err),
 		)
+
 		return metadata.Template{}, fmt.Errorf("error checking provisioned filesystem integrity: %w", err)
 	}
 	zap.L().Debug("provisioned filesystem ext4 integrity",
@@ -278,6 +279,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 		if err != nil {
 			return metadata.Template{}, fmt.Errorf("error running sync command: %w", err)
 		}
+
 		return meta, nil
 	})
 
@@ -380,6 +382,7 @@ func (bb *BaseBuilder) Layer(
 
 			return notCachedResult, nil
 		}
+
 		return phases.LayerResult{
 			Metadata: meta,
 			Cached:   true,

--- a/packages/orchestrator/internal/template/build/phases/base/provision.go
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.go
@@ -145,6 +145,7 @@ func (bb *BaseBuilder) enlargeDiskAfterProvisioning(
 	)
 	if sizeDiff <= 0 {
 		zap.L().Debug("no need to enlarge rootfs, skipping")
+
 		return nil
 	}
 	rootfsFinalSize, err := filesystem.Enlarge(ctx, rootfsPath, sizeDiff)

--- a/packages/orchestrator/internal/template/build/phases/errors.go
+++ b/packages/orchestrator/internal/template/build/phases/errors.go
@@ -33,5 +33,6 @@ func UnwrapPhaseBuildError(err error) *PhaseBuildError {
 	if errors.As(err, &phaseBuildError) {
 		return phaseBuildError
 	}
+
 	return nil
 }

--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -202,6 +202,7 @@ func (ppb *PostProcessingBuilder) postProcessingFn(userLogger *zap.Logger) layer
 			)
 			if err != nil {
 				e = fmt.Errorf("error running sync command: %w", err)
+
 				return
 			}
 		}()
@@ -248,6 +249,7 @@ func (ppb *PostProcessingBuilder) postProcessingFn(userLogger *zap.Logger) layer
 				if err != nil && !errors.Is(err, context.Canceled) {
 					// Cancel the ready command context, so the ready command does not wait anymore if an error occurs.
 					commandsCancel()
+
 					return fmt.Errorf("error running start command: %w", err)
 				}
 

--- a/packages/orchestrator/internal/template/build/phases/finalize/ready.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/ready.go
@@ -53,6 +53,7 @@ func (ppb *PostProcessingBuilder) runReadyCommand(
 
 		if err == nil {
 			userLogger.Info("Template is ready")
+
 			return nil
 		}
 
@@ -65,6 +66,7 @@ func (ppb *PostProcessingBuilder) runReadyCommand(
 			}
 			// Template is ready, the start command finished before the ready command
 			userLogger.Info("Template is ready")
+
 			return nil
 		case <-time.After(readyCommandRetryInterval):
 			// Wait for readyCommandRetryInterval time before retrying the ready command

--- a/packages/orchestrator/internal/template/build/phases/phase.go
+++ b/packages/orchestrator/internal/template/build/phases/phase.go
@@ -52,6 +52,7 @@ func layerInfo(
 	if cached {
 		cachedPrefix = "CACHED "
 	}
+
 	return fmt.Sprintf("%s[%s] %s [%s]", cachedPrefix, prefix, text, hash)
 }
 
@@ -105,6 +106,7 @@ func Run(
 			metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, true)
 
 			sourceLayer = currentLayer
+
 			continue
 		}
 

--- a/packages/orchestrator/internal/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/builder.go
@@ -208,6 +208,7 @@ func (sb *StepBuilder) Build(
 		}
 
 		meta.Context = cmdMeta
+
 		return meta, nil
 	})
 

--- a/packages/orchestrator/internal/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/internal/template/build/sandboxtools/command.go
@@ -171,6 +171,7 @@ func runCommandWithAllOptions(
 			e := msg.GetEvent()
 			if e == nil {
 				zap.L().Error("received nil command event")
+
 				return nil
 			}
 

--- a/packages/orchestrator/internal/template/build/sandboxtools/file.go
+++ b/packages/orchestrator/internal/template/build/sandboxtools/file.go
@@ -64,11 +64,13 @@ func CopyFile(
 		part, err := writer.CreateFormFile("file", filepath.Base(sourcePath))
 		if err != nil {
 			err = fmt.Errorf("failed to create form file: %w", err)
+
 			return
 		}
 
 		if _, errCopy := io.Copy(part, file); errCopy != nil {
 			err = fmt.Errorf("failed to copy file: %w", errCopy)
+
 			return
 		}
 	}()

--- a/packages/orchestrator/internal/template/build/storage/cache/cache.go
+++ b/packages/orchestrator/internal/template/build/storage/cache/cache.go
@@ -116,6 +116,7 @@ func HashKeys(baseKey string, keys ...string) string {
 		sha.Write([]byte(";"))
 		sha.Write([]byte(key))
 	}
+
 	return fmt.Sprintf("%x", sha.Sum(nil))
 }
 

--- a/packages/orchestrator/internal/template/build/writer/filtered_writer.go
+++ b/packages/orchestrator/internal/template/build/writer/filtered_writer.go
@@ -31,6 +31,7 @@ func (w *PrefixFilteredWriter) writeLine(line []byte) (remaining []byte) {
 	if idx < 0 {
 		// If there are no newlines, buffer the entire string.
 		w.buff.Write(line)
+
 		return nil
 	}
 
@@ -41,6 +42,7 @@ func (w *PrefixFilteredWriter) writeLine(line []byte) (remaining []byte) {
 	// in the buffer, skip the buffer and log directly.
 	if w.buff.Len() == 0 {
 		w.log(line)
+
 		return
 	}
 
@@ -62,6 +64,7 @@ func (w *PrefixFilteredWriter) Sync() error {
 	// because we don't want an extraneous empty message at the end of the
 	// stream -- it's common for files to end with a newline.
 	w.flush(false)
+
 	return nil
 }
 

--- a/packages/orchestrator/internal/template/build/writer/postprocessor.go
+++ b/packages/orchestrator/internal/template/build/writer/postprocessor.go
@@ -20,6 +20,7 @@ type postProcessor struct {
 
 func (p *postProcessor) hook(_ zapcore.Entry) error {
 	p.ticker.Reset(p.interval)
+
 	return nil
 }
 
@@ -29,6 +30,7 @@ func (p *postProcessor) run() {
 		select {
 		case <-p.done:
 			p.ticker.Stop()
+
 			return
 		case <-p.ticker.C:
 			p.logger.Info("...")

--- a/packages/orchestrator/internal/template/cache/build_cache.go
+++ b/packages/orchestrator/internal/template/cache/build_cache.go
@@ -101,6 +101,7 @@ func NewBuildCache(meterProvider metric.MeterProvider) *BuildCache {
 		for teamID, count := range teamCounts {
 			observer.Observe(int64(count), metric.WithAttributes(telemetry.WithTeamID(teamID)))
 		}
+
 		return nil
 	})
 	if err != nil {

--- a/packages/orchestrator/internal/template/metadata/template_metadata.go
+++ b/packages/orchestrator/internal/template/metadata/template_metadata.go
@@ -175,6 +175,7 @@ func deserialize(reader io.Reader) (Template, error) {
 	if err != nil {
 		return Template{}, fmt.Errorf("error unmarshaling template metadata: %w", err)
 	}
+
 	return templateMetadata, nil
 }
 
@@ -185,5 +186,6 @@ func serialize(template Template) (io.Reader, error) {
 	}
 
 	buf := bytes.NewBuffer(marshaled)
+
 	return buf, nil
 }

--- a/packages/orchestrator/internal/template/metadata/template_metadata_test.go
+++ b/packages/orchestrator/internal/template/metadata/template_metadata_test.go
@@ -129,6 +129,7 @@ func TestDeserialize(t *testing.T) {
 			if tt.expectedError != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
+
 				return
 			}
 

--- a/packages/orchestrator/internal/template/server/create_template.go
+++ b/packages/orchestrator/internal/template/server/create_template.go
@@ -40,6 +40,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 
 	if s.info.GetStatus() != orchestrator.ServiceInfoStatus_Healthy {
 		s.logger.Error("Requesting template creation while server not healthy is not possible", logger.WithTemplateID(cfg.GetTemplateID()))
+
 		return nil, fmt.Errorf("server is draining")
 	}
 
@@ -129,6 +130,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 				if res.Status == templatemanager.TemplateBuildState_Failed {
 					cancel()
 				}
+
 				return
 			}
 		}()

--- a/packages/orchestrator/internal/template/template/main.go
+++ b/packages/orchestrator/internal/template/template/main.go
@@ -31,6 +31,7 @@ func Delete(ctx context.Context, artifactRegistry artifactsregistry.ArtifactsReg
 		}
 
 		telemetry.ReportEvent(childCtx, err.Error())
+
 		return err
 	}
 

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -315,6 +315,7 @@ func run(config cfg.Config) (success bool) {
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
+
 		return err
 	})
 	closers = append(closers, closer{"sandbox proxy", sandboxProxy.Close})
@@ -326,6 +327,7 @@ func run(config cfg.Config) (success bool) {
 	}
 	startService("nbd device pool", func() error {
 		devicePool.Populate(ctx)
+
 		return nil
 	})
 	closers = append(closers, closer{"device pool", devicePool.Close})
@@ -337,6 +339,7 @@ func run(config cfg.Config) (success bool) {
 	}
 	startService("network pool", func() error {
 		networkPool.Populate(ctx)
+
 		return nil
 	})
 	closers = append(closers, closer{"network pool", networkPool.Close})
@@ -374,6 +377,7 @@ func run(config cfg.Config) (success bool) {
 			if err := tmplSbxLoggerExternal.Sync(); err != nil && !errors.Is(err, syscall.EINVAL) {
 				return err
 			}
+
 			return nil
 		},
 	})
@@ -388,6 +392,7 @@ func run(config cfg.Config) (success bool) {
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
+
 		return err
 	})
 	closers = append(closers, closer{"hyperloop server", hyperloopSrv.Shutdown})
@@ -436,11 +441,13 @@ func run(config cfg.Config) (success bool) {
 		if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
 			return nil
 		}
+
 		return err
 	})
 	closers = append(closers, closer{"cmux server", func(context.Context) error {
 		zap.L().Info("Shutting down cmux server")
 		cmuxServer.Close()
+
 		return nil
 	}})
 
@@ -476,6 +483,7 @@ func run(config cfg.Config) (success bool) {
 	closers = append(closers, closer{"grpc server", func(context.Context) error {
 		zap.L().Info("Shutting down grpc server")
 		grpcServer.GracefulStop()
+
 		return nil
 	}})
 

--- a/packages/shared/pkg/dockerhub/repository_test.go
+++ b/packages/shared/pkg/dockerhub/repository_test.go
@@ -60,6 +60,7 @@ func TestRemoveRegistryFromTag(t *testing.T) {
 			got, err := removeRegistryFromTag(tt.tag)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("removeRegistryFromTag() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {

--- a/packages/shared/pkg/edge/events.go
+++ b/packages/shared/pkg/edge/events.go
@@ -140,5 +140,6 @@ func getMetadataValue(md metadata.MD, key string) (value string, found bool) {
 	if values, ok := md[key]; ok && len(values) > 0 {
 		return values[0], true
 	}
+
 	return "", false
 }

--- a/packages/shared/pkg/env/env.go
+++ b/packages/shared/pkg/env/env.go
@@ -26,6 +26,7 @@ func GetEnv(key, defaultValue string) string {
 	if len(value) == 0 {
 		return defaultValue
 	}
+
 	return value
 }
 

--- a/packages/shared/pkg/feature-flags/client.go
+++ b/packages/shared/pkg/feature-flags/client.go
@@ -84,6 +84,7 @@ func (c *Client) Close(context.Context) error {
 	err := c.ld.Close()
 	if err != nil {
 		zap.L().Error("Error during launch-darkly client shutdown", zap.Error(err))
+
 		return err
 	}
 

--- a/packages/shared/pkg/feature-flags/context.go
+++ b/packages/shared/pkg/feature-flags/context.go
@@ -21,6 +21,7 @@ func SetContext(ctx context.Context, contexts ...ldcontext.Context) context.Cont
 	}
 
 	ctx = context.WithValue(ctx, ctxKey{}, val)
+
 	return ctx
 }
 
@@ -28,6 +29,7 @@ func getContext(ctx context.Context) (ldcontext.Context, bool) {
 	if val, ok := ctx.Value(ctxKey{}).(ldcontext.Context); ok {
 		return val, true
 	}
+
 	return ldcontext.Context{}, false
 }
 
@@ -46,6 +48,7 @@ func flattenContexts(contexts []ldcontext.Context) []ldcontext.Context {
 			} else {
 				contextMap[item.Kind()] = item
 			}
+
 			continue
 		}
 

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -40,6 +40,7 @@ func newBoolFlag(name string, fallback bool) BoolFlag {
 	flag := BoolFlag{name: name, fallback: fallback}
 	builder := LaunchDarklyOfflineStore.Flag(flag.name).VariationForAll(fallback)
 	LaunchDarklyOfflineStore.Update(builder)
+
 	return flag
 }
 
@@ -72,6 +73,7 @@ func newIntFlag(name string, fallback int) IntFlag {
 	flag := IntFlag{name: name, fallback: fallback}
 	builder := LaunchDarklyOfflineStore.Flag(flag.name).ValueForAll(ldvalue.Int(fallback))
 	LaunchDarklyOfflineStore.Update(builder)
+
 	return flag
 }
 

--- a/packages/shared/pkg/grpc/envd_command.go
+++ b/packages/shared/pkg/grpc/envd_command.go
@@ -31,6 +31,7 @@ func StreamToChannel[Res any](ctx context.Context, stream *connect.ServerStreamF
 
 		if err := stream.Err(); err != nil {
 			errCh <- err
+
 			return
 		}
 	}()

--- a/packages/shared/pkg/grpc/filter.go
+++ b/packages/shared/pkg/grpc/filter.go
@@ -47,5 +47,6 @@ func (s *statsWrapper) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) contex
 		// Add to context we don't want to trace this.
 		return context.WithValue(ctx, noTraceKey{}, noTrace)
 	}
+
 	return s.statsHandler.TagRPC(ctx, rti)
 }

--- a/packages/shared/pkg/ioutils/write_to_file.go
+++ b/packages/shared/pkg/ioutils/write_to_file.go
@@ -21,5 +21,6 @@ func WriteToFileFromReader(path string, r io.Reader) (err error) {
 	if _, err = io.Copy(f, r); err != nil {
 		return err
 	}
+
 	return f.Sync() // ensure contents hit disk
 }

--- a/packages/shared/pkg/keys/sha256.go
+++ b/packages/shared/pkg/keys/sha256.go
@@ -25,5 +25,6 @@ func (h *Sha256Hashing) Hash(key []byte) string {
 
 func (h *Sha256Hashing) HashWithoutPrefix(key []byte) string {
 	hashBytes := sha256.Sum256(key)
+
 	return base64.RawStdEncoding.EncodeToString(hashBytes[:])
 }

--- a/packages/shared/pkg/logger/exporter.go
+++ b/packages/shared/pkg/logger/exporter.go
@@ -56,6 +56,7 @@ func (h *HTTPWriter) Write(source []byte) (n int, err error) {
 					line := p[start:i]
 					if err := h.sendLogLine(line); err != nil {
 						log.Printf("%v: %s\n", err, line)
+
 						return
 					}
 				}
@@ -68,6 +69,7 @@ func (h *HTTPWriter) Write(source []byte) (n int, err error) {
 			line := p[start:]
 			if err := h.sendLogLine(line); err != nil {
 				log.Printf("%v: %s\n", err, line)
+
 				return
 			}
 		}
@@ -85,6 +87,7 @@ func (h *HTTPWriter) Sync() error {
 	h.wgLock.Unlock()
 
 	wg.Wait()
+
 	return nil
 }
 
@@ -106,5 +109,6 @@ func (h *HTTPWriter) sendLogLine(line []byte) error {
 	if err != nil {
 		return fmt.Errorf("error closing response body: %w", err)
 	}
+
 	return nil
 }

--- a/packages/shared/pkg/logger/grpc.go
+++ b/packages/shared/pkg/logger/grpc.go
@@ -83,6 +83,7 @@ func WithoutRoutes(routes ...string) selector.Matcher {
 				return false
 			}
 		}
+
 		return true
 	})
 }

--- a/packages/shared/pkg/logs/logs.go
+++ b/packages/shared/pkg/logs/logs.go
@@ -41,6 +41,7 @@ func StringToLevel(name string) LogLevel {
 	if level, ok := stringToLevel[name]; ok {
 		return level
 	}
+
 	return LevelInfo // Default to info if not found
 }
 
@@ -48,6 +49,7 @@ func LevelToString(level LogLevel) string {
 	if name, ok := levelToString[level]; ok {
 		return name
 	}
+
 	return "info"
 }
 
@@ -60,6 +62,7 @@ func CompareLevels(as, bs string) int32 {
 	} else if a > b {
 		return 1
 	}
+
 	return 0
 }
 

--- a/packages/shared/pkg/logs/logs_test.go
+++ b/packages/shared/pkg/logs/logs_test.go
@@ -123,11 +123,13 @@ func TestFlatJsonLogLineParser(t *testing.T) {
 				if err == nil {
 					t.Errorf("expected error but got none")
 				}
+
 				return
 			}
 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+
 				return
 			}
 

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -106,6 +106,7 @@ func TestHostParser(t *testing.T) {
 				if !errors.Is(err, tt.wantErr) || reflect.TypeOf(err) != reflect.TypeOf(tt.wantErr) {
 					t.Fatalf("ParseHost(%q) error type = %T, want %T", tt.host, err, tt.wantErr)
 				}
+
 				return // no further checks when an error was expected
 			}
 

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -55,6 +55,7 @@ func newProxyClient(
 
 				if err == nil {
 					totalConnsCounter.Add(1)
+
 					return tracking.NewConnection(conn, currentConnsCounter), nil
 				}
 

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -70,6 +70,7 @@ func newTestBackend(listener net.Listener, id string) (*testBackend, error) {
 	backendURL, err := url.Parse(fmt.Sprintf("http://%s", listener.Addr().String()))
 	if err != nil {
 		listener.Close()
+
 		return nil, fmt.Errorf("failed to parse backend URL: %w", err)
 	}
 	backend.url = backendURL
@@ -424,6 +425,7 @@ func TestProxyRetriesOnDelayedBackendStartup(t *testing.T) {
 		listener, err := lisCfg.Listen(t.Context(), "tcp", backendAddr)
 		if err != nil {
 			backendReady <- backendResult{nil, fmt.Errorf("failed to create delayed backend listener: %w", err)}
+
 			return
 		}
 
@@ -431,6 +433,7 @@ func TestProxyRetriesOnDelayedBackendStartup(t *testing.T) {
 		if err != nil {
 			listener.Close()
 			backendReady <- backendResult{nil, fmt.Errorf("failed to create delayed backend: %w", err)}
+
 			return
 		}
 

--- a/packages/shared/pkg/pubsub/mock_pubsub.go
+++ b/packages/shared/pkg/pubsub/mock_pubsub.go
@@ -36,6 +36,7 @@ func (m *MockPubSub[PayloadT, SubMetaDataT]) GetSubMetaData(_ context.Context, k
 	if meta, exists := m.metadata[key]; exists {
 		return meta, nil
 	}
+
 	return metadata, nil
 }
 
@@ -45,12 +46,14 @@ func (m *MockPubSub[PayloadT, SubMetaDataT]) SetSubMetaData(_ context.Context, k
 		m.metadata = make(map[string]SubMetaDataT)
 	}
 	m.metadata[key] = metaData
+
 	return nil
 }
 
 func (m *MockPubSub[PayloadT, SubMetaDataT]) DeleteSubMetaData(_ context.Context, key string) error {
 	// Mock implementation - deletes metadata
 	delete(m.metadata, key)
+
 	return nil
 }
 

--- a/packages/shared/pkg/pubsub/redis_pubsub.go
+++ b/packages/shared/pkg/pubsub/redis_pubsub.go
@@ -28,6 +28,7 @@ func (r *RedisPubSub[PayloadT, SubMetaDataT]) ShouldPublish(ctx context.Context,
 	if err != nil {
 		return false, err
 	}
+
 	return exists > 0, nil
 }
 
@@ -45,6 +46,7 @@ func (r *RedisPubSub[PayloadT, SubMetaDataT]) GetSubMetaData(ctx context.Context
 	if err != nil {
 		return metadata, err
 	}
+
 	return metadata, nil
 }
 
@@ -78,6 +80,7 @@ func (r *RedisPubSub[PayloadT, SubMetaDataT]) DeleteSubMetaData(ctx context.Cont
 	if r.redisClient == nil {
 		return fmt.Errorf("redis client is not initialized")
 	}
+
 	return (r.redisClient).Del(ctx, key).Err()
 }
 

--- a/packages/shared/pkg/pubsub/redis_streams.go
+++ b/packages/shared/pkg/pubsub/redis_streams.go
@@ -34,6 +34,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) ShouldPublish(ctx context.Context
 	if err != nil {
 		return false, err
 	}
+
 	return exists > 0, nil
 }
 
@@ -51,6 +52,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) GetSubMetaData(ctx context.Contex
 	if err != nil {
 		return metadata, err
 	}
+
 	return metadata, nil
 }
 
@@ -71,6 +73,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) DeleteSubMetaData(ctx context.Con
 	if r.redisClient == nil {
 		return fmt.Errorf("redis client is not initialized")
 	}
+
 	return (r.redisClient).Del(ctx, key).Err()
 }
 
@@ -140,6 +143,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) ensureConsumerGroup(ctx context.C
 	if err != nil {
 		// Stream doesn't exist, create it with the group
 		_, err = r.redisClient.XGroupCreate(ctx, r.streamName, r.groupName, "0").Result()
+
 		return err
 	}
 
@@ -152,6 +156,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) ensureConsumerGroup(ctx context.C
 
 	// Group doesn't exist, create it
 	_, err = r.redisClient.XGroupCreate(ctx, r.streamName, r.groupName, "0").Result()
+
 	return err
 }
 
@@ -229,6 +234,7 @@ func (r *RedisStreams[PayloadT, SubMetaDataT]) readNewMessages(ctx context.Conte
 			// No messages, continue
 			return nil
 		}
+
 		return err
 	}
 
@@ -287,5 +293,6 @@ func structToMapJSON(obj any) (map[string]any, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return result, nil
 }

--- a/packages/shared/pkg/sandbox-catalog/catalog_memory.go
+++ b/packages/shared/pkg/sandbox-catalog/catalog_memory.go
@@ -49,6 +49,7 @@ func (c *MemorySandboxCatalog) StoreSandbox(ctx context.Context, sandboxID strin
 	defer c.mtx.Unlock()
 
 	c.cache.Set(sandboxID, sandboxInfo, expiration)
+
 	return nil
 }
 
@@ -75,5 +76,6 @@ func (c *MemorySandboxCatalog) DeleteSandbox(ctx context.Context, sandboxID stri
 	}
 
 	c.cache.Delete(sandboxID)
+
 	return nil
 }

--- a/packages/shared/pkg/sandbox-catalog/catalog_redis.go
+++ b/packages/shared/pkg/sandbox-catalog/catalog_redis.go
@@ -87,6 +87,7 @@ func (c *RedisSandboxCatalog) StoreSandbox(ctx context.Context, sandboxID string
 	status := c.redisClient.Set(ctx, c.getCatalogKey(sandboxID), string(bytes), expiration)
 	if status.Err() != nil {
 		zap.L().Error("Error while storing sandbox in redis", logger.WithSandboxID(sandboxID), zap.Error(status.Err()))
+
 		return fmt.Errorf("failed to store sandbox info in redis: %w", status.Err())
 	}
 
@@ -121,6 +122,7 @@ func (c *RedisSandboxCatalog) DeleteSandbox(ctx context.Context, sandboxID strin
 
 	c.redisClient.Del(ctx, c.getCatalogKey(sandboxID))
 	c.cache.Delete(sandboxID)
+
 	return nil
 }
 

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -59,6 +59,7 @@ func createRetryableClient(config RetryConfig) *retryablehttp.Client {
 			backoff = time.Duration(float64(backoff) * config.BackoffMultiplier)
 			if backoff > maxBackoff {
 				backoff = maxBackoff
+
 				break
 			}
 		}
@@ -73,6 +74,7 @@ func createRetryableClient(config RetryConfig) *retryablehttp.Client {
 		if backoff > 0 {
 			return time.Duration(rand.Int63n(int64(backoff)))
 		}
+
 		return backoff
 	}
 
@@ -167,6 +169,7 @@ func (m *MultipartUploader) InitiateUpload() (string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return "", fmt.Errorf("failed to initiate upload (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -204,6 +207,7 @@ func (m *MultipartUploader) UploadPart(uploadID string, partNumber int, data []b
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return "", fmt.Errorf("failed to upload part %d (status %d): %s", partNumber, resp.StatusCode, string(body))
 	}
 
@@ -247,6 +251,7 @@ func (m *MultipartUploader) CompleteUpload(uploadID string, parts []Part) error 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return fmt.Errorf("failed to complete upload (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -224,6 +224,7 @@ func TestMultipartUploader_InitiateUpload_WithRetries(t *testing.T) {
 		count := atomic.AddInt32(&requestCount, 1)
 		if count < 2 {
 			w.WriteHeader(http.StatusInternalServerError)
+
 			return
 		}
 
@@ -359,6 +360,7 @@ func TestMultipartUploader_RandomFailures_ChaosTest(t *testing.T) {
 			// Randomly fail some requests
 			if rand.Float64() < failureRate {
 				w.WriteHeader(http.StatusInternalServerError)
+
 				return
 			}
 
@@ -425,6 +427,7 @@ func TestMultipartUploader_PartialFailures_Recovery(t *testing.T) {
 			if currentAttempts < int32(maxAttempts-1) {
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte("simulated failure"))
+
 				return
 			}
 
@@ -451,6 +454,7 @@ func TestMultipartUploader_PartialFailures_Recovery(t *testing.T) {
 	partAttempts.Range(func(key, value any) bool {
 		attempts := atomic.LoadInt32(value.(*int32))
 		require.Equal(t, int32(maxAttempts-1), attempts, "Part %s should have exactly %d attempts", key, maxAttempts-1)
+
 		return true
 	})
 }
@@ -688,6 +692,7 @@ func TestMultipartUploader_ConcurrentRetries_RaceCondition(t *testing.T) {
 				// Add random delay to increase race condition probability
 				time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
 				w.WriteHeader(http.StatusInternalServerError)
+
 				return
 			}
 
@@ -716,6 +721,7 @@ func TestMultipartUploader_ConcurrentRetries_RaceCondition(t *testing.T) {
 	retryAttempts.Range(func(key, value any) bool {
 		attempts := atomic.LoadInt32(value.(*int32))
 		require.GreaterOrEqual(t, attempts, int32(3), "Part %s should have at least 3 attempts", key)
+
 		return true
 	})
 }

--- a/packages/shared/pkg/storage/header/diff_test.go
+++ b/packages/shared/pkg/storage/header/diff_test.go
@@ -15,6 +15,7 @@ func createSource(blockSize int, blocksData []byte) []byte {
 	for i, data := range blocksData {
 		sourceSlice[i*blockSize] = data
 	}
+
 	return sourceSlice
 }
 
@@ -196,5 +197,6 @@ func (r *largeOffsetReader) ReadAt(p []byte, _ int64) (n int, err error) {
 	for i := len(r.data); i < len(p); i++ {
 		p[i] = 0
 	}
+
 	return len(p), nil
 }

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -68,6 +68,7 @@ func GetTemplateStorageProvider(ctx context.Context, limiter *limit.Limiter) (St
 
 	if provider == LocalStorageProvider {
 		basePath := env.GetEnv("LOCAL_TEMPLATE_STORAGE_BASE_PATH", "/tmp/templates")
+
 		return NewFileSystemStorageProvider(basePath)
 	}
 
@@ -89,6 +90,7 @@ func GetBuildCacheStorageProvider(ctx context.Context, limiter *limit.Limiter) (
 
 	if provider == LocalStorageProvider {
 		basePath := env.GetEnv("LOCAL_BUILD_CACHE_STORAGE_BASE_PATH", "/tmp/build-cache")
+
 		return NewFileSystemStorageProvider(basePath)
 	}
 

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -72,6 +72,7 @@ func (a *AWSBucketStorageProvider) DeleteObjectsWithPrefix(ctx context.Context, 
 	// AWS S3 delete operation requires at least one object to delete.
 	if len(objects) == 0 {
 		zap.L().Warn("No objects found to delete with the given prefix", zap.String("prefix", prefix), zap.String("bucket", a.bucketName))
+
 		return nil
 	}
 
@@ -90,6 +91,7 @@ func (a *AWSBucketStorageProvider) DeleteObjectsWithPrefix(ctx context.Context, 
 		for _, delErr := range output.Errors {
 			errStr += fmt.Sprintf("Key: %s, Code: %s, Message: %s; ", aws.ToString(delErr.Key), aws.ToString(delErr.Code), aws.ToString(delErr.Message))
 		}
+
 		return errors.New("errors occurred during deletion: " + errStr)
 	}
 
@@ -115,6 +117,7 @@ func (a *AWSBucketStorageProvider) UploadSignedURL(ctx context.Context, path str
 	if err != nil {
 		return "", fmt.Errorf("failed to presign PUT URL: %w", err)
 	}
+
 	return resp.URL, nil
 }
 

--- a/packages/shared/pkg/storage/storage_cache.go
+++ b/packages/shared/pkg/storage/storage_cache.go
@@ -133,6 +133,7 @@ func (c *CachedFileObjectProvider) ReadAt(ctx context.Context, buff []byte, offs
 	if ignoreEOF(err) == nil {
 		cacheHits.Add(ctx, 1)
 		readTimer.End(ctx, int64(count))
+
 		return count, err // return `err` in case it's io.EOF
 	}
 	cacheMisses.Add(ctx, 1)
@@ -165,6 +166,7 @@ var (
 func (c *CachedFileObjectProvider) Size(ctx context.Context) (int64, error) {
 	if size, ok := c.readLocalSize(); ok {
 		cacheHits.Add(ctx, 1)
+
 		return size, nil
 	}
 	cacheMisses.Add(ctx, 1)
@@ -190,6 +192,7 @@ func (c *CachedFileObjectProvider) readLocalSize() (int64, bool) {
 		zap.L().Warn("failed to read cached size, falling back to remote read",
 			zap.String("path", fname),
 			zap.Error(err))
+
 		return 0, false
 	}
 
@@ -199,6 +202,7 @@ func (c *CachedFileObjectProvider) readLocalSize() (int64, bool) {
 			zap.String("path", fname),
 			zap.String("content", string(content)),
 			zap.Error(err))
+
 		return 0, false
 	}
 
@@ -218,6 +222,7 @@ func (c *CachedFileObjectProvider) validateReadAtParams(buffSize, offset int64) 
 	if (offset%c.chunkSize)+buffSize > c.chunkSize {
 		return ErrMultipleChunks
 	}
+
 	return nil
 }
 
@@ -232,6 +237,7 @@ func (c *CachedFileObjectProvider) writeLocalSize(size int64) {
 		zap.L().Warn("failed to write to temp file",
 			zap.String("path", tempFilename),
 			zap.Error(err))
+
 		return
 	}
 
@@ -241,6 +247,7 @@ func (c *CachedFileObjectProvider) writeLocalSize(size int64) {
 			zap.String("temp_path", tempFilename),
 			zap.String("final_path", finalFilename),
 			zap.Error(err))
+
 		return
 	}
 }
@@ -357,6 +364,7 @@ func (c *CachedFileObjectProvider) copyFullFileFromCache(ctx context.Context, ds
 				zap.String("path", path),
 				zap.Error(err))
 		}
+
 		return 0, false
 	}
 
@@ -367,10 +375,12 @@ func (c *CachedFileObjectProvider) copyFullFileFromCache(ctx context.Context, ds
 		zap.L().Error("failed to read full cached file",
 			zap.String("path", path),
 			zap.Error(err))
+
 		return 0, false
 	}
 
 	cachedRead.End(ctx, count)
+
 	return count, true
 }
 
@@ -396,6 +406,7 @@ func (c *CachedFileObjectProvider) readAndCacheFullRemoteFile(ctx context.Contex
 	}()
 
 	written, err := dst.Write(writer.Bytes())
+
 	return int64(written), err
 }
 
@@ -409,6 +420,7 @@ func ignoreEOF(err error) error {
 	if errors.Is(err, io.EOF) {
 		return nil
 	}
+
 	return err
 }
 

--- a/packages/shared/pkg/storage/storage_cache_test.go
+++ b/packages/shared/pkg/storage/storage_cache_test.go
@@ -81,6 +81,7 @@ func TestCachedFileObjectProvider_WriteTo(t *testing.T) {
 				end := off + int64(len(buff))
 				end = min(end, int64(len(fakeData)))
 				copy(buff, fakeData[start:end])
+
 				return int(end - start), nil
 			})
 
@@ -118,6 +119,7 @@ func TestCachedFileObjectProvider_WriteTo(t *testing.T) {
 			WriteTo(mock.Anything, mock.Anything).
 			RunAndReturn(func(_ context.Context, dst io.Writer) (int64, error) {
 				num, err := dst.Write(fakeData)
+
 				return int64(num), err
 			})
 

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -31,6 +31,7 @@ func NewFileSystemStorageProvider(basePath string) (*FileSystemStorageProvider, 
 
 func (fs *FileSystemStorageProvider) DeleteObjectsWithPrefix(_ context.Context, prefix string) error {
 	filePath := fs.getPath(prefix)
+
 	return os.RemoveAll(filePath)
 }
 
@@ -97,6 +98,7 @@ func (f *FileSystemStorageObjectProvider) Write(_ context.Context, data []byte) 
 	defer handle.Close()
 
 	count, err := handle.Write(data)
+
 	return count, err
 }
 

--- a/packages/shared/pkg/storage/storage_fs_test.go
+++ b/packages/shared/pkg/storage/storage_fs_test.go
@@ -16,6 +16,7 @@ func newTempProvider(t *testing.T) *FileSystemStorageProvider {
 	base := t.TempDir()
 	p, err := NewFileSystemStorageProvider(base)
 	require.NoError(t, err)
+
 	return p
 }
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -208,6 +208,7 @@ func (g *GCPBucketStorageObjectProvider) ReadAt(ctx context.Context, buff []byte
 	}
 
 	timer.End(ctx, int64(n))
+
 	return n, nil
 }
 
@@ -223,6 +224,7 @@ func (g *GCPBucketStorageObjectProvider) Write(ctx context.Context, data []byte)
 	}
 
 	timer.End(ctx, int64(n))
+
 	return n, nil
 }
 
@@ -250,6 +252,7 @@ func (g *GCPBucketStorageObjectProvider) WriteTo(ctx context.Context, dst io.Wri
 	}
 
 	timer.End(ctx, n)
+
 	return n, nil
 }
 
@@ -278,6 +281,7 @@ func (g *GCPBucketStorageObjectProvider) WriteFromFileSystem(ctx context.Context
 		}
 
 		timer.End(ctx, int64(len(data)), attribute.String("method", "one-shot"))
+
 		return nil
 	}
 
@@ -320,6 +324,7 @@ func (g *GCPBucketStorageObjectProvider) WriteFromFileSystem(ctx context.Context
 	)
 
 	timer.End(ctx, fileInfo.Size(), attribute.String("method", "multipart"))
+
 	return nil
 }
 

--- a/packages/shared/pkg/synchronization/synchronization.go
+++ b/packages/shared/pkg/synchronization/synchronization.go
@@ -63,6 +63,7 @@ func (s *Synchronize[SourceItem, PoolItem]) Start(syncInterval time.Duration, sy
 		select {
 		case <-s.cancel:
 			zap.L().Info(s.getLog("Background synchronization ended"))
+
 			return
 		case <-timer.C:
 			syncTimeout, syncCancel := context.WithTimeout(context.Background(), syncRoundTimeout)
@@ -135,6 +136,7 @@ func (s *Synchronize[SourceItem, PoolItem]) syncOutdated(ctx context.Context, so
 			found := s.store.SourceExists(ctx, sourceItems, poolItem)
 			if found {
 				s.store.PoolUpdate(ctx, poolItem)
+
 				return
 			}
 

--- a/packages/shared/pkg/synchronization/synchronization_test.go
+++ b/packages/shared/pkg/synchronization/synchronization_test.go
@@ -57,6 +57,7 @@ func (s *testStore) PoolExists(_ context.Context, item string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	_, ok := s.pool[item]
+
 	return ok
 }
 
@@ -76,6 +77,7 @@ func (s *testStore) PoolRemove(_ context.Context, item string) {
 	for k, v := range s.pool {
 		if v == item {
 			delete(s.pool, k)
+
 			break
 		}
 	}
@@ -85,6 +87,7 @@ func (s *testStore) PoolRemove(_ context.Context, item string) {
 
 func newSynchronizer(store Store[string, string]) *Synchronize[string, string] {
 	zap.ReplaceGlobals(zap.NewNop())
+
 	return &Synchronize[string, string]{
 		store:            store,
 		tracerSpanPrefix: "test synchronization",

--- a/packages/shared/pkg/telemetry/fields.go
+++ b/packages/shared/pkg/telemetry/fields.go
@@ -43,6 +43,7 @@ func WithEnvdVersion(envdVersion string) attribute.KeyValue {
 func zapFieldToOTELAttribute(f zap.Field) attribute.KeyValue {
 	e := &ZapFieldToOTELAttributeEncoder{}
 	f.AddTo(e)
+
 	return e.KeyValue
 }
 
@@ -149,6 +150,7 @@ func (z *ZapFieldToOTELAttributeEncoder) AddUintptr(key string, value uintptr) {
 
 func (z *ZapFieldToOTELAttributeEncoder) AddReflected(key string, value any) error {
 	z.KeyValue = attribute.String(key, fmt.Sprintf("%v", value))
+
 	return nil
 }
 

--- a/packages/shared/pkg/telemetry/main.go
+++ b/packages/shared/pkg/telemetry/main.go
@@ -47,6 +47,7 @@ func New(ctx context.Context, nodeID, serviceName, serviceCommit, serviceVersion
 				NoMinMax: false,
 			}
 		}
+
 		return sdkmetric.DefaultAggregationSelector(kind)
 	}))
 	if err != nil {

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -177,6 +177,7 @@ var gaugeIntUnits = map[GaugeIntType]string{
 func GetCounter(meter metric.Meter, name CounterType) (metric.Int64Counter, error) {
 	desc := counterDesc[name]
 	unit := counterUnits[name]
+
 	return meter.Int64Counter(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -186,6 +187,7 @@ func GetCounter(meter metric.Meter, name CounterType) (metric.Int64Counter, erro
 func GetUpDownCounter(meter metric.Meter, name UpDownCounterType) (metric.Int64UpDownCounter, error) {
 	desc := upDownCounterDesc[name]
 	unit := upDownCounterUnits[name]
+
 	return meter.Int64UpDownCounter(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -195,6 +197,7 @@ func GetUpDownCounter(meter metric.Meter, name UpDownCounterType) (metric.Int64U
 func GetObservableCounter(meter metric.Meter, name ObservableCounterType, callback metric.Int64Callback) (metric.Int64ObservableCounter, error) {
 	desc := observableCounterDesc[name]
 	unit := observableCounterUnits[name]
+
 	return meter.Int64ObservableCounter(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -205,6 +208,7 @@ func GetObservableCounter(meter metric.Meter, name ObservableCounterType, callba
 func GetObservableUpDownCounter(meter metric.Meter, name ObservableUpDownCounterType, callback metric.Int64Callback) (metric.Int64ObservableUpDownCounter, error) {
 	desc := observableUpDownCounterDesc[name]
 	unit := observableUpDownCounterUnits[name]
+
 	return meter.Int64ObservableUpDownCounter(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -215,6 +219,7 @@ func GetObservableUpDownCounter(meter metric.Meter, name ObservableUpDownCounter
 func GetGaugeFloat(meter metric.Meter, name GaugeFloatType) (metric.Float64ObservableGauge, error) {
 	desc := gaugeFloatDesc[name]
 	unit := gaugeFloatUnits[name]
+
 	return meter.Float64ObservableGauge(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -224,6 +229,7 @@ func GetGaugeFloat(meter metric.Meter, name GaugeFloatType) (metric.Float64Obser
 func GetGaugeInt(meter metric.Meter, name GaugeIntType) (metric.Int64ObservableGauge, error) {
 	desc := gaugeIntDesc[name]
 	unit := gaugeIntUnits[name]
+
 	return meter.Int64ObservableGauge(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
@@ -249,6 +255,7 @@ var histogramUnits = map[HistogramType]string{
 func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram, error) {
 	desc := histogramDesc[name]
 	unit := histogramUnits[name]
+
 	return meter.Int64Histogram(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -130,5 +130,6 @@ func attributesToZapFields(attrs ...attribute.KeyValue) []zap.Field {
 			fields = append(fields, zap.Any(key, attr.Value.AsInterface()))
 		}
 	}
+
 	return fields
 }

--- a/packages/shared/pkg/utils/copy.go
+++ b/packages/shared/pkg/utils/copy.go
@@ -7,5 +7,6 @@ func ShallowCopyMap[K comparable, V any](m map[K]V) map[K]V {
 	for k, v := range m {
 		newMap[k] = v
 	}
+
 	return newMap
 }

--- a/packages/shared/pkg/utils/error_once.go
+++ b/packages/shared/pkg/utils/error_once.go
@@ -31,6 +31,7 @@ func (e *ErrorOnce) SetSuccess() error {
 // Returns nil if the operation completed successfully.
 func (e *ErrorOnce) Wait() error {
 	_, err := e.setOnce.Wait()
+
 	return err
 }
 
@@ -38,6 +39,7 @@ func (e *ErrorOnce) Wait() error {
 // Unlike Wait, this doesn't block.
 func (e *ErrorOnce) Error() error {
 	_, err := e.setOnce.Result()
+
 	return err
 }
 
@@ -45,6 +47,7 @@ func (e *ErrorOnce) Error() error {
 // Returns the set error or ctx.Err() if the context is cancelled first.
 func (e *ErrorOnce) WaitWithContext(ctx context.Context) error {
 	_, err := e.setOnce.WaitWithContext(ctx)
+
 	return err
 }
 

--- a/packages/shared/pkg/utils/filter.go
+++ b/packages/shared/pkg/utils/filter.go
@@ -10,5 +10,6 @@ func Filter[T any](input []T, f func(T) bool) []T {
 			output = append(output, v)
 		}
 	}
+
 	return output
 }

--- a/packages/shared/pkg/utils/map.go
+++ b/packages/shared/pkg/utils/map.go
@@ -7,5 +7,6 @@ func Map[T any, U any](input []T, f func(T) U) []U {
 	for i, v := range input {
 		output[i] = f(v)
 	}
+
 	return output
 }

--- a/packages/shared/pkg/utils/map_values.go
+++ b/packages/shared/pkg/utils/map_values.go
@@ -6,5 +6,6 @@ func MapValues[K comparable, V any](m map[K]V) []V {
 	for _, v := range m {
 		values = append(values, v)
 	}
+
 	return values
 }

--- a/packages/shared/pkg/utils/ptr.go
+++ b/packages/shared/pkg/utils/ptr.go
@@ -9,6 +9,7 @@ func ToPtr[T any](v T) *T {
 func FromPtr[T any](s *T) T {
 	if s == nil {
 		var zero T
+
 		return zero
 	}
 

--- a/packages/shared/pkg/utils/resizable_semaphore.go
+++ b/packages/shared/pkg/utils/resizable_semaphore.go
@@ -27,6 +27,7 @@ func NewAdjustableSemaphore(limit int64) (*AdjustableSemaphore, error) {
 
 	as := &AdjustableSemaphore{limit: limit}
 	as.cond = sync.NewCond(&as.mu)
+
 	return as, nil
 }
 
@@ -52,6 +53,7 @@ func (s *AdjustableSemaphore) Acquire(ctx context.Context, n int64) error {
 	}
 
 	s.used += n
+
 	return nil
 }
 
@@ -68,6 +70,7 @@ func (s *AdjustableSemaphore) TryAcquire(n int64) bool {
 	}
 
 	s.used += n
+
 	return true
 }
 

--- a/packages/shared/pkg/utils/set_once.go
+++ b/packages/shared/pkg/utils/set_once.go
@@ -48,6 +48,7 @@ func (s *SetOnce[T]) SetResult(value T, err error) error {
 	if err != nil {
 		return s.SetError(err)
 	}
+
 	return s.SetValue(value)
 }
 

--- a/packages/shared/pkg/utils/strings.go
+++ b/packages/shared/pkg/utils/strings.go
@@ -10,5 +10,6 @@ func Truncate(s string, maxLen int) string {
 	if maxLen <= len(ellipses) {
 		return string(runes[:maxLen])
 	}
+
 	return string(runes[:maxLen-len(ellipses)]) + ellipses
 }

--- a/packages/shared/pkg/utils/symlink.go
+++ b/packages/shared/pkg/utils/symlink.go
@@ -7,5 +7,6 @@ import (
 func SymlinkForce(oldname, newname string) error {
 	// Ignore error if the symlink does not exist
 	_ = os.Remove(newname)
+
 	return os.Symlink(oldname, newname)
 }

--- a/packages/shared/pkg/utils/version.go
+++ b/packages/shared/pkg/utils/version.go
@@ -10,6 +10,7 @@ func sanitizeVersion(version string) string {
 	if len(version) > 0 && version[0] != 'v' {
 		version = "v" + version
 	}
+
 	return version
 }
 

--- a/packages/shared/scripts/seed/postgres/seed-db.go
+++ b/packages/shared/scripts/seed/postgres/seed-db.go
@@ -49,6 +49,7 @@ func main() {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		fmt.Println("Error getting home directory:", err)
+
 		return
 	}
 

--- a/tests/integration/internal/setup/api_client.go
+++ b/tests/integration/internal/setup/api_client.go
@@ -42,6 +42,7 @@ func WithTestsUserAgent() api.RequestEditorFn {
 func WithUserAgent(userAgent string) api.RequestEditorFn {
 	return func(_ context.Context, req *http.Request) error {
 		req.Header.Set("User-Agent", userAgent)
+
 		return nil
 	}
 }

--- a/tests/integration/internal/setup/envd_client.go
+++ b/tests/integration/internal/setup/envd_client.go
@@ -51,6 +51,7 @@ func WithSandbox(sandboxID string) func(context.Context, *http.Request) error {
 func WithEnvdAccessToken(accessToken string) func(ctx context.Context, req *http.Request) error {
 	return func(_ context.Context, req *http.Request) error {
 		SetAccessTokenHeader(req.Header, accessToken)
+
 		return nil
 	}
 }

--- a/tests/integration/internal/tests/api/apikey_test.go
+++ b/tests/integration/internal/tests/api/apikey_test.go
@@ -139,6 +139,7 @@ func TestDeleteAPIKey(t *testing.T) {
 		for _, key := range *listResp.JSON200 {
 			if key.Id == apiKeyID {
 				found = true
+
 				break
 			}
 		}
@@ -158,6 +159,7 @@ func TestDeleteAPIKey(t *testing.T) {
 		for _, key := range *listResp2.JSON200 {
 			if key.Id == apiKeyID {
 				found = true
+
 				break
 			}
 		}
@@ -293,6 +295,7 @@ func TestPatchAPIKey(t *testing.T) {
 			if key.Id == apiKeyID {
 				assert.Equal(t, "legitimate-update", key.Name)
 				found = true
+
 				break
 			}
 		}

--- a/tests/integration/internal/tests/api/metrics/sandbox_list_metrics_test.go
+++ b/tests/integration/internal/tests/api/metrics/sandbox_list_metrics_test.go
@@ -36,6 +36,7 @@ func TestSandboxListMetrics(t *testing.T) {
 		}
 
 		metrics = response.JSON200.Sandboxes
+
 		return true
 	}, maxDuration, tick, "sandbox metrics not available in time")
 

--- a/tests/integration/internal/tests/api/metrics/sandbox_metrics_test.go
+++ b/tests/integration/internal/tests/api/metrics/sandbox_metrics_test.go
@@ -33,6 +33,7 @@ func TestSandboxMetrics(t *testing.T) {
 		}
 
 		metrics = *response.JSON200
+
 		return true
 	}, maxDuration, tick, "sandbox metrics not available in time")
 

--- a/tests/integration/internal/tests/api/metrics/team_metrics_max_test.go
+++ b/tests/integration/internal/tests/api/metrics/team_metrics_max_test.go
@@ -42,6 +42,7 @@ func TestTeamMetricsMaxConcurrentSandboxes(t *testing.T) {
 		}
 
 		maxMetric = *response.JSON200
+
 		return maxMetric.Value > 1
 	}, maxDuration, tick, "max concurrent sandboxes metric not available in time")
 
@@ -81,6 +82,7 @@ func TestTeamMetricsMaxSandboxStartRate(t *testing.T) {
 		}
 
 		maxMetric = *response.JSON200
+
 		return maxMetric.Value > 0
 	}, maxDuration, tick, "max sandbox start rate metric not available in time")
 

--- a/tests/integration/internal/tests/api/metrics/team_metrics_test.go
+++ b/tests/integration/internal/tests/api/metrics/team_metrics_test.go
@@ -35,6 +35,7 @@ func TestTeamMetrics(t *testing.T) {
 		}
 
 		metrics = *response.JSON200
+
 		return true
 	}, maxDuration, tick, "team metrics not available in time")
 
@@ -89,6 +90,7 @@ func TestTeamMetricsWithTimeRange(t *testing.T) {
 		}
 
 		metrics = *resp.JSON200
+
 		return true
 	}, maxDuration, tick, "team metrics not available in time")
 

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_auto_pause_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_auto_pause_test.go
@@ -40,6 +40,7 @@ func TestSandboxAutoPausePauseResume(t *testing.T) {
 	require.Eventually(t, func() bool {
 		res, err := c.GetSandboxesSandboxIDWithResponse(t.Context(), sbxId, setup.WithAPIKey())
 		require.NoError(t, err)
+
 		return res.StatusCode() == http.StatusOK && res.JSON200 != nil && res.JSON200.State == api.Paused
 	}, 10*time.Second, 10*time.Millisecond, "Sandbox is not stopped")
 
@@ -76,6 +77,7 @@ func TestSandboxAutoPauseResumePersisted(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.StatusCode())
 		require.NotNil(t, res.JSON200)
+
 		return res.JSON200.State == api.Paused
 	}, 10*time.Second, 10*time.Millisecond, "Sandbox is not paused")
 
@@ -111,6 +113,7 @@ func TestSandboxAutoPauseResumePersisted(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, res.StatusCode())
 		require.NotNil(t, res.JSON200)
+
 		return res.JSON200.State == api.Paused
 	}, 10*time.Second, 10*time.Millisecond, "Sandbox is not paused")
 
@@ -153,6 +156,7 @@ func TestSandboxNotAutoPause(t *testing.T) {
 	require.Eventually(t, func() bool {
 		res, err := c.GetSandboxesSandboxIDWithResponse(t.Context(), sbxId, setup.WithAPIKey())
 		require.NoError(t, err)
+
 		return res.StatusCode() == http.StatusNotFound
 	}, 10*time.Second, 10*time.Millisecond, "Sandbox is not stopped")
 

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
@@ -45,6 +45,7 @@ func TestSandboxList(t *testing.T) {
 	for _, s := range *listResponse.JSON200 {
 		if s.SandboxID == sbx.SandboxID {
 			found = true
+
 			break
 		}
 	}
@@ -97,6 +98,7 @@ func TestSandboxListRunning(t *testing.T) {
 		if s.SandboxID == sbx.SandboxID {
 			found = true
 			assert.Equal(t, api.Running, s.State)
+
 			break
 		}
 	}
@@ -148,6 +150,7 @@ func TestSandboxListPaused(t *testing.T) {
 		if s.SandboxID == sandboxID {
 			found = true
 			assert.Equal(t, api.Paused, s.State)
+
 			break
 		}
 	}
@@ -201,6 +204,7 @@ func TestSandboxListPausing(t *testing.T) {
 
 		// The sandbox has to be always present
 		require.True(t, found)
+
 		return false
 	}, 10*time.Second, 100*time.Millisecond, "Sandbox did not reach paused state in time")
 
@@ -487,6 +491,7 @@ func TestSandboxListRunningV1(t *testing.T) {
 		if s.SandboxID == sbx.SandboxID {
 			found = true
 			assert.Equal(t, api.Running, s.State)
+
 			break
 		}
 	}

--- a/tests/integration/internal/tests/api/templates/build_template_test.go
+++ b/tests/integration/internal/tests/api/templates/build_template_test.go
@@ -90,9 +90,11 @@ func buildTemplate(
 		switch statusResp.JSON200.Status {
 		case api.TemplateBuildStatusReady:
 			tb.Log("Build completed successfully")
+
 			return true
 		case api.TemplateBuildStatusError:
 			tb.Fatalf("Build failed: %v", safe(statusResp.JSON200.Reason))
+
 			return false
 		}
 
@@ -105,6 +107,7 @@ func safe[T any](item *T) T {
 		return *item
 	}
 	var t T
+
 	return t
 }
 
@@ -310,6 +313,7 @@ func TestTemplateBuildCache(t *testing.T) {
 				return true
 			}
 		}
+
 		return false
 	}, "Expected to contain cached ENV layer")
 }
@@ -780,6 +784,7 @@ func TestTemplateBuildStartReadyCommandExecution(t *testing.T) {
 				for _, msg := range logMessages {
 					if strings.Contains(msg, expectedLog) {
 						found = true
+
 						break
 					}
 				}
@@ -858,6 +863,7 @@ func TestTemplateBuildWithDifferentSourceImages(t *testing.T) {
 				for _, msg := range logMessages {
 					if strings.Contains(msg, expectedLog) {
 						found = true
+
 						break
 					}
 				}

--- a/tests/integration/internal/tests/api/templates/template_update_test.go
+++ b/tests/integration/internal/tests/api/templates/template_update_test.go
@@ -44,6 +44,7 @@ func TestUpdateTemplateVisibilityToPublicWithAPIKey(t *testing.T) {
 		if tmpl.TemplateID == template.TemplateID {
 			assert.True(t, tmpl.Public, "Template should be public")
 			found = true
+
 			break
 		}
 	}
@@ -92,6 +93,7 @@ func TestUpdateTemplateVisibilityToPrivateWithAPIKey(t *testing.T) {
 		if tmpl.TemplateID == template.TemplateID {
 			assert.False(t, tmpl.Public, "Template should be private")
 			found = true
+
 			break
 		}
 	}
@@ -177,6 +179,7 @@ func TestUpdateTemplateWithSupabaseToken(t *testing.T) {
 		if tmpl.TemplateID == template.TemplateID {
 			assert.True(t, tmpl.Public, "Template should be public")
 			found = true
+
 			break
 		}
 	}
@@ -237,6 +240,7 @@ func TestUpdateTemplateNotOwnedByTeam(t *testing.T) {
 		if tmpl.TemplateID == team1TemplateID {
 			assert.True(t, tmpl.Public, "Template should be public after update")
 			found = true
+
 			break
 		}
 	}

--- a/tests/integration/internal/tests/envd/watcher_test.go
+++ b/tests/integration/internal/tests/envd/watcher_test.go
@@ -56,6 +56,7 @@ func TestWatcher(t *testing.T) {
 		getResp, err := envdClient.FilesystemClient.GetWatcherEvents(t.Context(), getReq)
 		require.NoError(t, err)
 		events = getResp.Msg.GetEvents()
+
 		return len(events) > 0
 	}, 5*time.Second, 20*time.Millisecond, "Expected to receive file system events")
 	require.NotEmpty(t, events)

--- a/tests/integration/internal/tests/proxies/closed_port_test.go
+++ b/tests/integration/internal/tests/proxies/closed_port_test.go
@@ -29,6 +29,7 @@ func waitForStatus(t *testing.T, client *http.Client, sbx *api.Sandbox, url *url
 		resp, err := client.Do(req)
 		if err != nil {
 			t.Logf("Error: %v", err)
+
 			continue
 		}
 
@@ -46,6 +47,7 @@ func waitForStatus(t *testing.T, client *http.Client, sbx *api.Sandbox, url *url
 	}
 
 	t.Fail()
+
 	return nil
 }
 

--- a/tests/integration/internal/utils/process.go
+++ b/tests/integration/internal/utils/process.go
@@ -81,6 +81,7 @@ func ExecCommandWithOptions(tb testing.TB, ctx context.Context, sbx *api.Sandbox
 					return fmt.Errorf("command %s in sandbox %s failed with exit code %d", command, sbx.SandboxID, msg.GetEvent().GetEnd().GetExitCode())
 				}
 				tb.Logf("Command [%s] completed successfully in sandbox %s", command, sbx.SandboxID)
+
 				return nil
 			}
 		}

--- a/tests/integration/internal/utils/template.go
+++ b/tests/integration/internal/utils/template.go
@@ -112,6 +112,7 @@ func WaitForBuildCompletion(
 		select {
 		case <-ctx.Done():
 			tb.Fatal("Build timeout exceeded")
+
 			return
 		default:
 		}
@@ -138,9 +139,11 @@ func WaitForBuildCompletion(
 		switch statusResp.JSON200.Status {
 		case api.TemplateBuildStatusReady:
 			tb.Log("Build completed successfully")
+
 			return
 		case api.TemplateBuildStatusError:
 			tb.Fatalf("Build failed: %v", safeValue(statusResp.JSON200.Reason))
+
 			return
 		}
 
@@ -209,6 +212,7 @@ func safeValue[T any](item *T) T {
 		return *item
 	}
 	var t T
+
 	return t
 }
 

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -43,12 +43,14 @@ func run(ctx context.Context) int {
 	connectionString := os.Getenv("POSTGRES_CONNECTION_STRING")
 	if connectionString == "" {
 		log.Printf("POSTGRES_CONNECTION_STRING is not set")
+
 		return 1
 	}
 
 	database, err := db.NewClient(1, 1)
 	if err != nil {
 		log.Printf("Failed to connect to database: %v", err)
+
 		return 1
 	}
 	defer database.Close()
@@ -56,6 +58,7 @@ func run(ctx context.Context) int {
 	sqlcDB, err := client.NewClient(ctx)
 	if err != nil {
 		log.Printf("Failed to connect to database: %v", err)
+
 		return 1
 	}
 	defer sqlcDB.Close()
@@ -72,10 +75,12 @@ func run(ctx context.Context) int {
 	err = seed(ctx, database, sqlcDB, data)
 	if err != nil {
 		log.Printf("Failed to execute seed: %v", err)
+
 		return 1
 	}
 
 	fmt.Println("Seed completed successfully.")
+
 	return 0
 }
 


### PR DESCRIPTION
https://github.com/ssgreg/nlreturn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables the nlreturn linter and adds required blank lines before return statements across the codebase (no functional changes).
> 
> - **Linting/Tooling**:
>   - Enable `nlreturn` in `.golangci.yml`.
> - **Codebase-wide style updates**:
>   - Insert blank lines before `return` statements to satisfy `nlreturn` across many packages (API handlers, orchestrator, client-proxy, storage, utils, tests). No logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd1154b9c4a6d86c1288752e892152b9481253c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->