### PR TITLE
Add sandbox memory integrity tests

### DIFF
--- a/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
+++ b/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
@@ -20,7 +20,7 @@ func TestSandboxMemoryIntegrity(t *testing.T) {
 
 	c := setup.GetAPIClient()
 
-	t.Run("via tmpfs hash", func(t *testing.T) {
+	t.Run("tmpfs hash", func(t *testing.T) {
 		t.Parallel()
 
 		// Create a sandbox with auto-pause disabled
@@ -94,7 +94,7 @@ echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 		}
 	})
 
-	t.Run("via stress-ng verify", func(t *testing.T) {
+	t.Run("stress-ng verify", func(t *testing.T) {
 		t.Parallel()
 
 		// Create a sandbox with auto-pause disabled

--- a/tests/integration/internal/utils/process.go
+++ b/tests/integration/internal/utils/process.go
@@ -97,6 +97,10 @@ func ExecCommandWithOutput(tb testing.TB, ctx context.Context, sbx *api.Sandbox,
 				if stdout := msg.GetEvent().GetData().GetStdout(); stdout != nil {
 					output += string(stdout)
 				}
+
+				if stderr := msg.GetEvent().GetData().GetStderr(); stderr != nil {
+					output += string(stderr)
+				}
 			}
 
 			if msg.GetEvent().GetEnd() != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add integration tests validating sandbox RAM integrity (tmpfs hash, stress-ng) and extend process utils to return command output.
> 
> - **Tests (orchestrator)**:
>   - Add `tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go` with two subtests:
>     - `tmpfs hash`: mounts tmpfs using ~80% free RAM, writes random data, hashes file, pauses/resumes sandbox twice, and verifies hash stability.
>     - `stress-ng verify`: disables swap, allocates ~80% free RAM with `stress-ng --verify`, asserts successful run and metrics sanity.
> - **Utils**:
>   - Enhance `tests/integration/internal/utils/process.go`:
>     - New `ExecCommandAsRootWithOutput` and `ExecCommandWithOutput` to execute commands and capture combined stdout/stderr.
>     - Refactor `ExecCommandWithOptions` to use output-capable function and propagate output in error paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48178949f31d5471be70c0ccc40d5b99bb961f67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->