### PR TITLE
Use bucket prefix for `copy-public-builds`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PROVIDER ?= gcp
 -include ${ENV_FILE}
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
+GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 .PHONY: provider-login
 provider-login:
@@ -107,8 +108,8 @@ ifeq ($(PROVIDER),aws)
 	rm -rf ./.kernels
 	rm -rf ./.firecrackers
 else
-	gsutil cp -r gs://e2b-prod-public-builds/kernels/* gs://$(GCP_PROJECT_ID)-fc-kernels/
-	gsutil cp -r gs://e2b-prod-public-builds/firecrackers/* gs://$(GCP_PROJECT_ID)-fc-versions/
+	gsutil cp -r gs://e2b-prod-public-builds/kernels/* gs://$(GCP_BUCKET_PREFIX)fc-kernels/
+	gsutil cp -r gs://e2b-prod-public-builds/firecrackers/* gs://$(GCP_BUCKET_PREFIX)fc-versions/
 endif
 
 .PHONY: download-public-kernels


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small Makefile change that only affects where build artifacts are copied in GCS; low risk aside from potential misconfiguration leading to uploads to the wrong bucket.
> 
> **Overview**
> Updates the `copy-public-builds` Makefile target to use a configurable `GCP_BUCKET_PREFIX` (instead of hard-coding `$(GCP_PROJECT_ID)-`) when copying Firecracker kernels/versions into GCS, aligning GCP bucket naming with the existing AWS prefix approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c7e63fffce581294fc6f7a88b2f52cf2b96bee0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->