### PR TITLE
chore: add index on env_builds.created_at

### DIFF
--- a/packages/db/migrations/20260210120000_add_env_builds_created_at_index.sql
+++ b/packages/db/migrations/20260210120000_add_env_builds_created_at_index.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_created_at ON env_builds (created_at DESC);
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_builds_created_at;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an online index build on a potentially large table; while `CONCURRENTLY` reduces locking, it can still increase DB load and the `IF NOT EXISTS` may skip creation if an older index with the same name already exists.
> 
> **Overview**
> Adds a Goose migration that creates a concurrent `idx_env_builds_created_at` index on `env_builds(created_at DESC)` and drops it on rollback, aiming to speed up queries ordered by build creation time.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07ad9ebb0342879977f8c2066bed6f3624f6ee74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->