### PR TITLE
feat: make host stats sampling interval configurable

### DIFF
--- a/packages/orchestrator/internal/sandbox/hoststats.go
+++ b/packages/orchestrator/internal/sandbox/hoststats.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -21,6 +22,7 @@ func initializeHostStatsCollector(
 	runtime RuntimeMetadata,
 	config Config,
 	hostStatsDelivery hoststats.Delivery,
+	samplingInterval time.Duration,
 ) {
 	if hostStatsDelivery == nil {
 		return
@@ -52,6 +54,7 @@ func initializeHostStatsCollector(
 		},
 		int32(firecrackerPID),
 		hostStatsDelivery,
+		samplingInterval,
 	)
 	if err != nil {
 		logger.L().Error(ctx, "failed to create host stats collector",

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -672,7 +672,8 @@ func (f *Factory) ResumeSandbox(
 	telemetry.ReportEvent(execCtx, "envd initialized")
 
 	if f.featureFlags.BoolFlag(execCtx, featureflags.HostStatsEnabled) {
-		initializeHostStatsCollector(execCtx, sbx, fcHandle, meta.Template.BuildID, runtime, config, f.hostStatsDelivery)
+		samplingInterval := time.Duration(f.featureFlags.IntFlag(execCtx, featureflags.HostStatsSamplingInterval)) * time.Millisecond
+		initializeHostStatsCollector(execCtx, sbx, fcHandle, meta.Template.BuildID, runtime, config, f.hostStatsDelivery, samplingInterval)
 	}
 
 	go sbx.Checks.Start(execCtx)

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -132,6 +132,7 @@ var (
 	BestOfKMaxOvercommit          = newIntFlag("best-of-k-max-overcommit", 400)              // Default R=4 (stored as percentage, max over-commit ratio)
 	BestOfKAlpha                  = newIntFlag("best-of-k-alpha", 50)                        // Default Alpha=0.5 (stored as percentage for int flag, current usage weight)
 	EnvdInitTimeoutMilliseconds   = newIntFlag("envd-init-request-timeout-milliseconds", 50) // Timeout for envd init request in milliseconds
+	HostStatsSamplingInterval     = newIntFlag("host-stats-sampling-interval", 5000)         // Host stats sampling interval in milliseconds (default 5s)
 	MaxCacheWriterConcurrencyFlag = newIntFlag("max-cache-writer-concurrency", 10)
 
 	// BuildCacheMaxUsagePercentage the maximum percentage of the cache disk storage


### PR DESCRIPTION
- Add HostStatsSamplingInterval feature flag (default: 5000ms)
- Read sampling interval directly from feature flags when initializing collector
- Update HostStatsCollector to use configurable interval instead of hardcoded constant
- Add validation to enforce minimum interval of 100ms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to metrics sampling cadence; main risk is increased CPU/ClickHouse load if the flag is set too low (partially mitigated by the 100ms minimum).
> 
> **Overview**
> Host stats collection for sandboxes now uses a configurable sampling interval sourced from a new `HostStatsSamplingInterval` feature flag (default 5000ms) instead of a hardcoded 5s ticker. The interval is passed through sandbox initialization into `HostStatsCollector`, which enforces a 100ms minimum to prevent overly aggressive sampling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1c17c7bd15adc377e67854befcda4976d043e47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->