### PR TITLE
feat: add more host metrics

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -157,6 +157,7 @@ receivers:
 
       # entirely disabled, so we omit the module
       process:
+        mute_process_all_errors: true
         metrics:
           process.cpu.time:
             enabled: false


### PR DESCRIPTION
Add metrics per host for:
- file descriptors
- context switches
- threads count

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables process metrics and aggregates them per node into host-level metrics for open file descriptors, context switches, and thread count.
> 
> - **Observability (otel-collector)** in `iac/provider-gcp/nomad/configs/otel-collector.yaml`:
>   - **Receivers**:
>     - Enable `process` receiver (with `mute_process_all_errors: true`) and collect selected metrics: `process.open_file_descriptors`, `process.context_switches`, `process.threads`.
>   - **Processors**:
>     - Add `metricstransform/aggregate_process_metrics` to rename and aggregate per `node.id`:
>       - `process.open_file_descriptors` → `system.open_file_descriptors` (sum)
>       - `process.context_switches` → `system.context_switches` (sum)
>       - `process.threads` → `system.threads` (sum)
>   - **Pipelines**:
>     - Update `metrics/host` to include `metricstransform/aggregate_process_metrics` alongside existing processors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e588b2a92557471074bc358c057cc5bee07b3384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->