### PR TITLE
chore: improve periodic tests sandbox timeout

### DIFF
--- a/tests/periodic-test/bun.lock
+++ b/tests/periodic-test/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "e2b-periodic-tests",

--- a/tests/periodic-test/internet-works.ts
+++ b/tests/periodic-test/internet-works.ts
@@ -1,11 +1,11 @@
 import { Sandbox } from "@e2b/code-interpreter";
-import { log, runTestWithSandbox } from "./utils.ts";
+import { DEBUG_TIMEOUT_MS, log, runTestWithSandbox } from "./utils.ts";
 
 log("Starting sandbox logs test");
 
 // Create sandbox
 log("creating sandbox");
-const sandbox = await Sandbox.create();
+const sandbox = await Sandbox.create({ timeoutMs: DEBUG_TIMEOUT_MS });
 log("ℹ️ sandbox created", sandbox.sandboxId);
 
 await runTestWithSandbox(sandbox, "internet-works", async () => {

--- a/tests/periodic-test/run-code.ts
+++ b/tests/periodic-test/run-code.ts
@@ -1,17 +1,21 @@
 import { Sandbox } from "@e2b/code-interpreter";
-import { log, runTestWithSandbox } from "./utils.ts";
+import { DEBUG_TIMEOUT_MS, log, runTestWithSandbox } from "./utils.ts";
 
 // Create a E2B Code Interpreter with JavaScript kernel
 log("creating sandbox");
-const sandbox = await Sandbox.create();
+const sandbox = await Sandbox.create({ timeoutMs: DEBUG_TIMEOUT_MS });
 log("ℹ️ sandbox created", sandbox.sandboxId);
 
 await runTestWithSandbox(sandbox, "run-code", async () => {
   // Execute JavaScript cells
   log("running code");
-  await sandbox.runCode("x = 1");
+  await sandbox.runCode("x = 1", {
+    requestTimeoutMs: 10000,
+  });
   log("first code executed");
-  const execution = await sandbox.runCode("x+=1; x");
+  const execution = await sandbox.runCode("x+=1; x", {
+    requestTimeoutMs: 10000,
+  });
   log("second code executed");
   // Output result
   log(execution.text);

--- a/tests/periodic-test/snapshot-and-resume.ts
+++ b/tests/periodic-test/snapshot-and-resume.ts
@@ -1,11 +1,13 @@
 import { Sandbox } from "@e2b/code-interpreter";
-import { log, runTestWithSandbox } from "./utils.ts";
+import { DEBUG_TIMEOUT_MS, log, runTestWithSandbox } from "./utils.ts";
 
-const sbx = await Sandbox.create();
+const sbx = await Sandbox.create({ timeoutMs: DEBUG_TIMEOUT_MS });
 log("ℹ️ sandbox created", sbx.sandboxId);
 
 await runTestWithSandbox(sbx, "snapshot-and-resume", async () => {
-  await sbx.runCode("x = 1");
+  await sbx.runCode("x = 1", {
+    requestTimeoutMs: 10000,
+  });
   log("Sandbox code executed");
 
   const success = await sbx.betaPause();
@@ -15,7 +17,9 @@ await runTestWithSandbox(sbx, "snapshot-and-resume", async () => {
   const sameSbx = await Sandbox.connect(sbx.sandboxId);
   log("Sandbox resumed", sameSbx.sandboxId);
 
-  const execution = await sameSbx.runCode("x+=1; x");
+  const execution = await sameSbx.runCode("x+=1; x", {
+    requestTimeoutMs: 10000,
+  });
   // Output result
   log("RunCode Output:", execution.text);
 

--- a/tests/periodic-test/time-is-synchronized/index.ts
+++ b/tests/periodic-test/time-is-synchronized/index.ts
@@ -1,7 +1,7 @@
 import { Sandbox } from "@e2b/code-interpreter";
 import { readFile, rm } from "fs/promises";
 
-import { log, runTestWithSandbox } from "../utils.ts";
+import { DEBUG_TIMEOUT_MS, log, runTestWithSandbox } from "../utils.ts";
 
 const uniqueID = crypto.randomUUID();
 const templateName = `test-template-${uniqueID}`;
@@ -41,13 +41,15 @@ try {
   await new Promise((resolve) => setTimeout(resolve, 15000));
 
   log("ℹ️ creating sandbox");
-  const sandbox = await Sandbox.create(templateID, { timeoutMs: 10000 });
+  const sandbox = await Sandbox.create(templateID, { timeoutMs: DEBUG_TIMEOUT_MS });
 
   await runTestWithSandbox(sandbox, "time-is-synchronized", async () => {
     log("ℹ️ starting command");
     const localDateStart = new Date();
     const localDateStartUnix = localDateStart.getTime() / 1000;
-    const dateStdout = await sandbox.commands.run("date +%s%3N");
+    const dateStdout = await sandbox.commands.run("date +%s%3N", {
+      requestTimeoutMs: 10000,
+    });
     const dateUnix = parseFloat(dateStdout.stdout) / 1000;
     const sandboxDate = new Date(dateUnix * 1000);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use shared DEBUG_TIMEOUT_MS for sandbox creation and add explicit request timeouts to code/command executions across periodic tests.
> 
> - **Tests (periodic-test)**:
>   - Use `DEBUG_TIMEOUT_MS` for `Sandbox.create({ timeoutMs })` in `internet-works.ts`, `run-code.ts`, `snapshot-and-resume.ts`, and `time-is-synchronized/index.ts`.
>   - Add `requestTimeoutMs: 10000` to `sandbox.runCode(...)` and `sandbox.commands.run(...)` calls where applicable.
>   - Minor lockfile metadata update in `tests/periodic-test/bun.lock` (adds `configVersion`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c5597d00d31fc968715ff0f38a620b6c462b7cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->