### PR TITLE
Clean up old Makefile scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,24 +188,3 @@ tidy:
 .PHONY: local-infra
 local-infra:
 	docker compose --file ./packages/local-dev/docker-compose.yaml up --abort-on-container-failure
-
-
-# Migration: Detach old template-manager-system job from Terraform state
-# TODO: Remove after template-manager migration is complete
-.PHONY: migrate-template-manager-detach
-migrate-template-manager-detach:
-	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
-	$(MAKE) -C iac/provider-gcp migrate-template-manager-detach
-
-# TODO 2025-12-29: [ENG-3410] - Remove after migration period (14 days)
-define env_var_or_default
-$(if $(value $(strip $(1))),$($(strip $(1))),$(2))
-endef
-
-.PHONY: migrate-clusters-terraform
-migrate-clusters-terraform:
-	$(eval CLIENT_CLUSTER_SIZE := $(call env_var_or_default,CLIENT_CLUSTER_SIZE,1))
-
-	@echo "\nBUILD_CLUSTERS_CONFIG='{\"default\":{\"cluster_size\": $(call env_var_or_default,BUILD_CLUSTER_SIZE,1), \"machine\":{\"type\":\"$(BUILD_MACHINE_TYPE)\",\"min_cpu_platform\":\"$(call env_var_or_default,MIN_CPU_PLATFORM,"Intel Skylake")\"}, \"boot_disk\":{\"disk_type\":\"$(call env_var_or_default,BUILD_BOOT_DISK_TYPE,"pd-ssd")\",\"size_gb\":$(call env_var_or_default,BUILD_CLUSTER_ROOT_DISK_SIZE_GB,200)}, \"cache_disks\":{\"disk_type\":\"$(call env_var_or_default,BUILD_CLUSTER_CACHE_DISK_TYPE,"local-ssd")\",\"size_gb\":$(call env_var_or_default,BUILD_CLUSTER_CACHE_DISK_SIZE_GB,375),\"count\":$(call env_var_or_default,BUILD_CLUSTER_CACHE_DISK_COUNT,3)}}}'" >> ${ENV_FILE}
-	@echo "CLIENT_CLUSTERS_CONFIG='{\"default\":{\"cluster_size\": $(CLIENT_CLUSTER_SIZE), \"autoscaler\": {\"size_max\": $(call env_var_or_default,CLIENT_CLUSTER_SIZE_MAX,$(CLIENT_CLUSTER_SIZE)), \"memory_target\": $(call env_var_or_default,CLIENT_CLUSTER_AUTOSCALING_MEMORY_TARGET,85), \"cpu_target\": $(call env_var_or_default,CLIENT_CLUSTER_AUTOSCALING_CPU_TARGET,0.6) }, \"machine\":{\"type\":\"$(CLIENT_MACHINE_TYPE)\",\"min_cpu_platform\":\"$(call env_var_or_default,MIN_CPU_PLATFORM,"Intel Skylake")\"}, \"boot_disk\":{\"disk_type\":\"$(call env_var_or_default,CLIENT_BOOT_DISK_TYPE,"pd-ssd")\",\"size_gb\":$(call env_var_or_default,CLIENT_CLUSTER_ROOT_DISK_SIZE_GB,300)}, \"cache_disks\":{\"disk_type\":\"$(call env_var_or_default,CLIENT_CLUSTER_CACHE_DISK_TYPE,"local-ssd")\",\"size_gb\":$(call env_var_or_default,CLIENT_CLUSTER_CACHE_DISK_SIZE_GB,375),\"count\":$(call env_var_or_default,CLIENT_CLUSTER_CACHE_DISK_COUNT,3)}}}'" >> ${ENV_FILE}
-	$(MAKE) -C iac/provider-gcp migrate-clusters-terraform

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -161,25 +161,3 @@ provider-login:
 	gcloud config set project "$(GCP_PROJECT_ID)"
 	gcloud --quiet auth configure-docker "$(GCP_REGION)-docker.pkg.dev"
 	gcloud --quiet auth application-default login
-
-# Migration: Detach old template-manager-system job from Terraform state
-# This keeps the Nomad job running but removes it from Terraform management
-# TODO: Remove after template-manager migration is complete
-.PHONY: migrate-template-manager-detach
-migrate-template-manager-detach:
-	@ printf "Detaching old template-manager-system from Terraform state for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n"
-	$(tf_vars) $(TF) state rm module.nomad.nomad_job.template_manager || true
-
-# TODO 2025-12-29: [ENG-3410] - Remove after migration period (14 days)
-.PHONY: migrate-clusters-terraform
-migrate-clusters-terraform:
-	@ printf "Planning Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
-	@ $(TF) fmt -recursive
-	@ $(tf_vars) $(TF) plan -out=.tfplan.$(ENV) -compact-warnings \
-		 -target="module.cluster.module.build_cluster" \
-		 -target="module.cluster.module.client_cluster" \
-		 -target="module.cluster.google_compute_health_check.client_nomad_check" \
-		 -target="module.cluster.google_compute_instance_template.client" \
-		 -target="module.cluster.google_compute_region_instance_group_manager.client_pool" \
-		 -target="module.cluster.google_compute_region_autoscaler.client"
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Cleanup deprecated Makefile targets**
> 
> - Removes `migrate-template-manager-detach` and `migrate-clusters-terraform` targets from `Makefile` and `iac/provider-gcp/Makefile`
> - Deletes the `env_var_or_default` helper macro used only by removed targets
> - Core `plan/apply/import/provider-login` and related workflows remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8250099a5ead7b901db843f4c5aa43c3bcab05fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->