### PR TITLE
Add the 'early-return' linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,7 +113,6 @@ linters:
         - { disabled: true, name: context-as-argument }
         - { disabled: true, name: cyclomatic }
         - { disabled: true, name: deep-exit }
-        - { disabled: true, name: early-return }
         - { disabled: true, name: enforce-switch-style }
         - { disabled: true, name: exported }
         - { disabled: true, name: flag-parameter } # todo: enable this

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -136,14 +136,14 @@ func run() int {
 		}()
 		catalog = e2bcatalog.NewRedisSandboxesCatalog(redisClient)
 	} else {
-		if errors.Is(err, factories.ErrRedisDisabled) {
-			l.Warn(ctx, "Redis environment variable is not set, will fallback to in-memory sandboxes catalog that works only with one instance setup")
-			catalog = e2bcatalog.NewMemorySandboxesCatalog()
-		} else {
+		if !errors.Is(err, factories.ErrRedisDisabled) {
 			l.Error(ctx, "Failed to create redis client", zap.Error(err))
 
 			return 1
 		}
+
+		l.Warn(ctx, "Redis environment variable is not set, will fallback to in-memory sandboxes catalog that works only with one instance setup")
+		catalog = e2bcatalog.NewMemorySandboxesCatalog()
 	}
 
 	orchestrators := e2borchestrators.NewOrchestratorsPool(ctx, l, tel.TracerProvider, tel.MeterProvider, orchestratorsSD)

--- a/packages/orchestrator/internal/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/steps/builder.go
@@ -117,15 +117,15 @@ func (sb *StepBuilder) Layer(
 		} else {
 			// Check if the layer is cached
 			meta, err := sb.index.Cached(ctx, m.Template.BuildID)
-			if err != nil {
-				logger.L().Info(ctx, "layer not cached, building new layer", zap.Error(err), zap.String("hash", hash))
-			} else {
+			if err == nil {
 				return phases.LayerResult{
 					Metadata: meta,
 					Cached:   true,
 					Hash:     hash,
 				}, nil
 			}
+
+			logger.L().Info(ctx, "layer not cached, building new layer", zap.Error(err), zap.String("hash", hash))
 		}
 	}
 


### PR DESCRIPTION
Also tweak some integration tests to try and make them less flaky. Success?

Demonstration of why the test changes are necessary: https://go.dev/play/p/f2B4sJgHvmr


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable the 'early-return' linter and refactor Redis init, NBD dispatch, and file-lock logic to use early returns and simpler control flow.
> 
> - **Lint/config**:
>   - Enable revive `early-return` rule in `.golangci.yml`.
> - **Client Proxy (`packages/client-proxy/main.go`)**:
>   - Simplify Redis init error handling: only error on non-`ErrRedisDisabled`; otherwise warn and fallback to in-memory catalog.
> - **Orchestrator NBD (`packages/orchestrator/internal/sandbox/nbd/dispatch.go`)**:
>   - Flatten header parsing/dispatch loop with early breaks; refactor command handling.
>   - Change shutdown checks to early-return and adjust `pendingResponses` accounting.
> - **Storage lock (`packages/shared/pkg/storage/lock/file_lock.go`)**:
>   - Early-return when lock is within TTL; remove stale lock files before acquiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbe41a8da62ad40069747802b214ee5dea887369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->