### PR TITLE
Use prefix for gcp image repository and buckets

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -8,6 +8,7 @@ TF_VAR_FILE := ./.terraform.${ENV}.tfvars
 TF_VAR_FILE_ARG := $(if $(wildcard $(TF_VAR_FILE)),-var-file=$(TF_VAR_FILE))
 TERRAFORM_STATE_BUCKET ?= $(GCP_PROJECT_ID)-terraform-state
 TEMPLATE_BUCKET_LOCATION ?= $(GCP_REGION)
+BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 # Set the terraform environment variable only if the environment variable is set
 # Strip the passed variable name (it's space sensitive) and check if the variable is set, if yes return TF_VAR_<variable_name>=<value> with the variable name in lower case
@@ -63,6 +64,7 @@ tf_vars := \
 	$(call tfvar, SERVER_BOOT_DISK_TYPE) \
 	$(call tfvar, SERVER_BOOT_DISK_SIZE_GB) \
 	$(call tfvar, CLICKHOUSE_BOOT_DISK_TYPE) \
+	$(call tfvar, BUCKET_PREFIX) \
 	$(call tfvar, LOKI_BOOT_DISK_TYPE)
 
 .PHONY: init

--- a/iac/provider-gcp/init/buckets.tf
+++ b/iac/provider-gcp/init/buckets.tf
@@ -1,5 +1,5 @@
 resource "google_storage_bucket" "loki_storage_bucket" {
-  name     = "${var.gcp_project_id}-loki-storage"
+  name     = "${var.bucket_prefix}loki-storage"
   location = var.gcp_region
 
   public_access_prevention    = "enforced"
@@ -25,7 +25,7 @@ resource "google_storage_bucket" "loki_storage_bucket" {
 
 # TODO: Not needed anymore, BUT! we may need it for rebuilding templates
 resource "google_storage_bucket" "envs_docker_context" {
-  name     = "${var.gcp_project_id}-envs-docker-context"
+  name     = "${var.bucket_prefix}envs-docker-context"
   location = var.gcp_region
 
   public_access_prevention    = "enforced"
@@ -37,7 +37,7 @@ resource "google_storage_bucket" "envs_docker_context" {
 
 resource "google_storage_bucket" "setup_bucket" {
   location = var.gcp_region
-  name     = "${var.gcp_project_id}-instance-setup"
+  name     = "${var.bucket_prefix}instance-setup"
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -48,7 +48,7 @@ resource "google_storage_bucket" "setup_bucket" {
 
 resource "google_storage_bucket" "fc_kernels_bucket" {
   location = var.gcp_region
-  name     = "${var.gcp_project_id}-fc-kernels"
+  name     = "${var.bucket_prefix}fc-kernels"
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -59,7 +59,7 @@ resource "google_storage_bucket" "fc_kernels_bucket" {
 
 resource "google_storage_bucket" "fc_versions_bucket" {
   location = var.gcp_region
-  name     = "${var.gcp_project_id}-fc-versions"
+  name     = "${var.bucket_prefix}fc-versions"
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -70,7 +70,7 @@ resource "google_storage_bucket" "fc_versions_bucket" {
 
 resource "google_storage_bucket" "fc_env_pipeline_bucket" {
   location = var.template_bucket_location
-  name     = "${var.gcp_project_id}-fc-env-pipeline"
+  name     = "${var.bucket_prefix}fc-env-pipeline"
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -80,7 +80,7 @@ resource "google_storage_bucket" "fc_env_pipeline_bucket" {
 }
 
 resource "google_storage_bucket" "clickhouse_backups_bucket" {
-  name     = "${var.gcp_project_id}-clickhouse-backups"
+  name     = "${var.bucket_prefix}clickhouse-backups"
   location = var.gcp_region
 
   lifecycle_rule {
@@ -106,7 +106,7 @@ resource "google_storage_bucket" "clickhouse_backups_bucket" {
 
 resource "google_storage_bucket" "fc_template_bucket" {
   location = var.gcp_region
-  name     = (var.template_bucket_name != "" ? var.template_bucket_name : "${var.gcp_project_id}-fc-templates")
+  name     = (var.template_bucket_name != "" ? var.template_bucket_name : "${var.bucket_prefix}fc-templates")
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -121,7 +121,7 @@ resource "google_storage_bucket" "fc_template_bucket" {
 
 resource "google_storage_bucket" "fc_build_cache_bucket" {
   location = var.gcp_region
-  name     = "${var.gcp_project_id}-fc-build-cache"
+  name     = "${var.bucket_prefix}fc-build-cache"
 
   public_access_prevention    = "enforced"
   storage_class               = "STANDARD"
@@ -194,7 +194,7 @@ resource "google_storage_bucket_iam_member" "fc_template_bucket_iam_reader" {
 
 resource "google_storage_bucket" "public_builds_storage_bucket" {
   count    = var.gcp_project_id == "e2b-prod" ? 1 : 0
-  name     = "${var.gcp_project_id}-public-builds"
+  name     = "${var.bucket_prefix}public-builds"
   location = var.gcp_region
 
   storage_class               = "STANDARD"

--- a/iac/provider-gcp/init/main.tf
+++ b/iac/provider-gcp/init/main.tf
@@ -77,7 +77,7 @@ resource "google_service_account_key" "google_service_key" {
   service_account_id = google_service_account.infra_instances_service_account.name
 }
 
-
+// todo: delete after migration period
 resource "google_artifact_registry_repository" "orchestration_repository" {
   format        = "DOCKER"
   repository_id = "e2b-orchestration"
@@ -94,6 +94,22 @@ resource "time_sleep" "artifact_registry_api_wait_90_seconds" {
 
 resource "google_artifact_registry_repository_iam_member" "orchestration_repository_member" {
   repository = google_artifact_registry_repository.orchestration_repository.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.infra_instances_service_account.email}"
+
+  depends_on = [time_sleep.artifact_registry_api_wait_90_seconds]
+}
+
+resource "google_artifact_registry_repository" "orchestration" {
+  format        = "DOCKER"
+  repository_id = "${var.prefix}orchestration"
+  labels        = var.labels
+
+  depends_on = [time_sleep.artifact_registry_api_wait_90_seconds]
+}
+
+resource "google_artifact_registry_repository_iam_member" "orchestration" {
+  repository = google_artifact_registry_repository.orchestration.name
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${google_service_account.infra_instances_service_account.email}"
 

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -35,7 +35,7 @@ output "routing_domains_secret_name" {
 }
 
 output "orchestration_repository_name" {
-  value = google_artifact_registry_repository.orchestration_repository.name
+  value = google_artifact_registry_repository.orchestration.name
 }
 
 output "cloudflare_api_token_secret_name" {

--- a/iac/provider-gcp/init/variables.tf
+++ b/iac/provider-gcp/init/variables.tf
@@ -2,6 +2,10 @@ variable "prefix" {
   type = string
 }
 
+variable "bucket_prefix" {
+  type = string
+}
+
 variable "labels" {
   description = "The labels to attach to resources created by this module"
   type        = map(string)

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -48,8 +48,9 @@ locals {
 module "init" {
   source = "./init"
 
-  labels = var.labels
-  prefix = var.prefix
+  labels        = var.labels
+  prefix        = var.prefix
+  bucket_prefix = var.bucket_prefix
 
   gcp_project_id = var.gcp_project_id
   gcp_region     = var.gcp_region

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -320,6 +320,10 @@ variable "prefix" {
   default     = "e2b-"
 }
 
+variable "bucket_prefix" {
+  type = string
+}
+
 variable "labels" {
   description = "The labels to attach to resources created by this module"
   type        = map(string)

--- a/packages/api/Makefile
+++ b/packages/api/Makefile
@@ -6,7 +6,7 @@ expectedMigration := $(shell ./../../scripts/get-latest-migration.sh)
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)orchestration/api
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/e2b-orchestration/api
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)orchestration/api
 endif
 
 .PHONY: generate

--- a/packages/clickhouse/Makefile
+++ b/packages/clickhouse/Makefile
@@ -6,7 +6,7 @@ CLICKHOUSE_HOST ?= clickhouse
 ifeq ($(PROVIDER),aws)
 	CLICKHOUSE_MIGRATOR_IMAGE ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)orchestration/clickhouse-migrator
 else
-	CLICKHOUSE_MIGRATOR_IMAGE ?= $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/e2b-orchestration/clickhouse-migrator
+	CLICKHOUSE_MIGRATOR_IMAGE ?= $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)orchestration/clickhouse-migrator
 endif
 
 .PHONY: migrate

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -4,7 +4,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)orchestration/client-proxy
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/e2b-orchestration/client-proxy
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)orchestration/client-proxy
 endif
 
 .PHONY: build

--- a/packages/db/Makefile
+++ b/packages/db/Makefile
@@ -7,7 +7,7 @@ goose-local := GOOSE_DBSTRING=postgres://postgres:postgres@localhost:5432/postgr
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)orchestration/db-migrator
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/e2b-orchestration/db-migrator
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)orchestration/db-migrator
 endif
 
 .PHONY: migrate

--- a/packages/docker-reverse-proxy/Makefile
+++ b/packages/docker-reverse-proxy/Makefile
@@ -4,7 +4,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)orchestration/docker-reverse-proxy
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/e2b-orchestration/docker-reverse-proxy
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)orchestration/docker-reverse-proxy
 endif
 
 .PHONY: build

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -3,7 +3,9 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 
 BUILD := $(shell git rev-parse --short HEAD)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
+
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
+GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 .PHONY: init
 init:
@@ -14,7 +16,7 @@ upload:
 ifeq ($(PROVIDER),aws)
 	aws s3 cp ./bin/envd "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp bin/envd "gs://${GCP_PROJECT_ID}-fc-env-pipeline/envd"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp bin/envd "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd"
 endif
 
 build:

--- a/packages/nomad-nodepool-apm/Makefile
+++ b/packages/nomad-nodepool-apm/Makefile
@@ -2,6 +2,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
+GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 PLUGIN_NAME := nomad-nodepool-apm
 BIN_DIR := bin
@@ -26,7 +27,7 @@ upload:
 ifeq ($(PROVIDER),aws)
 	aws s3 cp $(BINARY) "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp $(BINARY) "gs://${GCP_PROJECT_ID}-fc-env-pipeline/nomad-nodepool-apm"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp $(BINARY) "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm"
 endif
 
 .PHONY: build-and-upload

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -2,6 +2,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
+GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 .PHONY: init
 init:
@@ -58,7 +59,7 @@ upload/clean-nfs-cache:
 ifeq ($(PROVIDER),aws)
 	aws s3 cp ./bin/clean-nfs-cache "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/clean-nfs-cache" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/clean-nfs-cache "gs://${GCP_PROJECT_ID}-fc-env-pipeline/clean-nfs-cache"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/clean-nfs-cache "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/clean-nfs-cache"
 endif
 
 .PHONY: upload/orchestrator
@@ -67,7 +68,7 @@ upload/orchestrator:
 ifeq ($(PROVIDER),aws)
 	aws s3 cp ./bin/orchestrator "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/orchestrator" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/orchestrator "gs://${GCP_PROJECT_ID}-fc-env-pipeline/orchestrator"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/orchestrator "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/orchestrator"
 endif
 
 .PHONY: upload/template-manager
@@ -76,7 +77,7 @@ upload/template-manager:
 ifeq ($(PROVIDER),aws)
 	aws s3 cp ./bin/orchestrator "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/template-manager" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/orchestrator "gs://${GCP_PROJECT_ID}-fc-env-pipeline/template-manager"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp ./bin/orchestrator "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/template-manager"
 endif
 
 .PHONY: build-and-upload/clean-nfs-cache


### PR DESCRIPTION
- Introduction of `BUCKET_PREFIX` that can be used to specify a prefix for GCP buckets
- Uses prefix for container repository - the old one is still in place for future removal.
- Makefile for build and upload to bucket/docker repository are also using new ENVs.

For buckets, everything should be the same unless you specify `BUCKET_PREFIX` in the .env file.
Ideally, for Docker images, run `make init`, then build & upload all images and apply the jobs. After we migrate, we can remove the old Docker registry with the hardcoded prefix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Terraform resource names and image registry paths, which can accidentally create new buckets/repos or break deployments if prefixes aren’t set consistently during migration. Also introduces a required `bucket_prefix` variable that may fail plans/applies if not provided in all environments.
> 
> **Overview**
> Adds configurable prefixing for GCP infrastructure artifacts by introducing `bucket_prefix`/`BUCKET_PREFIX` and applying it to all Terraform-managed GCS bucket names, while also migrating container image publishing to a new prefixed Artifact Registry repository (keeping the legacy `e2b-orchestration` repo temporarily) and updating package Makefiles/uploads to push to the prefixed registry/bucket paths via `PREFIX`/`GCP_BUCKET_PREFIX`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fce4639cd0ef59fddec8371af22a11e11219e27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->