### PR TITLE
Fix ENV value escaping in template builds

### DIFF
--- a/packages/orchestrator/internal/template/build/commands/env.go
+++ b/packages/orchestrator/internal/template/build/commands/env.go
@@ -62,11 +62,21 @@ func evaluateValue(
 	sandboxID string,
 	envValue string,
 ) (string, error) {
+	// Escape characters that would break parsing or cause command execution.
+	// $VAR expansion is preserved for environment variable interpolation.
+	escaped := envValue
+	escaped = strings.ReplaceAll(escaped, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, "`", "\\`")
+	escaped = strings.ReplaceAll(escaped, "$(", "\\$(")
+
+	cmd := fmt.Sprintf(`printf "%%s" "%s"`, escaped)
+
 	err := sandboxtools.RunCommandWithOutput(
 		ctx,
 		proxy,
 		sandboxID,
-		fmt.Sprintf(`printf "%s"`, envValue),
+		cmd,
 		metadata.Context{
 			User: "root",
 		},

--- a/tests/integration/internal/tests/api/templates/build_template_test.go
+++ b/tests/integration/internal/tests/api/templates/build_template_test.go
@@ -216,6 +216,139 @@ func TestTemplateBuildENV(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name:         "ENV with PEM-style dashes",
+			templateName: "test-ubuntu-env-pem-dashes",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"PEM_HEADER", "-----BEGIN DATA-----"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{"[[ \"$PEM_HEADER\" == \"-----BEGIN DATA-----\" ]] || exit 1"}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV with double quotes",
+			templateName: "test-ubuntu-env-quotes",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"QUOTED_VAR", `say "hello"`}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ "$QUOTED_VAR" == 'say "hello"' ]] || exit 1`}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV with single quotes",
+			templateName: "test-ubuntu-env-single-quotes",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"SINGLE_QUOTED", "it's working"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ "$SINGLE_QUOTED" == "it's working" ]] || exit 1`}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV with backslashes",
+			templateName: "test-ubuntu-env-backslash",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"PATH_VAR", `path\to\file`}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ "$PATH_VAR" == 'path\to\file' ]] || exit 1`}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV with multiline value",
+			templateName: "test-ubuntu-env-multiline",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"MULTILINE", "line1\nline2\nline3"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ $(echo "$MULTILINE" | wc -l) -eq 3 ]] || exit 1`}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV blocks command substitution with backticks",
+			templateName: "test-ubuntu-env-backticks",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"LITERAL_CMD", "`echo pwned`"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ "$LITERAL_CMD" == '` + "`echo pwned`" + `' ]] || exit 1`}),
+					},
+				}),
+			},
+		},
+		{
+			name:         "ENV blocks command substitution with dollar paren",
+			templateName: "test-ubuntu-env-dollarparen",
+			buildConfig: api.TemplateBuildStartV2{
+				Force:     utils.ToPtr(ForceBaseBuild),
+				FromImage: utils.ToPtr("ubuntu:22.04"),
+				Steps: utils.ToPtr([]api.TemplateStep{
+					{
+						Type:  "ENV",
+						Force: utils.ToPtr(true),
+						Args:  utils.ToPtr([]string{"LITERAL_CMD2", "$(echo pwned)"}),
+					},
+					{
+						Type: "RUN",
+						Args: utils.ToPtr([]string{`[[ "$LITERAL_CMD2" == '$(echo pwned)' ]] || exit 1`}),
+					},
+				}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -886,6 +1019,7 @@ func TestTemplateBuildInstalledPackagesAvailable(t *testing.T) {
 		"curl",
 		"ca-certificates",
 		"fuse3",
+		"iptables",
 		"git",
 		"mount-s3",
 	}


### PR DESCRIPTION
we pass the input as a string to printf and then replace env vars in the string with envsubst

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell command construction for template builds, so escaping mistakes could break env interpolation or cause build failures; changes are scoped and backed by added integration tests.
> 
> **Overview**
> Fixes template-build `ENV` handling by safely escaping values before piping them through `printf`, preventing malformed parsing and blocking command substitution (backticks/`$()`), while still allowing `$VAR` interpolation. Expands integration coverage with new `ENV` test cases for quotes, backslashes, PEM-style strings, multiline values, and injection attempts, and updates the expected base image package set to include `iptables`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1887c12370e2a68368653436e21a0d568bc71e8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->