### PR TITLE
fix: correct .PHONY typo in shared Makefile

### DIFF
--- a/packages/shared/Makefile
+++ b/packages/shared/Makefile
@@ -1,7 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
-.PHONE: generate
+.PHONY: generate
 generate:
 	go generate ./...
 


### PR DESCRIPTION
I noticed one more `.PHONY` typo in `Makefile`, see #1867 for previous ones. Yes, I greped the whole repo now, it is the last one :)