### PR TITLE
fix: nomad nodepool apm naming

### DIFF
--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -527,7 +527,7 @@ data "external" "nomad_nodepool_apm_checksum" {
 }
 
 # Nomad Autoscaler - required for template-manager dynamic scaling
-resource "nomad_job" "nomad_autoscaler" {
+resource "nomad_job" "nomad_nodepool_apm" {
   count = var.template_manages_clusters_size_gt_1 ? 1 : 0
 
   jobspec = templatefile("${path.module}/jobs/nomad-autoscaler.hcl", {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns Nomad autoscaler resource naming with APM artifact/checksum identifiers.
> 
> - Renames `resource "nomad_job" "nomad_autoscaler"` to `resource "nomad_job" "nomad_nodepool_apm"` in `iac/provider-gcp/nomad/main.tf`; `jobspec` and variables unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 708769065d2c03110726469417b4505a6fdad917. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->