### PR TITLE
Change source image to use image family for GCP

### DIFF
--- a/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
@@ -14,7 +14,7 @@ source "googlecompute" "orch" {
   # TODO: Overwrite the image instead of creating timestamped images every time we build its
   image_name    = "e2b-orch-${formatdate("YYYY-MM-DD-hh-mm-ss", timestamp())}"
   project_id    = var.gcp_project_id
-  source_image_family = "ubuntu-2204-lts"
+  source_image  = "ubuntu-2204-jammy-v20251023"
   ssh_username  = "ubuntu"
   zone          = var.gcp_zone
   disk_size     = 10


### PR DESCRIPTION
Changes fixed ubuntu 22.04 image to latest ubuntu 22.04 lts image family, this is follow up on #1430 dns-fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bump Packer `source_image` in `iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl` to `ubuntu-2204-jammy-v20251023`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b452c0c41598771a06f3b7a281d5173d9af19d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->