### PR TITLE
Sandbox store - Prefix redis key with `api:`

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	sandboxKeyPrefix = "sandbox:"
+	sandboxKeyPrefix = "sandbox:storage:"
 	lockTimeout      = time.Minute
 )
 


### PR DESCRIPTION
We already have keys with prefix `sandbox:catalog:`, let's move this to `sandbox:storage:` to separate it better

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Redis sandbox storage key prefix from `sandbox:` to `sandbox:storage:`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1de09de64a05ca1ffc0f3f9af60682fee5cf3e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->