### PR TITLE
Get the golangci version in CI/CD from tools file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@ on: [workflow_call]
 
 permissions:
   contents: read
-env:
-  GOLANGCI_LINT_VERSION: v2.4.0
 
 jobs:
   detect-modules:
@@ -30,8 +28,12 @@ jobs:
         uses: ./.github/actions/go-setup-cache
         with:
           job_key: lint-${{ matrix.modules }}
+
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+
       - name: golangci-lint ${{ matrix.modules }}
         uses: golangci/golangci-lint-action@v8
         with:
-          version: ${{ env.GOLANGCI_LINT_VERSION }}
+          version: "v${{ env.GOLANGCI_LINT }}"
           working-directory: ${{ matrix.modules }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lint workflow now reads `golangci-lint` version from `.tool-versions` and uses `env.GOLANGCI_LINT` instead of a hardcoded env var.
> 
> - **CI/CD – Lint Workflow (`.github/workflows/lint.yml`)**:
>   - Add step to parse `.tool-versions` using `wistia/parse-tool-versions@v2.1.1`.
>   - Switch `golangci-lint-action` `version` input to `"v${{ env.GOLANGCI_LINT }}"`.
>   - Remove previous `env` var `GOLANGCI_LINT_VERSION`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2775f10721cb944887ebb05c172cee3d11550a2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->