### PR TITLE
fix: change default io engine

### DIFF
--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -116,5 +116,5 @@ func newStringFlag(name string, fallback string) StringFlag {
 	return flag
 }
 
-// BuildIoEngine Sync might be used for now as there seems to be a bad interaction between NBD and Async.
-var BuildIoEngine = newStringFlag("build-io-engine", "Async")
+// BuildIoEngine Sync is used by default as there seems to be a bad interaction between Async and a lot of io operations.
+var BuildIoEngine = newStringFlag("build-io-engine", "Sync")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets `build-io-engine` flag default from "Async" to "Sync".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7475de5ca2d8e665927808fff9f9eaa3387785cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->