### PR TITLE
Fix claude PR review checkout

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,10 +16,12 @@ jobs:
       id-token: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head commit
+        id: pr-sha
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
https://github.com/e2b-dev/infra/actions/runs/19410837608?pr=1494+%28comment%29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update the Claude review workflow to check out the PR head commit with full history before running the review action.
> 
> - **CI/GitHub Actions** (`.github/workflows/claude-code-review.yml`):
>   - Checkout PR head commit using `actions/checkout@v4` with `ref: ${{ github.event.pull_request.head.sha }}` and `fetch-depth: 0`.
>   - Rename step to “Checkout PR head commit” and add step `id: pr-sha`.
>   - Keep Claude review step unchanged aside from running against the checked-out head commit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a10be95a3f4034acf25e575d0c8d99d1ddb6b79c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->