### PR TITLE
feat: add unique index on users_teams for user_id and team_id

### DIFF
--- a/packages/db/migrations/20251124110249_users_teams_unique.sql
+++ b/packages/db/migrations/20251124110249_users_teams_unique.sql
@@ -1,6 +1,6 @@
 -- +goose NO TRANSACTION
 -- +goose Up
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_users_teams_unique ON "public"."users_teams"(user_id, team_id);
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_users_teams_unique ON "public"."users_teams"(user_id, team_id);
 
 -- +goose Down
 DROP INDEX CONCURRENTLY IF EXISTS idx_users_teams_unique;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a concurrent unique index on `users_teams(user_id, team_id)` with up/down migration.
> 
> - **Database / Migrations**:
>   - Add `goose` migration `packages/db/migrations/20251124110249_users_teams_unique.sql` to create `UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` `idx_users_teams_unique` on `public.users_teams(user_id, team_id)`.
>   - Down migration drops the index with `DROP INDEX CONCURRENTLY IF EXISTS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ecd79371b00bf2a2ac233351d90144075e9872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->