### PR TITLE
Add timeout for periodic tests

### DIFF
--- a/.github/workflows/periodic-test.yml
+++ b/.github/workflows/periodic-test.yml
@@ -28,6 +28,7 @@ jobs:
   changes:
     name: Check
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a 15-minute timeout to the `changes` job in the periodic tests GitHub Actions workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c853a3ab5c250313e65c099c408f056472e66f5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->