### PR TITLE
chore: remove long running sandboxes call

### DIFF
--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -16,74 +16,10 @@ import (
 )
 
 const (
-	// syncAnalyticsTime if this value is updated, it should be correctly updated in analytics too.
-	syncAnalyticsTime   = 10 * time.Minute
-	oldSandboxThreshold = 30 * time.Minute // Threshold to consider a sandbox as old
-
 	// reportTimeout is the timeout for the analytics report
 	// This timeout is also set in the CloudRun for Analytics Collector, there it is 3 minutes.
 	reportTimeout = 4 * time.Minute
 )
-
-func (o *Orchestrator) reportLongRunningSandboxes(ctx context.Context) {
-	ticker := time.NewTicker(syncAnalyticsTime)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			logger.L().Info(ctx, "Stopping node analytics reporting due to context cancellation")
-
-			return
-		case <-ticker.C:
-			sandboxes, err := o.sandboxStore.AllItems(ctx, []sandbox.State{sandbox.StateRunning})
-			if err != nil {
-				logger.L().Error(ctx, "failed to list running sandboxes", zap.Error(err))
-
-				continue
-			}
-
-			longRunningSandboxes := make([]sandbox.Sandbox, 0, len(sandboxes))
-			for _, sandbox := range sandboxes {
-				if time.Since(sandbox.StartTime) > oldSandboxThreshold {
-					longRunningSandboxes = append(longRunningSandboxes, sandbox)
-				}
-			}
-
-			sendAnalyticsForLongRunningSandboxes(ctx, o.analytics, longRunningSandboxes)
-		}
-	}
-}
-
-// sendAnalyticsForLongRunningSandboxes sends long-running instances event to analytics
-func sendAnalyticsForLongRunningSandboxes(ctx context.Context, analytics *analyticscollector.Analytics, instances []sandbox.Sandbox) {
-	if len(instances) == 0 {
-		logger.L().Debug(ctx, "No long-running instances to report to analytics")
-
-		return
-	}
-
-	childCtx, cancel := context.WithTimeout(ctx, syncAnalyticsTime)
-	defer cancel()
-
-	instanceIds := make([]string, len(instances))
-	executionIds := make([]string, len(instances))
-	for idx, i := range instances {
-		instanceIds[idx] = i.SandboxID
-		executionIds[idx] = i.ExecutionID
-	}
-
-	_, err := analytics.RunningInstances(childCtx,
-		&analyticscollector.RunningInstancesEvent{
-			InstanceIds:  instanceIds,
-			ExecutionIds: executionIds,
-			Timestamp:    timestamppb.Now(),
-		},
-	)
-	if err != nil {
-		logger.L().Error(ctx, "error sending running instances event to analytics", zap.Error(err))
-	}
-}
 
 func (o *Orchestrator) analyticsRemove(ctx context.Context, sandbox sandbox.Sandbox, stateAction sandbox.StateAction) {
 	ctx, cancel := context.WithTimeout(ctx, reportTimeout)

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -175,7 +175,6 @@ func New(
 		return nil, fmt.Errorf("failed to setup metrics: %w", err)
 	}
 
-	go o.reportLongRunningSandboxes(ctx)
 	go o.startStatusLogging(ctx)
 	go o.updateBestOfKConfig(ctx)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes a background analytics-reporting goroutine and related code; main risk is reduced observability for long-running sandboxes, with minimal runtime impact otherwise.
> 
> **Overview**
> This PR removes the orchestrator’s periodic long-running sandbox analytics reporting (the ticker-based scan of running sandboxes and `RunningInstances` event emission) and stops starting that background goroutine, leaving only per-instance start/stop analytics events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d59d73a37735283e33ba0901897aaeb3bafbb0c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->