### PR TITLE
Bring network storage up to main scope

### DIFF
--- a/packages/orchestrator/benchmark_test.go
+++ b/packages/orchestrator/benchmark_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
@@ -70,7 +69,6 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 
 	// ephemeral data
 	tempDir := b.TempDir()
-	clientID := uuid.NewString()
 
 	abs := func(s string) string {
 		return utils.Must(filepath.Abs(s))
@@ -126,8 +124,9 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 	sbxlogger.SetSandboxLoggerInternal(logger)
 	// sbxlogger.SetSandboxLoggerExternal(logger)
 
-	networkPool, err := network.NewPool(8, 8, clientID, config.NetworkConfig)
+	slotStorage, err := network.NewStorageLocal(config.NetworkConfig)
 	require.NoError(b, err)
+	networkPool := network.NewPool(8, 8, slotStorage, config.NetworkConfig)
 	go func() {
 		networkPool.Populate(b.Context())
 		logger.Info("network pool populated")

--- a/packages/orchestrator/cmd/build-template/main.go
+++ b/packages/orchestrator/cmd/build-template/main.go
@@ -130,10 +130,11 @@ func buildTemplate(
 		}
 	}()
 
-	networkPool, err := network.NewPool(8, 8, clientID, networkConfig)
+	slotStorage, err := network.NewStorageLocal(networkConfig)
 	if err != nil {
 		return fmt.Errorf("could not create network pool: %w", err)
 	}
+	networkPool := network.NewPool(8, 8, slotStorage, networkConfig)
 	go func() {
 		networkPool.Populate(ctx)
 		logger.Info("network pool done populating")

--- a/packages/orchestrator/internal/sandbox/network/pool.go
+++ b/packages/orchestrator/internal/sandbox/network/pool.go
@@ -72,14 +72,9 @@ type Pool struct {
 
 var ErrClosed = errors.New("cannot read from a closed pool")
 
-func NewPool(newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string, config Config) (*Pool, error) {
+func NewPool(newSlotsPoolSize, reusedSlotsPoolSize int, slotStorage Storage, config Config) *Pool {
 	newSlots := make(chan *Slot, newSlotsPoolSize-1)
 	reusedSlots := make(chan *Slot, reusedSlotsPoolSize)
-
-	slotStorage, err := NewStorage(vrtSlotsSize, nodeID, config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create slot storage: %w", err)
-	}
 
 	pool := &Pool{
 		config:      config,
@@ -89,7 +84,7 @@ func NewPool(newSlotsPoolSize, reusedSlotsPoolSize int, nodeID string, config Co
 		slotStorage: slotStorage,
 	}
 
-	return pool, nil
+	return pool
 }
 
 func (p *Pool) createNetworkSlot(ctx context.Context) (*Slot, error) {

--- a/packages/orchestrator/internal/sandbox/network/storage.go
+++ b/packages/orchestrator/internal/sandbox/network/storage.go
@@ -2,20 +2,9 @@ package network
 
 import (
 	"context"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
 type Storage interface {
 	Acquire(ctx context.Context) (*Slot, error)
 	Release(s *Slot) error
-}
-
-// NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
-func NewStorage(slotsSize int, nodeID string, config Config) (Storage, error) {
-	if env.IsDevelopment() || config.UseLocalNamespaceStorage {
-		return NewStorageLocal(slotsSize, config)
-	}
-
-	return NewStorageKV(slotsSize, nodeID, config)
 }

--- a/packages/orchestrator/internal/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_kv.go
@@ -22,7 +22,7 @@ func (s *StorageKV) getKVKey(slotIdx int) string {
 	return fmt.Sprintf("%s/%d", s.nodeID, slotIdx)
 }
 
-func NewStorageKV(slotsSize int, nodeID string, config Config) (*StorageKV, error) {
+func NewStorageKV(nodeID string, config Config) (*StorageKV, error) {
 	consulToken := utils.RequiredEnv("CONSUL_TOKEN", "Consul token for authenticating requests to the Consul API")
 
 	consulClient, err := newConsulClient(consulToken)
@@ -32,7 +32,7 @@ func NewStorageKV(slotsSize int, nodeID string, config Config) (*StorageKV, erro
 
 	return &StorageKV{
 		config:       config,
-		slotsSize:    slotsSize,
+		slotsSize:    vrtSlotsSize,
 		consulClient: consulClient,
 		nodeID:       nodeID,
 	}, nil

--- a/packages/orchestrator/internal/sandbox/network/storage_local.go
+++ b/packages/orchestrator/internal/sandbox/network/storage_local.go
@@ -22,7 +22,7 @@ type StorageLocal struct {
 
 const netNamespacesDir = "/var/run/netns"
 
-func NewStorageLocal(slotsSize int, config Config) (*StorageLocal, error) {
+func NewStorageLocal(config Config) (*StorageLocal, error) {
 	// get namespaces that we want to always skip
 	foreignNs, err := getForeignNamespaces()
 	if err != nil {
@@ -38,8 +38,8 @@ func NewStorageLocal(slotsSize int, config Config) (*StorageLocal, error) {
 	return &StorageLocal{
 		config:       config,
 		foreignNs:    foreignNsMap,
-		slotsSize:    slotsSize,
-		acquiredNs:   make(map[string]struct{}, slotsSize),
+		slotsSize:    vrtSlotsSize,
+		acquiredNs:   make(map[string]struct{}, vrtSlotsSize),
 		acquiredNsMu: sync.Mutex{},
 	}, nil
 }

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -333,10 +333,11 @@ func run(config cfg.Config) (success bool) {
 	closers = append(closers, closer{"device pool", devicePool.Close})
 
 	// network pool
-	networkPool, err := network.NewPool(network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, nodeID, config.NetworkConfig)
+	slotStorage, err := newStorage(nodeID, config.NetworkConfig)
 	if err != nil {
 		zap.L().Fatal("failed to create network pool", zap.Error(err))
 	}
+	networkPool := network.NewPool(network.NewSlotsPoolSize, network.ReusedSlotsPoolSize, slotStorage, config.NetworkConfig)
 	startService("network pool", func() error {
 		networkPool.Populate(ctx)
 
@@ -549,4 +550,13 @@ type serviceDoneError struct {
 
 func (e serviceDoneError) Error() string {
 	return fmt.Sprintf("service %s finished", e.name)
+}
+
+// NewStorage creates a new slot storage based on the environment, we are ok with using a memory storage for local
+func newStorage(nodeID string, config network.Config) (network.Storage, error) {
+	if env.IsDevelopment() || config.UseLocalNamespaceStorage {
+		return network.NewStorageLocal(config)
+	}
+
+	return network.NewStorageKV(nodeID, config)
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves network storage selection to top-level, updates `Pool` to accept a `Storage` and adjusts local/KV storage constructors and call sites.
> 
> - **Network**:
>   - **Pool API**: `NewPool` now accepts a `Storage` and no longer returns an error; internal storage creation removed.
>   - **Storage selection**: Introduce `newStorage(nodeID, config)` in `main.go` to choose between `StorageLocal` and `StorageKV` based on env/config.
>   - **Constructors**:
>     - `NewStorageLocal(config)` and `NewStorageKV(nodeID, config)` now infer `vrtSlotsSize` internally (remove `slotsSize` arg).
>     - Remove `NewStorage` factory from `storage.go`.
> - **Call sites**:
>   - Update orchestrator startup, `build-template` cmd, and benchmark to create storage (`NewStorageLocal` in non-prod paths) and pass it to `network.NewPool`.
>   - Minor cleanup: remove unused UUID/clientID in benchmark.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd7a287c91ee77fb1c6d4230565962a1dd0f3f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->