### PR TITLE
Allow claude review manual trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,22 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened]
+  issue_comment:
+    types: [created]
 
 jobs:
   claude-review:
     name: Claude Code Review
 
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request != null && 
+       contains(github.event.comment.body, '@claude review') &&
+       (github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
     permissions:
       contents: read
       pull-requests: read
@@ -21,6 +31,19 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Get PR head SHA
+        id: pr-sha
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "sha=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            PR_NUMBER=${{ github.event.issue.number }}
+            HEAD_SHA=$(gh pr view $PR_NUMBER --json headRefOid -q .headRefOid)
+            echo "sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -28,7 +51,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Please review this pull request and provide feedback on:
             - Potential bugs or issues
@@ -48,7 +71,7 @@ jobs:
             To comment inline, use this format exactly (MUST be a single line, no backslashes or line breaks):
 
             ```bash
-            gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments -f body='${BODY}' -f commit_id="${{ github.event.pull_request.head.sha }}" -f path='${PATH}' -F line='${LINE}' -f side="RIGHT"
+            gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number || github.event.issue.number }}/comments -f body='${BODY}' -f commit_id="${{ steps.pr-sha.outputs.sha }}" -f path='${PATH}' -F line='${LINE}' -f side="RIGHT"
             ```
 
             IMPORTANT: 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds issue_comment trigger to run reviews via '@claude review' on PRs and resolves correct PR number and head SHA for inline comments.
> 
> - **GitHub Actions: `./.github/workflows/claude-code-review.yml`**
>   - **Triggers**: Add `issue_comment` trigger; gate on PR-linked comments containing `@claude review` from OWNER/MEMBER/COLLABORATOR.
>   - **Execution guard**: Conditional `if` to run on PR open or qualified comment.
>   - **PR context resolution**: Use `${{ github.event.pull_request.number || github.event.issue.number }}` throughout.
>   - **Head SHA retrieval**: New step to fetch PR head SHA (via `gh pr view`) when triggered by comment; export to `steps.pr-sha.outputs.sha`.
>   - **Inline comment command**: Post comments using dynamic PR number and retrieved head SHA.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5630ea533555a7cea08db7be34ded70ea5f85f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->