### PR TITLE
Fix clean up nfs

### DIFF
--- a/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
+++ b/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
@@ -20,7 +20,7 @@ job "filestore-cleanup" {
           driver = "raw_exec"
 
           env {
-            NODE_ID                      = "$${node.unique.name}"
+            NODE_ID = "$${node.unique.name}"
           }
 
           config {


### PR DESCRIPTION
Pass node id

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes the Nomad node ID to the filestore cleanup task via an environment variable.
> 
> - **Nomad job `iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl`**:
>   - Add `env` block to task `filestore-cleanup`, exporting `NODE_ID = "$${node.unique.name}"`.
>   - Keep `driver = "raw_exec"` and existing command/args unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a24ef174da16bfa61c7ca9bd2e700362f0e6330d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->