### PR TITLE
docs: fix inaccuracies in self-host.md guide

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -41,7 +41,7 @@
 **Optional**
 
 Recommended for monitoring and logging
-- Grafana Account & Stack (see Step 15 for detailed notes)
+- Grafana Account & Stack
 - Posthog Account
 
 ## Steps
@@ -54,8 +54,8 @@ Check if you can use config for terraform state management
     > Get Postgres database connection string from your database, e.g. [from Supabase](https://supabase.com/docs/guides/database/connecting-to-postgres#direct-connection): Create a new project in Supabase and go to your project in Supabase -> Settings -> Database -> Connection Strings -> Postgres -> Direct
     
     > Your Postgres database needs to have enabled IPv4 access. You can do that in Connect screen
-3. Run `make set-env ENV={prod,staging,dev}` to start using your env
-4. Run `make login-gcloud` to login to `gcloud`
+3. Run `make switch-env ENV={prod,staging,dev}` to start using your env
+4. Run `make provider-login` to login to `gcloud`
 5. Run `make init`. If this errors, run it a second time--it's due to a race condition on Terraform enabling API access for the various GCP services; this can take several seconds. A full list of services that will be enabled for API access:
    - [Secret Manager API](https://console.cloud.google.com/apis/library/secretmanager.googleapis.com)
    - [Certificate Manager API](https://console.cloud.google.com/apis/library/certificatemanager.googleapis.com)
@@ -64,15 +64,16 @@ Check if you can use config for terraform state management
    - [OS Config API](https://console.cloud.google.com/apis/library/osconfig.googleapis.com)
    - [Stackdriver Monitoring API](https://console.cloud.google.com/apis/library/monitoring.googleapis.com)
    - [Stackdriver Logging API](https://console.cloud.google.com/apis/library/logging.googleapis.com)
+   - [Filestore API](https://console.cloud.google.com/apis/library/file.googleapis.com)
 6. Run `make build-and-upload`
 7. Run `make copy-public-builds`. This will copy kernel and rootfs builds for Firecracker to your bucket. You can [build your own](#building-firecracker-and-uffd-from-source) kernel and Firecracker roots.
-8. Secrets are created and stored in GCP Secrets Manager. Once created, that is the source of truth--you will need to update values there to make changes. Create a secret value for the following secrets:
+8. Terraform creates empty secret containers in GCP Secrets Manager. You need to add a **secret version** with the actual value for each secret. Go to [GCP Secrets Manager](https://console.cloud.google.com/security/secret-manager), click on the secret, then click "New Version" to add the value. Add versions for the following secrets:
   - e2b-cloudflare-api-token
       > Get Cloudflare API Token: go to the [Cloudflare dashboard](https://dash.cloudflare.com/) -> Manage Account -> Account API Tokens -> Create Token -> Edit Zone DNS -> in "Zone Resources" select your domain and generate the token
-  - Posthog API keys for monitoring (optional)
+  - e2b-posthog-api-key (optional, for monitoring)
 9. Run `make plan-without-jobs` and then `make apply`
-10. Fill out the following secret in the GCP Secrets Manager:
-  - e2b-postgres-connection-string
+10. Add secret versions for the following secrets in [GCP Secrets Manager](https://console.cloud.google.com/security/secret-manager) (click on each secret, then "New Version"):
+  - e2b-postgres-connection-string (**required** - this secret does not have a placeholder version, so you must add one before step 11)
   - e2b-supabase-jwt-secrets (optional / required to self-host the [E2B dashboard](https://github.com/e2b-dev/dashboard))
       > Get Supabase JWT Secret: go to the [Supabase dashboard](https://supabase.com/dashboard) -> Select your Project -> Project Settings -> Data API -> JWT Settings
 11. Run `make plan` and then `make apply`. Note: This will work after the TLS certificates was issued. It can take some time; you can check the status in the Google Cloud Console
@@ -110,7 +111,7 @@ E2B_DOMAIN=<your-domain> e2b <command>
 
 To access the nomad web UI, go to https://nomad.<your-domain.com>. Go to sign in, and when prompted for an API token, you can find this in GCP Secrets Manager. From here, you can see nomad jobs and tasks for both client and server, including logging.
 
-To update jobs running in the cluster look inside packages/nomad for config files. This can be useful for setting your logging and monitoring agents.
+To update jobs running in the cluster look inside `iac/provider-gcp/nomad/jobs/` for config files. This can be useful for setting your logging and monitoring agents.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary

- Fix step 3: change `make set-env` to `make switch-env` (the correct command that also reinitializes Terraform backend)
- Fix step 4: change `make login-gcloud` to `make provider-login` (the actual Makefile target)
- Add Filestore API to the GCP APIs list in step 5
- Clarify that users must add secret **versions** in GCP Console (Terraform creates empty secret containers)
- Note that `e2b-postgres-connection-string` requires manual version creation before step 11 (unlike other secrets, it doesn't get a placeholder version)
- Remove reference to non-existent "Step 15" for Grafana setup
- Fix Nomad config path from `packages/nomad` to `iac/provider-gcp/nomad/jobs/`

## Test plan

- [ ] Review documentation changes for accuracy
- [ ] Verify make targets exist in Makefile

Made with [Cursor](https://cursor.com)