### PR TITLE
fix: db null config stored

### DIFF
--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/auth"
-	"github.com/e2b-dev/infra/packages/api/internal/db/types"
+	typesteam "github.com/e2b-dev/infra/packages/api/internal/db/types"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/db/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -26,7 +27,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 	ctx := c.Request.Context()
 
 	// Get team from context, use TeamContextKey
-	teamInfo := c.Value(auth.TeamContextKey).(*types.Team)
+	teamInfo := c.Value(auth.TeamContextKey).(*typesteam.Team)
 
 	span := trace.SpanFromContext(ctx)
 	traceID := span.SpanContext().TraceID().String()
@@ -138,6 +139,11 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		envdAccessToken = &accessToken
 	}
 
+	var network *types.SandboxNetworkConfig
+	if snap.Config != nil {
+		network = snap.Config.Network
+	}
+
 	sbx, createErr := a.startSandbox(
 		ctx,
 		snap.SandboxID,
@@ -154,7 +160,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		autoPause,
 		envdAccessToken,
 		snap.AllowInternetAccess,
-		snap.Config.Network,
+		network,
 		nil, // mcp
 	)
 	if createErr != nil {

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/auth"
-	"github.com/e2b-dev/infra/packages/api/internal/db/types"
+	typesteam "github.com/e2b-dev/infra/packages/api/internal/db/types"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/db/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -26,7 +27,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	ctx := c.Request.Context()
 
 	// Get team from context, use TeamContextKey
-	teamInfo := c.Value(auth.TeamContextKey).(*types.Team)
+	teamInfo := c.Value(auth.TeamContextKey).(*typesteam.Team)
 
 	span := trace.SpanFromContext(ctx)
 	traceID := span.SpanContext().TraceID().String()
@@ -137,6 +138,11 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		envdAccessToken = &accessToken
 	}
 
+	var network *types.SandboxNetworkConfig
+	if snap.Config != nil {
+		network = snap.Config.Network
+	}
+
 	sbx, createErr := a.startSandbox(
 		ctx,
 		snap.SandboxID,
@@ -153,7 +159,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		autoPause,
 		envdAccessToken,
 		snap.AllowInternetAccess,
-		snap.Config.Network,
+		network,
 		nil, // mcp
 	)
 	if createErr != nil {

--- a/packages/db/queries/models.go
+++ b/packages/db/queries/models.go
@@ -110,7 +110,7 @@ type Snapshot struct {
 	AllowInternetAccess *bool
 	AutoPause           bool
 	TeamID              uuid.UUID
-	Config              types.PausedSandboxConfig
+	Config              *types.PausedSandboxConfig
 }
 
 type Team struct {

--- a/packages/db/sqlc.yaml
+++ b/packages/db/sqlc.yaml
@@ -13,7 +13,11 @@ sql:
           - column: "public.env_builds.reason"
             go_type: "github.com/e2b-dev/infra/packages/db/types.BuildReason"
           - column: "public.snapshots.config"
-            go_type: "github.com/e2b-dev/infra/packages/db/types.PausedSandboxConfig"
+            go_type:
+              import: "github.com/e2b-dev/infra/packages/db/types"
+              type: "PausedSandboxConfig"
+              pointer: true
+            nullable: true
           - db_type: "uuid"
             go_type:
               import: "github.com/google/uuid"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make `snapshots.config` nullable (pointer) in queries/sqlc and update sandbox connect/resume handlers to treat config as optional and pass `network` only when present.
> 
> - **DB/Queries**:
>   - Change `Snapshot.Config` to `*types.PausedSandboxConfig` in `queries/models.go`.
>   - Update `sqlc.yaml` override for `public.snapshots.config` to use a pointer type and mark it `nullable`.
> - **API Handlers**:
>   - In `handlers/sandbox_connect.go` and `handlers/sandbox_resume.go`:
>     - Import team types as `typesteam` and use `*typesteam.Team` from `api/internal/db/types`.
>     - Safely derive `network`: set `network` only if `snap.Config != nil`; pass `network` to `startSandbox`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0ae24ba74ffd6169c53d52921b2cff5ad705e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->