### PR TITLE
Improve sandbox log messages for clarity

### DIFF
--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -184,7 +184,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 			sbxlogger.I(sbx).Warn(ctx, "errors when manually closing connections to sandbox", zap.Error(closeErr))
 		}
 
-		sbxlogger.E(sbx).Info(ctx, "Sandbox killed")
+		sbxlogger.E(sbx).Info(ctx, "Sandbox stopped")
 	}()
 
 	eventType := events.SandboxCreatedEventPair
@@ -308,6 +308,8 @@ func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 		return nil, status.Errorf(codes.NotFound, "sandbox '%s' not found", in.GetSandboxId())
 	}
 
+	sbxlogger.E(sbx).Info(ctx, "Killing sandbox")
+
 	// Remove the sandbox from the cache to prevent loading it again in API during the time the instance is stopping.
 	// Old comment:
 	// 	Ensure the sandbox is removed from cache.
@@ -374,6 +376,8 @@ func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 
 		return nil, status.Error(codes.NotFound, "sandbox not found")
 	}
+
+	sbxlogger.E(sbx).Info(ctx, "Pausing sandbox")
 
 	s.sandboxes.Remove(in.GetSandboxId())
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies sandbox lifecycle logging by changing cleanup message to "Sandbox stopped" and adding explicit logs for kill and pause actions.
> 
> - **Orchestrator `server/sandboxes.go`**
>   - **Logging**:
>     - Update deferred cleanup log to `"Sandbox stopped"` (was `"Sandbox killed"`).
>     - Add `"Killing sandbox"` log in `Delete` flow before removal and stop.
>     - Add `"Pausing sandbox"` log in `Pause` flow before removal and snapshot.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8146f15bc14021265a3d4a179ee0de20089b76f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->