### PR TITLE
Change Redis lock constant retry strategy with jitter

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/backoff.go
+++ b/packages/api/internal/sandbox/storage/redis/backoff.go
@@ -5,12 +5,12 @@ import (
 	"time"
 )
 
-type ConstantBackoff struct {
+type constantBackoff struct {
 	backoff time.Duration
 }
 
-func NewConstantBackoff(backoff time.Duration) *ConstantBackoff {
-	return &ConstantBackoff{backoff: backoff}
+func newConstantBackoff(backoff time.Duration) *constantBackoff {
+	return &constantBackoff{backoff: backoff}
 }
 
 const jitter = 0.25 // ±25%
@@ -22,7 +22,7 @@ const jitter = 0.25 // ±25%
 // Without jitter, concurrent goroutines using a constant 20ms backoff would retry
 // simultaneously, hitting the Redis lock at the same time on every attempt. The
 // randomization breaks this synchronization pattern while maintaining fast retries.
-func (b *ConstantBackoff) NextBackoff() time.Duration {
+func (b *constantBackoff) NextBackoff() time.Duration {
 	factor := 1 + jitter*(2*(rand.Float64()-0.5))
 
 	return time.Duration(float64(b.backoff) * factor)

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -30,7 +30,7 @@ func NewStorage(
 		redisClient: redisClient,
 		lockService: redislock.New(redisClient),
 		lockOption: &redislock.Options{
-			RetryStrategy: NewConstantBackoff(retryInterval),
+			RetryStrategy: newConstantBackoff(retryInterval),
 		},
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a jittered constant retry strategy for Redis locks and wires it into storage initialization.
> 
> - Adds `constantBackoff` with ±25% jitter in `backoff.go`
> - Replaces `redislock.LinearBackoff(50ms)` with `newConstantBackoff(retryInterval)` in `main.go`; sets `retryInterval` to `20ms`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7fed776b17ade585fb99ab78fcf21a3dede3f065. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->