### PR TITLE
Replace Ubuntu runner with `ci-builder` in workflow

### DIFF
--- a/.github/workflows/build-and-upload-job.yml
+++ b/.github/workflows/build-and-upload-job.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   deploy:
     name: Build and upload job to the ${{ inputs.environment }} environment
-    runs-on: ubuntu-22.04
+    runs-on: ci-builder
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the GitHub Actions runner for the `deploy` job in `build-and-upload-job.yml` from `ubuntu-22.04` to `ci-builder`.
> 
> - Updates `runs-on` to `ci-builder` for the build-and-upload workflow
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a220217a37ed3230d54a1acd86742320734f973. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->