### PR TITLE
Update default kernel version to vmlinux-6.1.158

### DIFF
--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -3,7 +3,7 @@ package cfg
 import "github.com/caarlos0/env/v11"
 
 const (
-	DefaultKernelVersion = "vmlinux-6.1.102"
+	DefaultKernelVersion = "vmlinux-6.1.158"
 	// The Firecracker version the last tag + the short SHA (so we can build our dev previews)
 	// TODO: The short tag here has only 7 characters — the one from our build pipeline will likely have exactly 8 so this will break.
 	DefaultFirecrackerVersion = "v1.12.1_d990331"


### PR DESCRIPTION
Related to https://github.com/e2b-dev/fc-kernels/pull/6  -> Bump kernel version to 6.1.158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the default kernel version constant to vmlinux-6.1.158 in `packages/api/internal/cfg/model.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9768ab104e8010673b69074915db6fdc97bc573. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->