### PR TITLE
fix: handle NotFound error for S3 HeadObject

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -253,7 +253,8 @@ func (a *AWSBucketStorageObjectProvider) Size(ctx context.Context) (int64, error
 	resp, err := a.client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &a.bucketName, Key: &a.path})
 	if err != nil {
 		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
+		var nfd *types.NotFound
+		if errors.As(err, &nsk) || errors.As(err, &nfd) {
 			return 0, ErrObjectNotExist
 		}
 


### PR DESCRIPTION
### Problem

When uploading a file to S3, the code checks object existence using HeadObject.
However, when the object does not exist, S3 HeadObject returns `NotFound (404)`
instead of `NoSuchKey`, causing the existence check to fail and the upload
process to break.


### Expected vs Actual Behavior

According to the official AWS documentation, `HeadObject` should return
`404 NotFound` when the object does not exist:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html

This behavior is confirmed by AWS SDK maintainers:
https://github.com/aws/aws-sdk-go/issues/2095


### Root Cause

The code only handles `NoSuchKey` as "object not found", but S3 HeadObject
actually returns `NotFound`.

### Solution

Handle `NotFound` error code properly when calling HeadObject, and treat it 
as object missing.

### Result

Uploading a file now works correctly when the target object does not exist.

### Evidence

Local logs show that `HeadObject` returns `NotFound` when the object does not exist:

<img width="1518" height="37" alt="image" src="https://github.com/user-attachments/assets/1c0662bf-42ff-4c73-b7d1-05b2dc1030f1" />
