### PR TITLE
Api auth error handling

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -112,9 +112,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 			err = a.SetData(ctx, logger, initRequest)
 			if err != nil {
 				switch {
-				case errors.Is(err, ErrAccessTokenMismatch):
-					w.WriteHeader(http.StatusUnauthorized)
-				case errors.Is(err, ErrAccessTokenResetNotAuthorized):
+				case errors.Is(err, ErrAccessTokenMismatch), errors.Is(err, ErrAccessTokenResetNotAuthorized):
 					w.WriteHeader(http.StatusUnauthorized)
 				default:
 					logger.Error().Msgf("Failed to set data: %v", err)


### PR DESCRIPTION
Combine duplicate switch cases for `ErrAccessTokenMismatch` and `ErrAccessTokenResetNotAuthorized` to improve maintainability.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor to HTTP status mapping with no behavior change beyond consolidating duplicate branches; low chance of affecting request handling.
> 
> **Overview**
> Simplifies `/init` error handling by combining the `ErrAccessTokenMismatch` and `ErrAccessTokenResetNotAuthorized` switch cases into a single branch that returns `401 Unauthorized`, reducing duplicated logic while preserving response behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbb84e5789ab302aa7a58f6ffd1933a52eb0e69d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->