### PR TITLE
Implement snapshot editor command execution

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/client.go
+++ b/packages/orchestrator/internal/sandbox/fc/client.go
@@ -3,6 +3,7 @@ package fc
 import (
 	"context"
 	"fmt"
+	"os/exec"
 
 	"github.com/firecracker-microvm/firecracker-go-sdk"
 	"github.com/go-openapi/strfmt"


### PR DESCRIPTION
Added a function to run snapshot editor commands before loading snapshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Executes `snapshot-editor tsc set` on the VM state file before loading a snapshot, with telemetry and error handling.
> 
> - **Orchestrator (Firecracker client `packages/orchestrator/internal/sandbox/fc/client.go`)**:
>   - **Snapshot load flow**: Invoke `runSnapshotEditor` before `LoadSnapshot` to modify the vmstate (`snapfile.Path()`).
>   - **New helper**: Add `runSnapshotEditor(ctx, vmstatePath)` which runs `/usr/local/bin/snapshot-editor tsc set --vmstate-path <path>` via `exec.CommandContext`, capturing output and reporting telemetry.
>   - **Imports**: Add `os/exec` for command execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 754b99b5dd9649641dafacdea43443f84c5cca19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->