### PR TITLE
Enable system.cpu.utilization and improve aggregation logic for otel-collector

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -201,12 +201,6 @@ processors:
     timeout: 5s
     send_batch_size: 50000
 
-  attributes/host_metrics_node:
-    actions:
-      - key: node.id
-        value: $${NODE_ID}
-        action: insert
-
   # keep only metrics that are used
   filter/otlp:
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/filterprocessor
@@ -444,7 +438,6 @@ service:
       receivers:
         - hostmetrics
       processors:
-        - attributes/host_metrics_node
         - resourcedetection
         - transform/set-name
         - metricstransform/single_cpu


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables CPU utilization metrics and simplifies label cardinality while aligning aggregation with instance IDs.
> 
> - Enable `system.cpu.utilization` in `hostmetrics` receiver
> - Update `metricstransform/single_cpu`:
>   - Aggregate by `service.instance.id` (replacing `node.id`) for `system.cpu.time`
>   - Add transforms for `system.cpu.utilization` with state rollups (`user+system+nice` → `work`, `interrupt+softirq` → `irq`, `wait` → `blocked`)
> - Remove `attributes/host_metrics_node` processor and reorder `metrics/host` pipeline to run `metricstransform/single_cpu` after `transform/set-name`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c07f1a5e0b08b92c65a14b9bd87532eddbc88c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->