### PR TITLE
Fix docker reverse build

### DIFF
--- a/packages/docker-reverse-proxy/Dockerfile
+++ b/packages/docker-reverse-proxy/Dockerfile
@@ -10,6 +10,10 @@ WORKDIR /build/shared
 COPY ./shared/go.mod ./shared/go.sum ./
 RUN go mod download
 
+WORKDIR /build/db
+COPY ./db/go.mod ./db/go.sum ./
+RUN go mod download
+
 WORKDIR /build/docker-reverse-proxy
 COPY ./docker-reverse-proxy/go.mod ./docker-reverse-proxy/go.sum ./
 RUN go mod download
@@ -18,6 +22,10 @@ RUN go mod download
 WORKDIR /build
 
 COPY ./shared/pkg ./shared/pkg
+COPY ./db/client ./db/client
+COPY ./db/dberrors ./db/dberrors
+COPY ./db/queries ./db/queries
+COPY ./db/types ./db/types
 
 COPY ./docker-reverse-proxy/internal ./docker-reverse-proxy/internal
 COPY ./docker-reverse-proxy/main.go ./docker-reverse-proxy/main.go


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Dockerfile to cache `db` module dependencies and include `db` source directories in the build context.
> 
> - **Dockerfile (`packages/docker-reverse-proxy/Dockerfile`)**:
>   - Cache `db` module dependencies by adding `WORKDIR /build/db`, copying `./db/go.mod` and `./db/go.sum`, and running `go mod download`.
>   - Include `db` sources in build context by copying `./db/client`, `./db/dberrors`, `./db/queries`, and `./db/types` before building the binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 116bf6ed75f7e17cc7eef03f20836db6f9c509ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->