### PR TITLE
Use our go-nfs fork, which has more race condition fixes

### DIFF
--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -124,3 +124,7 @@ build-template:
 .PHONY: migrate
 migrate:
 	./scripts/upload-envs.sh /mnt/disks/fc-envs/v1 $(TEMPLATE_BUCKET_NAME)
+
+.PHONY: lint
+lint:
+	golangci-lint run --fix ./...

--- a/packages/orchestrator/go.mod
+++ b/packages/orchestrator/go.mod
@@ -10,6 +10,8 @@ replace (
 // Fix non existent garyburd/redigo from Microsoft/hcsshim/test v0.0.0
 replace github.com/garyburd/redigo => github.com/gomodule/redigo v1.9.2
 
+replace github.com/willscott/go-nfs v0.0.3 => github.com/e2b-dev/go-nfs v0.0.0-20260219005151-377638440f63
+
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
 
 require (
@@ -55,7 +57,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.15
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
-	github.com/willscott/go-nfs v0.0.0-20260218081127-527fb181bfaa
+	github.com/willscott/go-nfs v0.0.3
 	github.com/willscott/go-nfs-client v0.0.0-20251022144359-801f10d98886
 	github.com/zeldovich/go-rpcgen v0.1.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0

--- a/packages/orchestrator/go.sum
+++ b/packages/orchestrator/go.sum
@@ -410,6 +410,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvyukov/go-fuzz v0.0.0-20210914135545-4980593459a1/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/e2b-dev/go-nfs v0.0.0-20260219005151-377638440f63 h1:BBKgU71H8lFkl8U+YC+0XXxFdU1cigXJsjYWDgrSJ30=
+github.com/e2b-dev/go-nfs v0.0.0-20260219005151-377638440f63/go.mod h1:VhNccO67Oug787VNXcyx9JDI3ZoSpqoKMT/lWMhUIDg=
 github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
 github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/edsrzf/mmap-go v1.2.0 h1:hXLYlkbaPzt1SaQk+anYwKSRNhufIDCchSPkUD6dD84=
@@ -1228,8 +1230,6 @@ github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9N
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
-github.com/willscott/go-nfs v0.0.0-20260218081127-527fb181bfaa h1:x5BlhHIuJ6O/oR3Nys8dpCmgAxZAERUSWA/huWwUtyw=
-github.com/willscott/go-nfs v0.0.0-20260218081127-527fb181bfaa/go.mod h1:VhNccO67Oug787VNXcyx9JDI3ZoSpqoKMT/lWMhUIDg=
 github.com/willscott/go-nfs-client v0.0.0-20251022144359-801f10d98886 h1:DtrBtkgTJk2XGt4T7eKdKVkd9A5NCevN2e4inLXtsqA=
 github.com/willscott/go-nfs-client v0.0.0-20251022144359-801f10d98886/go.mod h1:Tq++Lr/FgiS3X48q5FETemXiSLGuYMQT2sPjYNPJSwA=
 github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Dependency override changes the NFS implementation behavior and could affect runtime stability or I/O semantics; lint auto-fixes can also introduce unintended code changes if run in CI or developer workflows.
> 
> **Overview**
> Updates the orchestrator build to **use an `e2b-dev` fork of `github.com/willscott/go-nfs`** via a `go.mod` `replace`, while keeping the public requirement pinned to `v0.0.3` and updating `go.sum` accordingly.
> 
> Adds a `make lint` target that runs `golangci-lint` with `--fix`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bd6c3fbee8379fd02599649bb8aefca1598a9e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->