### PR TITLE
Fix Makefile indentation in generate-tests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,9 @@ generate/%:
 .PHONY: generate-tests
 generate-tests: generate-tests/integration
 generate-tests/%:
-		@echo "Generating code for *$(notdir $@)*"
-		$(MAKE) -C tests/$(notdir $@) generate
-		@printf "\n\n"
+	@echo "Generating code for *$(notdir $@)*"
+	$(MAKE) -C tests/$(notdir $@) generate
+	@printf "\n\n"
 
 .PHONY: migrate
 migrate:


### PR DESCRIPTION
Remove extra leading tab to use single tab indentation for recipe lines, making it consistent with the rest of the Makefile.

---

technically, the make rules start with one tab, the second tab goes to the shell interpreter.