### PR TITLE
chore(api): decrease log level for auth error

### DIFF
--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -116,7 +116,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 	}
 
 	if lastSnapshot.Snapshot.TeamID != teamID {
-		telemetry.ReportCriticalError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxID, teamID.String()), nil)
+		telemetry.ReportError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxID, teamID.String()), nil)
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox \"%s\"", sandboxID))
 
 		return

--- a/packages/api/internal/handlers/sandbox_get.go
+++ b/packages/api/internal/handlers/sandbox_get.go
@@ -99,7 +99,7 @@ func (a *APIStore) GetSandboxesSandboxID(c *gin.Context, id string) {
 	}
 
 	if lastSnapshot.Snapshot.TeamID != team.ID {
-		telemetry.ReportCriticalError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxId, team.ID.String()), nil)
+		telemetry.ReportError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxId, team.ID.String()), nil)
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox \"%s\"", id))
 
 		return

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -112,7 +112,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	}
 
 	if lastSnapshot.Snapshot.TeamID != teamID {
-		telemetry.ReportCriticalError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxID, teamID.String()), nil)
+		telemetry.ReportError(ctx, fmt.Sprintf("snapshot for sandbox '%s' doesn't belong to team '%s'", sandboxID, teamID.String()), nil)
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox \"%s\"", sandboxID))
 
 		return


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small change limited to telemetry severity; request handling and authorization outcomes are unchanged.
> 
> **Overview**
> This PR lowers telemetry severity from `ReportCriticalError` to `ReportError` when the API detects a snapshot/team ownership mismatch while connecting to, resuming, or fetching a sandbox, without changing the returned HTTP errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d48df83ea971f4071b669f3e0b391aa1a0080e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->