### PR TITLE
Fully migrate to regional nomad servers

### DIFF
--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -56,7 +56,7 @@ resource "google_compute_instance_group_manager" "server_pool" {
   }
 
   target_pools = []
-  target_size  = var.server_cluster_size
+  target_size  = 0
 
   depends_on = [
     google_compute_instance_template.server,
@@ -82,9 +82,8 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
   base_instance_name = local.server_pool_name
 
 
-  target_pools = []
-  // TODO: 2026-01-21: To be changed back to var.server_cluster_size after migration period (at least 1 weeks) - 2026-01-28
-  target_size                      = var.server_cluster_size > 1 ? var.server_cluster_size - 1 : var.server_cluster_size
+  target_pools                     = []
+  target_size                      = var.server_cluster_size
   distribution_policy_target_shape = "EVEN"
 
   version {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes desired instance counts for stateful Nomad servers; an apply could scale up/down nodes and impact cluster quorum/availability if timing or sizing assumptions are wrong.
> 
> **Overview**
> Switches the Nomad server migration setup to fully rely on the **regional** instance group manager at the intended size.
> 
> The legacy zonal `google_compute_instance_group_manager` is explicitly scaled down to `target_size = 0`, and the temporary regional sizing workaround (running one fewer server) is removed so the regional `server_pool` now uses `target_size = var.server_cluster_size`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 151bbfb097edf356611d81b5b222353831a9e175. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->