### PR TITLE
Return otelcol metrics

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -221,6 +221,7 @@ processors:
           - "vault.*"
           - "client_proxy.*"
           - "Click*"
+          - "otelcol.*"
           - "pgxpool.*"
 
   filter/only_client_allocs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds "otelcol.*" to the `filter/otlp` include list to emit otel-collector metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcae12280e23730f91ef32fe954131db76c024f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->