### PR TITLE
fix: speed up provisioning shutdown

### DIFF
--- a/packages/orchestrator/internal/sandbox/block/cache.go
+++ b/packages/orchestrator/internal/sandbox/block/cache.go
@@ -112,11 +112,15 @@ func (m *Cache) ExportToDiff(out io.Writer) (*header.DiffMetadata, error) {
 		}
 
 		dirty.Set(uint(blockIdx))
-		_, err = out.Write(block)
+		n, err := out.Write(block)
 		if err != nil {
 			zap.L().Error("error writing to out", zap.Error(err))
 
 			return nil, err
+		}
+
+		if int64(n) != m.blockSize {
+			return nil, fmt.Errorf("short write: %d != %d", int64(n), m.blockSize)
 		}
 	}
 

--- a/packages/orchestrator/internal/template/build/phases/base/provision.go
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.go
@@ -14,7 +14,6 @@ import (
 	tt "text/template"
 	"time"
 
-	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapio"
 
@@ -27,8 +26,6 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/core/rootfs"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/writer"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
-	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -150,17 +147,10 @@ func (bb *BaseBuilder) provisionSandbox(
 
 	userLogger.Info("Provisioning was successful, cleaning up")
 
-	snapshot, err := sbx.Pause(ctx, metadata.Template{
-		Template: storage.TemplateFiles{
-			BuildID:            uuid.NewString(),
-			KernelVersion:      fcVersions.KernelVersion,
-			FirecrackerVersion: fcVersions.FirecrackerVersion,
-		},
-	})
+	err = sbx.Shutdown(ctx)
 	if err != nil {
-		return fmt.Errorf("error pausing provisioned sandbox: %w", err)
+		return fmt.Errorf("error shutting down provisioned sandbox: %w", err)
 	}
-	defer snapshot.Close(context.WithoutCancel(ctx))
 
 	err = filesystem.RemoveFile(ctx, rootfsPath, provisionScriptResultPath)
 	if err != nil {

--- a/packages/orchestrator/internal/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/builder.go
@@ -112,7 +112,7 @@ func (sb *StepBuilder) Layer(
 	if !forceBuild {
 		m, err := sb.index.LayerMetaFromHash(ctx, hash)
 		if err != nil {
-			sb.logger.Info("layer not found in cache, building new base layer", zap.Error(err), zap.String("hash", hash))
+			sb.logger.Info("layer not found in cache, building new step layer", zap.Error(err), zap.String("hash", hash))
 		} else {
 			// Check if the layer is cached
 			meta, err := sb.index.Cached(ctx, m.Template.BuildID)

--- a/packages/shared/pkg/storage/template_cache.go
+++ b/packages/shared/pkg/storage/template_cache.go
@@ -47,3 +47,7 @@ func (c TemplateCacheFiles) CacheMetadataPath(config BuilderConfig) string {
 func (c TemplateCacheFiles) cacheDir(config BuilderConfig) string {
 	return filepath.Join(config.GetTemplateCacheDir(), c.BuildID, "cache", c.CacheIdentifier)
 }
+
+func (c TemplateCacheFiles) Close(config BuilderConfig) error {
+	return os.RemoveAll(c.cacheDir(config))
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce Sandbox.Shutdown for faster, clean VM teardown during provisioning; ensure full block writes in diff export and add cache cleanup for template cache files.
> 
> - **Sandbox / Provisioning**:
>   - Add `Sandbox.Shutdown(ctx)` to pause VM, disable uffd, snapshot to temp files, and close resources.
>   - Use `Shutdown` in base provision phase instead of `Pause` snapshot workflow; remove unused snapshot handling.
> - **Block Diff**:
>   - In `block/cache.ExportToDiff`, verify full block writes by checking `n` against `blockSize` and error on short write.
> - **Storage**:
>   - Add `TemplateCacheFiles.Close(config)` to remove cache dir; used by `Sandbox.Shutdown`.
> - **Logs**:
>   - Tweak cache miss log: "building new step layer".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7ce236abfec7fde361d48866f3141394176cd09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->