### PR TITLE
fix: report also zero running builds

### DIFF
--- a/packages/orchestrator/internal/template/cache/build_cache.go
+++ b/packages/orchestrator/internal/template/cache/build_cache.go
@@ -90,9 +90,24 @@ func NewBuildCache(ctx context.Context, meterProvider metric.MeterProvider) *Bui
 		// Group by teamID
 		teamCounts := make(map[string]int)
 		for _, item := range items {
-			// Filter only running builds
-			if item != nil && item.Value() != nil && item.Value().IsRunning() {
-				teamID := item.Value().TeamID
+			if item == nil {
+				continue
+			}
+			build := item.Value()
+			if build == nil {
+				continue
+			}
+
+			teamID := build.TeamID
+
+			// Include 0 too to reset the counter if the team has no builds anymore
+			_, ok := teamCounts[teamID]
+			if !ok {
+				teamCounts[teamID] = 0
+			}
+
+			// Count running builds
+			if build.IsRunning() {
 				teamCounts[teamID]++
 			}
 		}

--- a/packages/shared/pkg/id/id.go
+++ b/packages/shared/pkg/id/id.go
@@ -14,7 +14,11 @@ import (
 
 var caseInsensitiveAlphabet = []byte("abcdefghijklmnopqrstuvwxyz1234567890")
 
-const DefaultTag = "default"
+const (
+	DefaultTag = "default"
+
+	TagSeparator = ":"
+)
 
 func Generate() string {
 	return uniuri.NewLenChars(uniuri.UUIDLen, caseInsensitiveAlphabet)
@@ -87,7 +91,7 @@ func ParseTemplateIDOrAliasWithTag(input string) (templateIDOrAlias string, tag 
 	input = strings.TrimSpace(input)
 
 	// Split by colon to separate template ID and tag
-	parts := strings.SplitN(input, ":", 2)
+	parts := strings.SplitN(input, TagSeparator, 2)
 
 	templateIDOrAlias = strings.ToLower(strings.TrimSpace(parts[0]))
 	templateIDOrAlias, err = cleanTemplateIDOrAlias(templateIDOrAlias)
@@ -111,4 +115,12 @@ func ParseTemplateIDOrAliasWithTag(input string) (templateIDOrAlias string, tag 
 	}
 
 	return templateIDOrAlias, tag, nil
+}
+
+func NameWithTag(name string, tag *string) string {
+	if tag == nil {
+		return name + TagSeparator + DefaultTag
+	}
+
+	return name + TagSeparator + *tag
 }


### PR DESCRIPTION
includes also a cleanup of few places plus added tracing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Metrics**
> - Observes running builds per team including zero counts; adds nil-safety when reading build cache items.
> 
> **API cache/manager**
> - Uses `id.NameWithTag` for template cache keys; `InvalidateAllTags` now returns invalidated keys and uses `id.TagSeparator`.
> - Background build sync logs with build/template IDs, reports completion, and emits telemetry with invalidated cache keys.
> 
> **Shared ID utilities**
> - Adds `TagSeparator` and `NameWithTag`; parsing now uses the separator consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a4a9c8cfc6c99f06cb95c6721f447ccb080c221. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->