### PR TITLE
Fix an issue with updating data in redis

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -132,7 +132,7 @@ func (s *Storage) Update(ctx context.Context, sandboxID string, updateFunc func(
 	}
 
 	// Execute transaction
-	err = s.redisClient.Set(ctx, key, newData, redis.KeepTTL).Err()
+	err = s.redisClient.Set(ctx, key, newData, 0).Err()
 	if err != nil {
 		return sandbox.Sandbox{}, err
 	}


### PR DESCRIPTION
There's no ttl, so redis returns an error if you try to keep it. You have to explicitly set 0 (disabled)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Redis update behavior to avoid TTL-related errors.
> 
> - In `packages/api/internal/sandbox/storage/redis/operations.go`, change `Set(..., redis.KeepTTL)` to `Set(..., 0)` in `Update` so updates succeed when the key has no TTL, aligning with `Add`'s behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6a85f0bf671900fd0a68a04215dd7e263c1db9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->