### PR TITLE
fix: return correct metadata for failed templates

### DIFF
--- a/packages/api/internal/handlers/templates_list.go
+++ b/packages/api/internal/handlers/templates_list.go
@@ -4,10 +4,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -63,8 +61,6 @@ func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 		envdVersion := ""
 		if item.BuildEnvdVersion != nil {
 			envdVersion = *item.BuildEnvdVersion
-		} else {
-			zap.L().Error("failed to determine envd version", logger.WithTemplateID(item.Env.ID))
 		}
 
 		diskMB := int64(0)
@@ -75,9 +71,9 @@ func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 		templates = append(templates, &api.Template{
 			TemplateID:    item.Env.ID,
 			BuildID:       item.BuildID.String(),
-			CpuCount:      int32(item.BuildVcpu),
-			MemoryMB:      int32(item.BuildRamMb),
-			DiskSizeMB:    int32(diskMB),
+			CpuCount:      api.CPUCount(item.BuildVcpu),
+			MemoryMB:      api.MemoryMB(item.BuildRamMb),
+			DiskSizeMB:    api.DiskSizeMB(diskMB),
 			Public:        item.Env.Public,
 			Aliases:       item.Aliases,
 			CreatedAt:     item.Env.CreatedAt,

--- a/packages/db/queries/get_team_templates.sql
+++ b/packages/db/queries/get_team_templates.sql
@@ -1,6 +1,12 @@
 -- name: GetTeamTemplates :many
 SELECT sqlc.embed(e),
-       eb.id as build_id, eb.vcpu as build_vcpu, eb.ram_mb as build_ram_mb, eb.total_disk_size_mb as build_total_disk_size_mb, eb.envd_version as build_envd_version, eb.firecracker_version as build_firecracker_version, eba.status as build_status,
+       COALESCE(eb.id, '00000000-0000-0000-0000-000000000000'::uuid) as build_id,
+       COALESCE(eb.vcpu, 0) as build_vcpu,
+       COALESCE(eb.ram_mb, 0) as build_ram_mb,
+       eb.total_disk_size_mb as build_total_disk_size_mb,
+       eb.envd_version as build_envd_version,
+       COALESCE(eb.firecracker_version, 'N/A') as build_firecracker_version,
+       COALESCE(eba.status, 'waiting') as build_status,
        u.id as creator_id, u.email as creator_email,
        COALESCE(ea.aliases, ARRAY[]::text[])::text[] AS aliases
 FROM public.envs AS e
@@ -13,20 +19,19 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
     SELECT b.*
     FROM public.env_builds AS b
-    WHERE b.env_id = e.id AND b.status = 'uploaded'
-    ORDER BY b.finished_at DESC
-    LIMIT 1
-) eb ON TRUE
-LEFT JOIN LATERAL (
-    SELECT b.*
-    FROM public.env_builds AS b
     WHERE b.env_id = e.id
     ORDER BY b.finished_at DESC
     LIMIT 1
 ) eba ON TRUE
+LEFT JOIN LATERAL (
+    SELECT b.*
+    FROM public.env_builds AS b
+    WHERE b.env_id = e.id AND b.status = 'uploaded'
+    ORDER BY b.finished_at DESC
+    LIMIT 1
+) eb ON TRUE
 WHERE
   e.team_id = $1
-  AND eb.id IS NOT NULL
   AND NOT EXISTS (
     SELECT 1
     FROM public.snapshots AS s

--- a/packages/db/queries/get_team_templates.sql.go
+++ b/packages/db/queries/get_team_templates.sql.go
@@ -13,7 +13,13 @@ import (
 
 const getTeamTemplates = `-- name: GetTeamTemplates :many
 SELECT e.id, e.created_at, e.updated_at, e.public, e.build_count, e.spawn_count, e.last_spawned_at, e.team_id, e.created_by, e.cluster_id,
-       eb.id as build_id, eb.vcpu as build_vcpu, eb.ram_mb as build_ram_mb, eb.total_disk_size_mb as build_total_disk_size_mb, eb.envd_version as build_envd_version, eb.firecracker_version as build_firecracker_version, eba.status as build_status,
+       COALESCE(eb.id, '00000000-0000-0000-0000-000000000000'::uuid) as build_id,
+       COALESCE(eb.vcpu, 0) as build_vcpu,
+       COALESCE(eb.ram_mb, 0) as build_ram_mb,
+       eb.total_disk_size_mb as build_total_disk_size_mb,
+       eb.envd_version as build_envd_version,
+       COALESCE(eb.firecracker_version, 'N/A') as build_firecracker_version,
+       COALESCE(eba.status, 'waiting') as build_status,
        u.id as creator_id, u.email as creator_email,
        COALESCE(ea.aliases, ARRAY[]::text[])::text[] AS aliases
 FROM public.envs AS e
@@ -26,20 +32,19 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
     SELECT b.id, b.created_at, b.updated_at, b.finished_at, b.status, b.dockerfile, b.start_cmd, b.vcpu, b.ram_mb, b.free_disk_size_mb, b.total_disk_size_mb, b.kernel_version, b.firecracker_version, b.env_id, b.envd_version, b.ready_cmd, b.cluster_node_id, b.reason, b.version
     FROM public.env_builds AS b
-    WHERE b.env_id = e.id AND b.status = 'uploaded'
-    ORDER BY b.finished_at DESC
-    LIMIT 1
-) eb ON TRUE
-LEFT JOIN LATERAL (
-    SELECT b.id, b.created_at, b.updated_at, b.finished_at, b.status, b.dockerfile, b.start_cmd, b.vcpu, b.ram_mb, b.free_disk_size_mb, b.total_disk_size_mb, b.kernel_version, b.firecracker_version, b.env_id, b.envd_version, b.ready_cmd, b.cluster_node_id, b.reason, b.version
-    FROM public.env_builds AS b
     WHERE b.env_id = e.id
     ORDER BY b.finished_at DESC
     LIMIT 1
 ) eba ON TRUE
+LEFT JOIN LATERAL (
+    SELECT b.id, b.created_at, b.updated_at, b.finished_at, b.status, b.dockerfile, b.start_cmd, b.vcpu, b.ram_mb, b.free_disk_size_mb, b.total_disk_size_mb, b.kernel_version, b.firecracker_version, b.env_id, b.envd_version, b.ready_cmd, b.cluster_node_id, b.reason, b.version
+    FROM public.env_builds AS b
+    WHERE b.env_id = e.id AND b.status = 'uploaded'
+    ORDER BY b.finished_at DESC
+    LIMIT 1
+) eb ON TRUE
 WHERE
   e.team_id = $1
-  AND eb.id IS NOT NULL
   AND NOT EXISTS (
     SELECT 1
     FROM public.snapshots AS s


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Return templates with correct metadata even when latest build failed or is missing, adding DB fallbacks and typed API field mappings.
> 
> - **DB/query (`packages/db/queries/get_team_templates.sql` + generated `.go`)**:
>   - Include templates even without an uploaded build by removing `AND eb.id IS NOT NULL` and separating latest build (`eba`) from latest uploaded build (`eb`).
>   - Provide sane defaults via `COALESCE` (e.g., `build_id` zero UUID, `build_vcpu`/`build_ram_mb` 0, `build_firecracker_version` 'N/A', `build_status` from latest build or 'waiting').
> - **API (`packages/api/internal/handlers/templates_list.go`)**:
>   - Map resource fields using typed wrappers (`api.CPUCount`, `api.MemoryMB`, `api.DiskSizeMB`) instead of plain casts.
>   - Remove unused logging when `envd_version` is missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a98466cd3c5b50e55d440ccf2d3799aeffe064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->