### PR TITLE
Ingress deployment size dependent on api cluster size

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -35,7 +35,6 @@ tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \
 	$(call tfvar, API_RESOURCES_CPU_COUNT) \
 	$(call tfvar, API_RESOURCES_MEMORY_MB) \
-	$(call tfvar, INGRESS_COUNT) \
 	$(call tfvar, CLIENT_PROXY_COUNT) \
 	$(call tfvar, CLIENT_PROXY_RESOURCES_CPU_COUNT) \
 	$(call tfvar, CLIENT_PROXY_RESOURCES_MEMORY_MB) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -158,8 +158,7 @@ module "nomad" {
   clickhouse_node_pool             = var.clickhouse_node_pool
 
   # Ingress
-  ingress_port  = var.ingress_port
-  ingress_count = var.ingress_count
+  ingress_port = var.ingress_port
 
   # API
   api_resources_cpu_count                   = var.api_resources_cpu_count

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -44,11 +44,10 @@ data "google_secret_manager_secret_version" "redis_tls_ca_base64" {
   secret = var.redis_tls_ca_base64_secret_version.secret
 }
 
-
 resource "nomad_job" "ingress" {
   jobspec = templatefile("${path.module}/jobs/ingress.hcl",
     {
-      count         = var.ingress_count
+      count         = var.api_machine_count
       update_stanza = var.api_machine_count > 1
       cpu_count     = 1
       memory_mb     = 512

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -72,10 +72,6 @@ variable "ingress_port" {
   })
 }
 
-variable "ingress_count" {
-  type = number
-}
-
 variable "api_resources_cpu_count" {
   type = number
 }

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -121,11 +121,6 @@ variable "client_proxy_count" {
   default = 1
 }
 
-variable "ingress_count" {
-  type    = number
-  default = 1
-}
-
 variable "client_proxy_resources_memory_mb" {
   type    = number
   default = 1024


### PR DESCRIPTION
Before this change, there was the ENV `INGRESS_COUNT` that could be used to set how many ingress instances we want to deploy. Now migrated to safer `var.api_machine_count`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns ingress deployment with API cluster sizing and removes the separate ingress count configuration.
> 
> - `nomad_job.ingress` now sets `count` from `api_machine_count` and toggles updates when `> 1`
> - Deleted `ingress_count` variable and all references: removed from `variables.tf` (root and `nomad`), `main.tf` module wiring, and `Makefile` TF var passthrough
> - Kept `ingress_port` unchanged; only sizing behavior is updated
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b99e3e4955f744567712631d43342ee38197a551. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->