### PR TITLE
Speed up client proxy deployment

### DIFF
--- a/iac/provider-gcp/nomad/jobs/client-proxy.hcl
+++ b/iac/provider-gcp/nomad/jobs/client-proxy.hcl
@@ -56,6 +56,7 @@ job "client-proxy" {
     # An update stanza to enable rolling updates of the service
     update {
       # The number of instances that can be updated at the same time
+      # Use double the max parallel to allow for surge
       max_parallel     = ${2 * update_max_parallel}
       # Number of extra instances that can be spawn before killing the old one
       canary           = ${update_max_parallel}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes rollout behavior for a production service; higher parallelism can increase temporary capacity usage and amplify impact if a bad version is deployed.
> 
> **Overview**
> Speeds up `client-proxy` deployments by increasing Nomad rolling-update concurrency: `max_parallel` is now set to `2 * update_max_parallel` (surge-style) when `update_stanza` is enabled, with an added comment explaining the intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa7e6ad9e6fee6408af6f4fe72701e1072fd51a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->