### PR TITLE
Fix the build

### DIFF
--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -84,7 +84,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 		acquireCtx, acquireCancel := context.WithTimeout(ctx, acquireTimeout)
 		defer acquireCancel()
 
-		err = s.startingSandboxes.Acquire(acquireCtx, 1)
+		err := s.startingSandboxes.Acquire(acquireCtx, 1)
 		if err != nil {
 			telemetry.ReportEvent(ctx, "too many resuming sandboxes on node")
 


### PR DESCRIPTION
Too many merged stale PRs broke something

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes build by using short variable declaration for `err` in `Create` when acquiring `startingSandboxes` for snapshot resumes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 799198f87fc65408bce5b9db3a9a720deb9990fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->