### PR TITLE
Added: explicit make terraform target to run ARGS

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -118,6 +118,12 @@ plan:
 	@ $(TF) fmt -recursive
 	@ $(tf_vars) $(TF) plan -out=.tfplan.$(ENV) -compact-warnings
 
+.PHONY: terraform
+terraform:
+	@ printf "Terraform command for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
+	@ $(TF) fmt -recursive
+	@ $(tf_vars) $(TF) $(ARGS)
+
 # Deploy all jobs in Nomad
 .PHONY: plan-only-jobs
 plan-only-jobs:


### PR DESCRIPTION
@djeebus-authored change that allows to run terraform commands with `make terraform ARGS=<command>`