### PR TITLE
feat: add ca-certificates to the default installed packages

### DIFF
--- a/packages/orchestrator/internal/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.sh
@@ -7,7 +7,7 @@ echo "Making configuration immutable"
 {{ .BusyBox }} chattr +i /etc/resolv.conf
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl"
+PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl ca-certificates"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""


### PR DESCRIPTION
do not merge yet, thinking about granular deployment of this update to not invalidate all templates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ca-certificates to the default packages installed by the base provisioning script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e2429c70f7b15971c56be39cc06988e8b4ff731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->