### PR TITLE
Upgrade to loki 2.9.17

### DIFF
--- a/iac/provider-gcp/nomad/jobs/loki.hcl
+++ b/iac/provider-gcp/nomad/jobs/loki.hcl
@@ -47,7 +47,7 @@ job "loki" {
 
       config {
         network_mode = "host"
-        image = "grafana/loki:2.9.8"
+        image = "grafana/loki:2.9.17"
 
         args = [
           "-config.file",


### PR DESCRIPTION
Should be done before #1816 and #1815 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple image tag bump in deployment configs; main risk is Loki version incompatibility/regressions during rollout, with no code-path or data-model changes in this PR.
> 
> **Overview**
> Upgrades Loki to `grafana/loki:2.9.17` in both the GCP Nomad job (`iac/provider-gcp/nomad/jobs/loki.hcl`) and the local dev `docker-compose.yaml`, aligning environments on the same Loki release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 300f1a576211a4169a087dff9fe35d319b8e4fb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->