### PR TITLE
Fix error message

### DIFF
--- a/packages/api/internal/orchestrator/placement/placement_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_test.go
@@ -3,6 +3,7 @@ package placement
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -128,7 +129,7 @@ func TestPlaceSandbox_ContextTimeout(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, resultNode)
 	// The error could be either "timeout" from the algorithm or "request timed out" from ctx.Done()
-	assert.True(t, err.Error() == "timeout" || errors.Is(err, context.DeadlineExceeded))
+	assert.True(t, err.Error() == "timeout" || strings.Contains(err.Error(), "request timed out"))
 }
 
 func TestPlaceSandbox_NoNodes(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Loosens the timeout assertion in `placement_test.go` to match "request timed out" via string containment in addition to "timeout".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d968719a99ce819abbd47a8765bc42b6a2392bf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->