### PR TITLE
refactor: use logger.WithSandboxID helper in host stats logging

### DIFF
--- a/packages/orchestrator/internal/sandbox/hoststats.go
+++ b/packages/orchestrator/internal/sandbox/hoststats.go
@@ -31,7 +31,7 @@ func initializeHostStatsCollector(
 	firecrackerPID, err := fcHandle.Pid()
 	if err != nil {
 		logger.L().Error(ctx, "failed to get firecracker PID for host stats",
-			zap.String("sandbox_id", runtime.SandboxID),
+			logger.WithSandboxID(runtime.SandboxID),
 			zap.Error(err))
 
 		return
@@ -58,7 +58,7 @@ func initializeHostStatsCollector(
 	)
 	if err != nil {
 		logger.L().Error(ctx, "failed to create host stats collector",
-			zap.String("sandbox_id", runtime.SandboxID),
+			logger.WithSandboxID(runtime.SandboxID),
 			zap.Error(err))
 
 		return

--- a/packages/orchestrator/internal/sandbox/hoststats_collector.go
+++ b/packages/orchestrator/internal/sandbox/hoststats_collector.go
@@ -105,7 +105,7 @@ func (h *HostStatsCollector) Start(ctx context.Context) {
 	if err := h.CollectSample(ctx); err != nil {
 		// Log error but continue with periodic sampling - don't kill the sandbox
 		logger.L().Error(ctx, "failed to collect initial host stats sample",
-			zap.String("sandbox_id", h.metadata.SandboxID),
+			logger.WithSandboxID(h.metadata.SandboxID),
 			zap.Error(err))
 	}
 
@@ -118,7 +118,7 @@ func (h *HostStatsCollector) Start(ctx context.Context) {
 			if err := h.CollectSample(ctx); err != nil {
 				// Log error but continue sampling - don't kill the sandbox
 				logger.L().Error(ctx, "failed to collect host stats sample",
-					zap.String("sandbox_id", h.metadata.SandboxID),
+					logger.WithSandboxID(h.metadata.SandboxID),
 					zap.Error(err))
 			}
 		case <-h.stopCh:
@@ -139,7 +139,7 @@ func (h *HostStatsCollector) Stop(ctx context.Context) {
 		if err := h.CollectSample(ctx); err != nil {
 			// Log but don't fail the shutdown
 			logger.L().Error(ctx, "failed to collect final host stats sample",
-				zap.String("sandbox_id", h.metadata.SandboxID),
+				logger.WithSandboxID(h.metadata.SandboxID),
 				zap.Error(err))
 		}
 	})


### PR DESCRIPTION
Replace raw zap.String("sandbox_id", ...) calls with the structured logger.WithSandboxID() helper for consistent sandbox ID logging across hoststats and hoststats_collector.

This is minor follow up to PR #1880.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure logging-field refactor in error paths; no changes to host stats collection logic or data flow.
> 
> **Overview**
> This PR standardizes sandbox ID structured logging in host stats initialization and collection by replacing `zap.String("sandbox_id", ...)` with `logger.WithSandboxID(...)` in relevant error paths, improving log consistency without changing runtime behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee042348e80b973f4d2fe96c18a573d3fa3891c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->