### PR TITLE
Add project id to logs, traces and metrics

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -290,13 +290,13 @@ processors:
       # We have to set the service instance here as it's necessary to set it as a datapoint attribute
       - set(datapoint.attributes["service.instance.id"], resource.attributes["host.name"])
       - set(datapoint.attributes["deployment.environment"], resource.attributes["cloud.account.id"])
+      - delete_key(datapoint.attributes, "datacenter")
       - delete_key(datapoint.attributes, "instance")
       - delete_key(datapoint.attributes, "node_id")
       - delete_key(datapoint.attributes, "node_scheduling_eligibility")
       - delete_key(datapoint.attributes, "node_class")
       - delete_key(datapoint.attributes, "node_status")
       - delete_key(datapoint.attributes, "service_name")
-      - delete_key(datapoint.attributes, "host.name")
 
   filter/rpc_duration_only:
     metrics:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables `cloud.account.id` detection and propagates it (and `service.instance.id`) into metrics, traces, and logs via new transform/resource processors, with pipelines updated accordingly.
> 
> - **OTel processors**:
>   - **`resourcedetection` (GCP)**: enable `cloud.account.id`; disable `host.type`, `host.id`, `gcp.gce.instance.name`; add disabled `gcp.gce.instance_group_manager.*` attrs.
>   - **`transform/set-name`**: set datapoint attributes `service.instance.id` from `host.name` and `deployment.environment` from `cloud.account.id`; remove several redundant datapoint keys.
>   - **`resource/set_attributes`**: upsert `deployment.environment` from `cloud.account.id` and `service.instance.id` from `host.name`; delete `cloud.account.id`, `host.name`, and other nonessential attributes.
>   - Add `resource/remove_instance` processor (deletes `service.instance.id`).
> - **Pipelines**:
>   - `metrics/host`: add `resourcedetection` and `transform/set-name`.
>   - `traces` and `logs`: add `resourcedetection` and `resource/set_attributes`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75c278e2dede5e996e0c894b1b7334545dbcb857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->