### PR TITLE
Tweak nfs mount options for performance

### DIFF
--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -15,12 +15,11 @@ locals {
     "nocto",                // skip "close-to-open" attribute checks
     "nolock",               // do not use locking
     "noresvport",           // use a non-privileged source port
-    "resvport",             // use a privileged source port when communicating with the NFS server
-    "retrans=3",            // retry three times before performing recovery actions
-    "rsize=524288",         // receive 512 KB per read request
+    "retrans=2",            // retry two times before performing recovery actions
+    "rsize=1048576",        // receive 1 MB per read request
     "sec=sys",              // use AUTH_SYS for all requests
     "timeo=600",            // wait 60 seconds (measured in deci-seconds) before retrying a failed request
-    "wsize=524288",         // receive 512 KB per write request
+    "wsize=1048576",        // receive 1 MB per write request
   ])
 
   file_hash = {


### PR DESCRIPTION
This should reduce network round trips, increase thread count


| removed | added | effect |
| ---- | ----- | ---- |
| `noac`  | `actimeo=600`| increase the attribute cache to 1 minute, fewer metadata operations |
|  (default=cto) |  `nocto` | disables close-to-open cache consistency, which slows down writes |
| `rsize=524288` | `rsize=1048576` | doubling the receive size means fewer tcp round trips, currently negotiated back down to 512 KB |
| (default=1)  |  `nconnect=7` | more connections increases parallel requests |
| `lookupcache=none` | `lookupcache=pos` | cache successful lookups of directory entries |
| (default=resvport)| `noresvport` | do not use a privileged port when making connections. increases maximum nfs mount points. unlikely to help, but recommended by google |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes `nfs_mount_opts` in `iac/provider-gcp/nomad-cluster/main.tf` to improve NFS throughput and reduce latency.
> 
> - **IaC (GCP Nomad cluster)**:
>   - Update `locals.nfs_mount_opts` in `iac/provider-gcp/nomad-cluster/main.tf` to optimize NFS behavior:
>     - Add: `actimeo=600`, `async`, `hard`, `lookupcache=positive`, `nconnect=7`, `nocto`, `noresvport`, `retrans=2`, `rsize=1048576`, `wsize=1048576`, `timeo=600`, `sec=sys`.
>     - Remove/replace: `lookupcache=none`, `noac`, `tcp`.
>     - Keep: dynamic `nfsvers`, `noacl`, `nolock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2942fde20596823da41d8ec686b329d5ffea4ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->