### PR TITLE
Support local ephemeral nvme disks

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -91,12 +91,8 @@ module "cluster" {
   gcp_zone                         = var.gcp_zone
   google_service_account_key       = module.init.google_service_account_key
 
-  client_cluster_size_max           = var.client_cluster_size_max
-  client_cluster_cache_disk_size_gb = var.client_cluster_cache_disk_size_gb
-  client_cluster_cache_disk_type    = var.client_cluster_cache_disk_type
-  build_cluster_root_disk_size_gb   = var.build_cluster_root_disk_size_gb
-  build_cluster_cache_disk_size_gb  = var.build_cluster_cache_disk_size_gb
-  build_cluster_cache_disk_type     = var.build_cluster_cache_disk_type
+  client_cluster_size_max         = var.client_cluster_size_max
+  build_cluster_root_disk_size_gb = var.build_cluster_root_disk_size_gb
 
   api_cluster_size        = var.api_cluster_size
   build_cluster_size      = var.build_cluster_size
@@ -104,6 +100,9 @@ module "cluster" {
   client_cluster_size     = var.client_cluster_size
   server_cluster_size     = var.server_cluster_size
   loki_cluster_size       = var.loki_cluster_size
+
+  build_cluster_cache_disk_count  = var.build_cluster_cache_disk_count
+  client_cluster_cache_disk_count = var.client_cluster_cache_disk_count
 
   server_machine_type     = var.server_machine_type
   client_machine_type     = var.client_machine_type

--- a/iac/provider-gcp/nomad-cluster/nodepool-build.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-build.tf
@@ -22,7 +22,7 @@ locals {
     USE_FILESTORE_CACHE          = var.filestore_cache_enabled
     NODE_POOL                    = var.build_node_pool
     BASE_HUGEPAGES_PERCENTAGE    = var.build_base_hugepages_percentage
-    LOCAL_CACHE_DISK_COUNT       = local.cache_disk_count
+    LOCAL_CACHE_DISK_COUNT       = var.build_cluster_cache_disk_count
   })
 }
 
@@ -120,12 +120,17 @@ resource "google_compute_instance_template" "build" {
     disk_type    = "pd-ssd"
   }
 
-  disk {
-    auto_delete  = true
-    boot         = false
-    type         = "PERSISTENT"
-    disk_size_gb = var.build_cluster_cache_disk_size_gb
-    disk_type    = var.build_cluster_cache_disk_type
+  dynamic "disk" {
+    for_each = [for n in range(var.build_cluster_cache_disk_count) : {}]
+
+    content {
+      auto_delete  = true
+      boot         = false
+      disk_size_gb = 375
+      interface    = "NVME"
+      disk_type    = "local-ssd"
+      type         = "SCRATCH"
+    }
   }
 
   network_interface {

--- a/iac/provider-gcp/nomad-cluster/nodepool-client.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-client.tf
@@ -1,7 +1,4 @@
 locals {
-  cache_disk_count = 3   # todo: make configurable
-  cache_disk_size  = 375 # todo: make configurable
-
   client_pool_name = "${var.prefix}${var.client_cluster_name}"
   client_startup_script = templatefile("${path.module}/scripts/start-client.sh", {
     CLUSTER_TAG_NAME             = var.cluster_tag_name
@@ -25,7 +22,7 @@ locals {
     USE_FILESTORE_CACHE          = var.filestore_cache_enabled
     NODE_POOL                    = var.orchestrator_node_pool
     BASE_HUGEPAGES_PERCENTAGE    = var.orchestrator_base_hugepages_percentage
-    LOCAL_CACHE_DISK_COUNT       = local.cache_disk_count
+    LOCAL_CACHE_DISK_COUNT       = var.client_cluster_cache_disk_count
   })
 }
 
@@ -143,12 +140,12 @@ resource "google_compute_instance_template" "client" {
   }
 
   dynamic "disk" {
-    for_each = [for n in range(local.cache_disk_count) : {}]
+    for_each = [for n in range(var.client_cluster_cache_disk_count) : {}]
 
     content {
       auto_delete  = true
       boot         = false
-      disk_size_gb = local.cache_disk_size
+      disk_size_gb = 375
       interface    = "NVME"
       disk_type    = "local-ssd"
       type         = "SCRATCH"

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -69,14 +69,6 @@ variable "build_cluster_root_disk_size_gb" {
   type = number
 }
 
-variable "build_cluster_cache_disk_size_gb" {
-  type = number
-}
-
-variable "build_cluster_cache_disk_type" {
-  type = string
-}
-
 variable "edge_api_port" {
   type = object({
     name = string
@@ -135,14 +127,6 @@ variable "client_cluster_size_max" {
 }
 
 variable "client_machine_type" {
-  type = string
-}
-
-variable "client_cluster_cache_disk_size_gb" {
-  type = number
-}
-
-variable "client_cluster_cache_disk_type" {
   type = string
 }
 
@@ -330,4 +314,22 @@ variable "api_nat_ips" {
 
 variable "api_nat_min_ports_per_vm" {
   type = number
+}
+
+variable "build_cluster_cache_disk_count" {
+  type = number
+
+  validation {
+    condition     = var.build_cluster_cache_disk_count > 0
+    error_message = "Must include at least 1 build cluster cache disk"
+  }
+}
+
+variable "client_cluster_cache_disk_count" {
+  type = number
+
+  validation {
+    condition     = var.client_cluster_cache_disk_count > 0
+    error_message = "Must include at least 1 client cluster cache disk"
+  }
 }

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -491,3 +491,15 @@ variable "remote_repository_enabled" {
   description = "Set to true to enable remote repository cache. Can be set via TF_VAR_remote_repository_enabled or REMOTE_REPOSITORY_ENABLED env var."
   default     = false
 }
+
+variable "build_cluster_cache_disk_count" {
+  type        = number
+  description = "The number of 375 GB NVME disks to raid together for storing build files."
+  default     = 3
+}
+
+variable "client_cluster_cache_disk_count" {
+  type        = number
+  description = "The number of 375 GB NVME disks to raid together for storing sandbox files."
+  default     = 3
+}


### PR DESCRIPTION
Local benchmarks indicate that this drop base sandbox latency ~20-30ms

Downsides:
- Live migrations will probably get slower for longer.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces PD cache disks with configurable local NVMe SSDs for client/build nodes, provisioning them via startup script and wiring new disk-count variables through Terraform.
> 
> - **Compute templates (client/build)**:
>   - Replace PD cache disks with dynamic `local-ssd` NVMe scratch disks (`375GB`) using `dynamic "disk"` and `range(var.*_cluster_cache_disk_count)`.
>   - Set boot disk `auto_delete` on client; keep root disk sizing via `build_cluster_root_disk_size_gb`.
> - **Startup script (`scripts/start-client.sh`)**:
>   - Partition local NVMe disks and assemble RAID0 (`mdadm`) when multiple; persist config.
>   - Format XFS, add to `/etc/fstab`, mount at `/orchestrator`; create `sandbox`, `template`, `build` dirs.
>   - Add 100G swap, persist swap and sysctl tuning; remove sudo usage; minor robustness (retry loops).
>   - Template var `LOCAL_CACHE_DISK_COUNT` passed from Terraform.
> - **Terraform variables/wiring**:
>   - Add `build_cluster_cache_disk_count` and `client_cluster_cache_disk_count` (with validation) in root and module; pass through in `main.tf`.
>   - Remove cache disk size/type vars from `nomad-cluster` module (PD-based settings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e008cd711f877203c5acd2326220495b0dbd6d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->