### PR TITLE
fix: update devcontainer to new go version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,6 @@
         "hashicorp.terraform",
         "foxundermoon.shell-format",
         "ms-vscode.makefile-tools",
-        "hashicorp.terraform",
         "redhat.vscode-yaml",
         "christian-kohler.path-intellisense",
         "googlecloudtools.cloudcode",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "hashicorp.terraform",
     "foxundermoon.shell-format",
     "ms-vscode.makefile-tools",
-    "hashicorp.terraform",
     "redhat.vscode-yaml",
     "christian-kohler.path-intellisense",
     "googlecloudtools.cloudcode",


### PR DESCRIPTION
note: this only updates the go to version 1.25.3. We require 1.25.4, but there is no devcontainer that would support it yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update devcontainer to Go image 2.0.3-1.25, add the mise feature, add VS Code extensions in devcontainer, and dedupe an extension in .vscode/extensions.json.
> 
> - **Devcontainer** (`.devcontainer/devcontainer.json`):
>   - Update base image to `mcr.microsoft.com/devcontainers/go:2.0.3-1.25-bookworm`.
>   - Add feature `ghcr.io/devcontainers-extra/features/mise:1`.
>   - Add VS Code extension recommendations under `customizations.vscode.extensions`.
> - **Editor config** (`.vscode/extensions.json`):
>   - Deduplicate `hashicorp.terraform` recommendation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea492602ee682f6978b3817fecb50330da32a9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->