### PR TITLE
Reorder steps for environment setup instructions

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -54,8 +54,8 @@ Check if you can use config for terraform state management
     > Get Postgres database connection string from your database, e.g. [from Supabase](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection): Create a new project in Supabase and go to your project in Supabase -> Settings -> Database -> Connection Strings -> Postgres -> Direct
     
     > Your Postgres database needs to have enabled IPv4 access. You can do that in Connect screen
-3. Run `make switch-env ENV={prod,staging,dev}` to start using your env
-4. Run `make login-gcloud` to login to `gcloud`
+3. Run `make login-gcloud` to login to `gcloud`
+4. Run `make switch-env ENV={prod,staging,dev}` to start using your env
 5. Run `make init`. If this errors, run it a second time--it's due to a race condition on Terraform enabling API access for the various GCP services; this can take several seconds. A full list of services that will be enabled for API access:
    - [Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com)
    - [Certificate Manager API](https://console.cloud.google.com/apis/library/certificatemanager.googleapis.com)


### PR DESCRIPTION
update self-host.md order of steps (switching 3 & 4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders self-hosting setup steps to run `make login-gcloud` before `make switch-env` in `self-host.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4380c4222430e06d81c271c9c32205228b0f2cf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->