### PR TITLE
fix: process otel scraping grouping

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -156,6 +156,16 @@ receivers:
             enabled: true
 
       # entirely disabled, so we omit the module
+      #system:
+      #  metrics:
+      #    system.uptime:
+      #      enabled: false
+
+  # Separate receiver for per-process metrics that will be aggregated
+  hostmetrics/process:
+    root_path: /hostfs
+    collection_interval: 30s
+    scrapers:
       process:
         mute_process_all_errors: true
         metrics:
@@ -188,12 +198,6 @@ receivers:
           process.uptime:
             enabled: false
 
-      # entirely disabled, so we omit the module
-      #system:
-      #  metrics:
-      #    system.uptime:
-      #      enabled: false
-
 processors:
   batch:
     timeout: 5s
@@ -204,6 +208,13 @@ processors:
 
   attributes/host_metrics_node:
     actions:
+      - key: node.id
+        value: $${NODE_ID}
+        action: insert
+
+  # Add node.id as a RESOURCE attribute (for groupbyattrs to work)
+  resource/host_metrics_node:
+    attributes:
       - key: node.id
         value: $${NODE_ID}
         action: insert
@@ -259,7 +270,7 @@ processors:
       - include: "process.open_file_descriptors"
         match_type: strict
         action: update
-        new_name: "system.open_file_descriptors"
+        new_name: "system.processes.open_file_descriptors"
         operations:
           - action: aggregate_labels
             label_set:
@@ -268,7 +279,7 @@ processors:
       - include: "process.context_switches"
         match_type: strict
         action: update
-        new_name: "system.context_switches"
+        new_name: "system.processes.context_switches"
         operations:
           - action: aggregate_labels
             label_set:
@@ -277,12 +288,48 @@ processors:
       - include: "process.threads"
         match_type: strict
         action: update
-        new_name: "system.threads"
+        new_name: "system.processes.threads"
         operations:
           - action: aggregate_labels
             label_set:
               - node.id
             aggregation_type: sum
+
+  groupbyattrs/process_metrics:
+    keys:
+      - node.id
+
+  # Delete process-specific resource attributes before grouping
+  # Without this, groupbyattrs won't merge resources properly
+  transform/delete_process_resource_attrs:
+    metric_statements:
+      - context: resource
+        statements:
+          - delete_key(attributes, "process.pid")
+          - delete_key(attributes, "process.parent_pid")
+          - delete_key(attributes, "process.executable.name")
+          - delete_key(attributes, "process.executable.path")
+          - delete_key(attributes, "process.command")
+          - delete_key(attributes, "process.command_line")
+          - delete_key(attributes, "process.owner")
+
+  # Normalize timestamps to allow aggregation across different processes
+  # Without this, each process has unique timestamps making them distinct time series
+  # Set all timestamps to 0 so they can be aggregated
+  transform/normalize_process_timestamps:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(start_time_unix_nano, 0)
+          - set(time_unix_nano, 0)
+
+  # Set real timestamps after aggregation so backends accept the metrics
+  transform/set_process_timestamps:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(start_time_unix_nano, UnixNano(Now()))
+          - set(time_unix_nano, UnixNano(Now()))
 
   resourcedetection:
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
@@ -376,6 +423,7 @@ extensions:
 exporters:
   debug:
     verbosity: detailed
+    use_internal_logger: false
   otlphttp/grafana_cloud:
     # https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter
     endpoint: "${grafana_otlp_url}/otlp"
@@ -446,7 +494,23 @@ service:
       processors:
         - attributes/host_metrics_node
         - metricstransform/single_cpu
+        - resourcedetection
+        - transform/set-name
+        - batch
+      exporters:
+        - otlphttp/grafana_cloud
+    # Dedicated pipeline for per-process metrics aggregated by node
+    metrics/host_process:
+      receivers:
+        - hostmetrics/process
+      processors:
+        - resource/host_metrics_node
+        - transform/delete_process_resource_attrs
+        - groupbyattrs/process_metrics
+        - attributes/host_metrics_node
+        - transform/normalize_process_timestamps
         - metricstransform/aggregate_process_metrics
+        - transform/set_process_timestamps
         - resourcedetection
         - transform/set-name
         - batch


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aggregates per-process metrics at the node level via a new `hostmetrics/process` receiver and processors to normalize, group, and rename metrics to `system.processes.*`, with a dedicated `metrics/host_process` pipeline and related resource tweaks.
> 
> - **Metrics processing**
>   - Add `hostmetrics/process` receiver for per-process scraping.
>   - Introduce processors: `resource/host_metrics_node`, `transform/delete_process_resource_attrs`, `groupbyattrs/process_metrics`, `transform/normalize_process_timestamps`, `metricstransform/aggregate_process_metrics` (renames to `system.processes.*`), `transform/set_process_timestamps`.
>   - Add `resource/host_metrics_node` to insert `node.id` as a resource attribute.
> - **Pipelines**
>   - New `service.pipelines.metrics/host_process` pipeline using the new receiver and processors; exports to `otlphttp/grafana_cloud`.
>   - `service.pipelines.metrics/host` now includes `resourcedetection`, `transform/set-name`, and `batch` before export.
> - **Exporters/other**
>   - `exporters.debug`: set `use_internal_logger: false`.
>   - Comment cleanups and minor config reordering for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2846c26844bcd0e83d577cf232b762f8305ae02c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->