### PR TITLE
chore: update devcontainer go version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,28 +1,28 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-    "name": "Go",
-    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "image": "mcr.microsoft.com/devcontainers/go:1-1.24-bookworm",
-    "features": {
-        "ghcr.io/devcontainers/features/terraform:1": {
-            "version": "1.5.7"
-        },
-        "ghcr.io/dhoeric/features/google-cloud-cli:1": {
-            "INSTALL_GKEGCLOUDAUTH_PLUGIN": true
-        },
-        "ghcr.io/wxw-matt/devcontainer-features/command_runner:0": {},
-        "ghcr.io/wxw-matt/devcontainer-features/script_runner:0": {},
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {}
-    }
-    // Features to add to the dev container. More info: https://containers.dev/features.
-    // "features": {},
-    // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    // "forwardPorts": [],
-    // Use 'postCreateCommand' to run commands after the container is created.
-    // "postCreateCommand": "go version",
-    // Configure tool-specific properties.
-    // "customizations": {},
-    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-    // "remoteUser": "root"
+  "name": "Go",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/terraform:1": {
+      "version": "1.5.7"
+    },
+    "ghcr.io/dhoeric/features/google-cloud-cli:1": {
+      "INSTALL_GKEGCLOUDAUTH_PLUGIN": true
+    },
+    "ghcr.io/wxw-matt/devcontainer-features/command_runner:0": {},
+    "ghcr.io/wxw-matt/devcontainer-features/script_runner:0": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "go version",
+  // Configure tool-specific properties.
+  // "customizations": {},
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update devcontainer base image to Go 1.25 (bookworm).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fada7f6d8e1c56bbd026f4823ee5dfad2dc173a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->