### PR TITLE
Improve the snapshot list query

### DIFF
--- a/packages/db/queries/get_snapshots_with_cursor.sql
+++ b/packages/db/queries/get_snapshots_with_cursor.sql
@@ -23,7 +23,7 @@ WHERE
         s.metadata @> @metadata OR @metadata = '{}'::jsonb
     )
     -- The order here is important, we want started_at descending, but sandbox_id ascending
-    AND (s.sandbox_started_at, @cursor_id) < (@cursor_time, s.sandbox_id)
+    AND (s.sandbox_started_at, @cursor_id::text) < (@cursor_time, s.sandbox_id)
     AND NOT (s.sandbox_id = ANY (@snapshot_exclude_sbx_ids::text[]))
 ORDER BY s.sandbox_started_at DESC, s.sandbox_id ASC
 LIMIT $1;

--- a/packages/db/queries/get_snapshots_with_cursor.sql.go
+++ b/packages/db/queries/get_snapshots_with_cursor.sql.go
@@ -38,7 +38,7 @@ WHERE
         s.metadata @> $3 OR $3 = '{}'::jsonb
     )
     -- The order here is important, we want started_at descending, but sandbox_id ascending
-    AND (s.sandbox_started_at, $4) < ($5, s.sandbox_id)
+    AND (s.sandbox_started_at, $4::text) < ($5, s.sandbox_id)
     AND NOT (s.sandbox_id = ANY ($6::text[]))
 ORDER BY s.sandbox_started_at DESC, s.sandbox_id ASC
 LIMIT $1
@@ -48,7 +48,7 @@ type GetSnapshotsWithCursorParams struct {
 	Limit                 int32
 	TeamID                uuid.UUID
 	Metadata              types.JSONBStringMap
-	CursorID              pgtype.Timestamptz
+	CursorID              string
 	CursorTime            pgtype.Timestamptz
 	SnapshotExcludeSbxIds []string
 }


### PR DESCRIPTION
*Before*
| QUERY PLAN                                                                                                                                                                                                         |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| Limit  (cost=3.36..231.54 rows=100 width=748) (actual time=1628.941..1744.904 rows=100 loops=1)                                                                                                                    |
|   ->  Nested Loop  (cost=3.36..2292711.14 rows=1004759 width=748) (actual time=1628.940..1744.870 rows=100 loops=1)                                                                                                |
|         ->  Nested Loop Left Join  (cost=2.93..248843.50 rows=1004759 width=253) (actual time=1628.324..1630.706 rows=100 loops=1)                                                                                 |
|               ->  Index Scan using idx_snapshots_team_time_id on snapshots s  (cost=0.43..223714.47 rows=1004759 width=221) (actual time=1628.220..1630.322 rows=100 loops=1)                                      |
|                     Index Cond: (team_id = 'xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx'::uuid)                                                                                                                           |
|                     Filter: ((sandbox_started_at < '2025-09-20 00:00:00+00'::timestamp with time zone) OR ((sandbox_started_at = '2025-09-20 00:00:00+00'::timestamp with time zone) AND (sandbox_id > ''::text))) |
|                     Rows Removed by Filter: 277449                                                                                                                                                                 |
|               ->  Memoize  (cost=2.50..2.52 rows=1 width=32) (actual time=0.002..0.002 rows=1 loops=100)                                                                                                           |
|                     Cache Key: s.base_env_id                                                                                                                                                                       |
|                     Cache Mode: binary                                                                                                                                                                             |
|                     Hits: 99  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 1kB                                                                                                                             |
|                     ->  Aggregate  (cost=2.50..2.50 rows=1 width=32) (actual time=0.092..0.093 rows=1 loops=1)                                                                                                     |
|                           ->  Index Scan using idx_envs_envs_aliases on env_aliases  (cost=0.27..2.49 rows=1 width=50) (actual time=0.035..0.036 rows=1 loops=1)                                                   |
|                                 Index Cond: (env_id = s.base_env_id)                                                                                                                                               |
|         ->  Limit  (cost=0.43..2.01 rows=1 width=495) (actual time=1.139..1.139 rows=1 loops=100)                                                                                                                  |
|               ->  Index Scan using idx_env_builds_env_status_created on env_builds eb  (cost=0.43..3.60 rows=2 width=495) (actual time=1.138..1.138 rows=1 loops=100)                                              |
|                     Index Cond: ((env_id = s.env_id) AND (status = 'success'::text))                                                                                                                               |
| Planning Time: 2.641 ms                                                                                                                                                                                            |
| Execution Time: 1745.111 ms                                                                                                                                                                                        |

*After*
| QUERY PLAN                                                                                                                                                                |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Limit  (cost=3.36..227.07 rows=100 width=748) (actual time=5.317..105.461 rows=100 loops=1)                                                                               |
|   ->  Nested Loop  (cost=3.36..2638655.63 rows=1179508 width=748) (actual time=5.316..105.433 rows=100 loops=1)                                                           |
|         ->  Nested Loop Left Join  (cost=2.93..239315.86 rows=1179508 width=253) (actual time=3.320..5.273 rows=100 loops=1)                                              |
|               ->  Index Scan using idx_snapshots_team_time_id on snapshots s  (cost=0.43..209818.11 rows=1179508 width=221) (actual time=3.224..4.971 rows=100 loops=1)   |
|                     Index Cond: ((team_id = 'xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx'::uuid) AND (sandbox_started_at <= '2025-10-10 00:00:00+00'::timestamp with time zone)) |
|                     Filter: (ROW(sandbox_started_at, ''::text) < ROW('2025-10-10 00:00:00+00'::timestamp with time zone, sandbox_id))                                     |
|               ->  Memoize  (cost=2.50..2.52 rows=1 width=32) (actual time=0.002..0.002 rows=1 loops=100)                                                                  |
|                     Cache Key: s.base_env_id                                                                                                                              |
|                     Cache Mode: binary                                                                                                                                    |
|                     Hits: 99  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 1kB                                                                                    |
|                     ->  Aggregate  (cost=2.50..2.50 rows=1 width=32) (actual time=0.086..0.087 rows=1 loops=1)                                                            |
|                           ->  Index Scan using idx_envs_envs_aliases on env_aliases  (cost=0.27..2.49 rows=1 width=50) (actual time=0.036..0.037 rows=1 loops=1)          |
|                                 Index Cond: (env_id = s.base_env_id)                                                                                                      |
|         ->  Limit  (cost=0.43..2.01 rows=1 width=495) (actual time=0.993..0.993 rows=1 loops=100)                                                                         |
|               ->  Index Scan using idx_env_builds_env_status_created on env_builds eb  (cost=0.43..3.60 rows=2 width=495) (actual time=0.992..0.992 rows=1 loops=100)     |
|                     Index Cond: ((env_id = s.env_id) AND (status = 'success'::text))                                                                                      |
| Planning Time: 1.498 ms                                                                                                                                                   |
| Execution Time: 105.644 ms                                                                                                                                                |


