### PR TITLE
Refactor `SetContext` to merge contexts instead of replacing

### DIFF
--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -30,7 +30,7 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 	team := c.Value(auth.TeamContextKey).(*types.Team)
 
 	// Build the context for feature flags
-	ctx = featureflags.SetContext(
+	ctx = featureflags.AddToContext(
 		ctx,
 		ldcontext.NewBuilder(sandboxID).
 			Kind(featureflags.SandboxKind).

--- a/packages/api/internal/handlers/sandboxes_list_metrics.go
+++ b/packages/api/internal/handlers/sandboxes_list_metrics.go
@@ -126,7 +126,7 @@ func (a *APIStore) GetSandboxesMetrics(c *gin.Context, params api.GetSandboxesMe
 	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "listed running instances with metrics", properties)
 
 	// Build the context for feature flags
-	ctx = featureflags.SetContext(
+	ctx = featureflags.AddToContext(
 		ctx,
 		ldcontext.NewBuilder(team.ID.String()).
 			Kind(featureflags.TeamKind).

--- a/packages/api/internal/middleware/launchdarkly.go
+++ b/packages/api/internal/middleware/launchdarkly.go
@@ -22,7 +22,7 @@ func InitLaunchDarklyContext(c *gin.Context) {
 
 	// store the context in ctx
 	ctx := c.Request.Context()
-	ctx = featureflags.SetContext(ctx, contexts...)
+	ctx = featureflags.AddToContext(ctx, contexts...)
 	c.Request = c.Request.WithContext(ctx)
 
 	// we're done, move on

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -59,7 +59,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	)
 
 	// setup launch darkly
-	ctx = featureflags.SetContext(
+	ctx = featureflags.AddToContext(
 		ctx,
 		ldcontext.NewBuilder(req.GetSandbox().GetSandboxId()).
 			Kind(featureflags.SandboxKind).
@@ -381,7 +381,7 @@ func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 	defer childSpan.End()
 
 	// setup launch darkly
-	ctx = featureflags.SetContext(
+	ctx = featureflags.AddToContext(
 		ctx,
 		ldcontext.NewBuilder(in.GetSandboxId()).
 			Kind(featureflags.SandboxKind).

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -116,7 +116,7 @@ func (b *Builder) Build(ctx context.Context, template storage.TemplateFiles, cfg
 	defer childSpan.End()
 
 	// setup launch darkly context
-	ctx = featureflags.SetContext(
+	ctx = featureflags.AddToContext(
 		ctx,
 		featureflags.TemplateContext(cfg.TemplateID),
 		featureflags.TeamContext(cfg.TeamID),

--- a/packages/shared/pkg/feature-flags/context.go
+++ b/packages/shared/pkg/feature-flags/context.go
@@ -8,7 +8,7 @@ import (
 
 type ctxKey struct{}
 
-func SetContext(ctx context.Context, contexts ...ldcontext.Context) context.Context {
+func AddToContext(ctx context.Context, contexts ...ldcontext.Context) context.Context {
 	if len(contexts) == 0 {
 		return ctx
 	}

--- a/packages/shared/pkg/feature-flags/context_test.go
+++ b/packages/shared/pkg/feature-flags/context_test.go
@@ -158,7 +158,7 @@ func newSet[T comparable](input ...T) set[T] {
 func TestSetContext(t *testing.T) {
 	t.Run("empty_contexts_returns_original_context", func(t *testing.T) {
 		ctx := context.Background()
-		result := SetContext(ctx)
+		result := AddToContext(ctx)
 
 		assert.Equal(t, ctx, result)
 		_, ok := getContext(result)
@@ -169,7 +169,7 @@ func TestSetContext(t *testing.T) {
 		ctx := context.Background()
 		teamCtx := TeamContext("team-123")
 
-		result := SetContext(ctx, teamCtx)
+		result := AddToContext(ctx, teamCtx)
 
 		embedded, ok := getContext(result)
 		assert.True(t, ok)
@@ -182,7 +182,7 @@ func TestSetContext(t *testing.T) {
 		teamCtx := TeamContext("team-123")
 		userCtx := UserContext("user-456")
 
-		result := SetContext(ctx, teamCtx, userCtx)
+		result := AddToContext(ctx, teamCtx, userCtx)
 
 		embedded, ok := getContext(result)
 		assert.True(t, ok)
@@ -197,10 +197,10 @@ func TestSetContext(t *testing.T) {
 		ctx := context.Background()
 
 		// First call adds team context
-		ctx = SetContext(ctx, TeamContext("team-123"))
+		ctx = AddToContext(ctx, TeamContext("team-123"))
 
 		// Second call adds user context - should merge, not replace
-		ctx = SetContext(ctx, UserContext("user-456"))
+		ctx = AddToContext(ctx, UserContext("user-456"))
 
 		embedded, ok := getContext(ctx)
 		assert.True(t, ok)
@@ -215,10 +215,10 @@ func TestSetContext(t *testing.T) {
 		ctx := context.Background()
 
 		// First call with team-123
-		ctx = SetContext(ctx, TeamContextWithName("team-123", "First Team"))
+		ctx = AddToContext(ctx, TeamContextWithName("team-123", "First Team"))
 
 		// Second call with different team - should override
-		ctx = SetContext(ctx, TeamContextWithName("team-456", "Second Team"))
+		ctx = AddToContext(ctx, TeamContextWithName("team-456", "Second Team"))
 
 		embedded, ok := getContext(ctx)
 		assert.True(t, ok)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Feature flags context handling refactor**
> 
> - Introduces `AddToContext` that merges provided LaunchDarkly `ldcontext.Context` values with any existing context in `ctx` (flattening multi-contexts, removing undefined, and ensuring later contexts of the same kind override earlier ones)
> - Changes merge order to prepend embedded context so newly added contexts take precedence
> - Replaces `SetContext` usages in API handlers (`sandbox_metrics.go`, `sandboxes_list_metrics.go`), middleware (`launchdarkly.go`), and orchestrator server (`sandboxes.go`)
> - Adds unit tests in `context_test.go` covering empty input, single/multiple contexts, sequential merges, and same-kind precedence
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3ce4e8c4916943fdc8cda12daf1be25e7a1375f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->