### PR TITLE
Fix the condition for redis cluster

### DIFF
--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -453,9 +453,9 @@ locals {
     clickhouse_connection_string = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${random_password.clickhouse_password.result}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
     redis_url                    = data.google_secret_manager_secret_version.redis_url.secret_data != "redis.service.consul" ? "" : "redis.service.consul:${var.redis_port.port}"
     # Secure redis url uses " " as a default, redis url uses "redis.service.consul"
-		redis_cluster_url            = trimspace(data.google_secret_manager_secret_version.redis_url.secret_data) != "" ? data.google_secret_manager_secret_version.redis_secure_cluster_url.secret_data : ""
-    redis_tls_ca_base64          = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
-    shared_chunk_cache_path      = var.shared_chunk_cache_path
+    redis_cluster_url       = trimspace(data.google_secret_manager_secret_version.redis_secure_cluster_url.secret_data) != "" ? data.google_secret_manager_secret_version.redis_secure_cluster_url.secret_data : ""
+    redis_tls_ca_base64     = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
+    shared_chunk_cache_path = var.shared_chunk_cache_path
   }
 
   orchestrator_job_check = templatefile("${path.module}/jobs/orchestrator.hcl", merge(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates orchestrator redis_cluster_url to use the secure cluster URL only when the secret is non-empty (trimmed), with minor related env var cleanups.
> 
> - **Infrastructure (Nomad/GCP)**
>   - **Orchestrator envs (`iac/provider-gcp/nomad/main.tf`)**:
>     - Adjust `redis_cluster_url` to use `redis_secure_cluster_url` only if its trimmed value is non-empty.
>     - Keep `redis_url` defaulting to `redis.service.consul:${var.redis_port.port}` when applicable and continue trimming `redis_tls_ca_base64`.
>     - Add clarifying comment and retain `shared_chunk_cache_path`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 229b53906f154b49cf1ecc1589966023f7bd88c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->