### PR TITLE
fix: orchestrator/template manager shutdown exit code

### DIFF
--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -60,7 +60,7 @@ func cleanNFSCache(ctx context.Context) error {
 	}))
 	defer func(l *zap.Logger) {
 		err := l.Sync()
-		if err != nil {
+		if logger.IsSyncError(err) {
 			log.Printf("error while shutting down logger: %v", err)
 		}
 	}(globalLogger)

--- a/packages/shared/pkg/logger/errors.go
+++ b/packages/shared/pkg/logger/errors.go
@@ -1,0 +1,12 @@
+package logger
+
+import (
+	"errors"
+	"syscall"
+)
+
+// IsSyncError checks if the error from Sync is not EINVAL.
+// Sync returns EINVAL when path is /dev/stdout (for example)
+func IsSyncError(err error) bool {
+	return err != nil && !errors.Is(err, syscall.EINVAL)
+}


### PR DESCRIPTION
Fix orchestrator/template manager shutdown exit code by properly handling exit errors and improving logger messages observability.