### PR TITLE
Update secured access error message

### DIFF
--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -194,7 +194,7 @@ func (a *APIStore) getEnvdAccessToken(envdVersion *string, sandboxID string) (st
 		}
 	}
 
-	// check if the envd version is newer than 0.2.0
+	// check if the envd version is at least 0.2.0
 	ok, err := sharedUtils.IsGTEVersion(*envdVersion, minEnvdVersionForSecureFlag)
 	if err != nil {
 		return "", &api.APIError{


### PR DESCRIPTION
- Add link to related docs page
- Typo in min envd version needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines secured access error messages during sandbox creation with a docs link and clarifies the minimum envd version requirement.
> 
> - **Backend (API)**:
>   - Update `getEnvdAccessToken` error messages in `packages/api/internal/handlers/sandbox_create.go` to reference secured access docs and clearer guidance when `envdVersion` is missing or unsupported.
>   - Clarify version check comment to indicate minimum supported version (`>= 0.2.0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da47faa0d00206aab2c5163690b227c1bb2ff05f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->