### PR TITLE
Refactor build and client cluster to use json config

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -14,8 +14,8 @@ $(if $(value $(strip $(1))), TF_VAR_$(shell echo $(strip $(1)) | tr A-Z a-z)=$($
 endef
 
 tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
-	$(call tfvar, BUILD_CLUSTERS_CONFIG_JSON) \
-	$(call tfvar, CLIENT_CLUSTERS_CONFIG_JSON) \
+	$(call tfvar, BUILD_CLUSTERS_CONFIG) \
+	$(call tfvar, CLIENT_CLUSTERS_CONFIG) \
 	$(call tfvar, API_MACHINE_TYPE) \
 	$(call tfvar, API_CLUSTER_SIZE) \
 	$(call tfvar, API_USE_NAT) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -39,12 +39,10 @@ data "google_secret_manager_secret_version" "routing_domains" {
 }
 
 locals {
-  additional_domains     = nonsensitive(jsondecode(data.google_secret_manager_secret_version.routing_domains.secret_data))
-  build_clusters_config  = jsondecode(var.build_clusters_config_json)
-  client_clusters_config = jsondecode(var.client_clusters_config_json)
+  additional_domains = nonsensitive(jsondecode(data.google_secret_manager_secret_version.routing_domains.secret_data))
 
   // Check if all clusters has size greater than 1
-  template_manages_clusters_size_gt_1 = alltrue([for c in local.build_clusters_config : c.cluster_size > 1])
+  template_manages_clusters_size_gt_1 = alltrue([for c in var.build_clusters_config : c.cluster_size > 1])
 }
 
 module "init" {
@@ -71,8 +69,8 @@ module "cluster" {
   gcp_zone                         = var.gcp_zone
   google_service_account_key       = module.init.google_service_account_key
 
-  build_clusters_config  = local.build_clusters_config
-  client_clusters_config = local.client_clusters_config
+  build_clusters_config  = var.build_clusters_config
+  client_clusters_config = var.client_clusters_config
 
   api_cluster_size        = var.api_cluster_size
   clickhouse_cluster_size = var.clickhouse_cluster_size

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -434,8 +434,33 @@ variable "remote_repository_enabled" {
   default     = false
 }
 
-variable "client_clusters_config_json" {
-  type        = string
+variable "client_clusters_config" {
+  type = list(object({
+    cluster_size = number
+
+    machine = object({
+      type             = string
+      min_cpu_platform = string
+    })
+
+    autoscaler = object({
+      size_max      = number
+      memory_target = number
+      cpu_target    = number
+    })
+
+    boot_disk = object({
+      disk_type = string
+      size_gb   = number
+    })
+
+    cache_disks = object({
+      disk_type = string
+      size_gb   = number
+      count     = number
+    })
+  }))
+
   description = <<EOT
 JSON configuration for the client clusters.
 Format: [
@@ -462,14 +487,34 @@ Format: [
   }
 ]
 EOT
-  validation {
-    condition     = can(jsondecode(var.client_clusters_config_json))
-    error_message = "client_cluster_config_json must be a valid JSON"
-  }
 }
 
-variable "build_clusters_config_json" {
-  type        = string
+variable "build_clusters_config" {
+  type = list(object({
+    cluster_size = number
+
+    machine = object({
+      type             = string
+      min_cpu_platform = string
+    })
+
+    autoscaler = object({
+      size_max      = number
+      memory_target = number
+      cpu_target    = number
+    })
+
+    boot_disk = object({
+      disk_type = string
+      size_gb   = number
+    })
+
+    cache_disks = object({
+      disk_type = string
+      size_gb   = string
+      count     = number
+    })
+  }))
   description = <<EOT
 JSON configuration for the build cluster.
 Format:
@@ -497,10 +542,6 @@ Format:
   }
 ]
 EOT
-  validation {
-    condition     = can(jsondecode(var.build_clusters_config_json))
-    error_message = "build_clusters_config_json must be a valid JSON"
-  }
 }
 
 # Boot disk type variables


### PR DESCRIPTION
This helps simplify things a little bit, and provides more explicit validation and documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor: typed cluster configs**
> 
> - Replace `*_clusters_config_json` with strongly typed `list(object)` vars: `build_clusters_config` and `client_clusters_config` in `variables.tf`, including embedded schemas and docs
> - Update `main.tf` to use typed vars directly (remove `jsondecode` locals) and compute `template_manages_clusters_size_gt_1` from `var.build_clusters_config`
> - Pass typed configs to the `cluster` module instead of locals; no changes to other module inputs
> - Makefile: switch TF_VAR export from `BUILD/CLIENT_CLUSTERS_CONFIG_JSON` to `BUILD/CLIENT_CLUSTERS_CONFIG`; keep `gcloud application-default login`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fda78b76d6852b1bf5e18ea60166a34a3dafa2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->