### PR TITLE
Security policy for ingress backend

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -26,8 +26,20 @@ resource "google_compute_backend_service" "ingress" {
   load_balancing_scheme = "EXTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"
 
+  security_policy = google_compute_security_policy.ingress.id
+
   backend {
     group = var.api_instance_group
+  }
+}
+
+resource "google_compute_security_policy" "ingress" {
+  name = "${var.prefix}ingress"
+
+  adaptive_protection_config {
+    layer_7_ddos_defense_config {
+      enable = true
+    }
   }
 }
 


### PR DESCRIPTION
Create and attache security policy to ingress backend.
This way, we can address the existing security policy from our internal tools and attach custom rules to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `google_compute_security_policy` with Layer 7 DDoS protection and attaches it to the ingress backend service.
> 
> - **Infra (GCP Ingress)**:
>   - **Backend Service**: Attach `security_policy = google_compute_security_policy.ingress.id` to `google_compute_backend_service.ingress`.
>   - **Security Policy**: Add `google_compute_security_policy.ingress` with `adaptive_protection_config.layer_7_ddos_defense_config.enable = true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 626456a217d0bc4191cf57d4363f60b275b0ba5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->