### PR TITLE
fix(tests): correct envdapi typo to envd in auth_test.go

### DIFF
--- a/tests/integration/internal/tests/envd/auth_test.go
+++ b/tests/integration/internal/tests/envd/auth_test.go
@@ -111,7 +111,7 @@ func TestInitWithWrongTokenOnSecuredSandboxReturnsUnauthorized(t *testing.T) {
 	sandboxEnvdInitCall(t, ctx, envdInitCall{
 		sbx:                   sbx,
 		client:                envdClient,
-		body:                  envdapi.PostInitJSONRequestBody{AccessToken: &wrongToken},
+		body:                  envd.PostInitJSONRequestBody{AccessToken: &wrongToken},
 		expectedResErr:        nil,
 		expectedResHttpStatus: http.StatusUnauthorized,
 	})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only change correcting a type reference; no production logic or security behavior is modified.
> 
> **Overview**
> Fixes the `TestInitWithWrongTokenOnSecuredSandboxReturnsUnauthorized` integration test to build the `/init` request body using `envd.PostInitJSONRequestBody` (instead of the mistyped `envdapi.PostInitJSONRequestBody`), aligning with the `envd` client types used elsewhere in the file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a994950a102724b90397e7d34b0a1dd9df4e2db1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->