### PR TITLE
Fix for event that are not yet migrated and versioned

### DIFF
--- a/packages/shared/pkg/events/migration.go
+++ b/packages/shared/pkg/events/migration.go
@@ -1,5 +1,7 @@
 package events
 
+import "errors"
+
 // Deprecated: use only for already existing events for during migration period
 type SandboxEventType struct {
 	Type           string
@@ -37,10 +39,12 @@ var SandboxKilledEventPair = SandboxEventType{
 	LegacyLabel:    "kill",
 }
 
+var ErrUnknownEventFormat = errors.New("unknown sandbox event format")
+
 // LegacySandboxEventMigrationMapping works for senders back compatibility and converting old event types to new ones
 // We will receive old event just with event category and label, so we need to map them to new event types that
 // are using new dot namespaced syntax for event names
-func LegacySandboxEventMigrationMapping(e SandboxEvent) SandboxEvent {
+func LegacySandboxEventMigrationMapping(e SandboxEvent) (SandboxEvent, error) {
 	if e.Version == "" {
 		e.Version = StructureVersionV1
 	}
@@ -62,6 +66,8 @@ func LegacySandboxEventMigrationMapping(e SandboxEvent) SandboxEvent {
 				e.Type = SandboxKilledEventPair.Type
 			}
 		}
+
+		return e, nil
 	case StructureVersionV2:
 		// Back compatibility for v2 events that might still have legacy fields set
 		switch e.Type {
@@ -81,7 +87,9 @@ func LegacySandboxEventMigrationMapping(e SandboxEvent) SandboxEvent {
 			e.EventCategory = SandboxKilledEventPair.LegacyCategory
 			e.EventLabel = SandboxKilledEventPair.LegacyLabel
 		}
+
+		return e, nil
 	}
 
-	return e
+	return SandboxEvent{}, ErrUnknownEventFormat
 }


### PR DESCRIPTION
Events coming from Clickhouse are already migrated and all old and new but still v1 events are properly versioned.
Issue with events sent to Redis from not yet rolled orchestrators that does not send version field.

Migration function missed that case and ignored migrating event without version, causing it to be filtered out during event delivery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates sandbox event migration to default empty version to v1 and return an error for unknown versions, with tests adjusted and expanded accordingly.
> 
> - **Events Migration (`packages/shared/pkg/events/migration.go`)**:
>   - Change `LegacySandboxEventMigrationMapping` signature to return `(SandboxEvent, error)`.
>   - Default empty `e.Version` to `v1` before mapping.
>   - Add `ErrUnknownEventFormat` and return it for unsupported versions.
>   - Preserve existing v1/v2 mapping behavior; return early with `nil` error on success.
> - **Tests (`packages/shared/pkg/events/migration_test.go`)**:
>   - Update tests to handle error return.
>   - Add cases for missing version (defaults to v1) and unknown version (returns `ErrUnknownEventFormat`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70d34fe43e35c381d40b5fa9e428b5dc38b84dc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->