### PR TITLE
Unify db connection pools

### DIFF
--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -84,7 +84,6 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Workiva/go-datastructures v1.1.0 // indirect
-	github.com/XSAM/otelsql v0.40.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/air-verse/air v1.61.7 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect

--- a/packages/api/go.sum
+++ b/packages/api/go.sum
@@ -91,8 +91,6 @@ github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/Workiva/go-datastructures v1.1.0 h1:hu20UpgZneBhQ3ZvwiOGlqJSKIosin2Rd5wAKUHEO/k=
 github.com/Workiva/go-datastructures v1.1.0/go.mod h1:1yZL+zfsztete+ePzZz/Zb1/t5BnDuE2Ya2MMGhzP6A=
-github.com/XSAM/otelsql v0.40.0 h1:8jaiQ6KcoEXF46fBmPEqb+pp29w2xjWfuXjZXTXBjaA=
-github.com/XSAM/otelsql v0.40.0/go.mod h1:/7F+1XKt3/sTlYtwKtkHQ5Gzoom+EerXmD1VdnTqfB4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/air-verse/air v1.61.7 h1:MtOZs6wYoYYXm+S4e+ORjkq9BjvyEamKJsHcvko8LrQ=

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -63,14 +63,15 @@ type APIStore struct {
 func NewAPIStore(ctx context.Context, tel *telemetry.Client, config cfg.Config) *APIStore {
 	zap.L().Info("Initializing API store and services")
 
-	dbClient, err := db.NewClient(40, 20)
-	if err != nil {
-		zap.L().Fatal("Initializing Supabase client", zap.Error(err))
-	}
-
 	sqlcDB, err := sqlcdb.NewClient(ctx, sqlcdb.WithMaxConnections(40), sqlcdb.WithMinIdle(5))
 	if err != nil {
 		zap.L().Fatal("Initializing SQLC client", zap.Error(err))
+	}
+
+	sqlDB := sqlcdb.Open(sqlcDB.Pool)
+	dbClient, err := db.NewClient(sqlDB)
+	if err != nil {
+		zap.L().Fatal("Initializing Supabase client", zap.Error(err))
 	}
 
 	zap.L().Info("Created database client")

--- a/packages/db/client/client.go
+++ b/packages/db/client/client.go
@@ -15,8 +15,7 @@ import (
 
 type Client struct {
 	*database.Queries
-
-	conn *pgxpool.Pool
+	*pgxpool.Pool
 }
 
 type Option func(config *pgxpool.Config)
@@ -64,23 +63,23 @@ func NewClient(ctx context.Context, options ...Option) (*Client, error) {
 	}
 	queries := database.New(pool)
 
-	return &Client{Queries: queries, conn: pool}, nil
+	return &Client{Queries: queries, Pool: pool}, nil
 }
 
 func (db *Client) Close() error {
-	db.conn.Close()
+	db.Pool.Close()
 
 	return nil
 }
 
 // WithTx runs the given function in a transaction.
 func (db *Client) WithTx(ctx context.Context) (*Client, pgx.Tx, error) {
-	tx, err := db.conn.BeginTx(ctx, pgx.TxOptions{})
+	tx, err := db.Pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	client := &Client{Queries: db.Queries.WithTx(tx), conn: db.conn}
+	client := &Client{Queries: db.Queries.WithTx(tx), Pool: db.Pool}
 
 	return client, tx, nil
 }

--- a/packages/db/client/conn.go
+++ b/packages/db/client/conn.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	pgxstdlib "github.com/jackc/pgx/v5/stdlib"
+)
+
+func Open(pool *pgxpool.Pool) *sql.DB {
+	connector := pgxstdlib.GetPoolConnector(pool)
+	db := sql.OpenDB(connector)
+
+	db.SetMaxIdleConns(0) // let the pool manage the number of connections
+	db.SetConnMaxLifetime(time.Minute * 30)
+
+	return db
+}

--- a/packages/db/client/tests.go
+++ b/packages/db/client/tests.go
@@ -5,7 +5,7 @@ import (
 )
 
 func (db *Client) TestsRawSQL(ctx context.Context, sql string, args ...any) error {
-	_, err := db.conn.Exec(ctx, sql, args...)
+	_, err := db.Pool.Exec(ctx, sql, args...)
 
 	return err
 }

--- a/packages/shared/go.mod
+++ b/packages/shared/go.mod
@@ -24,7 +24,6 @@ require (
 	cloud.google.com/go/storage v1.50.0
 	connectrpc.com/connect v1.18.1
 	entgo.io/ent v0.12.5
-	github.com/XSAM/otelsql v0.40.0
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74

--- a/packages/shared/go.sum
+++ b/packages/shared/go.sum
@@ -119,8 +119,6 @@ github.com/OneOfOne/xxhash v1.2.6/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/Workiva/go-datastructures v1.1.0 h1:hu20UpgZneBhQ3ZvwiOGlqJSKIosin2Rd5wAKUHEO/k=
 github.com/Workiva/go-datastructures v1.1.0/go.mod h1:1yZL+zfsztete+ePzZz/Zb1/t5BnDuE2Ya2MMGhzP6A=
-github.com/XSAM/otelsql v0.40.0 h1:8jaiQ6KcoEXF46fBmPEqb+pp29w2xjWfuXjZXTXBjaA=
-github.com/XSAM/otelsql v0.40.0/go.mod h1:/7F+1XKt3/sTlYtwKtkHQ5Gzoom+EerXmD1VdnTqfB4=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/packages/shared/pkg/db/client.go
+++ b/packages/shared/pkg/db/client.go
@@ -1,15 +1,11 @@
 package db
 
 import (
-	"fmt"
-	"os"
-	"time"
+	"database/sql"
 
 	"entgo.io/ent/dialect"
 	entsql "entgo.io/ent/dialect/sql"
-	"github.com/XSAM/otelsql"
 	_ "github.com/lib/pq"
-	semconv "go.opentelemetry.io/otel/semconv/v1.28.0"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/models"
 )
@@ -20,28 +16,7 @@ type DB struct {
 }
 
 // Deprecated: use db package instead
-func NewClient(maxConns, maxIdle int) (*DB, error) {
-	databaseURL := os.Getenv("POSTGRES_CONNECTION_STRING")
-	if databaseURL == "" {
-		return nil, fmt.Errorf("database URL is empty")
-	}
-
-	db, err := otelsql.Open(dialect.Postgres, databaseURL, otelsql.WithAttributes(
-		semconv.DBSystemPostgreSQL,
-	))
-	if err != nil {
-		return nil, fmt.Errorf("failed to open db: %w", err)
-	}
-
-	if err = otelsql.RegisterDBStatsMetrics(db, otelsql.WithAttributes(semconv.DBSystemPostgreSQL)); err != nil {
-		return nil, fmt.Errorf("failed to register db stats metrics: %w", err)
-	}
-
-	// Get the underlying sql.DB object of the driver.
-	db.SetMaxOpenConns(maxConns)
-	db.SetMaxIdleConns(maxIdle)
-	db.SetConnMaxLifetime(time.Minute * 30)
-
+func NewClient(db *sql.DB) (*DB, error) {
 	drv := entsql.OpenDB(dialect.Postgres, db)
 
 	client := models.NewClient(models.Driver(drv))


### PR DESCRIPTION
This guts the shared db.NewClient function to simpley take a *sql.DB, and changes the code higher up to create the *sql.DB from the pool. This should reduce open db connections and make the pool simpler to manage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch to a single pgx pool and pass `*sql.DB` derived from it into the shared Ent client; remove otelsql.
> 
> - **DB connection unification**:
>   - Update `packages/db/client` to embed `*pgxpool.Pool`, adjust `WithTx`/`Close`, and add `Open(*pgxpool.Pool) -> *sql.DB`.
>   - Simplify `packages/shared/pkg/db`: `NewClient` now accepts a `*sql.DB` (no env/driver setup, no otelsql).
>   - Change `packages/api/internal/handlers/store.go` to initialize `sqlcdb` first, derive `*sql.DB` via `sqlcdb.Open`, then create the shared `db` client with it.
> - **Dependencies**:
>   - Remove `github.com/XSAM/otelsql` from `go.mod`/`go.sum` in `packages/api` and `packages/shared`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3afa691691e184b7235216d756f615208a1371b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->