### PR TITLE
Envd port traffic is excluded from traffic access token

### DIFF
--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
@@ -55,8 +56,9 @@ func NewSandboxProxy(meterProvider metric.MeterProvider, port uint16, sandboxes 
 				accessToken = net.GetIngress().TrafficAccessToken
 			}
 
-			// Handle traffic access token validation
-			if accessToken != nil {
+			// Handle traffic access token validation.
+			// We are skipping envd port as it has its own access validation mechanism.
+			if accessToken != nil && int64(port) != consts.DefaultEnvdServerPort {
 				accessTokenRaw := r.Header.Get(trafficAccessTokenHeader)
 				if accessTokenRaw == "" {
 					return nil, reverseproxy.NewErrMissingTrafficAccessToken(sandboxId, trafficAccessTokenHeader)

--- a/tests/integration/internal/tests/proxies/traffic_access_token_test.go
+++ b/tests/integration/internal/tests/proxies/traffic_access_token_test.go
@@ -165,7 +165,7 @@ func TestSandboxWithEnabledTrafficAccessToken(t *testing.T) {
 	assert.Equal(t, port, errorResp.Port)
 }
 
-func TestEnvdPortIsEnforcingTrafficAccessToken(t *testing.T) {
+func TestEnvdPortIsNotAffectedByTrafficAccessToken(t *testing.T) {
 	c := setup.GetAPIClient()
 
 	sbxNetAllowPublic := false
@@ -183,10 +183,9 @@ func TestEnvdPortIsEnforcingTrafficAccessToken(t *testing.T) {
 		Timeout: 1000 * time.Second,
 	}
 
-	sbx.TrafficAccessToken = nil // Simulate missing header
-	resp := waitForStatus(t, client, sbx, url, int(consts.DefaultEnvdServerPort), nil, http.StatusForbidden)
-	require.NoError(t, err)
+	headers := &http.Header{"X-Access-Token": []string{*sbx.EnvdAccessToken}}
+	resp := waitForStatus(t, client, sbx, url, int(consts.DefaultEnvdServerPort), headers, http.StatusNotFound)
 	require.NotNil(t, resp)
 	require.NoError(t, resp.Body.Close())
-	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 }


### PR DESCRIPTION
Envd port is excluded from traffic access token so file upload and download URLs will still work.
We are enforcing envd secure flag to be true for sandboxes with disabled public traffic so there is already another security layer in place.