### PR TITLE
Fixed: clean-nfs-cache wrong sort order

### DIFF
--- a/packages/orchestrator/cmd/clean-nfs-cache/ex/clean.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/ex/clean.go
@@ -247,7 +247,7 @@ func (c *Cleaner) Clean(ctx context.Context) error {
 			del, reinsertBackToCache := c.splitBatch(batch)
 			c.reinsertCandidates(reinsertBackToCache)
 
-			if len(del) >= 0 {
+			if len(del) > 0 {
 				c.Info(ctx, "selected batch",
 					zap.Int("count", len(del)),
 					zap.Duration("oldest", time.Since(time.Unix(del[0].ATimeUnix, 0))),

--- a/packages/orchestrator/cmd/clean-nfs-cache/ex/clean_test.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/ex/clean_test.go
@@ -71,7 +71,7 @@ func TestCleanDeletesTwoFiles(t *testing.T) {
 
 			// file0 should be newest
 			ageMinutes := time.Duration(10*i) * time.Minute // ensure clear ordering
-			mtime := now.Add(time.Duration(-ageMinutes))
+			mtime := now.Add(-ageMinutes)
 			err = os.Chtimes(name, mtime, mtime)
 			require.NoError(t, err)
 		}


### PR DESCRIPTION
There was confusion between ATime and age, now fixed + test