### PR TITLE
fix: correct ipv6 socat handling

### DIFF
--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -56,7 +56,7 @@ func NewForwarder(
 		"port-forwarder",
 		// We only want to forward ports that are actively listening on localhost.
 		&ScannerFilter{
-			IPs:   []string{"127.0.0.1", "localhost", "::1", "::"},
+			IPs:   []string{"127.0.0.1", "localhost", "::1"},
 			State: "LISTEN",
 		},
 	)


### PR DESCRIPTION
The "::" is equivalent to "0.0.0.0" in ipv4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Narrows port-forward scanning to true loopback addresses only.
> 
> - In `forward.go`, updates `ScannerFilter.IPs` to remove `"::"`, keeping only `"127.0.0.1"`, `"localhost"`, and `"::1"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75600600d0c0e228b5c379694f6c60e5e5bc6111. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->