### PR TITLE
Pre-install iptables

### DIFF
--- a/packages/orchestrator/internal/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.sh
@@ -16,7 +16,7 @@ is_package_installed() {
 }
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl ca-certificates fuse3"
+PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl ca-certificates fuse3 iptables"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""


### PR DESCRIPTION
required for transparent proxying

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `iptables` is present on provisioned systems for networking needs like transparent proxying.
> 
> - Update `packages/orchestrator/internal/template/build/phases/base/provision.sh` to include `iptables` in the `PACKAGES` list checked/installed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54745f00e1524d2d9e27967b2100093107f9f993. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->