### PR TITLE
add terraform validate to prs

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,6 +2,9 @@ name: Run tests on PRs
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests for ${{ matrix.package }}
@@ -46,3 +49,24 @@ jobs:
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: go test -v ${{ matrix.test_path }}
+
+  validate-iac:
+    name: Validate terraform
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "${{ env.TERRAFORM }}"
+
+      - name: Validate terraform
+        working-directory: ./iac/provider-gcp
+        run: |
+          terraform init -backend=false
+          terraform validate


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Terraform validation job to the PR workflow and sets minimal `contents: read` permissions.
> 
> - **CI/Workflows (`.github/workflows/pr-tests.yml`)**:
>   - **New Job: `validate-iac`**
>     - Parses `.tool-versions`, sets up Terraform from `env.TERRAFORM`, and runs `terraform init -backend=false` + `terraform validate` in `iac/provider-gcp`.
>   - **Permissions**: Adds `permissions: contents: read` to the workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b5f84d4583dbc3a9f08235ff10440a9e6be28cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->