### PR TITLE
Add idempotency key for addons table

### DIFF
--- a/packages/db/migrations/20251026192416_addons_idempotency.sql
+++ b/packages/db/migrations/20251026192416_addons_idempotency.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE public.addons ADD COLUMN idempotency_key text;
+CREATE UNIQUE INDEX addons_idempotency_key_uidx
+    ON public.addons(idempotency_key) WHERE idempotency_key IS NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX addons_idempotency_key_uidx;
+ALTER TABLE public.addons DROP COLUMN idempotency_key;
+-- +goose StatementEnd

--- a/packages/db/queries/models.go
+++ b/packages/db/queries/models.go
@@ -38,6 +38,7 @@ type Addon struct {
 	ValidFrom                     time.Time
 	ValidTo                       *time.Time
 	AddedBy                       uuid.UUID
+	IdempotencyKey                *string
 }
 
 type AuthUser struct {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds nullable `idempotency_key` to `addons` with a unique partial index and updates the `Addon` model accordingly.
> 
> - **Database**:
>   - Adds nullable `idempotency_key` column to `public.addons`.
>   - Creates unique partial index `addons_idempotency_key_uidx` on `idempotency_key` when not null.
>   - Includes down migration to drop index and column.
> - **Models**:
>   - Updates `Addon` struct in `packages/db/queries/models.go` to include `IdempotencyKey *string`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c546db118ebdb4d4c584f2a2432d613679aabd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->