### PR TITLE
Different name for new repo

### DIFF
--- a/iac/provider-gcp/init/main.tf
+++ b/iac/provider-gcp/init/main.tf
@@ -100,16 +100,16 @@ resource "google_artifact_registry_repository_iam_member" "orchestration_reposit
   depends_on = [time_sleep.artifact_registry_api_wait_90_seconds]
 }
 
-resource "google_artifact_registry_repository" "opensource" {
+resource "google_artifact_registry_repository" "core" {
   format        = "DOCKER"
-  repository_id = "${var.prefix}opensource"
+  repository_id = "${var.prefix}core"
   labels        = var.labels
 
   depends_on = [time_sleep.artifact_registry_api_wait_90_seconds]
 }
 
-resource "google_artifact_registry_repository_iam_member" "opensource" {
-  repository = google_artifact_registry_repository.opensource.name
+resource "google_artifact_registry_repository_iam_member" "core" {
+  repository = google_artifact_registry_repository.core.name
   role       = "roles/artifactregistry.reader"
   member     = "serviceAccount:${google_service_account.infra_instances_service_account.email}"
 

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -34,8 +34,8 @@ output "routing_domains_secret_name" {
   value = google_secret_manager_secret.routing_domains.name
 }
 
-output "opensource_repository_name" {
-  value = google_artifact_registry_repository.opensource.name
+output "core_repository_name" {
+  value = google_artifact_registry_repository.core.name
 }
 
 output "cloudflare_api_token_secret_name" {

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -144,10 +144,10 @@ module "nomad" {
   gcp_region     = var.gcp_region
   gcp_zone       = var.gcp_zone
 
-  consul_acl_token_secret    = module.init.consul_acl_token_secret
-  nomad_acl_token_secret     = module.init.nomad_acl_token_secret
-  nomad_port                 = var.nomad_port
-  opensource_repository_name = module.init.opensource_repository_name
+  consul_acl_token_secret = module.init.consul_acl_token_secret
+  nomad_acl_token_secret  = module.init.nomad_acl_token_secret
+  nomad_port              = var.nomad_port
+  core_repository_name    = module.init.core_repository_name
 
   # Clickhouse
   clickhouse_resources_cpu_count   = var.clickhouse_resources_cpu_count

--- a/iac/provider-gcp/nomad/images.tf
+++ b/iac/provider-gcp/nomad/images.tf
@@ -1,29 +1,29 @@
 data "google_artifact_registry_docker_image" "api_image" {
   location      = var.gcp_region
-  repository_id = var.opensource_repository_name
+  repository_id = var.core_repository_name
   image_name    = "api:latest"
 }
 
 data "google_artifact_registry_docker_image" "db_migrator_image" {
   location      = var.gcp_region
   image_name    = "db-migrator:latest"
-  repository_id = var.opensource_repository_name
+  repository_id = var.core_repository_name
 }
 
 data "google_artifact_registry_docker_image" "docker_reverse_proxy_image" {
   location      = var.gcp_region
   image_name    = "docker-reverse-proxy:latest"
-  repository_id = var.opensource_repository_name
+  repository_id = var.core_repository_name
 }
 
 data "google_artifact_registry_docker_image" "client_proxy_image" {
   location      = var.gcp_region
   image_name    = "client-proxy:latest"
-  repository_id = var.opensource_repository_name
+  repository_id = var.core_repository_name
 }
 
 data "google_artifact_registry_docker_image" "clickhouse_migrator_image" {
   location      = var.gcp_region
   image_name    = "clickhouse-migrator:latest"
-  repository_id = var.opensource_repository_name
+  repository_id = var.core_repository_name
 }

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -14,7 +14,7 @@ variable "orchestrator_node_pool" {
   type = string
 }
 
-variable "opensource_repository_name" {
+variable "core_repository_name" {
   type = string
 }
 

--- a/packages/api/Makefile
+++ b/packages/api/Makefile
@@ -4,9 +4,9 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 expectedMigration := $(shell ./../../scripts/get-latest-migration.sh)
 
 ifeq ($(PROVIDER),aws)
-	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)opensource/api
+	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/api
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)opensource/api
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/api
 endif
 
 .PHONY: generate

--- a/packages/clickhouse/Makefile
+++ b/packages/clickhouse/Makefile
@@ -4,9 +4,9 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 CLICKHOUSE_HOST ?= clickhouse
 
 ifeq ($(PROVIDER),aws)
-	CLICKHOUSE_MIGRATOR_IMAGE ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)opensource/clickhouse-migrator
+	CLICKHOUSE_MIGRATOR_IMAGE ?= $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/clickhouse-migrator
 else
-	CLICKHOUSE_MIGRATOR_IMAGE ?= $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)opensource/clickhouse-migrator
+	CLICKHOUSE_MIGRATOR_IMAGE ?= $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/clickhouse-migrator
 endif
 
 .PHONY: migrate

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -2,9 +2,9 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 ifeq ($(PROVIDER),aws)
-	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)opensource/client-proxy
+	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/client-proxy
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)opensource/client-proxy
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/client-proxy
 endif
 
 .PHONY: build

--- a/packages/db/Makefile
+++ b/packages/db/Makefile
@@ -5,9 +5,9 @@ goose := GOOSE_DRIVER=postgres GOOSE_DBSTRING=$(POSTGRES_CONNECTION_STRING) go t
 goose-local := GOOSE_DBSTRING=postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable go tool goose -table "_migrations" -dir "migrations" postgres
 
 ifeq ($(PROVIDER),aws)
-	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)opensource/db-migrator
+	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/db-migrator
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)opensource/db-migrator
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/db-migrator
 endif
 
 .PHONY: migrate

--- a/packages/docker-reverse-proxy/Makefile
+++ b/packages/docker-reverse-proxy/Makefile
@@ -2,9 +2,9 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 ifeq ($(PROVIDER),aws)
-	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)opensource/docker-reverse-proxy
+	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/docker-reverse-proxy
 else
-	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)opensource/docker-reverse-proxy
+	IMAGE_REGISTRY := $(GCP_REGION)-docker.pkg.dev/$(GCP_PROJECT_ID)/$(PREFIX)core/docker-reverse-proxy
 endif
 
 .PHONY: build


### PR DESCRIPTION
Use a different name for the E2B OSS repository to make migration from the old one easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a rename, but it changes image repository IDs/paths and Terraform resource addresses, which can break deployments or force resource recreation if state/migration isn’t handled carefully.
> 
> **Overview**
> Renames the Docker image artifact repository used by GCP Nomad deployments and build/push Makefiles from `*orchestration*` to `*core*`, updating Terraform outputs/module wiring and Artifact Registry lookups accordingly to ease migration to a new registry name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d35fe6df5a64a89a5001729082ea57407cae78b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->