### PR TITLE
Save information for cpu on pause

### DIFF
--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -30,6 +30,7 @@ func (o *Orchestrator) pauseSandbox(ctx context.Context, node *nodemanager.Node,
 	ctx, span := tracer.Start(ctx, "pause-sandbox")
 	defer span.End()
 
+	machineInfo := node.MachineInfo()
 	snapshotConfig := queries.UpsertSnapshotParams{
 		// Used if there's no snapshot for this sandbox yet
 		TemplateID:     id.Generate(),
@@ -53,8 +54,13 @@ func (o *Orchestrator) pauseSandbox(ctx context.Context, node *nodemanager.Node,
 			Version: types.PausedSandboxConfigVersion,
 			Network: sbx.Network,
 		},
-		OriginNodeID: utils.ToPtr(node.ID),
-		Status:       string(types.BuildStatusSnapshotting),
+		OriginNodeID:    utils.ToPtr(node.ID),
+		Status:          string(types.BuildStatusSnapshotting),
+		CpuArchitecture: utils.ToPtr(machineInfo.CPUArchitecture),
+		CpuFamily:       utils.ToPtr(machineInfo.CPUFamily),
+		CpuModel:        utils.ToPtr(machineInfo.CPUModel),
+		CpuModelName:    utils.ToPtr(machineInfo.CPUModelName),
+		CpuFlags:        machineInfo.CPUFlags,
 	}
 
 	result, err := o.sqlcDB.UpsertSnapshot(ctx, snapshotConfig)

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -16,11 +16,11 @@ import (
 const upsertSnapshot = `-- name: UpsertSnapshot :one
 WITH new_template AS (
     INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at)
-    SELECT $10, FALSE, NULL, $11, now()
+    SELECT $15, FALSE, NULL, $16, now()
     WHERE NOT EXISTS (
         SELECT id
         FROM "public"."snapshots" s
-        WHERE s.sandbox_id = $12
+        WHERE s.sandbox_id = $17
     ) RETURNING id
 ),
 
@@ -39,18 +39,18 @@ snapshot as (
        config
     )
     VALUES (
-            $12,
-            $13,
-            $11,
+            $17,
+            $18,
+            $16,
             -- If snapshot already exists, new_template id will be null, env_id can't be null, so use placeholder ''
             COALESCE((SELECT id FROM new_template), ''),
-            $14,
-            $15,
-            $16,
-            $17,
+            $19,
+            $20,
+            $21,
+            $22,
             $8,
-            $18,
-            $19
+            $23,
+            $24
    )
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
@@ -72,7 +72,12 @@ INSERT INTO "public"."env_builds" (
     status,
     cluster_node_id,
     total_disk_size_mb,
-    updated_at
+    updated_at,
+    cpu_architecture,
+    cpu_family,
+    cpu_model,
+    cpu_model_name,
+    cpu_flags
 ) VALUES (
     (SELECT template_id FROM snapshot),
     $1,
@@ -84,7 +89,12 @@ INSERT INTO "public"."env_builds" (
     $7,
     $8,
     $9,
-    now()
+    now(),
+    $10,
+    $11,
+    $12,
+    $13,
+    $14
 ) RETURNING id as build_id, env_id as template_id
 `
 
@@ -98,6 +108,11 @@ type UpsertSnapshotParams struct {
 	Status              string
 	OriginNodeID        *string
 	TotalDiskSizeMb     *int64
+	CpuArchitecture     *string
+	CpuFamily           *string
+	CpuModel            *string
+	CpuModelName        *string
+	CpuFlags            []string
 	TemplateID          string
 	TeamID              uuid.UUID
 	SandboxID           string
@@ -128,6 +143,11 @@ func (q *Queries) UpsertSnapshot(ctx context.Context, arg UpsertSnapshotParams) 
 		arg.Status,
 		arg.OriginNodeID,
 		arg.TotalDiskSizeMb,
+		arg.CpuArchitecture,
+		arg.CpuFamily,
+		arg.CpuModel,
+		arg.CpuModelName,
+		arg.CpuFlags,
 		arg.TemplateID,
 		arg.TeamID,
 		arg.SandboxID,

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -59,7 +59,12 @@ INSERT INTO "public"."env_builds" (
     status,
     cluster_node_id,
     total_disk_size_mb,
-    updated_at
+    updated_at,
+    cpu_architecture,
+    cpu_family,
+    cpu_model,
+    cpu_model_name,
+    cpu_flags
 ) VALUES (
     (SELECT template_id FROM snapshot),
     @vcpu,
@@ -71,5 +76,10 @@ INSERT INTO "public"."env_builds" (
     @status,
     @origin_node_id,
     @total_disk_size_mb,
-    now()
+    now(),
+    @cpu_architecture,
+    @cpu_family,
+    @cpu_model,
+    @cpu_model_name,
+    @cpu_flags
 ) RETURNING id as build_id, env_id as template_id;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Capture and store CPU metadata (architecture, family, model, model name, flags) when pausing a sandbox and creating a snapshot/build.
> 
> - **Orchestrator**:
>   - `packages/api/internal/orchestrator/pause_instance.go`: Read node `MachineInfo()` and include CPU fields in `UpsertSnapshotParams` (`CpuArchitecture`, `CpuFamily`, `CpuModel`, `CpuModelName`, `CpuFlags`).
> - **Database**:
>   - Add CPU columns to `env_builds`: `cpu_architecture`, `cpu_family`, `cpu_model`, `cpu_model_name`, `cpu_flags` in snapshot/build insert.
>   - Update SQL and generated code:
>     - `packages/db/queries/snapshots/create_new_snapshot.sql`: extend insert to include CPU fields.
>     - `packages/db/queries/create_new_snapshot.sql.go`: adjust query parameter order; extend `UpsertSnapshotParams` with CPU fields and pass them to insert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e87785f37ea7961b2cbcbb973f9cacf303170481. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->