### PR TITLE
Remove allow sandbox internet from template manager

### DIFF
--- a/iac/provider-gcp/nomad/jobs/template-manager.hcl
+++ b/iac/provider-gcp/nomad/jobs/template-manager.hcl
@@ -73,7 +73,6 @@ job "template-manager-system" {
         OTEL_COLLECTOR_GRPC_ENDPOINT  = "${otel_collector_grpc_endpoint}"
         LOGS_COLLECTOR_ADDRESS        = "${logs_collector_address}"
         ORCHESTRATOR_SERVICES         = "${orchestrator_services}"
-        ALLOW_SANDBOX_INTERNET        = "${allow_sandbox_internet}"
         SHARED_CHUNK_CACHE_PATH       = "${shared_chunk_cache_path}"
         CLICKHOUSE_CONNECTION_STRING  = "${clickhouse_connection_string}"
         DOCKERHUB_REMOTE_REPOSITORY_URL  = "${dockerhub_remote_repository_url}"

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -527,7 +527,6 @@ resource "nomad_job" "template_manager" {
     otel_collector_grpc_endpoint    = "localhost:${var.otel_collector_grpc_port}"
     logs_collector_address          = "http://localhost:${var.logs_proxy_port.port}"
     orchestrator_services           = "template-manager"
-    allow_sandbox_internet          = var.allow_sandbox_internet
     clickhouse_connection_string    = local.clickhouse_connection_string
     dockerhub_remote_repository_url = var.dockerhub_remote_repository_url
     launch_darkly_api_key           = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `ALLOW_SANDBOX_INTERNET` from the template-manager job and its Terraform parameter wiring.
> 
> - **Nomad job (`template-manager`)**:
>   - Remove `ALLOW_SANDBOX_INTERNET` env var from `iac/provider-gcp/nomad/jobs/template-manager.hcl`.
> - **Terraform (`main.tf`)**:
>   - Remove `allow_sandbox_internet` argument from `nomad_job.template_manager` template inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 902b98d15b0d06e845ea7c317e9d2b63066e53d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->