### PR TITLE
Add progress deadline and auto rollback

### DIFF
--- a/iac/provider-gcp/nomad/jobs/api.hcl
+++ b/iac/provider-gcp/nomad/jobs/api.hcl
@@ -57,9 +57,10 @@ job "api" {
       # Time to wait for the canary to be healthy
       min_healthy_time  = "10s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
-      healthy_deadline  = "600s"
-      #Time to wait for the overall update to complete. Otherwise, the deployment is marked as failed and rolled back
-      progress_deadline = "601s"
+      healthy_deadline  = "900s"
+      # Time to wait for the overall update to complete. Otherwise, the deployment is marked as failed and rolled back
+      # This is on purpose very tight, we want to fail immediately if the deployment is marked as unhealthy
+      progress_deadline = "901s"
       # Whether to promote the canary if the rest of the group is not healthy
       auto_promote      = true
       # Whether to automatically rollback if the update fails


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the Nomad `update` stanza for the `api` job to refine deployment behavior.
> 
> - Increases `healthy_deadline` from `300s` to `900s`
> - Adds `progress_deadline = "901s"` to fail and rollback promptly if deployment stalls
> - Enables `auto_revert = true` to automatically rollback on failed updates
> - Minor alignment/spacing cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d0fa6c371828f706011acf34bab9b8ce36d0aaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->