### PR TITLE
fix(envd): load supplementary groups when spawning user processes

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -80,7 +80,9 @@ func New(
 	}
 
 	groups := []uint32{gid}
-	if gids, err := user.GroupIds(); err == nil {
+	if gids, err := user.GroupIds(); err != nil {
+		logger.Warn().Err(err).Str("user", user.Username).Msg("failed to get supplementary groups")
+	} else {
 		for _, g := range gids {
 			if parsed, err := strconv.ParseUint(g, 10, 32); err == nil {
 				groups = append(groups, uint32(parsed))


### PR DESCRIPTION
## Summary

- envd spawns user processes with `NoSetGroups: true` and `Groups: []uint32{gid}` (primary GID only). This skips the `setgroups()` syscall, so supplementary group memberships from `/etc/group` are never applied.
- Any user added to a group during template build (e.g. `usermod -aG docker user`) cannot access group-owned resources at runtime (e.g. Docker socket `srw-rw---- root:docker`).
- Fix: resolve supplementary groups via `user.GroupIds()`, pass them in `Credential.Groups`, and remove `NoSetGroups: true` so Go calls `setgroups()` before exec.

### Why this happens

Go's `syscall.Credential` has two relevant fields:
- `Groups []uint32` — the supplementary GIDs to set
- `NoSetGroups bool` — when `true`, Go skips calling `setgroups()` entirely

The current code sets `NoSetGroups: true` and only puts the primary GID in `Groups`. The child process inherits the parent's (root) group list instead of getting the user's groups from `/etc/group`. Running `id` in a sandbox shows `groups=1001(user)` with an empty `/proc/self/status Groups:` line, even when `getent group docker` correctly shows `docker:x:997:user`.

### Reproduction

In any E2B sandbox with a group-restricted resource:
```bash
# Template build: usermod -aG docker user
# Runtime:
$ id
uid=1001(user) gid=1001(user) groups=1001(user)    # no docker group
$ docker ps
permission denied

# But via login shell (which calls initgroups):
$ sudo su - user -c 'id'
uid=1001(user) gid=1001(user) groups=1001(user),27(sudo),100(users),997(docker)
$ sudo su - user -c 'docker ps'
CONTAINER ID   IMAGE   COMMAND   CREATED   STATUS   PORTS   NAMES
```

### Change

```diff
+  groups := []uint32{gid}
+  if gids, err := user.GroupIds(); err == nil {
+    for _, g := range gids {
+      if parsed, err := strconv.ParseUint(g, 10, 32); err == nil {
+        groups = append(groups, uint32(parsed))
+      }
+    }
+  }
+
   cmd.SysProcAttr = &syscall.SysProcAttr{
     Credential: &syscall.Credential{
-      Uid:         uid,
-      Gid:         gid,
-      Groups:      []uint32{gid},
-      NoSetGroups: true,
+      Uid:    uid,
+      Gid:    gid,
+      Groups: groups,
     },
   }
```

## Test plan

- [x] Validated fix in Linux Docker container — spawned process with `NoSetGroups: true` gets `Permission denied` on `root:docker 660` file; same process with the fix gets access
- [x] Validated `id` output shows supplementary groups with the fix
- [x] Reproduced the bug in live E2B sandboxes with both Docker group and custom groups