### PR TITLE
fix(feature-flags): add Offline flag when apiKey is not provided

### DIFF
--- a/packages/shared/pkg/feature-flags/client.go
+++ b/packages/shared/pkg/feature-flags/client.go
@@ -33,6 +33,7 @@ func NewClient() (*Client, error) {
 			"",
 			ldclient.Config{
 				DataSource: LaunchDarklyOfflineStore,
+				Offline:    true,
 			},
 			0)
 		if err != nil {


### PR DESCRIPTION
Without this, launchdarkly will keep trying to send events to remote.