### PR TITLE
remove processes metrics tracking

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -161,42 +161,37 @@ receivers:
       #    system.uptime:
       #      enabled: false
 
-  # Separate receiver for per-process metrics that will be aggregated
-  hostmetrics/process:
-    root_path: /hostfs
-    collection_interval: 30s
-    scrapers:
-      process:
-        mute_process_all_errors: true
-        metrics:
-          process.cpu.time:
-            enabled: false
-          process.disk.io:
-            enabled: false
-          process.memory.usage:
-            enabled: false
-          process.memory.virtual:
-            enabled: false
-          process.context_switches:
-            enabled: true
-          process.cpu.utilization:
-            enabled: false
-          process.disk.operations:
-            enabled: false
-          process.handles:
-            enabled: false
-          process.memory.utilization:
-            enabled: false
-          process.open_file_descriptors:
-            enabled: true
-          process.paging.faults:
-            enabled: false
-          process.signals_pending:
-            enabled: false
-          process.threads:
-            enabled: true
-          process.uptime:
-            enabled: false
+      # process:
+      #   mute_process_all_errors: true
+      #   metrics:
+      #     process.cpu.time:
+      #       enabled: false
+      #     process.disk.io:
+      #       enabled: false
+      #     process.memory.usage:
+      #       enabled: false
+      #     process.memory.virtual:
+      #       enabled: false
+      #     process.context_switches:
+      #       enabled: true
+      #     process.cpu.utilization:
+      #       enabled: false
+      #     process.disk.operations:
+      #       enabled: false
+      #     process.handles:
+      #       enabled: false
+      #     process.memory.utilization:
+      #       enabled: false
+      #     process.open_file_descriptors:
+      #       enabled: false
+      #     process.paging.faults:
+      #       enabled: false
+      #     process.signals_pending:
+      #       enabled: false
+      #     process.threads:
+      #       enabled: false
+      #     process.uptime:
+      #       enabled: false
 
 processors:
   batch:
@@ -208,13 +203,6 @@ processors:
 
   attributes/host_metrics_node:
     actions:
-      - key: node.id
-        value: $${NODE_ID}
-        action: insert
-
-  # Add node.id as a RESOURCE attribute (for groupbyattrs to work)
-  resource/host_metrics_node:
-    attributes:
       - key: node.id
         value: $${NODE_ID}
         action: insert
@@ -264,72 +252,6 @@ processors:
               - node.id
               - state
             aggregation_type: sum
-
-  metricstransform/aggregate_process_metrics:
-    transforms:
-      - include: "process.open_file_descriptors"
-        match_type: strict
-        action: update
-        new_name: "system.processes.open_file_descriptors"
-        operations:
-          - action: aggregate_labels
-            label_set:
-              - node.id
-            aggregation_type: sum
-      - include: "process.context_switches"
-        match_type: strict
-        action: update
-        new_name: "system.processes.context_switches"
-        operations:
-          - action: aggregate_labels
-            label_set:
-              - node.id
-            aggregation_type: sum
-      - include: "process.threads"
-        match_type: strict
-        action: update
-        new_name: "system.processes.threads"
-        operations:
-          - action: aggregate_labels
-            label_set:
-              - node.id
-            aggregation_type: sum
-
-  groupbyattrs/process_metrics:
-    keys:
-      - node.id
-
-  # Delete process-specific resource attributes before grouping
-  # Without this, groupbyattrs won't merge resources properly
-  transform/delete_process_resource_attrs:
-    metric_statements:
-      - context: resource
-        statements:
-          - delete_key(attributes, "process.pid")
-          - delete_key(attributes, "process.parent_pid")
-          - delete_key(attributes, "process.executable.name")
-          - delete_key(attributes, "process.executable.path")
-          - delete_key(attributes, "process.command")
-          - delete_key(attributes, "process.command_line")
-          - delete_key(attributes, "process.owner")
-
-  # Normalize timestamps to allow aggregation across different processes
-  # Without this, each process has unique timestamps making them distinct time series
-  # Set all timestamps to 0 so they can be aggregated
-  transform/normalize_process_timestamps:
-    metric_statements:
-      - context: datapoint
-        statements:
-          - set(start_time_unix_nano, 0)
-          - set(time_unix_nano, 0)
-
-  # Set real timestamps after aggregation so backends accept the metrics
-  transform/set_process_timestamps:
-    metric_statements:
-      - context: datapoint
-        statements:
-          - set(start_time_unix_nano, UnixNano(Now()))
-          - set(time_unix_nano, UnixNano(Now()))
 
   resourcedetection:
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
@@ -494,23 +416,6 @@ service:
       processors:
         - attributes/host_metrics_node
         - metricstransform/single_cpu
-        - resourcedetection
-        - transform/set-name
-        - batch
-      exporters:
-        - otlphttp/grafana_cloud
-    # Dedicated pipeline for per-process metrics aggregated by node
-    metrics/host_process:
-      receivers:
-        - hostmetrics/process
-      processors:
-        - resource/host_metrics_node
-        - transform/delete_process_resource_attrs
-        - groupbyattrs/process_metrics
-        - attributes/host_metrics_node
-        - transform/normalize_process_timestamps
-        - metricstransform/aggregate_process_metrics
-        - transform/set_process_timestamps
         - resourcedetection
         - transform/set-name
         - batch


### PR DESCRIPTION
Remove the following metrics about processes on the host:
- system.processes.open_file_descriptors
- system.processes.context_switches
- system.processes.threads

Because the OTEL Collector CPU usage to collect them is twice as high compared to the current load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables per-process metrics and deletes related processors/pipeline, retaining only host-level metrics.
> 
> - **OTel Collector config (`iac/provider-gcp/nomad/configs/otel-collector.yaml`)**:
>   - **Disable per-process collection**:
>     - Remove `hostmetrics/process` receiver.
>     - Comment out `process` scraper configuration.
>   - **Processors cleanup**:
>     - Remove process-focused processors: `metricstransform/aggregate_process_metrics`, `groupbyattrs/process_metrics`, `transform/delete_process_resource_attrs`, `transform/normalize_process_timestamps`, `transform/set_process_timestamps`, and `resource/host_metrics_node` (where used for process flow).
>   - **Pipelines**:
>     - Delete `service.pipelines.metrics/host_process` pipeline.
>     - Keep host-level pipelines (e.g., `metrics/host`) and existing transforms (e.g., `metricstransform/single_cpu`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73cea9e6089e46cb0eec93f41cf60602d0be2e73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->