### PR TITLE
feat(iac): make boot disk type and cache disk count configurable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -52,6 +52,15 @@ CLICKHOUSE_MACHINE_TYPE=
 # e.g. 2
 CLICKHOUSE_CLUSTER_SIZE=
 
+# Boot disk types (pd-ssd, pd-balanced, pd-standard, pd-extreme)
+# Default: pd-ssd
+CLIENT_BOOT_DISK_TYPE=
+BUILD_BOOT_DISK_TYPE=
+API_BOOT_DISK_TYPE=
+SERVER_BOOT_DISK_TYPE=
+CLICKHOUSE_BOOT_DISK_TYPE=
+LOKI_BOOT_DISK_TYPE=
+
 # your domain or subdomain name, eg great-innovations.dev, e2b.great-innovations.dev
 DOMAIN_NAME=
 

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -69,7 +69,13 @@ tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
 	$(call tfvar, BUILD_CLUSTER_CACHE_DISK_TYPE) \
 	$(call tfvar, CLIENT_CLUSTER_CACHE_DISK_TYPE) \
 	$(call tfvar, MIN_CPU_PLATFORM) \
-	$(call tfvar, REMOTE_REPOSITORY_ENABLED)
+	$(call tfvar, REMOTE_REPOSITORY_ENABLED) \
+	$(call tfvar, CLIENT_BOOT_DISK_TYPE) \
+	$(call tfvar, BUILD_BOOT_DISK_TYPE) \
+	$(call tfvar, API_BOOT_DISK_TYPE) \
+	$(call tfvar, SERVER_BOOT_DISK_TYPE) \
+	$(call tfvar, CLICKHOUSE_BOOT_DISK_TYPE) \
+	$(call tfvar, LOKI_BOOT_DISK_TYPE)
 
 .PHONY: init
 init:

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -135,6 +135,14 @@ module "cluster" {
   prefix = var.prefix
 
   min_cpu_platform = var.min_cpu_platform
+
+  # Boot disk types
+  client_boot_disk_type     = var.client_boot_disk_type
+  build_boot_disk_type      = var.build_boot_disk_type
+  api_boot_disk_type        = var.api_boot_disk_type
+  server_boot_disk_type     = var.server_boot_disk_type
+  clickhouse_boot_disk_type = var.clickhouse_boot_disk_type
+  loki_boot_disk_type       = var.loki_boot_disk_type
 }
 
 module "nomad" {

--- a/iac/provider-gcp/nomad-cluster/nodepool-api.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-api.tf
@@ -144,7 +144,7 @@ resource "google_compute_instance_template" "api" {
     boot         = true
     source_image = data.google_compute_image.api_source_image.id
     disk_size_gb = 200
-    disk_type    = "pd-ssd"
+    disk_type    = var.api_boot_disk_type
   }
 
   network_interface {

--- a/iac/provider-gcp/nomad-cluster/nodepool-build.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-build.tf
@@ -117,7 +117,7 @@ resource "google_compute_instance_template" "build" {
     boot         = true
     source_image = data.google_compute_image.build_source_image.id
     disk_size_gb = var.build_cluster_root_disk_size_gb
-    disk_type    = "pd-ssd"
+    disk_type    = var.build_boot_disk_type
   }
 
   dynamic "disk" {

--- a/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
@@ -135,7 +135,7 @@ resource "google_compute_instance_template" "clickhouse" {
     boot         = true
     source_image = data.google_compute_image.clickhouse_source_image.id
     disk_size_gb = 200
-    disk_type    = "pd-ssd"
+    disk_type    = var.clickhouse_boot_disk_type
   }
 
   network_interface {

--- a/iac/provider-gcp/nomad-cluster/nodepool-client.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-client.tf
@@ -146,7 +146,7 @@ resource "google_compute_instance_template" "client" {
     boot         = true
     source_image = data.google_compute_image.client_source_image.id
     disk_size_gb = 300
-    disk_type    = "pd-ssd"
+    disk_type    = var.client_boot_disk_type
   }
 
   dynamic "disk" {

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -103,7 +103,7 @@ resource "google_compute_instance_template" "server" {
     boot         = true
     source_image = data.google_compute_image.server_source_image.self_link
     disk_size_gb = 20
-    disk_type    = "pd-ssd"
+    disk_type    = var.server_boot_disk_type
   }
 
   network_interface {

--- a/iac/provider-gcp/nomad-cluster/nodepool-loki.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-loki.tf
@@ -106,7 +106,7 @@ resource "google_compute_instance_template" "loki" {
     boot         = true
     source_image = data.google_compute_image.loki_source_image.id
     disk_size_gb = 200
-    disk_type    = "pd-ssd"
+    disk_type    = var.loki_boot_disk_type
   }
 
   network_interface {

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -343,3 +343,34 @@ variable "client_cluster_cache_disk_count" {
     error_message = "Must include at least 1 client cluster cache disk"
   }
 }
+
+# Boot disk type variables
+variable "client_boot_disk_type" {
+  description = "The GCE boot disk type for the client (orchestrator) machines."
+  type        = string
+}
+
+variable "build_boot_disk_type" {
+  description = "The GCE boot disk type for the build machines."
+  type        = string
+}
+
+variable "api_boot_disk_type" {
+  description = "The GCE boot disk type for the API machines."
+  type        = string
+}
+
+variable "server_boot_disk_type" {
+  description = "The GCE boot disk type for the control server machines."
+  type        = string
+}
+
+variable "clickhouse_boot_disk_type" {
+  description = "The GCE boot disk type for the ClickHouse machines."
+  type        = string
+}
+
+variable "loki_boot_disk_type" {
+  description = "The GCE boot disk type for the Loki machines."
+  type        = string
+}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -511,3 +511,40 @@ variable "client_cluster_cache_disk_count" {
   description = "The number of 375 GB NVME disks to raid together for storing sandbox files."
   default     = 3
 }
+
+# Boot disk type variables
+variable "client_boot_disk_type" {
+  description = "The GCE boot disk type for the client (orchestrator) machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "build_boot_disk_type" {
+  description = "The GCE boot disk type for the build machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "api_boot_disk_type" {
+  description = "The GCE boot disk type for the API machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "server_boot_disk_type" {
+  description = "The GCE boot disk type for the control server machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "clickhouse_boot_disk_type" {
+  description = "The GCE boot disk type for the ClickHouse machines."
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "loki_boot_disk_type" {
+  description = "The GCE boot disk type for the Loki machines."
+  type        = string
+  default     = "pd-ssd"
+}


### PR DESCRIPTION
## Motivation

Default configurations are hardcoded and may be overkill for staging/dev environments. Making disk type configurable allows:

- Cost optimization by using `pd-balanced` instead of `pd-ssd` (~40% savings on boot disks)
- Flexibility to adjust configurations per environment without code changes

## Summary

- Add configurable boot disk type for all node pools (Client, Build, API, Server, ClickHouse, Loki)
- Add environment variables for cache disk count configuration

Thanks for reviewing! Happy to address any feedback or questions.