### PR TITLE
Expose api_nat_min_ports_per_vm, increase default to 140

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -118,8 +118,9 @@ module "cluster" {
   loki_node_pool         = var.loki_node_pool
   orchestrator_node_pool = var.orchestrator_node_pool
 
-  api_use_nat = var.api_use_nat
-  api_nat_ips = var.api_nat_ips
+  api_use_nat              = var.api_use_nat
+  api_nat_ips              = var.api_nat_ips
+  api_nat_min_ports_per_vm = var.api_nat_min_ports_per_vm
 
   ingress_port                 = var.ingress_port
   edge_api_port                = var.edge_api_port

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -93,8 +93,9 @@ module "network" {
   gcp_project_id = var.gcp_project_id
   gcp_region     = var.gcp_region
 
-  api_use_nat = var.api_use_nat
-  api_nat_ips = var.api_nat_ips
+  api_use_nat              = var.api_use_nat
+  api_nat_ips              = var.api_nat_ips
+  api_nat_min_ports_per_vm = var.api_nat_min_ports_per_vm
 
   ingress_port              = var.ingress_port
   api_port                  = var.api_port

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -726,6 +726,7 @@ resource "google_compute_router_nat" "api_nat" {
   nat_ip_allocate_option             = "MANUAL_ONLY"
   nat_ips                            = length(var.api_nat_ips) > 0 ? var.api_nat_ips : google_compute_address.nat_ips[*].self_link
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  min_ports_per_vm                   = var.api_nat_min_ports_per_vm
 
   log_config {
     enable = true

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -39,6 +39,10 @@ variable "api_nat_ips" {
   type = list(string)
 }
 
+variable "api_nat_min_ports_per_vm" {
+  type = number
+}
+
 variable "cloudflare_api_token_secret_name" {
   type = string
 }

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -327,3 +327,7 @@ variable "api_nat_ips" {
   type        = list(string)
   description = "List of names for static IP addresses to use for NAT. If empty and api_use_nat is true, IPs will be created automatically."
 }
+
+variable "api_nat_min_ports_per_vm" {
+  type = number
+}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -59,6 +59,12 @@ variable "api_nat_ips" {
   default     = []
 }
 
+variable "api_nat_min_ports_per_vm" {
+  type        = number
+  description = "The default API NAT minimum ports per VM."
+  default     = 140
+}
+
 variable "api_resources_cpu_count" {
   type    = number
   default = 2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a configurable `api_nat_min_ports_per_vm` (default 140) and wires it through modules to set Cloud NAT `min_ports_per_vm` for API nodes.
> 
> - **Infrastructure (GCP/Terraform)**:
>   - **Cloud NAT configuration**:
>     - Add `variable "api_nat_min_ports_per_vm"` (default `140`) in `iac/provider-gcp/variables.tf`.
>     - Plumb `api_nat_min_ports_per_vm` through `iac/provider-gcp/main.tf` -> `nomad-cluster/main.tf` -> `network/variables.tf`.
>     - Set `google_compute_router_nat.api_nat` `min_ports_per_vm = var.api_nat_min_ports_per_vm` in `network/main.tf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21afaaba06e7e202b5540672ba9d3e1d0e431b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->