### PR TITLE
fix: envd restart should ignore proxy pool removal

### DIFF
--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -213,7 +213,8 @@ func (lb *LayerExecutor) updateEnvdInSandbox(
 	// This might not be necessary if we don't use keepalives for the proxy.
 	err = lb.proxy.RemoveFromPool(sbx.Runtime.ExecutionID)
 	if err != nil {
-		return fmt.Errorf("failed to remove proxy from pool: %w", err)
+		// Errors here will be from forcefully closing the connections, so we can ignore them—they will at worst timeout on their own.
+		lb.logger.Warn(ctx, "errors when manually closing connections to sandbox after restarting envd", zap.Error(err))
 	}
 
 	lb.logger.Debug(

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -206,7 +206,7 @@ func (p *ProxyClient) resetAllConnections() error {
 
 	for _, conn := range p.activeConnections.Items() {
 		err := conn.Reset()
-		if err != nil {
+		if err != nil && !errors.Is(err, net.ErrClosed) {
 			errs = append(errs, err)
 		}
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves resilience around envd restarts by tolerating expected connection-close errors.
> 
> - Orchestrator: in `layer_executor.go`, `RemoveFromPool` errors after `systemctl restart envd` are no longer fatal—now logged as warnings instead of returning an error.
> - Proxy: in `proxy/pool/client.go`, `resetAllConnections` ignores `net.ErrClosed` when resetting tracked connections to avoid reporting benign errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7352906a5a41295b1cbb8f0f725a604217280247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->