### PR TITLE
fix: add env_id index to snapshots

### DIFF
--- a/packages/db/migrations/20251030130958_add_env_index_to_snapshots.sql
+++ b/packages/db/migrations/20251030130958_add_env_index_to_snapshots.sql
@@ -1,0 +1,7 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshots_env_id
+    ON public.snapshots (env_id);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_snapshots_env_id;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a DB migration to create a concurrent index on snapshots.env_id with a corresponding rollback.
> 
> - **Database**:
>   - **Migration**: Add concurrent index `idx_snapshots_env_id` on `public.snapshots(env_id)` (`+goose Up`).
>   - **Rollback**: Drop index `idx_snapshots_env_id` (`+goose Down`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c34cac0f906d8e2b2f8fb103e18af352c2f53ada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->