### PR TITLE
chore: run clean-nfs-cache job on builder nodes

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -235,11 +235,15 @@ module "nomad" {
   launch_darkly_api_key_secret_name = module.init.launch_darkly_api_key_secret_version.secret
 
   # Filestore
-  shared_chunk_cache_path                    = module.cluster.shared_chunk_cache_path
-  filestore_cache_cleanup_disk_usage_target  = var.filestore_cache_cleanup_disk_usage_target
-  filestore_cache_cleanup_dry_run            = var.filestore_cache_cleanup_dry_run
-  filestore_cache_cleanup_deletions_per_loop = var.filestore_cache_cleanup_deletions_per_loop
-  filestore_cache_cleanup_files_per_loop     = var.filestore_cache_cleanup_files_per_loop
+  shared_chunk_cache_path                       = module.cluster.shared_chunk_cache_path
+  filestore_cache_cleanup_disk_usage_target     = var.filestore_cache_cleanup_disk_usage_target
+  filestore_cache_cleanup_dry_run               = var.filestore_cache_cleanup_dry_run
+  filestore_cache_cleanup_deletions_per_loop    = var.filestore_cache_cleanup_deletions_per_loop
+  filestore_cache_cleanup_files_per_loop        = var.filestore_cache_cleanup_files_per_loop
+  filestore_cache_cleanup_max_concurrent_stat   = var.filestore_cache_cleanup_max_concurrent_stat
+  filestore_cache_cleanup_max_concurrent_scan   = var.filestore_cache_cleanup_max_concurrent_scan
+  filestore_cache_cleanup_max_concurrent_delete = var.filestore_cache_cleanup_max_concurrent_delete
+  filestore_cache_cleanup_max_retries           = var.filestore_cache_cleanup_max_retries
 }
 
 module "redis" {

--- a/iac/provider-gcp/nomad/clean-nfs-cache.tf
+++ b/iac/provider-gcp/nomad/clean-nfs-cache.tf
@@ -24,6 +24,10 @@ resource "nomad_job" "clean_nfs_cache" {
     dry_run                      = var.filestore_cache_cleanup_dry_run
     deletions_per_loop           = var.filestore_cache_cleanup_deletions_per_loop
     files_per_loop               = var.filestore_cache_cleanup_files_per_loop
+    max_concurrent_stat          = var.filestore_cache_cleanup_max_concurrent_stat
+    max_concurrent_scan          = var.filestore_cache_cleanup_max_concurrent_scan
+    max_concurrent_delete        = var.filestore_cache_cleanup_max_concurrent_delete
+    max_retries                  = var.filestore_cache_cleanup_max_retries
     otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
     launch_darkly_api_key        = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
   })

--- a/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
+++ b/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
@@ -37,6 +37,10 @@ job "filestore-cleanup" {
                     "--disk-usage-target-percent=${max_disk_usage_target}",
                     "--files-per-loop=${files_per_loop}",
                     "--deletions-per-loop=${deletions_per_loop}",
+                    "--max-concurrent-stat=${max_concurrent_stat}",
+                    "--max-concurrent-scan=${max_concurrent_scan}",
+                    "--max-concurrent-delete=${max_concurrent_delete}",
+                    "--max-retries=${max_retries}",
                     "--otel-collector-endpoint=${otel_collector_grpc_endpoint}",
                     "${nfs_cache_mount_path}",
                 ]

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -385,6 +385,26 @@ variable "filestore_cache_cleanup_files_per_loop" {
   type = number
 }
 
+variable "filestore_cache_cleanup_max_concurrent_stat" {
+  type        = number
+  description = "Number of concurrent stat goroutines"
+}
+
+variable "filestore_cache_cleanup_max_concurrent_scan" {
+  type        = number
+  description = "Number of concurrent scanner goroutines"
+}
+
+variable "filestore_cache_cleanup_max_concurrent_delete" {
+  type        = number
+  description = "Number of concurrent deleter goroutines"
+}
+
+variable "filestore_cache_cleanup_max_retries" {
+  type        = number
+  description = "Maximum number of continuous error or miss retries before giving up"
+}
+
 variable "dockerhub_remote_repository_url" {
   type = string
 }

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -411,6 +411,30 @@ variable "filestore_cache_cleanup_deletions_per_loop" {
   default = 900
 }
 
+variable "filestore_cache_cleanup_max_concurrent_stat" {
+  type        = number
+  description = "Number of concurrent stat goroutines"
+  default     = 16
+}
+
+variable "filestore_cache_cleanup_max_concurrent_scan" {
+  type        = number
+  description = "Number of concurrent scanner goroutines"
+  default     = 16
+}
+
+variable "filestore_cache_cleanup_max_concurrent_delete" {
+  type        = number
+  description = "Number of concurrent deleter goroutines"
+  default     = 4
+}
+
+variable "filestore_cache_cleanup_max_retries" {
+  type        = number
+  description = "Maximum number of continuous error or miss retries before giving up"
+  default     = 10000
+}
+
 variable "remote_repository_enabled" {
   type        = bool
   description = "Set to true to enable remote repository cache. Can be set via TF_VAR_remote_repository_enabled or REMOTE_REPOSITORY_ENABLED env var."

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -52,7 +52,7 @@ func newJSONFlag(name string, fallback ldvalue.Value) JSONFlag {
 	return flag
 }
 
-var CleanNFSCacheExperimental = newJSONFlag("clean-nfs-cache-experimental", ldvalue.Null())
+var CleanNFSCache = newJSONFlag("clean-nfs-cache", ldvalue.Null())
 
 type BoolFlag struct {
 	name     string


### PR DESCRIPTION
- moved `clean-nfs-cache` to build node group
- cleaned up feature flag naming (removed experimental) and dependency; now runs with production-grade settings in lieu of the feature flag