### PR TITLE
fix: prevent hang on shutdown

### DIFF
--- a/packages/orchestrator/internal/template/server/create_template.go
+++ b/packages/orchestrator/internal/template/server/create_template.go
@@ -104,8 +104,10 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 	)
 
 	s.wg.Add(1)
+	s.activeBuilds.Add(1)
 	go func(ctx context.Context) {
 		defer s.wg.Done()
+		defer s.activeBuilds.Add(-1)
 
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -569,6 +569,7 @@ func run(config cfg.Config) (success bool) {
 
 	// Mark service draining if not already.
 	// If service stats was previously changed via API, we don't want to override it.
+	logger.L().Info(ctx, "Starting drain phase", zap.Int("sandbox_count", sandboxes.Count()))
 	if serviceInfo.GetStatus() == orchestratorinfo.ServiceInfoStatus_Healthy {
 		serviceInfo.SetStatus(ctx, orchestratorinfo.ServiceInfoStatus_Draining)
 


### PR DESCRIPTION
Try to prevent hang here:

```
2026-01-27T10:10:44.082Z  INFO  Shutdown signal received  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:10:44.083Z  INFO  Service status changed  {"service": "template-manager", "internal": true, "pid": 1943188, "status": "Draining"}
2026-01-27T10:10:59.084Z  INFO  Waiting for all build jobs to finish  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:10:59.084Z  INFO  Waiting for consumers to check build status  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:11:14.085Z  INFO  Template build queue cleaned  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:11:14.085Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "grpc server", "forced": false}
2026-01-27T10:11:14.085Z  INFO  Shutting down grpc server  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:11:14.088Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "http server", "forced": false}
2026-01-27T10:11:14.089Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "cmux server", "forced": false}
2026-01-27T10:11:14.089Z  INFO  Shutting down cmux server  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:11:14.089Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "template server", "forced": false}
2026-01-27T10:11:14.089Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "hyperloop server", "forced": false}
2026-01-27T10:11:14.090Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "template manager sandbox logger", "forced": false}
2026-01-27T10:11:14.090Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "network pool", "forced": false}
2026-01-27T10:11:14.090Z  INFO  Closing network pool  {"service": "template-manager", "internal": true, "pid": 1943188}
2026-01-27T10:11:21.702Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "device pool", "forced": false}
2026-01-27T10:11:21.702Z  INFO  Closing device pool  {"service": "template-manager", "internal": true, "pid": 1943188, "used_slots": 65}
2026-01-27T10:11:21.703Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "tcp egress firewall", "forced": false}
2026-01-27T10:11:21.703Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "sandbox proxy", "forced": false}
2026-01-27T10:11:21.704Z  INFO  closing  {"service": "template-manager", "internal": true, "pid": 1943188, "service": "sandbox observer", "forced": false}
```

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves shutdown reliability and observability.
> 
> - Adds `10s` timeout when shutting down sandbox metrics meter exporter to avoid hangs
> - Tracks active template builds using an atomic counter; increments/decrements around build goroutines and logs `active_builds` during `Wait`
> - Logs start of drain phase with `sandbox_count` for better shutdown diagnostics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5cc2b6c2741da95db90a3c76b2b5038f192c37c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->