### PR TITLE
fix: make the sync command path absolute

### DIFF
--- a/packages/orchestrator/internal/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/internal/template/build/sandboxtools/command.go
@@ -235,7 +235,7 @@ func SyncChangesToDisk(
 		ctx,
 		proxy,
 		sandboxID,
-		"sync",
+		"/usr/bin/busybox sync",
 		metadata.Context{
 			User: "root",
 		},


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - `SyncChangesToDisk` now invokes `/usr/bin/busybox sync` instead of `sync`, ensuring an absolute path is used for the sandbox disk flush command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7221b5e4ffb7b221da606800edf18404cd36d51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->