### PR TITLE
Turn off prometheus for nomad server otel collector 

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector-nomad-server.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector-nomad-server.yaml
@@ -78,6 +78,9 @@ exporters:
     auth:
       authenticator: basicauth/grafana_cloud
 service:
+  telemetry:
+    metrics:
+      level: none
   extensions:
     - basicauth/grafana_cloud
     - health_check


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables Otel Collector self-telemetry metrics in `otel-collector-nomad-server.yaml`.
> 
> - Adds `service.telemetry.metrics.level: none` to stop the collector from emitting its own metrics; existing Prometheus scraping and export pipeline remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 731329c0bc223d282241a8d4e9814e4bfae39249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->