### PR TITLE
Use better message for http serve close error

### DIFF
--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -184,7 +184,7 @@ func run() int {
 		// Add different handling for the error
 		switch {
 		case errors.Is(err, http.ErrServerClosed):
-			proxyRunLogger.Info(ctx, "Http proxy shutdown successfully")
+			proxyRunLogger.Info(ctx, "Http proxy closed successfully")
 		case err != nil:
 			exitCode.Add(1)
 			proxyRunLogger.Error(ctx, "Http proxy encountered error", zap.Error(err))
@@ -203,7 +203,7 @@ func run() int {
 		err := healthServer.ListenAndServe()
 		switch {
 		case errors.Is(err, http.ErrServerClosed):
-			healthLogger.Info(ctx, "Health server shutdown successfully")
+			healthLogger.Info(ctx, "Health server closed successfully")
 		case err != nil:
 			exitCode.Add(1)
 			healthLogger.Error(ctx, "Health server encountered error", zap.Error(err))


### PR DESCRIPTION
Just nit.
Previously, we used `Http proxy shutdown successfully` for both server close log and shutdown process finish message.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log message wording only; no functional, networking, or shutdown behavior changes.
> 
> **Overview**
> Updates `client-proxy` logging to distinguish a normal `http.ErrServerClosed` exit from a full shutdown flow by changing the success messages from “shutdown successfully” to “closed successfully” for both the proxy and health servers’ `ListenAndServe` loops.
> 
> This is a log-only change; runtime behavior and shutdown sequencing are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c28e617795d4301da06a01187834620879b2a786. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->