### PR TITLE
chore: remove OTEL tracing print configuration and related code

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -47,7 +47,6 @@ tf_vars := \
 	$(call tfvar, CLIENT_PROXY_UPDATE_MAX_PARALLEL) \
 	$(call tfvar, LOKI_RESOURCES_CPU_COUNT) \
 	$(call tfvar, LOKI_RESOURCES_MEMORY_MB) \
-	$(call tfvar, OTEL_TRACING_PRINT) \
 	$(call tfvar, OTEL_COLLECTOR_RESOURCES_CPU_COUNT) \
 	$(call tfvar, OTEL_COLLECTOR_RESOURCES_MEMORY_MB) \
 	$(call tfvar, TEMPLATE_BUCKET_NAME) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -146,7 +146,6 @@ module "nomad" {
   consul_acl_token_secret       = module.init.consul_acl_token_secret
   nomad_acl_token_secret        = module.init.nomad_acl_token_secret
   nomad_port                    = var.nomad_port
-  otel_tracing_print            = var.otel_tracing_print
   orchestration_repository_name = module.init.orchestration_repository_name
 
   # Clickhouse

--- a/iac/provider-gcp/nomad/jobs/api.hcl
+++ b/iac/provider-gcp/nomad/jobs/api.hcl
@@ -100,7 +100,6 @@ job "api" {
         POSTHOG_API_KEY                = "${posthog_api_key}"
         ANALYTICS_COLLECTOR_HOST       = "${analytics_collector_host}"
         ANALYTICS_COLLECTOR_API_TOKEN  = "${analytics_collector_api_token}"
-        OTEL_TRACING_PRINT             = "${otel_tracing_print}"
         LOGS_COLLECTOR_ADDRESS         = "${logs_collector_address}"
         OTEL_COLLECTOR_GRPC_ENDPOINT   = "${otel_collector_grpc_endpoint}"
 

--- a/iac/provider-gcp/nomad/jobs/orchestrator.hcl
+++ b/iac/provider-gcp/nomad/jobs/orchestrator.hcl
@@ -61,7 +61,6 @@ job "orchestrator-${latest_orchestrator_job_id}" {
       env {
         NODE_ID                      = "$${node.unique.name}"
         CONSUL_TOKEN                 = "${consul_acl_token}"
-        OTEL_TRACING_PRINT           = "${otel_tracing_print}"
         LOGS_COLLECTOR_ADDRESS       = "${logs_collector_address}"
         ENVIRONMENT                  = "${environment}"
         DOMAIN_NAME                  = "${domain_name}"

--- a/iac/provider-gcp/nomad/jobs/template-manager.hcl
+++ b/iac/provider-gcp/nomad/jobs/template-manager.hcl
@@ -100,7 +100,6 @@ job "template-manager" {
         GCP_REGION                    = "${gcp_region}"
         GCP_DOCKER_REPOSITORY_NAME    = "${docker_registry}"
         API_SECRET                    = "${api_secret}"
-        OTEL_TRACING_PRINT            = "${otel_tracing_print}"
         ENVIRONMENT                   = "${environment}"
         DOMAIN_NAME                   = "${domain_name}"
         TEMPLATE_BUCKET_NAME          = "${template_bucket_name}"

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -97,7 +97,6 @@ resource "nomad_job" "api" {
     environment                             = var.environment
     analytics_collector_host                = trimspace(data.google_secret_manager_secret_version.analytics_collector_host.secret_data)
     analytics_collector_api_token           = trimspace(data.google_secret_manager_secret_version.analytics_collector_api_token.secret_data)
-    otel_tracing_print                      = var.otel_tracing_print
     nomad_acl_token                         = var.nomad_acl_token_secret
     admin_token                             = var.api_admin_token
     redis_url                               = local.redis_url
@@ -396,7 +395,6 @@ locals {
     bucket_name                  = var.fc_env_pipeline_bucket_name
     orchestrator_checksum        = data.external.orchestrator_checksum.result.hex
     logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
-    otel_tracing_print           = var.otel_tracing_print
     template_bucket_name         = var.template_bucket_name
     otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
     allow_sandbox_internet       = var.allow_sandbox_internet
@@ -498,7 +496,6 @@ resource "nomad_job" "template_manager" {
     docker_registry                 = var.custom_envs_repository_name
     google_service_account_key      = var.google_service_account_key
     template_manager_checksum       = data.external.template_manager.result.hex
-    otel_tracing_print              = var.otel_tracing_print
     template_bucket_name            = var.template_bucket_name
     build_cache_bucket_name         = var.build_cache_bucket_name
     otel_collector_grpc_endpoint    = "localhost:${var.otel_collector_grpc_port}"

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -51,10 +51,6 @@ variable "otel_collector_resources_cpu_count" {
   type = number
 }
 
-variable "otel_tracing_print" {
-  type = bool
-}
-
 # API
 variable "api_port" {
   type = object({

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -291,12 +291,6 @@ variable "clickhouse_resources_cpu_count" {
   default = 4
 }
 
-variable "otel_tracing_print" {
-  description = "Whether to print OTEL traces to stdout"
-  type        = bool
-  default     = false
-}
-
 variable "domain_name" {
   type        = string
   description = "The domain name where e2b will run"

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -70,9 +70,6 @@ func main() {
 		log.Fatal("-to-build required")
 	}
 
-	// Always suppress OTEL tracing logs
-	cmdutil.SuppressOTELLogs()
-
 	// Suppress other noisy output unless verbose, but keep std log for fatal errors
 	if !*verbose {
 		cmdutil.SuppressNoisyLogsKeepStdLog()

--- a/packages/orchestrator/cmd/internal/cmdutil/cmdutil.go
+++ b/packages/orchestrator/cmd/internal/cmdutil/cmdutil.go
@@ -12,20 +12,11 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
-	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
-
-// SuppressOTELLogs disables OTEL tracing debug prints (-> and Attrs set: messages).
-// This should always be called in CLI commands, even in verbose mode.
-func SuppressOTELLogs() {
-	telemetry.OTELTracingPrint = false
-	os.Setenv("OTEL_TRACING_PRINT", "false")
-}
 
 // SuppressNoisyLogs disables verbose output from OTEL tracing, LaunchDarkly, and standard log.
 // Only ERROR level and above will be logged.
 func SuppressNoisyLogs() {
-	SuppressOTELLogs()
 	// Silence standard log package
 	log.SetOutput(io.Discard)
 	// Replace global zap logger with error-only logger
@@ -34,7 +25,6 @@ func SuppressNoisyLogs() {
 
 // SuppressNoisyLogsKeepStdLog disables verbose output but keeps standard log enabled.
 func SuppressNoisyLogsKeepStdLog() {
-	SuppressOTELLogs()
 	setErrorOnlyLogger()
 }
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -821,9 +821,6 @@ func (r *runner) benchmark(ctx context.Context, n int) error {
 }
 
 func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefetch, verbose bool, pauseOpts pauseOptions, runOpts runOptions) error {
-	// Always suppress OTEL tracing logs
-	cmdutil.SuppressOTELLogs()
-
 	// Silence other loggers unless verbose mode
 	var l logger.Logger
 	if !verbose {

--- a/packages/shared/pkg/telemetry/tracing.go
+++ b/packages/shared/pkg/telemetry/tracing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -14,63 +13,13 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-var OTELTracingPrint = os.Getenv("OTEL_TRACING_PRINT") != "false"
-
-const DebugID = "debug_id"
-
-func getDebugID(ctx context.Context) *string {
-	if ctx.Value(DebugID) == nil {
-		return nil
-	}
-
-	value := ctx.Value(DebugID).(string)
-
-	return &value
-}
-
-func debugFormat(debugID *string, msg string) string {
-	if debugID == nil {
-		return msg
-	}
-
-	return fmt.Sprintf("[%s] %s", *debugID, msg)
-}
-
 func SetAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
-
-	if OTELTracingPrint {
-		var msg string
-
-		if len(attrs) == 0 {
-			msg = "No attrs set"
-		} else {
-			msg = fmt.Sprintf("Attrs set: %#v\n", attrs)
-		}
-
-		debugID := getDebugID(ctx)
-		fmt.Print(debugFormat(debugID, msg))
-	}
-
 	span.SetAttributes(attrs...)
 }
 
 func ReportEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
-
-	if OTELTracingPrint {
-		var msg string
-
-		if len(attrs) == 0 {
-			msg = fmt.Sprintf("-> %s\n", name)
-		} else {
-			msg = fmt.Sprintf("-> %s - %#v\n", name, attrs)
-		}
-
-		debugID := getDebugID(ctx)
-		fmt.Print(debugFormat(debugID, msg))
-	}
-
 	span.AddEvent(name,
 		trace.WithAttributes(attrs...),
 	)
@@ -79,8 +28,7 @@ func ReportEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) 
 func ReportCriticalError(ctx context.Context, message string, err error, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
-	debugID := getDebugID(ctx)
-	logger.L().With(attributesToZapFields(attrs...)...).Error(ctx, message, zap.Stringp("debug_id", debugID), zap.Error(err))
+	logger.L().With(attributesToZapFields(attrs...)...).Error(ctx, message, zap.Error(err))
 
 	errorAttrs := append(attrs, attribute.String("error.message", message))
 
@@ -97,8 +45,7 @@ func ReportCriticalError(ctx context.Context, message string, err error, attrs .
 func ReportError(ctx context.Context, message string, err error, attrs ...attribute.KeyValue) {
 	span := trace.SpanFromContext(ctx)
 
-	debugID := getDebugID(ctx)
-	logger.L().With(attributesToZapFields(attrs...)...).Warn(ctx, message, zap.Stringp("debug_id", debugID), zap.Error(err))
+	logger.L().With(attributesToZapFields(attrs...)...).Warn(ctx, message, zap.Error(err))
 
 	span.RecordError(fmt.Errorf("%s: %w", message, err),
 		trace.WithStackTrace(true),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes a debug-only tracing print toggle and its plumbing; main risk is reduced observability if anyone relied on stdout trace prints, but runtime behavior and data paths are otherwise unchanged.
> 
> **Overview**
> Removes the `OTEL_TRACING_PRINT` configuration end-to-end by deleting the Terraform/Nomad variable wiring and env injection, dropping the CLI helper that forcibly disabled it, and simplifying shared telemetry tracing helpers to stop printing spans/attrs (and to stop attaching `debug_id` to logs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95a09d5def5254071bc36e57bb7ffbb25c63406c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->