### PR TITLE
Refactor fd exit

### DIFF
--- a/packages/orchestrator/internal/sandbox/uffd/fdexit/fdexit.go
+++ b/packages/orchestrator/internal/sandbox/uffd/fdexit/fdexit.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 )
 
+var ErrFdExit = errors.New("fd exit signal")
+
 // FdExit is a wrapper around a pipe that allows to signal the exit of the uffd.
 type FdExit struct {
 	r    *os.File

--- a/packages/orchestrator/internal/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/internal/sandbox/uffd/uffd.go
@@ -162,6 +162,10 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string) error {
 		ctx,
 		u.fdExit,
 	)
+	if errors.Is(err, fdexit.ErrFdExit) {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed handling uffd: %w", err)
 	}

--- a/packages/orchestrator/internal/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/internal/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -184,6 +184,10 @@ func TestHelperServingProcess(t *testing.T) {
 	}
 
 	err := crossProcessServe()
+	if errors.Is(err, fdexit.ErrFdExit) {
+		os.Exit(2)
+	}
+
 	if err != nil {
 		fmt.Println("exit serving process", err)
 		os.Exit(1)
@@ -289,6 +293,14 @@ func crossProcessServe() error {
 		}()
 
 		serverErr := uffd.Serve(ctx, fdExit)
+		if errors.Is(serverErr, fdexit.ErrFdExit) {
+			err := fmt.Errorf("serving finished via fd exit: %w", serverErr)
+
+			cancel(err)
+
+			return
+		}
+
 		if serverErr != nil {
 			msg := fmt.Errorf("error serving: %w", serverErr)
 

--- a/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -113,7 +113,7 @@ outerLoop:
 				return fmt.Errorf("failed to handle uffd: %w", errMsg)
 			}
 
-			return nil
+			return fdexit.ErrFdExit
 		}
 
 		uffdFd := pollFds[0]


### PR DESCRIPTION
This is necessary to properly handle more complicated uffd tests.