### PR TITLE
Add span for acquire starting sandbox slot 

### DIFF
--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -83,14 +83,9 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 
 	// Check if we've reached the max number of starting instances on this node
 	if req.GetSandbox().GetSnapshot() {
-		acquireCtx, acquireCancel := context.WithTimeout(ctx, acquireTimeout)
-		defer acquireCancel()
-
-		err := s.startingSandboxes.Acquire(acquireCtx, 1)
+		err := s.waitForAcquire(ctx)
 		if err != nil {
-			telemetry.ReportEvent(ctx, "too many resuming sandboxes on node")
-
-			return nil, status.Errorf(codes.ResourceExhausted, "too many sandboxes resuming on this node, please retry")
+			return nil, err
 		}
 	} else {
 		acquired := s.startingSandboxes.TryAcquire(1)

--- a/packages/orchestrator/internal/server/utils.go
+++ b/packages/orchestrator/internal/server/utils.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+)
+
+func (s *Server) waitForAcquire(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, acquireTimeout)
+	defer cancel()
+
+	ctx, span := tracer.Start(ctx, "wait-for-acquire")
+	defer span.End()
+
+	err := s.startingSandboxes.Acquire(ctx, 1)
+	if err != nil {
+		telemetry.ReportEvent(ctx, "too many resuming sandboxes on node")
+
+		return status.Errorf(codes.ResourceExhausted, "too many sandboxes resuming on this node, please retry")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor plus additional tracing around the semaphore wait path; behavior is effectively unchanged aside from improved observability and centralized error handling.
> 
> **Overview**
> Adds a shared `Server.waitForAcquire` helper for snapshot-based sandbox creates that wraps the semaphore `Acquire` with a 15s timeout, a new tracing span (`wait-for-acquire`), and consistent `ResourceExhausted` telemetry/error mapping.
> 
> `Create` now calls this helper instead of inlining the acquire/timeout logic, keeping non-snapshot creates on the existing `TryAcquire` fast-path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa599cd88ec658514baaf10f61977abafc9a2b8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->