### PR TITLE
returns must be exported

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -110,7 +110,6 @@ linters:
         - { disabled: true, name: package-comments }
         - { disabled: true, name: unchecked-type-assertion }
         - { disabled: true, name: unexported-naming }
-        - { disabled: true, name: unexported-return }
         - { disabled: true, name: unhandled-error }  #  todo: enable this
         - { disabled: true, name: unnecessary-format }  # todo: enable this
         - { disabled: true, name: unnecessary-stmt }  # todo: enable this

--- a/packages/shared/pkg/proxy/handler.go
+++ b/packages/shared/pkg/proxy/handler.go
@@ -40,7 +40,7 @@ func (e *SandboxNotFoundError) Error() string {
 }
 
 func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Destination, error)) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		d, err := getDestination(r)
 
 		var invalidHostErr *InvalidHostError
@@ -89,5 +89,5 @@ func handler(p *pool.ProxyPool, getDestination func(r *http.Request) (*pool.Dest
 
 		proxy := p.Get(d)
 		proxy.ServeHTTP(w, r.WithContext(ctx))
-	})
+	}
 }

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -15,7 +15,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/tracking"
 )
 
-type proxyClient struct {
+type ProxyClient struct {
 	httputil.ReverseProxy
 
 	transport *http.Transport
@@ -29,7 +29,7 @@ func newProxyClient(
 	totalConnsCounter *atomic.Uint64,
 	currentConnsCounter *atomic.Int64,
 	logger *log.Logger,
-) *proxyClient {
+) *ProxyClient {
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		// Limit the max connection per host to avoid exhausting the number of available ports to one host.
@@ -80,7 +80,7 @@ func newProxyClient(
 		DisableCompression: true, // No need to request or manipulate compression
 	}
 
-	return &proxyClient{
+	return &ProxyClient{
 		transport: transport,
 		ReverseProxy: httputil.ReverseProxy{
 			Transport: transport,
@@ -163,6 +163,6 @@ func newProxyClient(
 	}
 }
 
-func (p *proxyClient) closeIdleConnections() {
+func (p *ProxyClient) closeIdleConnections() {
 	p.transport.CloseIdleConnections()
 }

--- a/packages/shared/pkg/proxy/pool/pool.go
+++ b/packages/shared/pkg/proxy/pool/pool.go
@@ -17,7 +17,7 @@ import (
 const hostConnectionSplit = 4
 
 type ProxyPool struct {
-	pool                  *smap.Map[*proxyClient]
+	pool                  *smap.Map[*ProxyClient]
 	maxClientConns        int
 	maxConnectionAttempts int
 	idleTimeout           time.Duration
@@ -27,15 +27,15 @@ type ProxyPool struct {
 
 func New(maxClientConns int, maxConnectionAttempts int, idleTimeout time.Duration) *ProxyPool {
 	return &ProxyPool{
-		pool:                  smap.New[*proxyClient](),
+		pool:                  smap.New[*ProxyClient](),
 		maxClientConns:        maxClientConns,
 		maxConnectionAttempts: maxConnectionAttempts,
 		idleTimeout:           idleTimeout,
 	}
 }
 
-func (p *ProxyPool) Get(d *Destination) *proxyClient {
-	return p.pool.Upsert(d.ConnectionKey, nil, func(exist bool, inMapValue *proxyClient, _ *proxyClient) *proxyClient {
+func (p *ProxyPool) Get(d *Destination) *ProxyClient {
+	return p.pool.Upsert(d.ConnectionKey, nil, func(exist bool, inMapValue *ProxyClient, _ *ProxyClient) *ProxyClient {
 		if exist && inMapValue != nil {
 			return inMapValue
 		}
@@ -70,7 +70,7 @@ func (p *ProxyPool) Get(d *Destination) *proxyClient {
 }
 
 func (p *ProxyPool) Close(connectionKey string) {
-	p.pool.RemoveCb(connectionKey, func(_ string, proxy *proxyClient, _ bool) bool {
+	p.pool.RemoveCb(connectionKey, func(_ string, proxy *ProxyClient, _ bool) bool {
 		if proxy != nil {
 			proxy.closeIdleConnections()
 		}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Exports ProxyClient and updates pool to use it, simplifies handler return, and enables the revive unexported-return rule.
> 
> - **Proxy**:
>   - **Client/Pool**: Rename `proxyClient` to exported `ProxyClient`; update constructors, receivers, pool map types, `Get`/`Close` signatures to use `*ProxyClient`.
>   - **Handler**: Simplify `handler` to return a plain `func(http.ResponseWriter, *http.Request)` instead of wrapping with `http.HandlerFunc`.
> - **Lint**:
>   - Enable `revive` rule `unexported-return` in `.golangci.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6f90c047c7ce61028067764eec0c744d5657d9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->