### PR TITLE
Removed privileged and cgroups flags in envd start-docker

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -29,8 +29,6 @@ start-docker:
 	docker run \
 	--name envd \
 	--platform linux/amd64 \
-	--privileged \
-	--cgroupns=host \
 	-p 49983:49983 \
 	-p 2345:2345 \
 	-p 9999:9999 \


### PR DESCRIPTION
there were some issues when trying to run commands locally on Mac in Docker, so let's just remove this for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only change affecting local debug container startup; main risk is reduced container capabilities for workflows that relied on privileged/cgroup access.
> 
> **Overview**
> The `envd` `start-docker` make target no longer runs the debug container with Docker `--privileged` or `--cgroupns=host`.
> 
> This reduces required host privileges for local Docker runs (notably on macOS) while keeping the same image build and port mappings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b175e3432a81099a0a5f0801cb0b88931c0ef9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->