### PR TITLE
Run linters in parallel

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,7 @@ linters:
 
 run:
   go: 1.24.7
+  allow-parallel-runners: true
 
 issues:
   max-issues-per-linter: 50

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ fmt:
 .PHONY: lint
 lint:
 	@./scripts/golangci-lint-install.sh "2.4.0"
-	go work edit -json | jq -r '.Use[].DiskPath'  | xargs -I{} golangci-lint run {}/... --fix
+	go work edit -json | jq -r '.Use[].DiskPath' | xargs -P 10 -I{} golangci-lint run {}/... --fix
 
 .PHONY: generate-mocks
 generate-mocks:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable parallel linting via golangci and Makefile to speed up runs.
> 
> - **Linting**:
>   - Enable parallel runners in `golangci-lint` via `run.allow-parallel-runners: true` in `.golangci.yml`.
>   - Run lint fixes in parallel across workspaces by adding `xargs -P 10` in `Makefile` `lint` target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fe7566ea0f1608b7350008675a19fe64aeb1db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->