### PR TITLE
Disable auto-exposed for Nomad ingress

### DIFF
--- a/iac/provider-gcp/nomad/jobs/ingress.hcl
+++ b/iac/provider-gcp/nomad/jobs/ingress.hcl
@@ -84,6 +84,7 @@ job "ingress" {
 
           # Traefik Nomad provider
           "--providers.nomad=true",
+          "--providers.nomad.exposedByDefault=false",
           "--providers.nomad.endpoint.address=${nomad_endpoint}",
           "--providers.nomad.endpoint.token=${nomad_token}",
 


### PR DESCRIPTION
Disabled option that was trying to scrape and map all services.
This was failing because we did not configure them to be exposed, and it was spamming the ingress logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables auto-exposure of Nomad services in Traefik to prevent unintended service discovery and log noise.
> 
> - Adds `--providers.nomad.exposedByDefault=false` to Traefik args in `iac/provider-gcp/nomad/jobs/ingress.hcl`, aligning Nomad behavior with the Consul provider setting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9166b1b7e2dee405511f15335abb4f01fa37039. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->