### PR TITLE
chore: cleanup builds to env assignments migration

### DIFF
--- a/packages/api/internal/handlers/sandbox.go
+++ b/packages/api/internal/handlers/sandbox.go
@@ -35,6 +35,7 @@ func (a *APIStore) startSandbox(
 	requestHeader *http.Header,
 	isResume bool,
 	nodeID *string,
+	templateID string,
 	baseTemplateID string,
 	autoPause bool,
 	envdAccessToken *string,
@@ -61,6 +62,7 @@ func (a *APIStore) startSandbox(
 		timeout,
 		isResume,
 		nodeID,
+		templateID,
 		baseTemplateID,
 		autoPause,
 		envdAccessToken,
@@ -79,7 +81,7 @@ func (a *APIStore) startSandbox(
 	a.posthog.IdentifyAnalyticsTeam(ctx, team.ID.String(), team.Name)
 	properties := a.posthog.GetPackageToPosthogProperties(requestHeader)
 	props := properties.
-		Set("environment", build.EnvID).
+		Set("environment", sandbox.TemplateID).
 		Set("instance_id", sandbox.SandboxID).
 		Set("alias", alias).
 		Set("resume", isResume).
@@ -115,7 +117,7 @@ func (a *APIStore) startSandbox(
 
 	sbxlogger.E(&sbxlogger.SandboxMetadata{
 		SandboxID:  sandbox.SandboxID,
-		TemplateID: build.EnvID,
+		TemplateID: sandbox.TemplateID,
 		TeamID:     team.ID.String(),
 	}).Info(ctx, "Sandbox created", zap.String("end_time", endTime.Format("2006-01-02 15:04:05 -07:00")))
 

--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -135,7 +135,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 
 	sbxlogger.E(&sbxlogger.SandboxMetadata{
 		SandboxID:  sandboxID,
-		TemplateID: build.EnvID,
+		TemplateID: snap.EnvID,
 		TeamID:     teamID.String(),
 	}).Debug(ctx, "Started resuming sandbox")
 
@@ -143,7 +143,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 	if snap.EnvSecure {
 		accessToken, tokenErr := a.getEnvdAccessToken(build.EnvdVersion, sandboxID)
 		if tokenErr != nil {
-			logger.L().Error(ctx, "Secure envd access token error", zap.Error(tokenErr.Err), logger.WithTemplateID(build.EnvID), logger.WithBuildID(build.ID.String()), logger.WithSandboxID(sandboxID))
+			logger.L().Error(ctx, "Secure envd access token error", zap.Error(tokenErr.Err), logger.WithTemplateID(snap.EnvID), logger.WithBuildID(build.ID.String()), logger.WithSandboxID(sandboxID))
 			a.sendAPIStoreError(c, tokenErr.Code, tokenErr.ClientMsg)
 
 			return
@@ -169,6 +169,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		&c.Request.Header,
 		true,
 		nodeID,
+		snap.EnvID,
 		snap.BaseEnvID,
 		autoPause,
 		envdAccessToken,

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -202,6 +202,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		false,
 		nil,
 		env.TemplateID,
+		env.TemplateID,
 		autoPause,
 		envdAccessToken,
 		allowInternetAccess,

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -134,7 +134,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 	sbxlogger.E(&sbxlogger.SandboxMetadata{
 		SandboxID:  sandboxID,
-		TemplateID: build.EnvID,
+		TemplateID: snap.EnvID,
 		TeamID:     teamID.String(),
 	}).Debug(ctx, "Started resuming sandbox")
 
@@ -142,7 +142,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	if snap.EnvSecure {
 		accessToken, tokenErr := a.getEnvdAccessToken(build.EnvdVersion, sandboxID)
 		if tokenErr != nil {
-			logger.L().Error(ctx, "Secure envd access token error", zap.Error(tokenErr.Err), logger.WithTemplateID(build.EnvID), logger.WithBuildID(build.ID.String()), logger.WithSandboxID(sandboxID))
+			logger.L().Error(ctx, "Secure envd access token error", zap.Error(tokenErr.Err), logger.WithTemplateID(snap.EnvID), logger.WithBuildID(build.ID.String()), logger.WithSandboxID(sandboxID))
 			a.sendAPIStoreError(c, tokenErr.Code, tokenErr.ClientMsg)
 
 			return
@@ -168,6 +168,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		&c.Request.Header,
 		true,
 		nodeID,
+		snap.EnvID,
 		snap.BaseEnvID,
 		autoPause,
 		envdAccessToken,

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -95,6 +95,7 @@ func (o *Orchestrator) CreateSandbox(
 	timeout time.Duration,
 	isResume bool,
 	nodeID *string,
+	templateID string,
 	baseTemplateID string,
 	autoPause bool,
 	envdAuthToken *string,
@@ -212,7 +213,7 @@ func (o *Orchestrator) CreateSandbox(
 	sbxRequest := &orchestrator.SandboxCreateRequest{
 		Sandbox: &orchestrator.SandboxConfig{
 			BaseTemplateId:      baseTemplateID,
-			TemplateId:          build.EnvID,
+			TemplateId:          templateID,
 			Alias:               &alias,
 			TeamId:              team.ID.String(),
 			BuildId:             build.ID.String(),
@@ -283,7 +284,7 @@ func (o *Orchestrator) CreateSandbox(
 
 	sbx = sandbox.NewSandbox(
 		sandboxID,
-		build.EnvID,
+		templateID,
 		consts.ClientID,
 		&alias,
 		executionID,

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -197,7 +197,6 @@ func RegisterBuild(
 	// Insert the new build
 	err = client.CreateTemplateBuild(ctx, queries.CreateTemplateBuildParams{
 		BuildID:            buildID,
-		TemplateID:         data.TemplateID,
 		RamMb:              ramMB,
 		Vcpu:               cpuCount,
 		KernelVersion:      data.KernelVersion,
@@ -314,24 +313,6 @@ func RegisterBuild(
 		}
 
 		telemetry.ReportEvent(ctx, "inserted alias", attribute.String("env.alias", alias))
-	}
-
-	if len(data.Tags) != 0 {
-		// TODO: Remove this once the migration is deployed [ENG-3268](https://linear.app/e2b/issue/ENG-3268)
-		err = client.DeleteTriggerTemplateBuildAssignment(ctx, queries.DeleteTriggerTemplateBuildAssignmentParams{
-			TemplateID: data.TemplateID,
-			BuildID:    buildID,
-			Tag:        id.DefaultTag,
-		})
-		if err != nil {
-			telemetry.ReportCriticalError(ctx, "error when deleting tag assignment", err, attribute.String("tag", id.DefaultTag))
-
-			return nil, &api.APIError{
-				Err:       err,
-				ClientMsg: fmt.Sprintf("Error when deleting tag assignment: %s", err),
-				Code:      http.StatusInternalServerError,
-			}
-		}
 	}
 
 	for _, tag := range tags {

--- a/packages/db/migrations/20260204172712_remove_build_assignment_triggers.sql
+++ b/packages/db/migrations/20260204172712_remove_build_assignment_triggers.sql
@@ -1,0 +1,124 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- +goose StatementBegin
+-- Remove triggers used during the transition period for build assignments.
+-- The application now directly manages env_build_assignments, so these are no longer needed.
+
+-- Drop the sync trigger that auto-created assignments when env_builds were updated
+DROP TRIGGER IF EXISTS trigger_sync_env_build_assignment ON env_builds;
+
+-- Drop the validation trigger that handled 'app' vs 'trigger' source conflicts
+DROP TRIGGER IF EXISTS trigger_validate_assignment_source ON env_build_assignments;
+
+-- Drop the functions used by these triggers
+DROP FUNCTION IF EXISTS sync_env_build_assignment();
+DROP FUNCTION IF EXISTS validate_assignment_source_takeover();
+-- +goose StatementEnd
+
+-- Drop the index on env_id since we're no longer using it
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_builds_env_status_created;
+
+-- +goose StatementBegin
+-- Drop the foreign key constraint and make env_id nullable (will be removed in a future migration)
+ALTER TABLE env_builds DROP CONSTRAINT IF EXISTS env_builds_envs_builds;
+ALTER TABLE env_builds ALTER COLUMN env_id DROP NOT NULL;
+
+-- Add a backfill trigger that populates env_id from assignments for backward compatibility
+-- This allows old code to read env_id while new code no longer writes it
+CREATE OR REPLACE FUNCTION backfill_env_id_from_assignment()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE env_builds SET env_id = NEW.env_id WHERE id = NEW.build_id AND env_id IS NULL;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_backfill_env_id
+    AFTER INSERT ON env_build_assignments
+    FOR EACH ROW EXECUTE FUNCTION backfill_env_id_from_assignment();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- +goose StatementBegin
+-- Drop the backfill trigger (added for backward compat during transition)
+DROP TRIGGER IF EXISTS trigger_backfill_env_id ON env_build_assignments;
+DROP FUNCTION IF EXISTS backfill_env_id_from_assignment();
+
+-- Populate env_id from env_build_assignments for any builds that have NULL env_id
+-- This is needed before we can restore the NOT NULL constraint
+UPDATE env_builds eb
+SET env_id = (
+    SELECT eba.env_id 
+    FROM env_build_assignments eba 
+    WHERE eba.build_id = eb.id 
+    LIMIT 1
+)
+WHERE eb.env_id IS NULL;
+
+-- Delete any orphaned builds that don't have an assignment (shouldn't happen, but safety first)
+DELETE FROM env_builds WHERE env_id IS NULL;
+
+-- Restore the NOT NULL constraint and foreign key constraint
+ALTER TABLE env_builds ALTER COLUMN env_id SET NOT NULL;
+ALTER TABLE env_builds ADD CONSTRAINT env_builds_envs_builds 
+    FOREIGN KEY (env_id) REFERENCES envs(id) ON DELETE CASCADE;
+-- +goose StatementEnd
+
+-- Recreate the index
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_env_status_created
+    ON env_builds (env_id, status, created_at DESC);
+
+-- +goose StatementBegin
+-- Recreate the sync trigger function
+CREATE OR REPLACE FUNCTION sync_env_build_assignment()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.env_id IS NOT NULL THEN
+        IF TG_OP = 'INSERT' OR (TG_OP = 'UPDATE' AND OLD.env_id != NEW.env_id) THEN
+            INSERT INTO env_build_assignments (env_id, build_id, tag, source, created_at)
+            VALUES (NEW.env_id, NEW.id, 'default', 'trigger', CURRENT_TIMESTAMP)
+            ON CONFLICT (env_id, build_id, tag) WHERE source IN ('trigger', 'migration') DO NOTHING;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate the sync trigger
+CREATE TRIGGER trigger_sync_env_build_assignment
+    AFTER INSERT OR UPDATE ON env_builds
+    FOR EACH ROW
+    EXECUTE FUNCTION sync_env_build_assignment();
+
+-- Recreate the validation trigger function
+CREATE OR REPLACE FUNCTION validate_assignment_source_takeover()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- If trigger tries to insert but an 'app' record already exists, skip it
+    IF NEW.source = 'trigger' THEN
+        IF EXISTS (
+            SELECT 1 FROM env_build_assignments 
+            WHERE env_id = NEW.env_id AND build_id = NEW.build_id AND tag = NEW.tag AND source = 'app'
+        ) THEN
+            RETURN NULL;
+        END IF;
+    
+    -- If 'app' inserts, we clean up any legacy 'trigger' or 'migration' records for this identity
+    ELSIF NEW.source = 'app' THEN
+        DELETE FROM env_build_assignments 
+        WHERE env_id = NEW.env_id AND build_id = NEW.build_id AND tag = NEW.tag 
+        AND source IN ('trigger', 'migration');
+    END IF;
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Recreate the validation trigger
+CREATE TRIGGER trigger_validate_assignment_source
+    BEFORE INSERT ON env_build_assignments
+    FOR EACH ROW EXECUTE FUNCTION validate_assignment_source_takeover();
+-- +goose StatementEnd

--- a/packages/db/pkg/auth/queries/models.go
+++ b/packages/db/pkg/auth/queries/models.go
@@ -91,7 +91,7 @@ type EnvBuild struct {
 	TotalDiskSizeMb    *int64
 	KernelVersion      string
 	FirecrackerVersion string
-	EnvID              string
+	EnvID              *string
 	EnvdVersion        *string
 	ReadyCmd           *string
 	ClusterNodeID      *string

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -63,7 +63,6 @@ snapshot as (
 
 new_build as (
     INSERT INTO "public"."env_builds" (
-        env_id,
         vcpu,
         ram_mb,
         free_disk_size_mb,
@@ -80,7 +79,6 @@ new_build as (
         cpu_model_name,
         cpu_flags
     ) VALUES (
-        (SELECT template_id FROM snapshot),
         $12,
         $13,
         $14,
@@ -96,20 +94,20 @@ new_build as (
         $22,
         $23,
         $24
-    ) RETURNING id as build_id, env_id as template_id
+    ) RETURNING id as build_id
 ),
 
 build_assignment as (
     INSERT INTO "public"."env_build_assignments" (env_id, build_id, tag)
     VALUES (
-        (SELECT template_id FROM new_build),
+        (SELECT template_id FROM snapshot),
         (SELECT build_id FROM new_build),
         'default'
     )
     RETURNING build_id, env_id as template_id
 )
 
-SELECT build_id, template_id FROM new_build
+SELECT build_id, template_id FROM build_assignment
 `
 
 type UpsertSnapshotParams struct {
@@ -145,7 +143,7 @@ type UpsertSnapshotRow struct {
 }
 
 // Create a new snapshot or update an existing one
-// Create a new build for the snapshot
+// Create a new build for the snapshot (env_id populated by trigger from assignment)
 // Create the build assignment edge (explicit, not relying on trigger)
 func (q *Queries) UpsertSnapshot(ctx context.Context, arg UpsertSnapshotParams) (UpsertSnapshotRow, error) {
 	row := q.db.QueryRow(ctx, upsertSnapshot,

--- a/packages/db/queries/create_template.sql.go
+++ b/packages/db/queries/create_template.sql.go
@@ -41,7 +41,6 @@ const createTemplateBuild = `-- name: CreateTemplateBuild :exec
 INSERT INTO "public"."env_builds" (
     id,
     updated_at,
-    env_id,
     status,
     ram_mb,
     vcpu,
@@ -55,8 +54,8 @@ INSERT INTO "public"."env_builds" (
 ) VALUES (
     $1,
     NOW(),
-    $2,
     'waiting',
+    $2,
     $3,
     $4,
     $5,
@@ -64,14 +63,12 @@ INSERT INTO "public"."env_builds" (
     $7,
     $8,
     $9,
-    $10,
-    $11
+    $10
 )
 `
 
 type CreateTemplateBuildParams struct {
 	BuildID            uuid.UUID
-	TemplateID         string
 	RamMb              int64
 	Vcpu               int64
 	KernelVersion      string
@@ -86,7 +83,6 @@ type CreateTemplateBuildParams struct {
 func (q *Queries) CreateTemplateBuild(ctx context.Context, arg CreateTemplateBuildParams) error {
 	_, err := q.db.Exec(ctx, createTemplateBuild,
 		arg.BuildID,
-		arg.TemplateID,
 		arg.RamMb,
 		arg.Vcpu,
 		arg.KernelVersion,

--- a/packages/db/queries/delete_template_build_assignment.sql.go
+++ b/packages/db/queries/delete_template_build_assignment.sql.go
@@ -7,8 +7,6 @@ package queries
 
 import (
 	"context"
-
-	"github.com/google/uuid"
 )
 
 const deleteTemplateTags = `-- name: DeleteTemplateTags :exec
@@ -24,22 +22,5 @@ type DeleteTemplateTagsParams struct {
 // Deletes tag assignments from a template (env)
 func (q *Queries) DeleteTemplateTags(ctx context.Context, arg DeleteTemplateTagsParams) error {
 	_, err := q.db.Exec(ctx, deleteTemplateTags, arg.TemplateID, arg.Tags)
-	return err
-}
-
-const deleteTriggerTemplateBuildAssignment = `-- name: DeleteTriggerTemplateBuildAssignment :exec
-DELETE FROM "public"."env_build_assignments"
-WHERE env_id = $1 AND build_id = $2 AND tag = $3::text AND source = 'trigger'
-`
-
-type DeleteTriggerTemplateBuildAssignmentParams struct {
-	TemplateID string
-	BuildID    uuid.UUID
-	Tag        string
-}
-
-// Deletes a tag assignment from a template (env)
-func (q *Queries) DeleteTriggerTemplateBuildAssignment(ctx context.Context, arg DeleteTriggerTemplateBuildAssignmentParams) error {
-	_, err := q.db.Exec(ctx, deleteTriggerTemplateBuildAssignment, arg.TemplateID, arg.BuildID, arg.Tag)
 	return err
 }

--- a/packages/db/queries/models.go
+++ b/packages/db/queries/models.go
@@ -91,7 +91,7 @@ type EnvBuild struct {
 	TotalDiskSizeMb    *int64
 	KernelVersion      string
 	FirecrackerVersion string
-	EnvID              string
+	EnvID              *string
 	EnvdVersion        *string
 	ReadyCmd           *string
 	ClusterNodeID      *string

--- a/packages/db/queries/templates/create_template.sql
+++ b/packages/db/queries/templates/create_template.sql
@@ -21,7 +21,6 @@ WHERE eba.build_id = eb.id
 INSERT INTO "public"."env_builds" (
     id,
     updated_at,
-    env_id,
     status,
     ram_mb,
     vcpu,
@@ -35,7 +34,6 @@ INSERT INTO "public"."env_builds" (
 ) VALUES (
     @build_id,
     NOW(),
-    @template_id,
     'waiting',
     @ram_mb,
     @vcpu,

--- a/packages/db/queries/templates/delete_template_build_assignment.sql
+++ b/packages/db/queries/templates/delete_template_build_assignment.sql
@@ -2,9 +2,3 @@
 -- Deletes tag assignments from a template (env)
 DELETE FROM "public"."env_build_assignments"
 WHERE env_id = @template_id AND tag = ANY(@tags::text[]);
-
-
--- name: DeleteTriggerTemplateBuildAssignment :exec
--- Deletes a tag assignment from a template (env)
-DELETE FROM "public"."env_build_assignments"
-WHERE env_id = @template_id AND build_id = @build_id AND tag = @tag::text AND source = 'trigger';

--- a/packages/docker-reverse-proxy/internal/auth/validate_test.go
+++ b/packages/docker-reverse-proxy/internal/auth/validate_test.go
@@ -158,8 +158,14 @@ func setupValidateTest(tb testing.TB, db *testutils.Database, userID, teamID uui
 		finishedAt = &now
 	}
 	err = db.SqlcClient.TestsRawSQL(tb.Context(), `
-		INSERT INTO env_builds (id, env_id, status, finished_at, dockerfile, updated_at, vcpu, ram_mb, free_disk_size_mb, firecracker_version, kernel_version, cluster_node_id)
-		VALUES ($1, $2, $3, $4, 'FROM ubuntu', NOW(), 1, 1024, 1024, '0.0.0', '0.0.0', 'abc')
-	`, buildID, envID, createdEnvStatus, finishedAt)
+		INSERT INTO env_builds (id, status, finished_at, dockerfile, updated_at, vcpu, ram_mb, free_disk_size_mb, firecracker_version, kernel_version, cluster_node_id)
+		VALUES ($1, $2, $3, 'FROM ubuntu', NOW(), 1, 1024, 1024, '0.0.0', '0.0.0', 'abc')
+	`, buildID, createdEnvStatus, finishedAt)
+	require.NoError(tb, err)
+
+	err = db.SqlcClient.TestsRawSQL(tb.Context(), `
+		INSERT INTO env_build_assignments (env_id, build_id, tag)
+		VALUES ($1, $2, 'default')
+	`, envID, buildID)
 	require.NoError(tb, err)
 }

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -183,16 +183,15 @@ VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
 
 	oldBuildTime := time.Now().Add(-time.Hour)
 	// Important: Insert builds in chronological order (oldest first, newest last)
-	// because the trigger on env_builds creates env_build_assignments with CURRENT_TIMESTAMP.
 	// The query uses ORDER BY eba.created_at DESC to get the latest build,
-	// so the last inserted build will be selected.
+	// so the last inserted build assignment will be selected.
 	builds := []buildData{
 		// An older build, so we have multiple builds - inserted FIRST
 		{
 			id:        uuid.New(),
 			createdAt: &oldBuildTime,
 		},
-		// Primary build - inserted LAST so it has the latest trigger-created timestamp
+		// Primary build - inserted LAST so it has the latest assignment timestamp
 		{
 			id:        data.BuildID,
 			createdAt: nil,
@@ -203,26 +202,47 @@ VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
 		if build.createdAt != nil {
 			err = db.TestsRawSQL(ctx, `
 INSERT INTO env_builds (
-	id, env_id, dockerfile, status, vcpu, ram_mb, free_disk_size_mb,
+	id, dockerfile, status, vcpu, ram_mb, free_disk_size_mb,
 	total_disk_size_mb, kernel_version, firecracker_version, envd_version,
 	cluster_node_id, version, created_at, updated_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, CURRENT_TIMESTAMP)
-`, build.id, data.EnvID, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
+`, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
 				2, 512, 512, 1982, "vmlinux-6.1.102", "v1.12.1_d990331", "0.2.4",
 				"integration-test-node", templates.TemplateV1Version, build.createdAt)
 		} else {
 			err = db.TestsRawSQL(ctx, `
 INSERT INTO env_builds (
-	id, env_id, dockerfile, status, vcpu, ram_mb, free_disk_size_mb,
+	id, dockerfile, status, vcpu, ram_mb, free_disk_size_mb,
 	total_disk_size_mb, kernel_version, firecracker_version, envd_version,
 	cluster_node_id, version, updated_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
-`, build.id, data.EnvID, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, CURRENT_TIMESTAMP)
+`, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
 				2, 512, 512, 1982, "vmlinux-6.1.102", "v1.12.1_d990331", "0.2.4",
 				"integration-test-node", templates.TemplateV1Version)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to create env build: %w", err)
+		}
+
+		// Create the build assignment (trigger will backfill env_id for backward compat)
+		var assignmentCreatedAt *time.Time
+		if build.createdAt != nil {
+			assignmentCreatedAt = build.createdAt
+		}
+
+		if assignmentCreatedAt != nil {
+			err = db.TestsRawSQL(ctx, `
+INSERT INTO env_build_assignments (env_id, build_id, tag, created_at)
+VALUES ($1, $2, 'default', $3)
+`, data.EnvID, build.id, assignmentCreatedAt)
+		} else {
+			err = db.TestsRawSQL(ctx, `
+INSERT INTO env_build_assignments (env_id, build_id, tag)
+VALUES ($1, $2, 'default')
+`, data.EnvID, build.id)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to create env build assignment: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Includes a DB migration that changes constraints/triggers on `env_builds` and alters how build/template relationships are written, which can break build selection and sandbox creation if assumptions are wrong. Also changes runtime identifiers used for orchestrator requests and analytics/logging.
> 
> **Overview**
> Completes the move from `env_builds.env_id` to explicit `env_build_assignments` ownership by making `env_id` nullable, removing legacy sync/validation triggers and the related cleanup code path, and updating snapshot/build creation to always create assignments directly. Sandbox start/resume paths now pass an explicit `templateID` through to the orchestrator and use snapshot/template IDs for logging/analytics instead of relying on `build.EnvID`. Tests and integration seeding are updated to insert build assignments explicitly, and `EnvBuild.EnvID` is now optional to reflect the transitional schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e627868642925e5a41a806ee278cf6c4565fe556. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->