### PR TITLE
Remove Docker reverse proxy from build instance group

### DIFF
--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -114,12 +114,10 @@ module "network" {
   domain_name               = var.domain_name
   additional_domains        = var.additional_domains
 
-  client_instance_group    = google_compute_region_instance_group_manager.client_pool.instance_group
   client_proxy_port        = var.edge_proxy_port
   client_proxy_health_port = var.edge_api_port
 
   api_instance_group    = google_compute_instance_group_manager.api_pool.instance_group
-  build_instance_group  = google_compute_instance_group_manager.build_pool.instance_group
   server_instance_group = google_compute_instance_group_manager.server_pool.instance_group
 
   nomad_port = var.nomad_port

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -64,10 +64,8 @@ locals {
         request_path = var.docker_reverse_proxy_port.health_path
         port         = var.docker_reverse_proxy_port.port
       }
-      # TODO: (2025-10-01) - this should be only api instance group, but keeping this here for a migration period (at least until 2025-10-15)
       groups = [
         { group = var.api_instance_group },
-        { group = var.build_instance_group },
       ]
     }
     nomad = {

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -94,14 +94,6 @@ variable "api_instance_group" {
   type = string
 }
 
-variable "build_instance_group" {
-  type = string
-}
-
-variable "client_instance_group" {
-  type = string
-}
-
 variable "server_instance_group" {
   type = string
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes build/client instance group inputs and updates the docker-reverse-proxy backend to target only the API instance group.
> 
> - **Infrastructure (GCP Nomad cluster)**:
>   - **Load balancer**: `docker-reverse-proxy` backend now targets only `api_instance_group`.
>   - **Module interface cleanup**: remove `build_instance_group` and `client_instance_group` variables from `network/variables.tf`.
>   - **Wiring**: stop passing removed instance groups in `nomad-cluster/main.tf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f5be55df74cd7c235f0c6bf1cc93a19b14c2dd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->