### PR TITLE
fix: golangci-lint definition to use the manually installed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -50,7 +50,7 @@
     },
   },
   "editor.tabCompletion": "on",
-  "go.lintTool": "golangci-lint-v2",
+  "go.lintTool": "golangci-lint",
   "go.lintFlags": [
     "--path-mode=abs",
     "--fast-only",


### PR DESCRIPTION
Use the golangci-lint version installed manually from mise.