### PR TITLE
Add ability to change FC IO engine

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/client.go
+++ b/packages/orchestrator/internal/sandbox/fc/client.go
@@ -6,28 +6,34 @@ import (
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"github.com/go-openapi/strfmt"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/socket"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
 	"github.com/e2b-dev/infra/packages/shared/pkg/fc/client"
 	"github.com/e2b-dev/infra/packages/shared/pkg/fc/client/operations"
 	"github.com/e2b-dev/infra/packages/shared/pkg/fc/models"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 type apiClient struct {
 	client *client.Firecracker
+
+	featureFlags *featureflags.Client
 }
 
-func newApiClient(socketPath string) *apiClient {
+func newApiClient(featureFlags *featureflags.Client, socketPath string) *apiClient {
 	client := client.NewHTTPClient(strfmt.NewFormats())
 
 	transport := firecracker.NewUnixSocketTransport(socketPath, nil, false)
 	client.SetTransport(transport)
 
 	return &apiClient{
-		client: client,
+		client:       client,
+		featureFlags: featureFlags,
 	}
 }
 
@@ -178,8 +184,15 @@ func (c *apiClient) setBootSource(ctx context.Context, kernelArgs string, kernel
 
 func (c *apiClient) setRootfsDrive(ctx context.Context, rootfsPath string) error {
 	rootfs := "rootfs"
-	// We use Sync for now as there seems to be a bad interaction between NBD and Async.
-	ioEngine := "Sync"
+
+	ioEngine, err := c.featureFlags.StringFlag(
+		ctx,
+		featureflags.BuildIoEngine,
+	)
+	if err != nil {
+		logger.L().Debug(ctx, "getting io engine failed, using default value", zap.String("io_engine", featureflags.BuildIoEngine.Fallback()), zap.Error(err))
+	}
+
 	isRootDevice := true
 	driversConfig := operations.PutGuestDriveByIDParams{
 		Context: ctx,
@@ -193,7 +206,7 @@ func (c *apiClient) setRootfsDrive(ctx context.Context, rootfsPath string) error
 		},
 	}
 
-	_, err := c.client.Operations.PutGuestDriveByID(&driversConfig)
+	_, err = c.client.Operations.PutGuestDriveByID(&driversConfig)
 	if err != nil {
 		return fmt.Errorf("error setting fc drivers config: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -21,6 +21,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/socket"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -73,6 +74,7 @@ type Process struct {
 func NewProcess(
 	ctx context.Context,
 	execCtx context.Context,
+	featureFlags *featureflags.Client,
 	config cfg.BuilderConfig,
 	slot *network.Slot,
 	files *storage.SandboxFiles,
@@ -125,7 +127,7 @@ func NewProcess(
 		cmd:                   cmd,
 		firecrackerSocketPath: files.SandboxFirecrackerSocketPath(),
 		config:                config,
-		client:                newApiClient(files.SandboxFirecrackerSocketPath()),
+		client:                newApiClient(featureFlags, files.SandboxFirecrackerSocketPath()),
 		providerRootfsPath:    rootfsProviderPath,
 		files:                 files,
 		slot:                  slot,

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -256,6 +256,7 @@ func (f *Factory) CreateSandbox(
 	fcHandle, err := fc.NewProcess(
 		ctx,
 		execCtx,
+		f.featureFlags,
 		f.config,
 		ips.slot,
 		sandboxFiles,
@@ -473,6 +474,7 @@ func (f *Factory) ResumeSandbox(
 	fcHandle, fcErr := fc.NewProcess(
 		ctx,
 		execCtx,
+		f.featureFlags,
 		f.config,
 		ips.slot,
 		sandboxFiles,

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -115,6 +115,13 @@ func (b *Builder) Build(ctx context.Context, template storage.TemplateFiles, cfg
 	ctx, childSpan := tracer.Start(ctx, "build")
 	defer childSpan.End()
 
+	// setup launch darkly context
+	ctx = featureflags.SetContext(
+		ctx,
+		featureflags.TemplateContext(cfg.TemplateID),
+		featureflags.TeamContext(cfg.TeamID),
+	)
+
 	// Record build duration and result at the end
 	startTime := time.Now()
 	defer func() {

--- a/packages/shared/pkg/feature-flags/client.go
+++ b/packages/shared/pkg/feature-flags/client.go
@@ -78,6 +78,19 @@ func (c *Client) IntFlag(ctx context.Context, flag IntFlag, contexts ...ldcontex
 	return value, nil
 }
 
+func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ldcontext.Context) (string, error) {
+	if c.ld == nil {
+		return flag.fallback, fmt.Errorf("LaunchDarkly client is not initialized")
+	}
+
+	value, err := c.ld.StringVariationCtx(ctx, flag.name, mergeContexts(ctx, contexts), flag.fallback)
+	if err != nil {
+		return value, fmt.Errorf("error evaluating %s: %w", flag, err)
+	}
+
+	return value, nil
+}
+
 func (c *Client) Close(ctx context.Context) error {
 	if c.ld == nil {
 		return nil

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -96,3 +96,27 @@ var (
 	BuildCacheMaxUsagePercentage = newIntFlag("build-cache-max-usage-percentage", 85)
 	BuildProvisionVersion        = newIntFlag("build-provision-version", 0)
 )
+
+type StringFlag struct {
+	name     string
+	fallback string
+}
+
+func (f StringFlag) String() string {
+	return f.name
+}
+
+func (f StringFlag) Fallback() string {
+	return f.fallback
+}
+
+func newStringFlag(name string, fallback string) StringFlag {
+	flag := StringFlag{name: name, fallback: fallback}
+	builder := LaunchDarklyOfflineStore.Flag(flag.name).ValueForAll(ldvalue.String(fallback))
+	LaunchDarklyOfflineStore.Update(builder)
+
+	return flag
+}
+
+// BuildIoEngine Sync might be used for now as there seems to be a bad interaction between NBD and Async.
+var BuildIoEngine = newStringFlag("build-io-engine", "Async")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Firecracker rootfs drive IO engine is now configurable via LaunchDarkly (BuildIoEngine) by wiring the feature-flags client through the orchestrator and adding string-flag support.
> 
> - **Firecracker/orchestrator**:
>   - `apiClient` now holds `featureFlags`; `setRootfsDrive` reads `featureflags.BuildIoEngine` to set `Drive.IoEngine` (with fallback logging).
>   - `newApiClient` and `NewProcess` accept `featureFlags`; `sandbox.Factory` passes it in both Create and Resume paths.
> - **Feature flags**:
>   - Add `StringFlag` type and `Client.StringFlag` API; define `BuildIoEngine` with default `"Async"`.
> - **Template Build**:
>   - Set LaunchDarkly contexts (template, team) at build start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0e4077b3fab7fc68b161879f27d13f138a9b730. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->