### PR TITLE
Load environment variables using `set -a`

### DIFF
--- a/.github/actions/deploy-setup/action.yml
+++ b/.github/actions/deploy-setup/action.yml
@@ -28,7 +28,11 @@ runs:
       run: |
         echo ${{ inputs.environment }} > .last_used_env
         cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > .env.${{ inputs.environment }}
-        export $(cat ".env.${{ inputs.environment }}" | xargs)
+
+        # Load environment variables from .env
+        set -a
+        . .env.${{ inputs.environment }}
+        set +a
 
         echo "GCP_REGION=${GCP_REGION}" >> $GITHUB_ENV
         echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the deploy setup action to source `.env` with `set -a` instead of exporting via `xargs`, ensuring variables from Infisical are loaded into the shell environment.
> 
> - Replaces `export $(cat .env.... | xargs)` with `set -a; . .env.${{ inputs.environment }}; set +a` in `deploy-setup/action.yml`
> - Downstream usage unchanged: selected vars are echoed to `$GITHUB_ENV` and used by GCP auth/Terraform steps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97ec07a060672d74b284642e4880d311d701e7c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->