### PR TITLE
Generalize build copy for local testing

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -343,7 +343,7 @@ func main() {
 				return nil
 			}
 
-			if fromDestination.isLocal {
+			if fromDestination.isLocal && toDestination.isLocal {
 				err := localCopy(ctx, fromDestination, toDestination)
 				if err != nil {
 					return fmt.Errorf("failed to copy local file: %w", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands copy-build to copy between local paths and GCS, reading headers from either source and skipping unchanged files via CRC.
> 
> - **orchestrator/cmd/copy-build**:
>   - **Local + GCS support**:
>     - Introduces `Destination` (path, CRC, isLocal) with `NewDestinationFromObject` and `NewDestinationFromPath`.
>     - Adds `localCopy` using `rsync`; updates `gcloudCopy` to work with `Destination`.
>   - **Header handling**:
>     - Adds `NewHeaderFromObject` and `NewHeaderFromPath`; `getReferencedData` now accepts `*header.Header`.
>   - **Skip unchanged files**:
>     - Computes/reads CRC for both local and GCS and skips copies when CRC matches.
>   - **CLI changes**:
>     - Renames flags to generic `--from` and `--to` “destination”; updates logs/messages.
>   - **File ops**:
>     - Ensures local destination directories exist (`os.MkdirAll`).
>   - Minor refactors: remove direct bucket provider usage; streamline copy loop and progress logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e67e380d5028a0bca3f585100a6b71d34842803. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->