### PR TITLE
Update sandbox rate limit error with billing/support links

### DIFF
--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -121,7 +121,7 @@ func (o *Orchestrator) CreateSandbox(
 				Code: http.StatusTooManyRequests,
 				ClientMsg: fmt.Sprintf(
 					"you have reached the maximum number of concurrent E2B sandboxes (%d). If you need more, "+
-						"please take a look at 'https://e2b.dev/docs/billing'", totalConcurrentInstances),
+						"please visit 'https://e2b.dev/docs/billing'", totalConcurrentInstances),
 				Err: fmt.Errorf("team '%s' has reached the maximum number of instances (%d)", team.ID, totalConcurrentInstances),
 			}
 		default:


### PR DESCRIPTION
## Summary
- Update the sandbox concurrent limit error message to direct users to the billing docs and new support page
- Old: `please contact us at 'https://e2b.dev/docs/getting-help'`
- New: `please take a look at https://e2b.dev/docs/billing or contact us at 'https://e2b.dev/docs/support'`

## Test plan
- [x] `make build/api` compiles successfully
- [x] `go test -race ./internal/orchestrator/` passes