### PR TITLE
Fixed typo in sandbox metrics handler

### DIFF
--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -56,8 +56,8 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 
 	metrics, err := cluster.GetResources().GetSandboxMetrics(ctx, team.ID.String(), sandboxID, params.Start, params.End)
 	if err != nil {
-		logger.L().Error(ctx, "error getting sandbox metrics from edge", zap.Error(err))
-		a.sendAPIStoreError(c, http.StatusInternalServerError, "error getting sandbox metrics from edge")
+		logger.L().Error(ctx, "error getting sandbox metrics", zap.Error(err))
+		a.sendAPIStoreError(c, http.StatusInternalServerError, "error getting sandbox metrics")
 
 		return
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Fixes/error message standardization**
> 
> - Updates error log and API response strings in `handlers/sandbox_metrics.go` to remove "from edge" from sandbox metrics failure messages; no behavioral or logic changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adaad054b6c97fd8fa5b5f9b2acff44eca43d9f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->