### PR TITLE
fix: add python to tool versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
+python 3.13
 gcloud 534.0.0
 golang 1.25.4
 golangci-lint 2.4.0


### PR DESCRIPTION
Add Python to tool versions as newer Python version are incompatible with the gcloud CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pin Python 3.13 in `.tool-versions` to align tooling versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50fe110dda6f8674c57d1094c5eb5b5574783899. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->