### PR TITLE
Stop scraping nomad series, filter using hostmetrics tools

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -72,7 +72,7 @@ receivers:
         include_virtual_filesystems: false
         exclude_devices:
           devices:
-            - "^/dev/loop\\d+$"
+            - "^/dev/loop.*$"
           match_type: regexp
         metrics:
           system.filesystem.inodes.usage:
@@ -116,7 +116,7 @@ receivers:
         exclude:
           interfaces:
             - "^lo$"
-            - "^docker\\d+$"
+            - "^docker.*$"
             - "^nomad$"
             - "^veth.*$"
           match_type: regexp


### PR DESCRIPTION
Nomad metrics duplicate metrics gathered via hostmetrics, without simple filters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits scraped Nomad metrics to client allocation series and applies filesystem/network filtering at the hostmetrics receiver, removing redundant processors.
> 
> - **Observability (otel-collector config)**:
>   - **Prometheus/Nomad metrics**:
>     - Add `filter/only_client_allocs` to include only `nomad_client_*alloc*` series in `metrics/prometheus` pipeline.
>     - Remove previous Prometheus filters/transforms targeting broader Nomad series.
>   - **Hostmetrics receiver**:
>     - Filesystem: `include_virtual_filesystems: false`; exclude loop devices via regexp.
>     - Network: exclude `lo`, `docker*`, `nomad`, `veth*` interfaces via regexp.
>     - Drop downstream processors that previously filtered by device/interface.
>   - **Pipelines**:
>     - Clean up processors by removing `filter/drop_by_device`, `attributes/strip_fs_labels`, and `filter/prometheus`; keep batching and resource detection unchanged.
>     - No changes to exporters or endpoints beyond pipeline adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b411fd43b58101557a1e1614423b84137dfa1f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->