### PR TITLE
Disable systemd time watchdog for networkd and journald

### DIFF
--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -35,6 +35,10 @@ const (
 	BusyBoxInitPath = "usr/bin/init"
 
 	ProvisioningExitPrefix = "E2B_PROVISIONING_EXIT:"
+
+	serviceWatchDogDisabledConfig = `[Service]
+WatchdogSec=0
+`
 )
 
 type Rootfs struct {
@@ -232,6 +236,8 @@ ff02::2	ip6-allrouters
 			storage.GuestEnvdPath:                                            {Bytes: envdFileData, Mode: 0o777},
 			"etc/systemd/system/envd.service":                                {Bytes: []byte(envdService), Mode: 0o644},
 			"etc/systemd/system/serial-getty@ttyS0.service.d/autologin.conf": {Bytes: []byte(autologinService), Mode: 0o644},
+			"etc/systemd/system/systemd-journald.service.d/override.conf":    {Bytes: []byte(serviceWatchDogDisabledConfig), Mode: 0o644},
+			"etc/systemd/system/systemd-networkd.service.d/override.conf":    {Bytes: []byte(serviceWatchDogDisabledConfig), Mode: 0o644},
 
 			// Provision script
 			"usr/local/bin/provision.sh": {Bytes: []byte(provisionScript), Mode: 0o777},


### PR DESCRIPTION
- [x] Test and compare restarts in journal logs for build and pause/resume


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables systemd watchdog for `systemd-journald` and `systemd-networkd` by adding override configs during rootfs build.
> 
> - **Rootfs build**:
>   - Add `etc/systemd/system/systemd-journald.service.d/override.conf` and `etc/systemd/system/systemd-networkd.service.d/override.conf` with `WatchdogSec=0` to disable service watchdogs.
>   - Introduce `serviceWatchDogDisabledConfig` constant reused for both overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92f6e4beb8c9df213a5ff6d6c5b4d139fe4c7581. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->