### PR TITLE
Remove Consul from load balancer

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -449,8 +449,8 @@ resource "google_compute_firewall" "default-hc" {
   dynamic "allow" {
     # TODO: Revert to for_each = local.health_checked_backends in [ENG-3386]
     for_each = {
-      for k,v in local.health_checked_backends :
-      k => v if k != "consul"   # skip consul
+      for k, v in local.health_checked_backends :
+      k => v if k != "consul" # skip consul
     }
 
     content {


### PR DESCRIPTION
There'll be second part removing the backend + firewall later as there's a dependency issue when deleting everything and also there could be a moment where the consul is accessible to the internet, if the firewall would be removed first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes Consul from the URL map (host rules and path matcher) and excludes its health checks from the firewall while leaving the backend defined temporarily.
> 
> - **GCP Load Balancer (Terraform in `iac/provider-gcp/nomad-cluster/network/main.tf`)**:
>   - Remove `consul` host rule and `consul-paths` path matcher from `google_compute_url_map.orch_map`.
>   - Firewall health-check rule: change dynamic `allow` to exclude `"consul"` from `local.health_checked_backends`.
>   - Add TODOs indicating temporary exclusion and future removal of `consul`.
> - **Backends**:
>   - Keep `backends.consul` definition intact (marked TODO to remove later).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ec85517720c7e51c581cff111822f40fcd8b5f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->