### PR TITLE
Fix otel envd init span status

### DIFF
--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -99,9 +99,15 @@ type PostInitJSONBody struct {
 	DefaultWorkdir *string            `json:"defaultWorkdir,omitempty"`
 }
 
-func (s *Sandbox) initEnvd(ctx context.Context) error {
+func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
 	ctx, span := tracer.Start(ctx, "envd-init", trace.WithAttributes(telemetry.WithEnvdVersion(s.Config.Envd.Version)))
-	defer span.End()
+	defer func() {
+		if e != nil {
+			span.SetStatus(codes.Error, e.Error())
+		}
+
+		span.End()
+	}()
 
 	attributes := []attribute.KeyValue{telemetry.WithEnvdVersion(s.Config.Envd.Version), attribute.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds())}
 	attributesFail := append(attributes, attribute.Bool("success", false))
@@ -154,8 +160,7 @@ func (s *Sandbox) initEnvd(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
 
-	request := response.Request
-	span.SetStatus(codes.Ok, fmt.Sprintf("%s %s returned %d", request.Method, request.RequestURI, response.StatusCode))
+	span.SetStatus(codes.Ok, fmt.Sprintf("envd init returned %d", response.StatusCode))
 
 	return nil
 }


### PR DESCRIPTION
The otel http transport sets the span status to failure, but never sets it to a success when it later succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure envd init span is marked Error on failures and Ok on success using OpenTelemetry codes.
> 
> - **Telemetry (envd init)**:
>   - Set OpenTelemetry span status to `Error` on failures via deferred handler in `sandbox.initEnvd`.
>   - Mark span `Ok` with response status on successful init.
>   - Import `otel/codes` and adjust function signature to use named error for status propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 024947e617d7eb8323a80fad347780df33029eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->