### PR TITLE
fix: template build home directory for relative paths

### DIFF
--- a/packages/orchestrator/internal/template/build/commands/copy.go
+++ b/packages/orchestrator/internal/template/build/commands/copy.go
@@ -39,8 +39,8 @@ type copyScriptData struct {
 
 	// Workdir is the working directory for the target path resolution if relative.
 	Workdir string
-	// WorkdirUserHome is used for filling the workdir if empty.
-	WorkdirUserHome string
+	// User is used for filling the workdir if empty.
+	User string
 }
 
 var copyScriptTemplate = txtTemplate.Must(txtTemplate.New("copy-script-template").Parse(`
@@ -51,7 +51,7 @@ workdir="{{ .Workdir }}"
 # Fill the workdir with user home directory if empty
 if [ -z "${workdir}" ]; then
  # Use the owner's home directory
- workdir=$(getent passwd "{{ .WorkdirUserHome }}" | cut -d: -f6)
+ workdir=$(getent passwd "{{ .User }}" | cut -d: -f6)
 fi
 cd "$workdir"
 
@@ -192,8 +192,8 @@ func (c *Copy) Execute(
 
 	var moveScript bytes.Buffer
 	err = copyScriptTemplate.Execute(&moveScript, copyScriptData{
-		Workdir:         utils.DerefOrDefault(cmdMetadata.WorkDir, ""),
-		WorkdirUserHome: cmdMetadata.User,
+		Workdir: utils.DerefOrDefault(cmdMetadata.WorkDir, ""),
+		User:    cmdMetadata.User,
 
 		SourcePath: filepath.Join(sbxUnpackPath, args.SourcePath),
 		TargetPath: args.TargetPath,


### PR DESCRIPTION
Copy command now resolves relative target paths from the specified workdir, or falls back to the owner's home directory.

The issue was that as the copy was done always under root, the home directory was always "/root" instead of the correct user one.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolve relative copy target paths using the specified workdir or, if absent, the owner’s home directory.
> 
> - **Build/template – copy command**:
>   - Resolve relative `TargetPath` based on provided `WorkDir`; fallback to owner’s home directory via `getent` when unset.
>   - Script now determines `workdir`, `cd`s into it, then computes absolute `targetPath`.
>   - Pass `WorkDir` and `User` from `cmdMetadata` into the copy script data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db87d104388bae59e3d7076ccae0c783e5629652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->