### PR TITLE
fix: change the db migration statement timeout

### DIFF
--- a/packages/db/scripts/migrator.go
+++ b/packages/db/scripts/migrator.go
@@ -39,6 +39,7 @@ func main() {
 		log.Fatalf("failed to parse connection string: %v", err)
 	}
 
+	poolConfig.MaxConns = 4
 	poolConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
 		_, err := conn.Exec(ctx, fmt.Sprintf("SET statement_timeout = %d", statementTimeout.Milliseconds()))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the migration runner to pgx with a pooled connection and enforces a longer statement timeout.
> 
> - Replace `sql.Open` (lib/pq) with `pgxpool` and set `MaxConns = 4`
> - Set per-connection `statement_timeout` to `10m` via `AfterConnect`
> - Use `stdlib.OpenDBFromPool` to keep `goose` compatibility
> - Minor log/comment tweaks; remove manual `db.Close()` handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c622e50595f8f4953f7f6603ef1cdb2f6ad337fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->