### PR TITLE
Remove `needs` dependency from PR test

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,7 @@ jobs:
   unit-tests:
     uses: ./.github/workflows/pr-tests.yml
   integration-tests:
+    needs: [out-of-order-migrations]
     uses: ./.github/workflows/integration_tests.yml
   publish-test-results:
     needs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `lint` dependency from `integration-tests` in the PR workflow, leaving only `out-of-order-migrations`; also standardizes a YAML string quote.
> 
> - **CI / GitHub Actions**:
>   - **Workflow `pull-request.yml`**:
>     - Update `integration-tests` `needs` to only `out-of-order-migrations` (remove `lint`).
>     - Normalize `fail_on` value quoting to double quotes in test results publishing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8a8b4ae1b2a7e600c59be9f77c1bb8d60c31a03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->