### PR TITLE
chore: add logging for uffd errors

### DIFF
--- a/packages/orchestrator/internal/sandbox/uffd/userfaultfd/counter_reporter.go
+++ b/packages/orchestrator/internal/sandbox/uffd/userfaultfd/counter_reporter.go
@@ -51,7 +51,7 @@ func (c *counterReporter) log(ctx context.Context, closing bool) {
 	total := c.totalCount()
 	if total > 0 {
 		fields := []zap.Field{
-			zap.Uint64("total", total),
+			zap.Uint64("count", total),
 			zap.Time("start", c.startTime),
 			zap.Time("end", c.endTime),
 			zap.Bool("closing", closing),

--- a/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -170,7 +170,7 @@ outerLoop:
 			// - https://man7.org/linux/man-pages/man2/userfaultfd.2.html
 			// It might be possible to just check for data != 0 in the syscall.Read loop
 			// but I don't feel confident about doing that.
-			noDataCounter.Increase("count")
+			noDataCounter.Increase("POLLIN")
 
 			continue
 		}
@@ -195,7 +195,7 @@ outerLoop:
 			}
 
 			if err == syscall.EAGAIN {
-				eagainCounter.Increase("count")
+				eagainCounter.Increase("EAGAIN")
 
 				// Continue polling the fd.
 				continue outerLoop


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves observability of UFFD polling/read behavior with labeled, aggregated counters and explicit poll error tracking.
> 
> - Replaces single counter with `counterReporter` that aggregates totals and per-event-type counts, logging them with time window metadata
> - In `Serve`, tracks and accumulates `POLLHUP`/`POLLERR`/`POLLNVAL` for both UFFD and exit fds via `exitFdErrorCounter` and `uffdErrorCounter`
> - Labels `EAGAIN` and no-data (`POLLIN` not set) occurrences in counters; flushes counts on successful reads
> - Adds `hasEvent` helper and refactors poll event checks to use it
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c6169d53fd096d689275313b05b1fb525998b9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->