### PR TITLE
Improve the logging + increase to 2 sec

### DIFF
--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -49,13 +49,13 @@ try {
     const localDateStartUnix = localDateStart.getTime() / 1000;
     const dateStdout = await sandbox.commands.run("date +%s%3N");
     const dateUnix = parseFloat(dateStdout.stdout) / 1000;
-    const date = new Date(dateUnix);
+    const sandboxDate = new Date(dateUnix * 1000);
 
     const localDateEnd = new Date();
     const localDateEndUnix = localDateEnd.getTime() / 1000;
 
     log(localDateStart.toISOString(), "local date - start of request");
-    log(date.toISOString(), "sandbox date");
+    log(sandboxDate.toISOString(), "sandbox date");
     log(localDateEnd.toISOString(), "local date - end of request");
 
     // check if the diff between sandbox time and local time is less than 2 second (taking into consideration the request latency)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors the time sync test to use Date objects with clearer ISO logging and increases the allowed time delta to ±2s.
> 
> - **Tests**:
>   - **`tests/periodic-test/time-is-synchronized/index.ts`**:
>     - Use `Date` objects for start/end times and derive Unix seconds; log ISO timestamps for local start/end and sandbox time.
>     - Increase synchronization tolerance from ±1s to ±2s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf438325de40e5ae74e80545b12afd88cfe738d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->