### PR TITLE
Fix inspect command bug

### DIFF
--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -41,7 +41,7 @@ func main() {
 	if *memfile {
 		artifactName = "memfile"
 	} else {
-		artifactName = "rootfs"
+		artifactName = "rootfs.ext4"
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change to a CLI-only artifact filename constant; no security-sensitive logic or data mutations involved.
> 
> **Overview**
> Fixes `inspect-build -rootfs` to look for the correct root filesystem artifact name by switching from `rootfs` to `rootfs.ext4`, so the command can successfully read the corresponding header/data files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 442c2367a5fed9d9b15fbca3755f351c7d9bc1e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->