### PR TITLE
chore: cleanup unnecessary wrappers

### DIFF
--- a/packages/api/internal/handlers/auth.go
+++ b/packages/api/internal/handlers/auth.go
@@ -19,22 +19,11 @@ func (a *APIStore) GetUserID(c *gin.Context) uuid.UUID {
 	return c.Value(auth.UserIDContextKey).(uuid.UUID)
 }
 
-func (a *APIStore) GetUserAndTeams(ctx context.Context, c *gin.Context) (*uuid.UUID, []*types.TeamWithDefault, error) {
-	userID := a.GetUserID(c)
-
-	teams, err := dbapi.GetTeamsByUser(ctx, a.sqlcDB, userID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error when getting default team: %w", err)
-	}
-
-	return &userID, teams, err
-}
-
 func (a *APIStore) GetTeamInfo(c *gin.Context) *types.Team {
 	return c.Value(auth.TeamContextKey).(*types.Team)
 }
 
-func (a *APIStore) GetTeamAndLimits(
+func (a *APIStore) GetTeam(
 	ctx context.Context,
 	c *gin.Context,
 	// Deprecated: use API Token authentication instead.
@@ -43,12 +32,14 @@ func (a *APIStore) GetTeamAndLimits(
 	ctx, span := tracer.Start(ctx, "get-team-and-tier")
 	defer span.End()
 
-	if c.Value(auth.TeamContextKey) != nil {
+	switch {
+	case c.Value(auth.TeamContextKey) != nil:
 		teamInfo := c.Value(auth.TeamContextKey).(*types.Team)
 
 		return teamInfo, nil
-	} else if c.Value(auth.UserIDContextKey) != nil {
-		_, teams, err := a.GetUserAndTeams(ctx, c)
+	case c.Value(auth.UserIDContextKey) != nil:
+		userID := a.GetUserID(c)
+		teams, err := dbapi.GetTeamsByUser(ctx, a.sqlcDB, userID)
 		if err != nil {
 			return nil, &api.APIError{
 				Code:      http.StatusInternalServerError,
@@ -75,12 +66,12 @@ func (a *APIStore) GetTeamAndLimits(
 		}
 
 		return team, nil
-	}
-
-	return nil, &api.APIError{
-		Code:      http.StatusUnauthorized,
-		ClientMsg: "You are not authenticated",
-		Err:       errors.New("invalid authentication context for team and tier"),
+	default:
+		return nil, &api.APIError{
+			Code:      http.StatusUnauthorized,
+			ClientMsg: "You are not authenticated",
+			Err:       errors.New("invalid authentication context for team and tier"),
+		}
 	}
 }
 

--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -33,7 +33,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 		return
 	}
 
-	team, apiErr := a.GetTeamAndLimits(ctx, c, body.TeamID)
+	team, apiErr := a.GetTeam(ctx, c, body.TeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and limits", apiErr.Err)
@@ -93,7 +93,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	}
 	span.SetAttributes(telemetry.WithTemplateID(templateID))
 
-	team, apiErr := a.GetTeamAndLimits(ctx, c, body.TeamID)
+	team, apiErr := a.GetTeam(ctx, c, body.TeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/deprecated_template_start_build.go
+++ b/packages/api/internal/handlers/deprecated_template_start_build.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	dbapi "github.com/e2b-dev/infra/packages/api/internal/db"
 	"github.com/e2b-dev/infra/packages/api/internal/db/types"
 	templatemanager "github.com/e2b-dev/infra/packages/api/internal/template-manager"
 	apiutils "github.com/e2b-dev/infra/packages/api/internal/utils"
@@ -79,7 +80,9 @@ func (a *APIStore) PostTemplatesTemplateIDBuildsBuildID(c *gin.Context, template
 		return
 	}
 
-	userID, teams, err := a.GetUserAndTeams(ctx, c)
+	userID := a.GetUserID(c)
+
+	teams, err := dbapi.GetTeamsByUser(ctx, a.sqlcDB, userID)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error when getting default team: %s", err))
 

--- a/packages/api/internal/handlers/template_build_status.go
+++ b/packages/api/internal/handlers/template_build_status.go
@@ -48,7 +48,7 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	}
 
 	infoTeamID := buildInfo.TeamID.String()
-	team, apiErr := a.GetTeamAndLimits(ctx, c, &infoTeamID)
+	team, apiErr := a.GetTeam(ctx, c, &infoTeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/template_delete.go
+++ b/packages/api/internal/handlers/template_delete.go
@@ -59,7 +59,7 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 	}
 
 	dbTeamID := template.TeamID.String()
-	team, apiErr := a.GetTeamAndLimits(ctx, c, &dbTeamID)
+	team, apiErr := a.GetTeam(ctx, c, &dbTeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/template_layer_files_upload.go
+++ b/packages/api/internal/handlers/template_layer_files_upload.go
@@ -25,7 +25,7 @@ func (a *APIStore) GetTemplatesTemplateIDFilesHash(c *gin.Context, templateID ap
 	}
 
 	dbTeamID := templateDB.TeamID.String()
-	team, apiErr := a.GetTeamAndLimits(ctx, c, &dbTeamID)
+	team, apiErr := a.GetTeam(ctx, c, &dbTeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -39,7 +39,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	telemetry.ReportEvent(ctx, "started environment build")
 
 	// Prepare info for rebuilding env
-	team, apiErr := a.GetTeamAndLimits(ctx, c, body.TeamID)
+	team, apiErr := a.GetTeam(ctx, c, body.TeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team, limits", apiErr.Err)

--- a/packages/api/internal/handlers/template_start_build_v2.go
+++ b/packages/api/internal/handlers/template_start_build_v2.go
@@ -69,7 +69,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 	}
 
 	dbTeamID := templateBuildDB.Env.TeamID.String()
-	team, apiErr := a.GetTeamAndLimits(ctx, c, &dbTeamID)
+	team, apiErr := a.GetTeam(ctx, c, &dbTeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/template_update.go
+++ b/packages/api/internal/handlers/template_update.go
@@ -65,7 +65,7 @@ func (a *APIStore) PatchTemplatesTemplateID(c *gin.Context, aliasOrTemplateID ap
 	}
 
 	dbTeamID := template.TeamID.String()
-	team, apiErr := a.GetTeamAndLimits(ctx, c, &dbTeamID)
+	team, apiErr := a.GetTeam(ctx, c, &dbTeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)

--- a/packages/api/internal/handlers/templates_list.go
+++ b/packages/api/internal/handlers/templates_list.go
@@ -13,7 +13,7 @@ import (
 func (a *APIStore) GetTemplates(c *gin.Context, params api.GetTemplatesParams) {
 	ctx := c.Request.Context()
 
-	team, apiErr := a.GetTeamAndLimits(ctx, c, params.TeamID)
+	team, apiErr := a.GetTeam(ctx, c, params.TeamID)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportCriticalError(ctx, "error when getting team and tier", apiErr.Err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces legacy team/limits wrappers with a unified GetTeam method and updates all template handlers to use it, simplifying auth flow.
> 
> - **API/Handlers**:
>   - **Auth helpers**:
>     - Remove `GetUserAndTeams` and replace `GetTeamAndLimits` with `GetTeam` using a switch on context (`TeamContextKey`/`UserIDContextKey`).
>     - Inline team lookup via `dbapi.GetTeamsByUser` and `findTeamAndLimits`.
>   - **Handlers refactor to `GetTeam`**:
>     - Updated `deprecated_template_request_build.go`, `template_request_build_v3.go`, `template_start_build_v2.go`, `template_build_status.go`, `template_delete.go`, `template_layer_files_upload.go`, `template_update.go`, `templates_list.go` to call `GetTeam`.
>     - `deprecated_template_start_build.go`: replace `GetUserAndTeams` usage with `GetUserID` + `dbapi.GetTeamsByUser`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7636b23633563a6e3ef0076cf5a2cc5871db510f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->