### PR TITLE
Add `destroy` make label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,6 @@ download-prod-env:
 plan:
 	$(MAKE) -C iac/provider-gcp plan
 
-.PHONY: destroy
-destroy:
-	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
-	$(MAKE) -C iac/provider-gcp destroy
-
 # Deploy all jobs in Nomad
 .PHONY: plan-only-jobs
 plan-only-jobs:


### PR DESCRIPTION
this ends with a lot of nomad errors, but works otherwise

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `destroy` make target and simplifies `plan` targets by removing detailed exit-code handling.
> 
> - **Makefile (`iac/provider-gcp/Makefile`)**:
>   - **New**: `destroy` target to run `terraform destroy` with env vars.
>   - **Simplified Plans**:
>     - `plan`, `plan-only-jobs`, and `plan-only-jobs/%` now run `terraform plan` with `-out` and `-compact-warnings`, removing `-detailed-exitcode` and related shell logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14e9b9ee2bfe343f44444b01887273ccd1f69c77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->