### PR TITLE
Add jsonb pointer handling

### DIFF
--- a/packages/db/sqlc.yaml
+++ b/packages/db/sqlc.yaml
@@ -47,3 +47,8 @@ sql:
           - db_type: "jsonb"
             go_type: "github.com/e2b-dev/infra/packages/db/types.JSONBStringMap"
             nullable: true
+          - db_type: "jsonb"
+            go_type:
+              import: "github.com/e2b-dev/infra/packages/db/types"
+              type: "JSONBStringMap"
+              pointer: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an sqlc override mapping `jsonb` to a pointer `types.JSONBStringMap` in `packages/db/sqlc.yaml`.
> 
> - **Config** (`packages/db/sqlc.yaml`):
>   - Add `jsonb` override to map to pointer `types.JSONBStringMap` for nullable handling.
>   - Retain existing non-pointer `jsonb` mapping alongside the new pointer variant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7ba5a9fd89cefd2860f087164f2e102a6472a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->