### PR TITLE
fix: propagate base template as user error

### DIFF
--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -317,7 +317,7 @@ func (bb *BaseBuilder) Layer(
 		tm, err := bb.index.Cached(ctx, bb.Config.FromTemplate.GetBuildID())
 		if err != nil {
 			if errors.Is(err, storage.ErrObjectNotExist) {
-				return phases.LayerResult{}, phases.NewPhaseBuildError(bb.Metadata(), fmt.Errorf("error getting base template, you may need to rebuild it first: %w", err))
+				return phases.LayerResult{}, phases.NewPhaseBuildError(bb.Metadata(), fmt.Errorf("error getting base template, you may need to rebuild it first"))
 			}
 
 			return phases.LayerResult{}, fmt.Errorf("error getting base template: %w", err)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves error classification and messaging when resolving `FromTemplate` during base build.
> 
> - In `builder.go`, if `bb.index.Cached(...)` returns `storage.ErrObjectNotExist`, return `phases.NewPhaseBuildError(bb.Metadata(), ...)` with guidance to rebuild the base template
> - For other lookup errors, wrap with "error getting base template" instead of the previous cache-specific message
> - `FromTemplate` behavior remains cached-only; no build path changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc1bfe386e45cf7c01a8a01c72381c720605a47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->