### PR TITLE
fix: gin mode release for orchestrator/template manager

### DIFF
--- a/iac/provider-gcp/nomad/jobs/orchestrator.hcl
+++ b/iac/provider-gcp/nomad/jobs/orchestrator.hcl
@@ -76,6 +76,7 @@ EOT
         REDIS_CLUSTER_URL            = "${redis_cluster_url}"
         GRPC_PORT                    = "${port}"
         PROXY_PORT                   = "${proxy_port}"
+        GIN_MODE                     = "release"
 
 %{ if launch_darkly_api_key != "" }
         LAUNCH_DARKLY_API_KEY         = "${launch_darkly_api_key}"

--- a/iac/provider-gcp/nomad/jobs/template-manager.hcl
+++ b/iac/provider-gcp/nomad/jobs/template-manager.hcl
@@ -78,6 +78,7 @@ job "template-manager-system" {
         CLICKHOUSE_CONNECTION_STRING  = "${clickhouse_connection_string}"
         DOCKERHUB_REMOTE_REPOSITORY_URL  = "${dockerhub_remote_repository_url}"
         GRPC_PORT                     = "${port}"
+        GIN_MODE                      = "release"
 %{ if !update_stanza }
         FORCE_STOP                    = "true"
 %{ endif }


### PR DESCRIPTION
The gin is used in hyperloop server.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6b67dd989d022bc477a5a6e6287aa4cc6be6390a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->