### PR TITLE
fix: github actions result condition evaluation

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -72,14 +72,14 @@ jobs:
         shell: bash
 
       - name: Upload Test Results
-        if: always() && ${{ inputs.publish == true }}
+        if: ${{ always() && inputs.publish == true }}
         uses: actions/upload-artifact@v4
         with:
           name: Integration Tests Results
           path: ./tests/integration/test-results.xml
 
       - name: Upload Service Logs
-        if: always() && ${{ inputs.publish == true }}
+        if: ${{ always() && inputs.publish == true }}
         uses: actions/upload-artifact@v4
         with:
           name: Service Logs


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small CI condition change limited to artifact upload gating; main risk is unintended always-on/off uploads if the expression semantics are misinterpreted.
> 
> **Overview**
> Fixes the artifact upload gating in the integration test workflow by moving `always()` inside the `${{ }}` expression, ensuring test results and service logs are still uploaded (when `inputs.publish` is true) even if earlier steps fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ea3a8ed3e16128fcd50864bccefaf4058bdcac8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->