### PR TITLE
Drop "X-" prefix from traffic access token

### DIFF
--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -27,7 +27,7 @@ const (
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
 	idleTimeout = 620 * time.Second
 
-	trafficAccessTokenHeader = "x-e2b-traffic-access-token"
+	trafficAccessTokenHeader = "e2b-traffic-access-token"
 )
 
 type SandboxProxy struct {

--- a/tests/integration/internal/tests/proxies/traffic_access_token_test.go
+++ b/tests/integration/internal/tests/proxies/traffic_access_token_test.go
@@ -52,7 +52,7 @@ func TestSandboxWithEnabledTrafficAccessTokenButMissingHeader(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&errorResp)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, "Sandbox is secured with traffic access token. Token header 'x-e2b-traffic-access-token' is missing", errorResp.Message)
+	assert.Equal(t, "Sandbox is secured with traffic access token. Token header 'e2b-traffic-access-token' is missing", errorResp.Message)
 	assert.Equal(t, sbx.SandboxID, errorResp.SandboxID)
 
 	// Pretend to be a browser
@@ -107,7 +107,7 @@ func TestSandboxWithEnabledTrafficAccessTokenButInvalidHeader(t *testing.T) {
 	err = json.NewDecoder(resp.Body).Decode(&errorResp)
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	assert.Equal(t, "Sandbox is secured with traffic access token. Provided token in header 'x-e2b-traffic-access-token' is invalid", errorResp.Message)
+	assert.Equal(t, "Sandbox is secured with traffic access token. Provided token in header 'e2b-traffic-access-token' is invalid", errorResp.Message)
 	assert.Equal(t, sbx.SandboxID, errorResp.SandboxID)
 
 	// Pretend to be a browser

--- a/tests/integration/internal/utils/request.go
+++ b/tests/integration/internal/utils/request.go
@@ -30,7 +30,7 @@ func NewRequest(sbx *api.Sandbox, url *url.URL, port int, extraHeaders *http.Hea
 	}
 
 	if sbx.TrafficAccessToken != nil {
-		header.Set("x-e2b-traffic-access-token", *sbx.TrafficAccessToken)
+		header.Set("e2b-traffic-access-token", *sbx.TrafficAccessToken)
 	}
 
 	if extraHeaders != nil {


### PR DESCRIPTION
Using of "X-" as prefix for custom headers is deprecated and company prefix is now preferred.
https://datatracker.ietf.org/doc/html/rfc6648

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames the traffic access token header to `e2b-traffic-access-token` and updates tests and request utilities accordingly.
> 
> - **Proxy**:
>   - Switch `trafficAccessTokenHeader` from `x-e2b-traffic-access-token` to `e2b-traffic-access-token` in `packages/orchestrator/internal/proxy/proxy.go`.
> - **Integration Tests**:
>   - Update expected error messages to reference `e2b-traffic-access-token` in `tests/integration/internal/tests/proxies/traffic_access_token_test.go`.
> - **Test Utils**:
>   - Set request header `e2b-traffic-access-token` in `tests/integration/internal/utils/request.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ea5144d92381c79062649ddbbd01aba4cc5b672. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->