### PR TITLE
Filter for otel-collector metrics

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -215,7 +215,17 @@ processors:
           - "vault.*"
           - "client_proxy.*"
           - "Click*"
-          - "otelcol.*"
+          - "otelcol_exporter_queue_capacity"
+          - "otelcol_exporter_queue_size"
+          - "otelcol_exporter_send_failed_log_records_total"
+          - "otelcol_exporter_send_failed_metric_points_total"
+          - "otelcol_exporter_send_failed_spans_total"
+          - "otelcol_exporter_sent_log_records_total"
+          - "otelcol_exporter_sent_metric_points_total"
+          - "otelcol_exporter_sent_spans_total"
+          - "otelcol_receiver_refused_log_records_total"
+          - "otelcol_receiver_refused_metric_points_total"
+          - "otelcol_receiver_refused_spans_total"
           - "pgxpool.*"
 
   filter/only_client_allocs:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Narrows and clarifies which metrics are forwarded by the collector.
> 
> - Replaces broad `otelcol.*` allowlist with explicit `otelcol_exporter_*` and `otelcol_receiver_refused_*` metrics in `filter/otlp`
> - Adds `^nomad_client_unallocated_.*$` to `filter/only_client_allocs` to include unallocated client allocation metrics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fff620887a3d54aefe2fcd8c2122d46cd86e7a50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->