### PR TITLE
fix: created_at population and snapshot deletion

### DIFF
--- a/packages/db/migrations/20251222113257_fix_snapshots_created_at_and_cascade.sql
+++ b/packages/db/migrations/20251222113257_fix_snapshots_created_at_and_cascade.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Fix 1: Set DEFAULT NOW() on created_at column so it auto-populates on insert
+ALTER TABLE "public"."snapshots"
+    ALTER COLUMN "created_at" SET DEFAULT NOW();
+
+-- Fix 2: Ensure the env_id foreign key has ON DELETE CASCADE
+-- First, drop the existing constraint if it exists
+ALTER TABLE "public"."snapshots"
+    DROP CONSTRAINT IF EXISTS "snapshots_envs_env_id";
+
+-- Clean up orphaned snapshots: delete rows where env_id doesn't exist in envs table
+-- This includes empty string env_ids and references to deleted envs
+DELETE FROM "public"."snapshots"
+WHERE env_id NOT IN (SELECT id FROM "public"."envs");
+
+-- Now recreate the constraint with ON DELETE CASCADE
+ALTER TABLE "public"."snapshots"
+    ADD CONSTRAINT "snapshots_envs_env_id"
+        FOREIGN KEY ("env_id")
+            REFERENCES "public"."envs" ("id")
+            ON UPDATE NO ACTION
+            ON DELETE CASCADE;
+
+COMMIT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE "public"."snapshots"
+    ALTER COLUMN "created_at" DROP DEFAULT;
+-- Note: We don't revert the CASCADE constraint as it was likely the intended behavior
+-- +goose StatementEnd
+


### PR DESCRIPTION
Fix snapshots missing created_at field (defaulting to null) and snapshots database entries not being deleted on sandbox kill (deletion).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set default NOW() for `snapshots.created_at` and enforce cascading deletion via `env_id` FK, with tests validating behavior.
> 
> - **Database Migration**:
>   - Set `DEFAULT NOW()` on `public.snapshots.created_at`.
>   - Recreate FK `snapshots_envs_env_id` with `ON DELETE CASCADE` (drops existing if present) and remove orphaned rows.
> - **Tests** (`packages/db/tests/snapshots/upsert_snapshot_test.go`):
>   - Add helpers `getSnapshotCreatedAt` and `snapshotExists`.
>   - Add tests for auto-populated `created_at` and cascade deletion when related `envs` row is removed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e896e300913b3197212d0c549c2ae522f3c7aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->