### PR TITLE
Clean up additional domains - use only the ones from GCP secrets

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -58,8 +58,6 @@ FILESTORE_CACHE_CAPACITY_GB=
 # ------------------------------------------- Optional block -----------------------------------------------------------
 # Managed Redis (default: false)
 REDIS_MANAGED=false
-# Additional domains (separated by commas)
-ADDITIONAL_DOMAINS=
 # Template bucket name (if you want to use a different bucket for templates then the default one)
 TEMPLATE_BUCKET_NAME=
 # Hash seed used for generating sandbox access tokens, not needed if you are not using them

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -36,7 +36,6 @@ tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
 	$(call tfvar, GCP_REGION) \
 	$(call tfvar, GCP_ZONE) \
 	$(call tfvar, DOMAIN_NAME) \
-	$(call tfvar, ADDITIONAL_DOMAINS) \
 	$(call tfvar, ADDITIONAL_API_SERVICES_JSON) \
 	$(call tfvar, PREFIX) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -59,12 +59,7 @@ data "google_secret_manager_secret_version" "routing_domains" {
 }
 
 locals {
-  // Taking additional domains from local env is there just for backward compatibility
-  additional_domains_from_secret = nonsensitive(jsondecode(data.google_secret_manager_secret_version.routing_domains.secret_data))
-  additional_domains_from_env = (var.additional_domains != "" ?
-  [for item in split(",", var.additional_domains) : trimspace(item)] : [])
-
-  additional_domains = distinct(concat(local.additional_domains_from_env, local.additional_domains_from_secret))
+  additional_domains = nonsensitive(jsondecode(data.google_secret_manager_secret_version.routing_domains.secret_data))
 }
 
 module "init" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -354,12 +354,6 @@ variable "domain_name" {
   description = "The domain name where e2b will run"
 }
 
-variable "additional_domains" {
-  type        = string
-  description = "Additional domains which can be used to access the e2b cluster, separated by commas"
-  default     = ""
-}
-
 variable "additional_api_services_json" {
   type        = string
   description = <<EOT


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Additional domains now come exclusively from GCP Secret Manager; removed the `additional_domains` variable/env and related Makefile wiring.
> 
> - **IaC (GCP/Terraform)**
>   - Use only routing domains from Secret Manager: `local.additional_domains` now decodes `routing_domains` secret; removed merging with `var.additional_domains`.
>   - Removed `variable "additional_domains"` and its propagation:
>     - Deleted `$(call tfvar, ADDITIONAL_DOMAINS)` from `iac/provider-gcp/Makefile`.
>     - Dropped `ADDITIONAL_DOMAINS` from `.env.template`.
> - **Config**
>   - `.env.template`: removed additional domains settings/comments; no longer configurable via env.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5af969eec1f638caf06a8fbaacf5c0d1dae03a75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->