### PR TITLE
Fix flaky API list pausing sandbox test

### DIFF
--- a/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
@@ -184,7 +184,7 @@ func TestSandboxListPausing(t *testing.T) {
 	require.Eventually(t, func() bool {
 		// List paused sandboxes
 		listResponse, err := c.GetV2SandboxesWithResponse(t.Context(), &api.GetV2SandboxesParams{
-			State:    &[]api.SandboxState{api.Paused},
+			State:    &[]api.SandboxState{api.Running, api.Paused},
 			Metadata: &metadataString,
 		}, setup.WithAPIKey())
 		require.NoError(t, err)


### PR DESCRIPTION
There's a race condition when the sandbox is still in state Running, which is then handled well. Just the request was incorrect.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broaden the state filter in `TestSandboxListPausing` to include `running` alongside `paused` when listing sandboxes during pause transition.
> 
> - **Tests**:
>   - Update `tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go`:
>     - In `TestSandboxListPausing`, change list filter `State` from `[]api.SandboxState{api.Paused}` to `[]api.SandboxState{api.Running, api.Paused}` to handle transition state during `Eventually` wait.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1bbf8ffd371a14af8716eb24b1f5e80c1e3fa4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->