### PR TITLE
Setup valkey cluster with enabled TLS

### DIFF
--- a/iac/provider-gcp/init/main.tf
+++ b/iac/provider-gcp/init/main.tf
@@ -266,3 +266,38 @@ resource "google_secret_manager_secret_version" "notification_email_value" {
 
   secret_data = "placeholder@example.com"
 }
+
+
+resource "google_secret_manager_secret" "redis_tls_ca_base64" {
+  secret_id = "${var.prefix}redis-tls-ca-base64"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "redis_tls_ca_base64" {
+  secret      = google_secret_manager_secret.redis_tls_ca_base64.name
+  secret_data = " "
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
+resource "google_secret_manager_secret" "redis_secure_cluster_url" {
+  secret_id = "${var.prefix}redis-secure-cluster-url"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "redis_secure_cluster_url" {
+  secret      = google_secret_manager_secret.redis_secure_cluster_url.name
+  secret_data = " "
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -46,6 +46,14 @@ output "notification_email_secret_version" {
   value = google_secret_manager_secret_version.notification_email_value
 }
 
+output "redis_tls_ca_base64_secret_version" {
+  value = google_secret_manager_secret_version.redis_tls_ca_base64
+}
+
+output "redis_secure_cluster_url_secret_version" {
+  value = google_secret_manager_secret_version.redis_secure_cluster_url
+}
+
 output "loki_bucket_name" {
   value = google_storage_bucket.loki_storage_bucket.name
 }

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -13,7 +13,7 @@ terraform {
 
     google = {
       source  = "hashicorp/google"
-      version = "6.49.3"
+      version = "6.50.0"
     }
 
     cloudflare = {
@@ -269,6 +269,9 @@ module "redis" {
   gcp_project_id = var.gcp_project_id
   gcp_region     = var.gcp_region
   gcp_zone       = var.gcp_zone
+
+  redis_secure_cluster_url_secret_version = module.init.redis_secure_cluster_url_secret_version
+  redis_tls_ca_base64_secret_version      = module.init.redis_tls_ca_base64_secret_version
 
   prefix = var.prefix
 }

--- a/iac/provider-gcp/redis/main.tf
+++ b/iac/provider-gcp/redis/main.tf
@@ -17,8 +17,19 @@ resource "google_project_service" "redis" {
   disable_on_destroy = false
 }
 
+resource "google_project_service" "memory_store" {
+  service            = "memorystore.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "time_sleep" "redis_api_wait_60_seconds" {
   depends_on = [google_project_service.redis]
+
+  create_duration = "60s"
+}
+
+resource "time_sleep" "memory_store_api_wait_60_seconds" {
+  depends_on = [google_project_service.memory_store]
 
   create_duration = "60s"
 }
@@ -52,6 +63,68 @@ resource "google_service_networking_connection" "private_service_connection" {
     google_project_service.service_networking
   ]
 }
+
+# PSC policy for Valkey on default VPC in europe-west1
+resource "google_network_connectivity_service_connection_policy" "valkey" {
+  name          = "${var.prefix}memorystore-valkey-connection-policy"
+  location      = var.gcp_region
+  service_class = "gcp-memorystore"
+  description   = "my basic service connection policy"
+  network       = "projects/${var.gcp_project_id}/global/networks/${var.network_name}"
+  psc_config {
+    subnetworks = [google_compute_subnetwork.default.id]
+  }
+}
+
+resource "google_memorystore_instance" "valkey_cluster" {
+  project     = var.gcp_project_id
+  location    = var.gcp_region
+  instance_id = "${var.prefix}redis-valkey-cluster"
+
+  engine_version = "VALKEY_8_0"
+  mode           = "CLUSTER"
+
+  desired_auto_created_endpoints {
+    network    = "projects/${var.gcp_project_id}/global/networks/${var.network_name}"
+    project_id = var.gcp_project_id
+  }
+
+  shard_count             = var.shard_count
+  replica_count           = var.replica_count
+  node_type               = "STANDARD_SMALL"
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
+  authorization_mode      = "AUTH_DISABLED"
+
+  zone_distribution_config {
+    mode = "MULTI_ZONE"
+  }
+
+  deletion_protection_enabled = true
+
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = "SUNDAY"
+      start_time {
+        hours = 1
+      }
+    }
+  }
+
+  persistence_config {
+    mode = "AOF"
+    aof_config {
+      append_fsync = "EVERY_SEC"
+    }
+  }
+
+  depends_on = [
+    google_network_connectivity_service_connection_policy.valkey,
+    google_service_networking_connection.private_service_connection,
+    google_project_service.memory_store,
+    time_sleep.memory_store_api_wait_60_seconds
+  ]
+}
+
 
 resource "google_redis_cluster" "redis_cluster_api" {
   name        = "${var.prefix}redis-cluster-api"
@@ -102,4 +175,18 @@ resource "google_network_connectivity_service_connection_policy" "default" {
 resource "google_secret_manager_secret_version" "redis_url" {
   secret      = "projects/${var.gcp_project_id}/secrets/${var.prefix}redis-url"
   secret_data = google_redis_cluster.redis_cluster_api.psc_connections[0].address
+}
+
+locals {
+  redis_connection = google_memorystore_instance.valkey_cluster.endpoints[0].connections[0].psc_auto_connection[0]
+}
+
+resource "google_secret_manager_secret_version" "redis_secure_cluster_url_secret_version" {
+  secret      = var.redis_secure_cluster_url_secret_version.secret
+  secret_data = "${local.redis_connection.ip_address}:${local.redis_connection.port}"
+}
+
+resource "google_secret_manager_secret_version" "redis_tls_ca_base64" {
+  secret      = var.redis_tls_ca_base64_secret_version.secret
+  secret_data = base64encode(google_memorystore_instance.valkey_cluster.managed_server_ca[0].ca_certs[0].certificates[0])
 }

--- a/iac/provider-gcp/redis/variables.tf
+++ b/iac/provider-gcp/redis/variables.tf
@@ -19,3 +19,23 @@ variable "network_name" {
   type    = string
   default = "default"
 }
+
+// https://registry.terraform.io/providers/hashicorp/google/6.38.0/docs/resources/memorystore_instance#shard_count-1
+variable "shard_count" {
+  type    = number
+  default = 1
+}
+
+// https://registry.terraform.io/providers/hashicorp/google/6.38.0/docs/resources/memorystore_instance#replica_count-1
+variable "replica_count" {
+  type    = number
+  default = 1
+}
+
+variable "redis_secure_cluster_url_secret_version" {
+  type = any
+}
+
+variable "redis_tls_ca_base64_secret_version" {
+  type = any
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a GCP Memorystore Valkey cluster with TLS, outputs its secure URL and CA via Secret Manager, and wires these through modules; bumps google provider to 6.50.0.
> 
> - **Redis/Memorystore (GCP)**:
>   - Enable `memorystore.googleapis.com` and add PSC policy for Valkey (`google_network_connectivity_service_connection_policy.valkey`).
>   - Provision `google_memorystore_instance.valkey_cluster` (VALKEY_8_0, CLUSTER, multi-zone, AOF, server-auth TLS).
>   - Derive connection endpoint and CA from the instance and publish to secrets.
> - **Secrets Manager**:
>   - New secrets: `redis-tls-ca-base64`, `redis-secure-cluster-url` with initial versions and `ignore_changes` for placeholder data.
>   - Create secret versions populated from Valkey instance: secure URL and base64 CA.
> - **Modules/Wiring**:
>   - Export new secret versions from `init` and pass to `redis` module; add variables (`shard_count`, `replica_count`, secret version inputs).
> - **Provider**:
>   - Bump `hashicorp/google` from `6.49.3` to `6.50.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2cbfe623ee4b764c69f1f188f57e3dcb6ed59be9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->