### PR TITLE
chore: move copy script to a file

### DIFF
--- a/packages/orchestrator/internal/template/build/commands/copy.go
+++ b/packages/orchestrator/internal/template/build/commands/copy.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io"
@@ -43,70 +44,9 @@ type copyScriptData struct {
 	User string
 }
 
-var copyScriptTemplate = txtTemplate.Must(txtTemplate.New("copy-script-template").Parse(`
-#!/bin/bash
-
-workdir="{{ .Workdir }}"
-
-# Fill the workdir with user home directory if empty
-if [ -z "${workdir}" ]; then
- # Use the owner's home directory
- workdir=$(getent passwd "{{ .User }}" | cut -d: -f6)
-fi
-cd "$workdir"
-
-# Get the parent folder of the source file/folder
-sourceFolder="$(dirname "{{ .SourcePath}}")"
-
-# Set targetPath relative to current working directory if not absolute
-inputPath="{{ .TargetPath }}"
-if [[ "$inputPath" = /* ]]; then
- targetPath="$inputPath"
-else
- targetPath="$(pwd)/$inputPath"
-fi
-
-cd "$sourceFolder" || exit 1
-
-# Get the first entry (file, directory, or symlink)
-entry=$(ls -A | head -n 1)
-
-if [ -z "$entry" ]; then
- echo "Error: sourceFolder is empty"
- exit 1
-fi
-
-# Check type BEFORE applying ownership/permissions to avoid dereferencing symlinks
-if [ -L "$entry" ]; then
- # It's a symlink – create parent folders and move+rename it to the exact path
- mkdir -p "$(dirname "$targetPath")"
- # Change ownership of the symlink itself (not the target)
- chown -h "{{ .Owner }}" "$entry"
- # Note: chmod on symlinks affects the target, not the link itself in most systems
- # We skip chmod for symlinks as it's typically not meaningful
- mv "$entry" "$targetPath"
-elif [ -f "$entry" ]; then
- # It's a file – create parent folders and move+rename it to the exact path
- chown "{{ .Owner }}" "$entry"
- {{ if .Permissions -}}
-  chmod "{{ .Permissions }}" "$entry"
- {{ end -}}
- mkdir -p "$(dirname "$targetPath")"
- mv "$entry" "$targetPath"
-elif [ -d "$entry" ]; then
- # It's a directory – apply ownership/permissions recursively, then move contents
- chown -R "{{ .Owner }}" "$entry"
- {{ if .Permissions -}}
-  chmod -R "{{ .Permissions }}" "$entry"
- {{ end -}}
- mkdir -p "$targetPath"
- # Move all contents including hidden files
- find "$entry" -mindepth 1 -maxdepth 1 -exec mv {} "$targetPath/" \;
-else
- echo "Error: entry is neither file, directory, nor symlink"
- exit 1
-fi
-`))
+//go:embed copy_script.sh
+var copyScriptFile string
+var copyScriptTemplate = txtTemplate.Must(txtTemplate.New("copy-script-template").Parse(copyScriptFile))
 
 // Execute implements the Copy command.
 // It works in the following steps:

--- a/packages/orchestrator/internal/template/build/commands/copy_script.sh
+++ b/packages/orchestrator/internal/template/build/commands/copy_script.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+targetPath="{{ .TargetPath }}"
+sourcePath="{{ .SourcePath }}"
+owner="{{ .Owner }}"
+permissions="{{ .Permissions }}"
+
+workdir="{{ .Workdir }}"
+user="{{ .User }}"
+
+# Fill the workdir with user home directory if empty
+if [ -z "${workdir}" ]; then
+    # Use the user's home directory
+    workdir=$(getent passwd "$user" | cut -d: -f6)
+fi
+cd "$workdir" || exit 1
+
+# Get the parent folder of the source file/folder
+sourceFolder="$(dirname "$sourcePath")"
+
+# Set targetPath relative to current working directory if not absolute
+inputPath="$targetPath"
+if [[ "$inputPath" = /* ]]; then
+    targetPath="$inputPath"
+else
+    targetPath="$(pwd)/$inputPath"
+fi
+
+cd "$sourceFolder" || exit 1
+
+# Get the first entry (file, directory, or symlink)
+entry=$(ls -A | head -n 1)
+
+if [ -z "$entry" ]; then
+    echo "Error: sourceFolder is empty"
+    exit 1
+fi
+
+# Check type BEFORE applying ownership/permissions to avoid dereferencing symlinks
+if [ -L "$entry" ]; then
+    # It's a symlink – create parent folders and move+rename it to the exact path
+    mkdir -p "$(dirname "$targetPath")"
+    # Change ownership of the symlink itself (not the target)
+    chown -h "$owner" "$entry"
+    # Note: chmod on symlinks affects the target, not the link itself in most systems
+    # We skip chmod for symlinks as it's typically not meaningful
+    mv "$entry" "$targetPath"
+elif [ -f "$entry" ]; then
+    # It's a file – create parent folders and move+rename it to the exact path
+    chown "$owner" "$entry"
+    if [ -n "$permissions" ]; then
+        chmod "$permissions" "$entry"
+    fi
+    mkdir -p "$(dirname "$targetPath")"
+    mv "$entry" "$targetPath"
+elif [ -d "$entry" ]; then
+    # It's a directory – apply ownership/permissions recursively, then move contents
+    chown -R "$owner" "$entry"
+    if [ -n "$permissions" ]; then
+        chmod -R "$permissions" "$entry"
+    fi
+    mkdir -p "$targetPath"
+    # Move all contents including hidden files
+    find "$entry" -mindepth 1 -maxdepth 1 -exec mv {} "$targetPath/" \;
+else
+    echo "Error: entry is neither file, directory, nor symlink"
+    exit 1
+fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the inline copy script template with an embedded `copy_script.sh` file and parses it via `go:embed`.
> 
> - **Build templates (`commands/copy.go`)**:
>   - Replace inline `copyScriptTemplate` with `//go:embed`-loaded `copy_script.sh` and parse it as the template.
> - **Scripts**:
>   - Add `packages/orchestrator/internal/template/build/commands/copy_script.sh` containing the copy logic (workdir resolution, ownership/permissions, symlink/file/dir handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 036501a6b9a62425e56e92533ce23725b4e4b50b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->