### PR TITLE
If allocation has no health, it is healthy

### DIFF
--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -132,13 +132,13 @@ func isHealthy(alloc *nomadapi.AllocationListStub) bool {
 	if alloc.DeploymentStatus == nil {
 		zap.L().Warn("Allocation deployment status is nil", zap.String("allocation_id", alloc.ID))
 
-		return false
+		return true
 	}
 
 	if alloc.DeploymentStatus.Healthy == nil {
 		zap.L().Warn("Allocation deployment status healthy is nil", zap.String("allocation_id", alloc.ID))
 
-		return false
+		return true
 	}
 
 	return *alloc.DeploymentStatus.Healthy

--- a/packages/api/internal/orchestrator/client_test.go
+++ b/packages/api/internal/orchestrator/client_test.go
@@ -20,7 +20,7 @@ func TestIsHealthy(t *testing.T) {
 			input: &nomadapi.AllocationListStub{
 				DeploymentStatus: nil,
 			},
-			expected: false,
+			expected: true,
 		},
 		"healthy is nil": {
 			input: &nomadapi.AllocationListStub{
@@ -28,7 +28,7 @@ func TestIsHealthy(t *testing.T) {
 					Healthy: nil,
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		"status is not healthy": {
 			input: &nomadapi.AllocationListStub{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> `isHealthy` now considers allocations with nil `DeploymentStatus` or nil `Healthy` as healthy; tests updated accordingly.
> 
> - **Orchestrator**:
>   - Update `isHealthy` in `packages/api/internal/orchestrator/client.go` to return `true` when `DeploymentStatus` is `nil` or `Healthy` is `nil`.
> - **Tests**:
>   - Adjust expectations in `packages/api/internal/orchestrator/client_test.go` to reflect the new health evaluation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd97bb016b00260eabdbf56f5e210d064474fd29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->