### PR TITLE
Use v2 endpoint for service discovery

### DIFF
--- a/packages/api/internal/clusters/discovery/remote.go
+++ b/packages/api/internal/clusters/discovery/remote.go
@@ -29,7 +29,7 @@ func (sd *RemoteServiceDiscovery) Query(ctx context.Context) ([]Item, error) {
 	ctx, span := tracer.Start(ctx, "query-remote-cluster-nodes", trace.WithAttributes(telemetry.WithClusterID(sd.clusterID)))
 	defer span.End()
 
-	res, err := sd.client.V2ServiceDiscoveryGetOrchestratorsWithResponse(ctx)
+	res, err := sd.client.V1ServiceDiscoveryWithResponse(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster instances from service discovery: %w", err)
 	}

--- a/spec/openapi-edge.yml
+++ b/spec/openapi-edge.yml
@@ -86,7 +86,7 @@ components:
         - orchestrator
         - template-builder
 
-    ClusterOrchestratorDiscovery:
+    ClusterServiceDiscovery:
       required:
         - orchestrators
       properties:
@@ -359,10 +359,10 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /v2/service-discovery/nodes/orchestrators:
+  /v1/service-discovery:
     get:
-      operationId: V2ServiceDiscoveryGetOrchestrators
-      summary: Get the discovered orchestrators
+      operationId: v1ServiceDiscovery
+      summary: Get the service discovery information
       security:
         - ApiKeyAuth: []
       tags: [service-discovery]
@@ -372,7 +372,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ClusterOrchestratorDiscovery"
+                $ref: "#/components/schemas/ClusterServiceDiscovery"
         "401":
           $ref: "#/components/responses/401"
         "500":


### PR DESCRIPTION
- Uses the new V2 endpoint for remote cluster discovery.
- Use of a limited OpenAPI spec that shows only public endpoints.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes a core discovery code path and the response schema it depends on; failures would impact cross-cluster node discovery until all services are deployed with the new endpoint.
> 
> **Overview**
> Remote cluster discovery now calls `GET /v1/service-discovery` (via `V1ServiceDiscoveryWithResponse`) and reads orchestrators from the new `ClusterServiceDiscovery` response shape.
> 
> The Edge OpenAPI spec and generated client were updated accordingly: adds `ClusterServiceDiscovery`, introduces `V1ServiceDiscovery` in the client, marks the old orchestrators-only endpoint as deprecated, and removes several previously-generated/internal endpoints and types (e.g., node drain/kill, traffic health check, `ClusterNode`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a3caf0d2be0aed4383ba833a3511007424becc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->