### PR TITLE
Fix API error log processing

### DIFF
--- a/packages/api/internal/handlers/template_build_status.go
+++ b/packages/api/internal/handlers/template_build_status.go
@@ -123,8 +123,21 @@ func (a *APIStore) GetTemplatesTemplateIDBuildsBuildIDStatus(c *gin.Context, tem
 	result.Logs = lgs
 	result.LogEntries = logEntries
 
+	// When build fails with an error step, fetch error logs specifically for that step
+	// This ensures we get the error logs even if offset has moved past them during polling
 	if result.Reason != nil && result.Reason.Step != nil {
-		result.Reason.LogEntries = sharedUtils.ToPtr(filterStepLogs(logEntries, *result.Reason.Step, api.LogLevelWarn))
+		// First try to filter from already fetched logs
+		errorLogs := filterStepLogs(logEntries, *result.Reason.Step, api.LogLevelWarn)
+		
+		// If no error logs found in current batch (likely due to offset pagination),
+		// fetch logs from the beginning specifically for the error step
+		if len(errorLogs) == 0 && result.Status == api.TemplateBuildStatusError {
+			// Fetch all logs from the beginning to capture error context
+			allLogs := cli.GetLogs(ctx, templateID, buildID, 0, nil)
+			errorLogs = filterStepLogs(convertToAPILogEntries(allLogs), *result.Reason.Step, api.LogLevelWarn)
+		}
+		
+		result.Reason.LogEntries = sharedUtils.ToPtr(errorLogs)
 	}
 
 	c.JSON(http.StatusOK, result)
@@ -159,6 +172,14 @@ func filterStepLogs(logEntries []api.BuildLogEntry, step string, minLevel api.Lo
 	return sharedUtils.Filter(logEntries, func(line api.BuildLogEntry) bool {
 		return logs.CompareLevels(string(line.Level), string(minLevel)) >= 0 && line.Step != nil && *line.Step == step
 	})
+}
+
+func convertToAPILogEntries(entries []logs.LogEntry) []api.BuildLogEntry {
+	result := make([]api.BuildLogEntry, 0, len(entries))
+	for _, entry := range entries {
+		result = append(result, getAPILogEntry(entry))
+	}
+	return result
 }
 
 func getAPILogEntry(entry logs.LogEntry) api.BuildLogEntry {


### PR DESCRIPTION
Ensure error logs are always included in build failure responses, even with pagination offsets or log limits.

Previously, error logs for a failed step might be omitted from the `reason.logEntries` field if the client's polling offset had moved past them or if the log limit truncated them. This PR introduces a fallback: if error logs for a failed step are not found within the currently paginated log batch, a fresh query is made from offset 0 specifically for that step to guarantee their inclusion in the API response.

---
[Slack Thread](https://e2b-team.slack.com/archives/C08MD7DR4LB/p1762816138689549?thread_ts=1762816138.689549&cid=C08MD7DR4LB)

<a href="https://cursor.com/background-agent?bcId=bc-68433430-d74d-441a-9ed0-aa483f8317a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-68433430-d74d-441a-9ed0-aa483f8317a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

