### PR TITLE
[Added] clean-nfs-cache: log a histogram of selected file atimes

### DIFF
--- a/packages/orchestrator/cmd/clean-nfs-cache/ex/clean.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/ex/clean.go
@@ -452,6 +452,7 @@ func (c *Cleaner) histogram(candidates []*Candidate) []int {
 			if age <= b {
 				hist[i]++
 				bucketed = true
+
 				break
 			}
 		}


### PR DESCRIPTION
For debugging, let's see the file atimes grouped into buckets
10, 100, 1000, ... (in seconds)