### PR TITLE
Remove printing commands in make

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -138,8 +138,7 @@ plan-without-jobs:
 .PHONY: apply
 apply:
 	@ printf "Applying Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
-	@ $(tf_vars) \
-	$(TF) apply \
+	@ $(TF) apply \
 	-auto-approve \
 	-input=false \
 	-compact-warnings \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Silences most `Makefile` commands by prefixing them with `@` across Terraform/GCP steps to reduce command echo noise.
> 
> - Adds `@` to `gcloud` bucket operations, `terraform init/plan/apply/import`, Nomad disk-image build, `switch`, and `plan-without-jobs` targets
> - Functional change: `apply` no longer includes `$(tf_vars)` (env var propagation removed), while other plan targets still do
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b04ad0bd79f5f72fbb19a4513a11fa06332a384d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->