### PR TITLE
Add `deployment.environment` to nomad server otel collector

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector-nomad-server.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector-nomad-server.yaml
@@ -97,9 +97,7 @@ processors:
   transform/set-name:
     metric_statements:
       - set(datapoint.attributes["deployment.environment"], resource.attributes["cloud.account.id"])
-      - delete_key(datapoint.attributes, "instance")
-      - delete_key(datapoint.attributes, "service_name")
-      - delete_key(datapoint.attributes, "job")
+      - delete_key(resource.attributes, "service.name")
 
 extensions:
   basicauth/grafana_cloud:
@@ -134,5 +132,3 @@ service:
         - batch
       exporters:
         - otlphttp/grafana_cloud
-
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds GCP resource detection and a transform step to Nomad server metrics to enrich and normalize attributes.
> 
> - Introduces `resourcedetection` (GCP) processor enabling only `cloud.account.id`
> - Adds `transform/set-name` to set `deployment.environment` from `cloud.account.id` and remove `service.name`
> - Wires both processors into the `metrics/prometheus` pipeline before `batch`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6ff954bce957b4277e0a688e4e10406501882b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->