### PR TITLE
Add `deployment.environment` label to Otel collector configuration

### DIFF
--- a/iac/provider-gcp/nomad/configs/otel-collector.yaml
+++ b/iac/provider-gcp/nomad/configs/otel-collector.yaml
@@ -249,6 +249,7 @@ processors:
             label_set:
               - service.instance.id
               - state
+              - deployment.environment
             aggregation_type: sum
 
       - include: "system.cpu.utilization"
@@ -259,6 +260,7 @@ processors:
             label_set:
               - service.instance.id
               - state
+              - deployment.environment
             aggregation_type: sum
           - action: aggregate_label_values
             label: state


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds environment context to host CPU metrics aggregation.
> 
> - Updates `metricstransform/single_cpu` to aggregate `system.cpu.time` and `system.cpu.utilization` by `deployment.environment` alongside `service.instance.id` and `state`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f99f511acbc232507cf6979655db69c968a3d2dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->