### PR TITLE
Add a few more useful attributes

### DIFF
--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/cfg"
@@ -127,7 +128,10 @@ func (c *Cache) GetTemplate(
 	isSnapshot bool,
 	isBuilding bool,
 ) (Template, error) {
-	ctx, span := tracer.Start(ctx, "get template")
+	ctx, span := tracer.Start(ctx, "get template", trace.WithAttributes(
+		attribute.Bool("is_snapshot", isSnapshot),
+		attribute.Bool("is_building", isBuilding),
+	))
 	defer span.End()
 
 	persistence := c.persistence


### PR DESCRIPTION
This should help us understand why cache is on or off in various scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances observability of template caching decisions.
> 
> - Adds OTel span attributes to `GetTemplate`: `is_snapshot`, `is_building`, and `use_cache` (explicitly set true/false)
> - Imports `go.opentelemetry.io/otel/trace` to support attribute initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c9e84913fe9d4f989f337227b51a194a6295d6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->