### PR TITLE
Add variable for server boot disk size in GCP Nomad cluster

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -59,6 +59,7 @@ tf_vars := 	TF_VAR_environment=$(TERRAFORM_ENVIRONMENT) \
 	$(call tfvar, REMOTE_REPOSITORY_ENABLED) \
 	$(call tfvar, API_BOOT_DISK_TYPE) \
 	$(call tfvar, SERVER_BOOT_DISK_TYPE) \
+	$(call tfvar, SERVER_BOOT_DISK_SIZE_GB) \
 	$(call tfvar, CLICKHOUSE_BOOT_DISK_TYPE) \
 	$(call tfvar, LOKI_BOOT_DISK_TYPE)
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -126,9 +126,10 @@ module "cluster" {
   labels = var.labels
   prefix = var.prefix
 
-  # Boot disk types
+  # Boot disks
   api_boot_disk_type        = var.api_boot_disk_type
   server_boot_disk_type     = var.server_boot_disk_type
+  server_boot_disk_size_gb  = var.server_boot_disk_size_gb
   clickhouse_boot_disk_type = var.clickhouse_boot_disk_type
   loki_boot_disk_type       = var.loki_boot_disk_type
 }

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -102,7 +102,7 @@ resource "google_compute_instance_template" "server" {
   disk {
     boot         = true
     source_image = data.google_compute_image.server_source_image.self_link
-    disk_size_gb = 20
+    disk_size_gb = var.server_boot_disk_size_gb
     disk_type    = var.server_boot_disk_type
   }
 

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -349,6 +349,11 @@ variable "server_boot_disk_type" {
   type        = string
 }
 
+variable "server_boot_disk_size_gb" {
+  description = "The GCE boot disk size in GB for the control server machines."
+  type        = number
+}
+
 variable "clickhouse_boot_disk_type" {
   description = "The GCE boot disk type for the ClickHouse machines."
   type        = string

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -548,6 +548,12 @@ variable "server_boot_disk_type" {
   default     = "pd-ssd"
 }
 
+variable "server_boot_disk_size_gb" {
+  description = "The GCE boot disk size (in GB) for the control server machines."
+  type        = number
+  default     = 20
+}
+
 variable "clickhouse_boot_disk_type" {
   description = "The GCE boot disk type for the ClickHouse machines."
   type        = string


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a configurable boot disk size for Nomad control servers and propagates it through the GCP IaC.
> 
> - Adds `server_boot_disk_size_gb` variable (default `20`) in `variables.tf` at root and `nomad-cluster`
> - Wires `server_boot_disk_size_gb` through `main.tf` into the `cluster` module
> - Replaces hardcoded `disk_size_gb = 20` with `disk_size_gb = var.server_boot_disk_size_gb` in `nomad-cluster/nodepool-control-server.tf`
> - Updates `Makefile` to pass `TF_VAR_server_boot_disk_size_gb` to Terraform
> - Minor comment tweak from "Boot disk types" to "Boot disks"
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2013e1c82bcef4d8813e47bd663c3bd7516efbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->