### PR TITLE
Use Nomads client node name as node id

### DIFF
--- a/packages/api/internal/clusters/discovery/local.go
+++ b/packages/api/internal/clusters/discovery/local.go
@@ -63,7 +63,7 @@ func (sd *LocalServiceDiscovery) Query(ctx context.Context) ([]Item, error) {
 
 	result := make([]Item, len(alloc))
 	for i, v := range alloc {
-		item := Item{
+		result[i] = Item{
 			UniqueIdentifier: v.AllocationID,
 			NodeID:           v.NodeID,
 
@@ -75,8 +75,6 @@ func (sd *LocalServiceDiscovery) Query(ctx context.Context) ([]Item, error) {
 			LocalIPAddress:       v.AllocationIP,
 			LocalInstanceApiPort: consts.OrchestratorAPIPort,
 		}
-
-		result[i] = item
 	}
 
 	return result, nil

--- a/packages/shared/pkg/clusters/discovery/nomad.go
+++ b/packages/shared/pkg/clusters/discovery/nomad.go
@@ -74,7 +74,9 @@ func ListOrchestratorAndTemplateBuilderAllocations(ctx context.Context, client *
 
 		net := nets[0]
 		item := Allocation{
-			NodeID:       v.NodeID,
+			// For some historical reasons and better developer experience we are using cloud instances name
+			// so we can easily map Nomad nodes to cloud instances and skip searching by Nomad client UUIDs.
+			NodeID:       v.NodeName,
 			AllocationID: v.ID,
 			AllocationIP: net.IP,
 		}


### PR DESCRIPTION
This issue was introduced in PR refactoring APIs service discovery to not use edge API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Service discovery adjustments**
> 
> - In `packages/shared/pkg/clusters/discovery/nomad.go`, set `Allocation.NodeID` to `v.NodeName` (was `v.NodeID`) to map allocations by Nomad client node name.
> - In `packages/api/internal/clusters/discovery/local.go`, simplify the loop by assigning `Item` directly to `result[i]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e815bb36317e22e96cca6ea63018f690deac515c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->