### PR TITLE
Trim spaces for local-cluster empty envs so in code assumptions are correct

### DIFF
--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -86,11 +86,11 @@ resource "nomad_job" "api" {
     port_number                    = var.api_port.port
     api_docker_image               = data.google_artifact_registry_docker_image.api_image.self_link
     postgres_connection_string     = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
-    supabase_jwt_secrets           = data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data
-    posthog_api_key                = data.google_secret_manager_secret_version.posthog_api_key.secret_data
+    supabase_jwt_secrets           = trimspace(data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data)
+    posthog_api_key                = trimspace(data.google_secret_manager_secret_version.posthog_api_key.secret_data)
     environment                    = var.environment
-    analytics_collector_host       = data.google_secret_manager_secret_version.analytics_collector_host.secret_data
-    analytics_collector_api_token  = data.google_secret_manager_secret_version.analytics_collector_api_token.secret_data
+    analytics_collector_host       = trimspace(data.google_secret_manager_secret_version.analytics_collector_host.secret_data)
+    analytics_collector_api_token  = trimspace(data.google_secret_manager_secret_version.analytics_collector_api_token.secret_data)
     otel_tracing_print             = var.otel_tracing_print
     nomad_acl_token                = var.nomad_acl_token_secret
     admin_token                    = var.api_admin_token


### PR DESCRIPTION
The analytics collector was initialized because `if host == ""` was false, since the provided env was not trimmed.
This caused errors as the collector tried to connect to the host with whitespace instead of the address.