### PR TITLE
Ensure temporary script file is removed after execution in copy_test.go

### DIFF
--- a/packages/orchestrator/internal/template/build/commands/copy_test.go
+++ b/packages/orchestrator/internal/template/build/commands/copy_test.go
@@ -31,6 +31,8 @@ func executeScript(t *testing.T, script string, workDir string) (stdout, stderr 
 	t.Helper()
 	scriptFile := filepath.Join(workDir, "test_script.sh")
 	err := os.WriteFile(scriptFile, []byte(script), 0o755)
+	defer os.Remove(scriptFile)
+
 	require.NoError(t, err, "Failed to write script file")
 
 	cmd := exec.CommandContext(t.Context(), "/bin/bash", scriptFile)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Delete the temporary bash script created in `executeScript` by deferring `os.Remove(scriptFile)` after writing it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26481c6e727a7f35824b6c47f2e7cd44b24f7e64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->