### PR TITLE
Modify storage policy for templates

### DIFF
--- a/iac/provider-gcp/init/buckets.tf
+++ b/iac/provider-gcp/init/buckets.tf
@@ -127,7 +127,7 @@ resource "google_storage_bucket" "fc_template_bucket" {
   }
 
   soft_delete_policy {
-    retention_duration_seconds = 10
+    retention_duration_seconds = 864000 # 10 days
   }
 
   labels = var.labels


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Applies new lifecycle/soft-delete behavior to an existing bucket, which can change retention and cost characteristics and may surprise consumers expecting immediate deletions or different storage classes.
> 
> **Overview**
> Updates the `fc_template_bucket` GCS configuration to enable Autoclass with `terminal_storage_class = "ARCHIVE"`, automatically abort incomplete multipart uploads after 1 day, and enforce a 10-day soft-delete retention window to reduce storage waste and improve recoverability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0591e61c8f295437cfcdc7c425fe41bebe458461. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->