### PR TITLE
fix: wait for builds to drain before restart

### DIFF
--- a/packages/orchestrator/internal/template/server/main.go
+++ b/packages/orchestrator/internal/template/server/main.go
@@ -130,21 +130,6 @@ func (s *ServerStore) Close(ctx context.Context) error {
 	case <-ctx.Done():
 		return errors.New("force exit, not waiting for builds to finish")
 	default:
-		// Wait for draining state to propagate to all consumers
-		if !env.IsLocal() {
-			time.Sleep(15 * time.Second)
-		}
-
-		s.logger.Info("Waiting for all build jobs to finish")
-		s.wg.Wait()
-
-		if !env.IsLocal() {
-			s.logger.Info("Waiting for consumers to check build status")
-			time.Sleep(15 * time.Second)
-		}
-
-		s.logger.Info("Template build queue cleaned")
-
 		var closersErr error
 		for _, closer := range s.closers {
 			err := closer.Close()
@@ -155,6 +140,25 @@ func (s *ServerStore) Close(ctx context.Context) error {
 		if closersErr != nil {
 			return fmt.Errorf("failed to close services: %w", closersErr)
 		}
+
+		return nil
+	}
+}
+
+func (s *ServerStore) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return errors.New("force exit, not waiting for builds to finish")
+	default:
+		s.logger.Info("Waiting for all build jobs to finish")
+		s.wg.Wait()
+
+		if !env.IsLocal() {
+			s.logger.Info("Waiting for consumers to check build status")
+			time.Sleep(15 * time.Second)
+		}
+
+		s.logger.Info("Template build queue cleaned")
 
 		return nil
 	}

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/soheilhy/cmux"
@@ -396,8 +397,9 @@ func run(config cfg.Config) (success bool) {
 	orchestrator.RegisterSandboxServiceServer(grpcServer, orchestratorService)
 
 	// template manager
+	var tmpl *tmplserver.ServerStore
 	if slices.Contains(services, cfg.TemplateManager) {
-		tmpl, err := tmplserver.New(
+		tmpl, err = tmplserver.New(
 			ctx,
 			tel.MeterProvider,
 			globalLogger,
@@ -497,6 +499,20 @@ func run(config cfg.Config) (success bool) {
 	// If service stats was previously changed via API, we don't want to override it.
 	if serviceInfo.GetStatus() == orchestratorinfo.ServiceInfoStatus_Healthy {
 		serviceInfo.SetStatus(orchestratorinfo.ServiceInfoStatus_Draining)
+
+		// Wait for draining state to propagate to all consumers
+		if !env.IsLocal() {
+			time.Sleep(15 * time.Second)
+		}
+	}
+
+	// Wait for services to be drained before closing them
+	if tmpl != nil {
+		err := tmpl.Wait(closeCtx)
+		if err != nil {
+			zap.L().Error("error while waiting for template manager to drain", zap.Error(err))
+			success = false
+		}
 	}
 
 	slices.Reverse(closers)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `ServerStore.Wait` and update orchestrator shutdown to mark draining, wait for propagation, then wait for template builds to finish before closing services.
> 
> - **Orchestrator shutdown**:
>   - Mark service as `Draining`, then pause 15s (non-local) for propagation.
>   - If template manager is running, call `tmpl.Wait(ctx)` before closing services; log errors and affect exit status.
> - **Template manager (`ServerStore`)**:
>   - Add `Wait(ctx)` to block until in-flight builds finish and perform non-local delay checks.
>   - Simplify `Close(ctx)` to only close internal resources and return aggregated errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac3857b159519db651081725947ce417f4fc32c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->