### PR TITLE
Tweak bot PR review prompts

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -21,4 +21,3 @@ Be constructive and helpful in your feedback and be **very conscise**.
 Skip general recommendations, skip summarizing the changes, and don't make any recommendations on code style.
 Also skip any summarization about why the PR was done well, focus only on the code changes and the potential issues.
 Don't output final summaries, or final lists of action items.
-Try not to use emojis.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   claude-review:
@@ -39,7 +39,7 @@ jobs:
             Skip general recommendations, skip summarizing the changes, and don't make any recommendations on code style.
             Also skip any summarization about why the PR was done well, focus only on the code changes and the potential issues.
             Don't output final summaries, or final lists of action items.
-            Try not to use emojis.
+            Reduce false positives—try to validate if the issue is really a valid problem in the changes.
 
             When you find a *specific issue* in the code (bug, performance concern, security risk, etc.),
             leave an **inline comment** on that exact file and line.  


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds BugBot config and tightens Claude Code Review workflow to trigger only on opened PRs with stricter, inline-comment guidance using gh api.
> 
> - **CI/Workflows**:
>   - Update `/.github/workflows/claude-code-review.yml` to trigger only on `pull_request: [opened]`.
>   - Expand review prompt with stricter guidance: avoid summaries, reduce false positives, and post issues only as inline comments using `gh api` with the provided payload format.
>   - Adjust `claude_args` to allow `gh api` while keeping other `gh` commands.
> - **Tooling/Config**:
>   - Add `/.cursor/BUGBOT.md` with concise rules for PR descriptions and reviews.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b49f9a7866a8f99dd1cd0581b2b9b251f62cc10c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->