### PR TITLE
fix: return body on errors

### DIFF
--- a/packages/api/internal/auth/middleware.go
+++ b/packages/api/internal/auth/middleware.go
@@ -85,7 +85,10 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.C
 			attribute.String("error.message", a.errorMessage),
 		)
 
-		ginCtx.Status(http.StatusUnauthorized)
+		ginCtx.JSON(http.StatusUnauthorized, api.Error{
+			Code:    http.StatusUnauthorized,
+			Message: a.errorMessage,
+		})
 
 		return err
 	}
@@ -103,7 +106,10 @@ func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.C
 			attribute.String("http.status_text", http.StatusText(validationError.Code)),
 		)
 
-		ginCtx.Status(validationError.Code)
+		ginCtx.JSON(validationError.Code, api.Error{
+			Code:    int32(validationError.Code),
+			Message: validationError.ClientMsg,
+		})
 
 		var forbiddenError *db.TeamForbiddenError
 		if errors.As(validationError.Err, &forbiddenError) {

--- a/packages/api/internal/handlers/admin.go
+++ b/packages/api/internal/handlers/admin.go
@@ -33,7 +33,7 @@ func (a *APIStore) GetNodesNodeID(c *gin.Context, nodeID api.NodeID, params api.
 	result, err := a.orchestrator.AdminNodeDetail(ctx, clusterID, nodeID)
 	if err != nil {
 		if errors.Is(err, orchestrator.ErrNodeNotFound) {
-			c.Status(http.StatusNotFound)
+			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Node '%s' not found", nodeID))
 
 			return
 		}
@@ -62,7 +62,7 @@ func (a *APIStore) PostNodesNodeID(c *gin.Context, nodeId api.NodeID) {
 	clusterID := utils.WithClusterFallback(body.ClusterID)
 	node := a.orchestrator.GetNodeByIDOrNomadShortID(clusterID, nodeId)
 	if node == nil {
-		c.Status(http.StatusNotFound)
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Node '%s' not found", nodeId))
 
 		return
 	}


### PR DESCRIPTION
This should fix this SDK part treating an error as success: https://github.com/e2b-dev/E2B/blob/ac979b80b7a9b4b806810cb4b7ff53116284c076/packages/js-sdk/src/api/index.ts#L17

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small response-shape change limited to error paths; main risk is minor client behavior changes if anything relied on empty bodies.
> 
> **Overview**
> **API error responses now include a JSON body instead of status-only replies.** Authentication failures in `commonAuthenticator.Authenticate` and admin node `404` cases now return `api.Error{code,message}` payloads (with more specific not-found messages), improving client/SDK error handling consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a961b9ccc2e768e11e03b8e275489afa2f72fbb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->