### PR TITLE
Use whole certificate chain for Redis

### DIFF
--- a/iac/provider-gcp/redis/main.tf
+++ b/iac/provider-gcp/redis/main.tf
@@ -188,5 +188,5 @@ resource "google_secret_manager_secret_version" "redis_secure_cluster_url_secret
 
 resource "google_secret_manager_secret_version" "redis_tls_ca_base64" {
   secret      = var.redis_tls_ca_base64_secret_version.secret
-  secret_data = base64encode(google_memorystore_instance.valkey_cluster.managed_server_ca[0].ca_certs[0].certificates[0])
+  secret_data = base64encode(join("\n", google_memorystore_instance.valkey_cluster.managed_server_ca[0].ca_certs[0].certificates))
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Terraform to save the full Redis/Valkey TLS CA chain (joined by newlines) instead of a single certificate.
> 
> - **Infra (Terraform/GCP Redis)**:
>   - Update `iac/provider-gcp/redis/main.tf` to write the full TLS CA certificate chain to `google_secret_manager_secret_version.redis_tls_ca_base64` by joining all `certificates` with newlines before base64-encoding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0646a9283aca3922b41d08c1b7013ae59f614f76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->