### PR TITLE
Remove datacenters attribute from template-manager system job

### DIFF
--- a/iac/provider-gcp/nomad/jobs/template-manager.hcl
+++ b/iac/provider-gcp/nomad/jobs/template-manager.hcl
@@ -1,5 +1,4 @@
 job "template-manager-system" {
-  datacenters = ["${gcp_zone}"]
   type = "system"
   node_pool  = "${node_pool}"
   priority = 70


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes explicit datacenter targeting from the Nomad job.
> 
> - Deletes `datacenters = ["${gcp_zone}"]` from `iac/provider-gcp/nomad/jobs/template-manager.hcl`; all other job settings (system type, `node_pool`, priority, update stanza) remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 067892a723bb97acc1b05a6aede5d2bd226cf55b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->