### PR TITLE
chore(api): simplify alias cache to return templateID only

### DIFF
--- a/packages/api/internal/cache/templates/alias_cache.go
+++ b/packages/api/internal/cache/templates/alias_cache.go
@@ -6,48 +6,41 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/zap"
 
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/cache"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
-	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
 const (
 	aliasCacheTTL             = 5 * time.Minute
 	aliasCacheRefreshInterval = time.Minute
 
-	aliasCacheKeyPrefix     = "template:alias"
-	aliasReverseIndexPrefix = "template:alias-reverse"
+	aliasCacheKeyPrefix = "template:alias"
 )
 
-// AliasInfo holds resolved alias information
-type AliasInfo struct {
-	TemplateID string    `json:"template_id"`
-	TeamID     uuid.UUID `json:"team_id"`
-	Public     bool      `json:"public"`
-	NotFound   bool      `json:"not_found"` // tombstone marker for caching negative lookups
+// AliasResult holds the minimal alias→templateID mapping cached per alias key.
+type AliasResult struct {
+	TemplateID string `json:"template_id"`
+	NotFound   bool   `json:"not_found"` // tombstone marker for caching negative lookups
 }
 
-var notFoundTombstone = &AliasInfo{NotFound: true}
+var notFoundTombstone = &AliasResult{NotFound: true}
 
 // AliasCache resolves namespace/alias to templateID with fallback logic.
 // This is the main resolution layer implementing the namespace lookup flowchart.
 type AliasCache struct {
-	cache *cache.RedisCache[*AliasInfo]
+	cache *cache.RedisCache[*AliasResult]
 	db    *sqlcdb.Client
 }
 
 func NewAliasCache(db *sqlcdb.Client, redisClient redis.UniversalClient) *AliasCache {
-	rc := cache.NewRedisCache[*AliasInfo](cache.RedisConfig[*AliasInfo]{
+	rc := cache.NewRedisCache[*AliasResult](cache.RedisConfig[*AliasResult]{
 		TTL:             aliasCacheTTL,
 		RefreshInterval: aliasCacheRefreshInterval,
 		RedisClient:     redisClient,
@@ -71,7 +64,7 @@ func buildAliasKey(namespace *string, alias string) string {
 // Resolve implements the namespace resolution flowchart:
 //   - Explicit namespace: lookup with namespace directly, no fallback
 //   - Bare alias: try namespaceFallback first, then NULL (promoted templates)
-func (c *AliasCache) Resolve(ctx context.Context, identifier string, namespaceFallback string) (*AliasInfo, error) {
+func (c *AliasCache) Resolve(ctx context.Context, identifier string, namespaceFallback string) (string, error) {
 	ctx, span := tracer.Start(ctx, "resolve alias", trace.WithAttributes(
 		attribute.String("identifier", identifier),
 		attribute.String("namespace_fallback", namespaceFallback),
@@ -86,100 +79,58 @@ func (c *AliasCache) Resolve(ctx context.Context, identifier string, namespaceFa
 	}
 
 	// Bare alias - try fallback namespace first (team's namespace)
-	info, err := c.lookup(ctx, &namespaceFallback, alias)
+	templateID, err := c.lookup(ctx, &namespaceFallback, alias)
 	if err == nil {
-		return info, nil
+		return templateID, nil
 	}
 
 	// If not found, try NULL namespace (promoted templates)
 	if errors.Is(err, ErrTemplateNotFound) {
-		info, err = c.lookup(ctx, nil, alias)
+		templateID, err = c.lookup(ctx, nil, alias)
 		if err == nil {
-			return info, nil
+			return templateID, nil
 		}
 	}
 
-	return nil, err
+	return "", err
 }
 
 // lookup performs a single lookup (cache then DB) for namespace/alias.
 // Caches both positive hits and negative hits to avoid repeated DB queries.
-func (c *AliasCache) lookup(ctx context.Context, namespace *string, alias string) (*AliasInfo, error) {
+func (c *AliasCache) lookup(ctx context.Context, namespace *string, alias string) (string, error) {
 	ctx, span := tracer.Start(ctx, "lookup alias")
 	defer span.End()
 
 	key := buildAliasKey(namespace, alias)
 
-	info, err := c.cache.GetOrSet(ctx, key, c.fetchFromDB)
+	result, err := c.cache.GetOrSet(ctx, key, c.fetchFromDB)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
-	if info.NotFound {
-		return nil, ErrTemplateNotFound
+	if result.NotFound {
+		return "", ErrTemplateNotFound
 	}
 
-	return info, nil
+	return result.TemplateID, nil
 }
 
-// cacheByTemplateID caches info also by template ID and tracks the alias key
-// in a Redis reverse index set for bulk invalidation by template ID.
-func (c *AliasCache) cacheByTemplateID(ctx context.Context, originalKey string, info *AliasInfo) {
-	if info.NotFound {
-		return
-	}
-
-	idKey := buildAliasKey(nil, info.TemplateID)
-	if idKey != originalKey {
-		c.cache.Set(ctx, idKey, info)
-	}
-
-	// Track alias key in reverse index for InvalidateByTemplateID
-	c.trackReverseKey(ctx, originalKey, idKey, info)
-}
-
-func (c *AliasCache) trackReverseKey(ctx context.Context, originalKey string, idKey string, info *AliasInfo) {
-	rc := c.cache.RedisClient()
-	reverseKey := redis_utils.CreateKey(aliasReverseIndexPrefix, info.TemplateID)
-
-	ctx, cancel := context.WithTimeout(ctx, cache.RedisDefaultTimeout)
-	defer cancel()
-
-	pipe := rc.Pipeline()
-	pipe.SAdd(ctx, reverseKey, originalKey, idKey)
-	pipe.Expire(ctx, reverseKey, aliasCacheTTL)
-	_, err := pipe.Exec(ctx)
-	if err != nil {
-		logger.L().Warn(ctx, "failed to cache alias by template ID", zap.Error(err))
-	}
-}
-
-func (c *AliasCache) fetchFromDB(ctx context.Context, key string) (info *AliasInfo, err error) {
+func (c *AliasCache) fetchFromDB(ctx context.Context, key string) (result *AliasResult, err error) {
 	ctx, span := tracer.Start(ctx, "fetch alias from DB", trace.WithAttributes(
 		attribute.String("key", key),
 	))
 	defer span.End()
 
-	// Also cache by template ID for direct ID lookups (use nil namespace since
-	// direct ID lookups don't have namespace context)
-	defer func() {
-		if err == nil {
-			c.cacheByTemplateID(ctx, key, info)
-		}
-	}()
-
 	namespace, alias := id.SplitIdentifier(key)
 
 	// Try alias lookup first
-	result, err := c.db.GetTemplateByAlias(ctx, queries.GetTemplateByAliasParams{
+	aliasRow, err := c.db.GetTemplateByAlias(ctx, queries.GetTemplateByAliasParams{
 		Alias:     alias,
 		Namespace: namespace,
 	})
 	if err == nil {
-		return &AliasInfo{
-			TemplateID: result.ID,
-			TeamID:     result.TeamID,
-			Public:     result.Public,
+		return &AliasResult{
+			TemplateID: aliasRow.ID,
 		}, nil
 	}
 
@@ -191,10 +142,8 @@ func (c *AliasCache) fetchFromDB(ctx context.Context, key string) (info *AliasIn
 		if namespace == nil {
 			idResult, idErr := c.db.GetTemplateById(ctx, alias)
 			if idErr == nil {
-				return &AliasInfo{
+				return &AliasResult{
 					TemplateID: idResult.ID,
-					TeamID:     idResult.TeamID,
-					Public:     idResult.Public,
 				}, nil
 			}
 
@@ -209,61 +158,13 @@ func (c *AliasCache) fetchFromDB(ctx context.Context, key string) (info *AliasIn
 	return nil, fmt.Errorf("fetching template by alias: %w", err)
 }
 
-// LookupByID looks up template info by direct template ID only (no alias resolution).
-// Uses the same cache as alias lookups since we cache by template ID too.
-func (c *AliasCache) LookupByID(ctx context.Context, templateID string) (*AliasInfo, error) {
+// LookupByID looks up a template by direct template ID only (no alias resolution).
+func (c *AliasCache) LookupByID(ctx context.Context, templateID string) (string, error) {
 	return c.lookup(ctx, nil, templateID)
 }
 
 func (c *AliasCache) Invalidate(ctx context.Context, namespace *string, alias string) {
 	c.cache.Delete(ctx, buildAliasKey(namespace, alias))
-}
-
-// popReverseIndexScript atomically reads all members from the reverse index set
-// and deletes the set. Both operations target the same key (same hash slot).
-// Returns the list of alias cache keys that were in the set.
-// KEYS[1] = reverse index set key
-var popReverseIndexScript = redis.NewScript(`
-	local members = redis.call("SMEMBERS", KEYS[1])
-	redis.call("DEL", KEYS[1])
-	return members
-`)
-
-// InvalidateByTemplateID removes all cache entries pointing to the given template ID.
-// It atomically pops the reverse index set (Lua script, single slot), then pipelines
-// DELs for the alias cache keys (which may span different slots).
-func (c *AliasCache) InvalidateByTemplateID(ctx context.Context, templateID string) {
-	rc := c.cache.RedisClient()
-	reverseKey := redis_utils.CreateKey(aliasReverseIndexPrefix, templateID)
-
-	ctx, cancel := context.WithTimeout(ctx, cache.RedisDefaultTimeout)
-	defer cancel()
-
-	members, err := popReverseIndexScript.Run(ctx, rc, []string{reverseKey}).StringSlice()
-	if err != nil {
-		if !errors.Is(err, redis.Nil) {
-			logger.L().Warn(ctx, "failed to pop alias reverse index",
-				zap.String("template_id", templateID),
-				zap.Error(err),
-			)
-		}
-	}
-
-	if len(members) == 0 {
-		return
-	}
-
-	pipe := rc.Pipeline()
-	for _, aliasKey := range members {
-		pipe.Del(ctx, c.cache.RedisKey(aliasKey))
-	}
-
-	if _, err := pipe.Exec(ctx); err != nil {
-		logger.L().Warn(ctx, "failed to delete alias cache entries",
-			zap.String("template_id", templateID),
-			zap.Error(err),
-		)
-	}
 }
 
 func (c *AliasCache) Close(ctx context.Context) error {

--- a/packages/api/internal/cache/templates/alias_cache_test.go
+++ b/packages/api/internal/cache/templates/alias_cache_test.go
@@ -1,0 +1,333 @@
+package templatecache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
+)
+
+// TestAliasCacheResolve_BareAliasInTeamNamespace tests that a bare alias
+// is found when it exists in the team's namespace
+func TestAliasCacheResolve_BareAliasInTeamNamespace(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "my-alias", &teamSlug)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Bare alias should resolve via team namespace fallback
+	resolvedID, err := cache.Resolve(ctx, "my-alias", teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+}
+
+// TestAliasCacheResolve_BareAliasFallbackToNullNamespace tests that a bare alias
+// falls back to NULL namespace (promoted templates) when not found in team namespace
+func TestAliasCacheResolve_BareAliasFallbackToNullNamespace(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	// Create requesting team (has no aliases)
+	requestingTeamID := testutils.CreateTestTeam(t, db)
+	requestingTeamSlug := testutils.GetTeamSlug(t, ctx, db, requestingTeamID)
+
+	// Create promoted template owned by another team
+	promotedTeamID := testutils.CreateTestTeam(t, db)
+	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
+
+	// Create alias with NULL namespace (promoted)
+	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "base", nil)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Bare alias "base" should:
+	// 1. Try requesting team's namespace -> not found
+	// 2. Fall back to NULL namespace -> found
+	resolvedID, err := cache.Resolve(ctx, "base", requestingTeamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, promotedTemplateID, resolvedID)
+}
+
+// TestAliasCacheResolve_ExplicitNamespaceNoFallback tests that an explicit namespace
+// does NOT fall back to NULL namespace
+func TestAliasCacheResolve_ExplicitNamespaceNoFallback(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	// Create team
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Create alias only in NULL namespace
+	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "only-promoted", nil)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Explicit namespace lookup should NOT fall back to NULL
+	resolvedID, err := cache.Resolve(ctx, teamSlug+"/only-promoted", teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+}
+
+// TestAliasCacheResolve_ExplicitNamespaceNoIDFallback tests that an explicit namespace
+// does NOT fall back to template ID lookup, even if the alias token matches a real template ID.
+// This prevents "team-x/<templateID>" from resolving when no alias exists.
+func TestAliasCacheResolve_ExplicitNamespaceNoIDFallback(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	// Create team and template
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Request "team-slug/<templateID>" - no alias exists with this name in team namespace.
+	// Even though templateID is a valid template ID, it should NOT resolve because
+	// explicit namespace lookups should not fall back to ID lookup.
+	resolvedID, err := cache.Resolve(ctx, teamSlug+"/"+templateID, teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+
+	// But bare templateID should still resolve via ID fallback
+	resolvedID, err = cache.Resolve(ctx, templateID, teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+}
+
+// TestAliasCacheResolve_TeamOverridesPromoted tests that team's alias
+// takes precedence over promoted template with same name.
+// NOTE: This test is for Phase 2 when PK becomes (alias, namespace).
+// During Phase 1, PK is still (alias) only, so duplicate alias names are not allowed.
+func TestAliasCacheResolve_TeamOverridesPromoted(t *testing.T) {
+	t.Skip("Phase 2 test: requires PK change to (alias, namespace) to allow duplicate alias names")
+
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	// Create team and its template
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	teamTemplateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Create promoted template
+	promotedTeamID := testutils.CreateTestTeam(t, db)
+	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
+
+	// Both have alias "shared-name"
+	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "shared-name", nil)
+	testutils.CreateTestTemplateAliasWithName(t, db, teamTemplateID, "shared-name", &teamSlug)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Team's alias should take precedence
+	resolvedID, err := cache.Resolve(ctx, "shared-name", teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, teamTemplateID, resolvedID, "Team's alias should override promoted")
+}
+
+// TestAliasCacheResolve_DirectTemplateID tests that direct template IDs work
+func TestAliasCacheResolve_DirectTemplateID(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Direct template ID should resolve
+	resolvedID, err := cache.Resolve(ctx, templateID, teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+}
+
+// TestAliasCacheResolve_NotFound tests that non-existent aliases return 404
+func TestAliasCacheResolve_NotFound(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	resolvedID, err := cache.Resolve(ctx, "non-existent", teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+}
+
+// TestAliasCacheLookupByID tests direct template ID lookup
+func TestAliasCacheLookupByID(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	resolvedID, err := cache.LookupByID(ctx, templateID)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+}
+
+// TestAliasCacheLookupByID_NotFound tests that non-existent template IDs return 404
+func TestAliasCacheLookupByID_NotFound(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	resolvedID, err := cache.LookupByID(ctx, "non-existent-id")
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+}
+
+// TestAliasCacheResolve_NegativeCaching tests that not-found results are cached (tombstones)
+func TestAliasCacheResolve_NegativeCaching(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// First lookup - not found, should cache tombstone
+	resolvedID, err := cache.Resolve(ctx, "non-existent-alias", teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+
+	// Create the template and alias AFTER the first lookup
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "non-existent-alias", &teamSlug)
+
+	// Second lookup should still return not found (cached tombstone)
+	resolvedID, err = cache.Resolve(ctx, "non-existent-alias", teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	assert.Empty(t, resolvedID)
+}
+
+// TestAliasCacheResolve_NegativeCachingFallback tests that tombstones are cached
+// for intermediate lookups during fallback resolution
+func TestAliasCacheResolve_NegativeCachingFallback(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	// Create requesting team
+	requestingTeamID := testutils.CreateTestTeam(t, db)
+	requestingTeamSlug := testutils.GetTeamSlug(t, ctx, db, requestingTeamID)
+
+	// Create promoted template with NULL namespace alias
+	promotedTeamID := testutils.CreateTestTeam(t, db)
+	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
+	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "promoted-alias", nil)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Resolve bare alias - tries team namespace first (not found, caches tombstone),
+	// then falls back to NULL namespace (found)
+	resolvedID, err := cache.Resolve(ctx, "promoted-alias", requestingTeamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, promotedTemplateID, resolvedID)
+
+	// Verify tombstone was cached for team namespace lookup
+	tombstoneKey := cache.cache.RedisKey(buildAliasKey(&requestingTeamSlug, "promoted-alias"))
+	exists, err := redis.Exists(ctx, tombstoneKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "tombstone should be cached for team namespace miss")
+
+	// Verify positive result was cached for NULL namespace lookup
+	positiveKey := cache.cache.RedisKey(buildAliasKey(nil, "promoted-alias"))
+	exists, err = redis.Exists(ctx, positiveKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "positive result should be cached for NULL namespace hit")
+}
+
+// TestAliasCacheResolve_InvalidateRefreshesCache tests that invalidating an alias
+// entry allows fresh data to be fetched from DB on next lookup
+func TestAliasCacheResolve_InvalidateRefreshesCache(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "alias-to-invalidate", &teamSlug)
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	// Resolve to populate cache
+	resolvedID, err := cache.Resolve(ctx, "alias-to-invalidate", teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+
+	// Verify alias key exists in Redis before invalidation
+	aliasKey := cache.cache.RedisKey(buildAliasKey(&teamSlug, "alias-to-invalidate"))
+	exists, err := redis.Exists(ctx, aliasKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "alias key should exist before invalidation")
+
+	// Invalidate the specific alias
+	cache.Invalidate(ctx, &teamSlug, "alias-to-invalidate")
+
+	// Verify alias key is deleted after invalidation
+	exists, err = redis.Exists(ctx, aliasKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "alias key should be deleted after invalidation")
+
+	// Re-resolve should still work (fresh fetch from DB)
+	resolvedID, err = cache.Resolve(ctx, "alias-to-invalidate", teamSlug)
+	require.NoError(t, err)
+	assert.Equal(t, templateID, resolvedID)
+}

--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -59,10 +59,6 @@ func NewTemplateCache(db *sqlcdb.Client, redisClient redis.UniversalClient) *Tem
 		RefreshInterval: templateCacheRefreshInterval,
 		RedisClient:     redisClient,
 		RedisPrefix:     templateCacheKeyPrefix,
-
-		ExtractKeyFunc: func(value *TemplateInfo) string {
-			return buildCacheKey(value.Template.TemplateID, value.Tag)
-		},
 	})
 
 	return &TemplateCache{
@@ -72,16 +68,11 @@ func NewTemplateCache(db *sqlcdb.Client, redisClient redis.UniversalClient) *Tem
 	}
 }
 
-// ResolveAlias resolves an identifier to AliasInfo (templateID, teamID, public).
+// ResolveAlias resolves an identifier to a templateID string.
 // The identifier is "namespace/alias" or just "alias" (already validated by id.ParseName).
 // namespaceFallback is used for bare aliases (no explicit namespace).
-func (c *TemplateCache) ResolveAlias(ctx context.Context, identifier string, namespaceFallback string) (*AliasInfo, error) {
+func (c *TemplateCache) ResolveAlias(ctx context.Context, identifier string, namespaceFallback string) (string, error) {
 	return c.aliasCache.Resolve(ctx, identifier, namespaceFallback)
-}
-
-// GetByID looks up template info by direct template ID only (no alias resolution).
-func (c *TemplateCache) GetByID(ctx context.Context, templateID string) (*AliasInfo, error) {
-	return c.aliasCache.LookupByID(ctx, templateID)
 }
 
 // Get fetches a template with build by templateID and tag.
@@ -92,7 +83,7 @@ func (c *TemplateCache) Get(ctx context.Context, templateID string, tag *string,
 	defer span.End()
 
 	// Step 1: Get template with build by ID and tag
-	templateInfo, err := c.getByID(ctx, templateID, tag)
+	templateInfo, err := c.GetByID(ctx, templateID, tag)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -110,8 +101,9 @@ func (c *TemplateCache) Get(ctx context.Context, templateID string, tag *string,
 	return templateInfo.Template, templateInfo.Build, nil
 }
 
-// getByID fetches template+build by templateID and tag
-func (c *TemplateCache) getByID(ctx context.Context, templateID string, tag *string) (*TemplateInfo, error) {
+// GetByID fetches template+build by templateID and tag from cache (or DB on miss).
+// Does NOT perform access control or cluster checks — use Get for that.
+func (c *TemplateCache) GetByID(ctx context.Context, templateID string, tag *string) (*TemplateInfo, error) {
 	tagValue := id.DefaultTag
 	if tag != nil {
 		tagValue = *tag
@@ -174,14 +166,10 @@ func (c *TemplateCache) Invalidate(ctx context.Context, templateID string, tag *
 	c.cache.Delete(ctx, cacheKey)
 }
 
-// InvalidateAllTags invalidates the cache for the given templateID across all tags
+// InvalidateAllTags invalidates the cache for the given templateID across all tags.
 func (c *TemplateCache) InvalidateAllTags(ctx context.Context, templateID string) []string {
 	pattern := buildCacheKey(templateID, "")
-	keys := c.cache.DeleteByPrefix(ctx, pattern)
-
-	c.aliasCache.InvalidateByTemplateID(ctx, templateID)
-
-	return keys
+	return c.cache.DeleteByPrefix(ctx, pattern)
 }
 
 // InvalidateAlias invalidates the alias cache entry

--- a/packages/api/internal/cache/templates/cache_test.go
+++ b/packages/api/internal/cache/templates/cache_test.go
@@ -11,385 +11,8 @@ import (
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
-// TestAliasCacheResolve_BareAliasInTeamNamespace tests that a bare alias
-// is found when it exists in the team's namespace
-func TestAliasCacheResolve_BareAliasInTeamNamespace(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "my-alias", &teamSlug)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Bare alias should resolve via team namespace fallback
-	info, err := cache.Resolve(ctx, "my-alias", teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, templateID, info.TemplateID)
-	assert.Equal(t, teamID, info.TeamID)
-}
-
-// TestAliasCacheResolve_BareAliasFallbackToNullNamespace tests that a bare alias
-// falls back to NULL namespace (promoted templates) when not found in team namespace
-func TestAliasCacheResolve_BareAliasFallbackToNullNamespace(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	// Create requesting team (has no aliases)
-	requestingTeamID := testutils.CreateTestTeam(t, db)
-	requestingTeamSlug := testutils.GetTeamSlug(t, ctx, db, requestingTeamID)
-
-	// Create promoted template owned by another team
-	promotedTeamID := testutils.CreateTestTeam(t, db)
-	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
-
-	// Create alias with NULL namespace (promoted)
-	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "base", nil)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Bare alias "base" should:
-	// 1. Try requesting team's namespace -> not found
-	// 2. Fall back to NULL namespace -> found
-	info, err := cache.Resolve(ctx, "base", requestingTeamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, promotedTemplateID, info.TemplateID)
-	assert.Equal(t, promotedTeamID, info.TeamID)
-}
-
-// TestAliasCacheResolve_ExplicitNamespaceNoFallback tests that an explicit namespace
-// does NOT fall back to NULL namespace
-func TestAliasCacheResolve_ExplicitNamespaceNoFallback(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	// Create team
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	// Create alias only in NULL namespace
-	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "only-promoted", nil)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Explicit namespace lookup should NOT fall back to NULL
-	info, err := cache.Resolve(ctx, teamSlug+"/only-promoted", teamSlug)
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-}
-
-// TestAliasCacheResolve_ExplicitNamespaceNoIDFallback tests that an explicit namespace
-// does NOT fall back to template ID lookup, even if the alias token matches a real template ID.
-// This prevents "team-x/<templateID>" from resolving when no alias exists.
-func TestAliasCacheResolve_ExplicitNamespaceNoIDFallback(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	// Create team and template
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Request "team-slug/<templateID>" - no alias exists with this name in team namespace.
-	// Even though templateID is a valid template ID, it should NOT resolve because
-	// explicit namespace lookups should not fall back to ID lookup.
-	info, err := cache.Resolve(ctx, teamSlug+"/"+templateID, teamSlug)
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-
-	// But bare templateID should still resolve via ID fallback
-	info, err = cache.Resolve(ctx, templateID, teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, templateID, info.TemplateID)
-}
-
-// TestAliasCacheResolve_TeamOverridesPromoted tests that team's alias
-// takes precedence over promoted template with same name.
-// NOTE: This test is for Phase 2 when PK becomes (alias, namespace).
-// During Phase 1, PK is still (alias) only, so duplicate alias names are not allowed.
-func TestAliasCacheResolve_TeamOverridesPromoted(t *testing.T) {
-	t.Skip("Phase 2 test: requires PK change to (alias, namespace) to allow duplicate alias names")
-
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	// Create team and its template
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	teamTemplateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	// Create promoted template
-	promotedTeamID := testutils.CreateTestTeam(t, db)
-	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
-
-	// Both have alias "shared-name"
-	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "shared-name", nil)
-	testutils.CreateTestTemplateAliasWithName(t, db, teamTemplateID, "shared-name", &teamSlug)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Team's alias should take precedence
-	info, err := cache.Resolve(ctx, "shared-name", teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, teamTemplateID, info.TemplateID, "Team's alias should override promoted")
-}
-
-// TestAliasCacheResolve_DirectTemplateID tests that direct template IDs work
-func TestAliasCacheResolve_DirectTemplateID(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Direct template ID should resolve
-	info, err := cache.Resolve(ctx, templateID, teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, templateID, info.TemplateID)
-}
-
-// TestAliasCacheResolve_NotFound tests that non-existent aliases return 404
-func TestAliasCacheResolve_NotFound(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	info, err := cache.Resolve(ctx, "non-existent", teamSlug)
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-}
-
-// TestAliasCacheLookupByID tests direct template ID lookup
-func TestAliasCacheLookupByID(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	info, err := cache.LookupByID(ctx, templateID)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, templateID, info.TemplateID)
-	assert.Equal(t, teamID, info.TeamID)
-}
-
-// TestAliasCacheLookupByID_NotFound tests that non-existent template IDs return 404
-func TestAliasCacheLookupByID_NotFound(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	info, err := cache.LookupByID(ctx, "non-existent-id")
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-}
-
-// TestAliasCacheLookupByID_UsesCache tests that LookupByID uses cached entries from Resolve
-func TestAliasCacheLookupByID_UsesCache(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "cached-alias", &teamSlug)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// First, resolve by alias (this caches by both alias and template ID)
-	_, err := cache.Resolve(ctx, "cached-alias", teamSlug)
-	require.NoError(t, err)
-
-	// Verify the template ID key was backfilled into Redis by the alias resolve
-	idKey := cache.cache.RedisKey(templateID)
-	exists, err := redis.Exists(ctx, idKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), exists, "template ID key should be cached after alias resolve")
-
-	// Lookup by ID should return correct data from cache
-	info2, err := cache.LookupByID(ctx, templateID)
-	require.NoError(t, err)
-	require.NotNil(t, info2)
-	assert.Equal(t, templateID, info2.TemplateID)
-	assert.Equal(t, teamID, info2.TeamID)
-}
-
-// TestAliasCacheResolve_NegativeCaching tests that not-found results are cached (tombstones)
-func TestAliasCacheResolve_NegativeCaching(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// First lookup - not found, should cache tombstone
-	info, err := cache.Resolve(ctx, "non-existent-alias", teamSlug)
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-
-	// Create the template and alias AFTER the first lookup
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "non-existent-alias", &teamSlug)
-
-	// Second lookup should still return not found (cached tombstone)
-	info, err = cache.Resolve(ctx, "non-existent-alias", teamSlug)
-	require.ErrorIs(t, err, ErrTemplateNotFound)
-	require.Nil(t, info)
-}
-
-// TestAliasCacheResolve_NegativeCachingFallback tests that tombstones are cached
-// for intermediate lookups during fallback resolution
-func TestAliasCacheResolve_NegativeCachingFallback(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	// Create requesting team
-	requestingTeamID := testutils.CreateTestTeam(t, db)
-	requestingTeamSlug := testutils.GetTeamSlug(t, ctx, db, requestingTeamID)
-
-	// Create promoted template with NULL namespace alias
-	promotedTeamID := testutils.CreateTestTeam(t, db)
-	promotedTemplateID := testutils.CreateTestTemplate(t, db, promotedTeamID)
-	testutils.CreateTestTemplateAliasWithName(t, db, promotedTemplateID, "promoted-alias", nil)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Resolve bare alias - tries team namespace first (not found, caches tombstone),
-	// then falls back to NULL namespace (found)
-	info, err := cache.Resolve(ctx, "promoted-alias", requestingTeamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info)
-	assert.Equal(t, promotedTemplateID, info.TemplateID)
-
-	// Verify tombstone was cached for team namespace lookup
-	tombstoneKey := cache.cache.RedisKey(buildAliasKey(&requestingTeamSlug, "promoted-alias"))
-	exists, err := redis.Exists(ctx, tombstoneKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), exists, "tombstone should be cached for team namespace miss")
-
-	// Verify positive result was cached for NULL namespace lookup
-	positiveKey := cache.cache.RedisKey(buildAliasKey(nil, "promoted-alias"))
-	exists, err = redis.Exists(ctx, positiveKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), exists, "positive result should be cached for NULL namespace hit")
-}
-
-// TestAliasCache_InvalidateByTemplateID tests that InvalidateByTemplateID
-// removes all cache entries pointing to that template
-func TestAliasCache_InvalidateByTemplateID(t *testing.T) {
-	t.Parallel()
-	db := testutils.SetupDatabase(t)
-	redis := redis_utils.SetupInstance(t)
-	ctx := t.Context()
-
-	teamID := testutils.CreateTestTeam(t, db)
-	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
-	templateID := testutils.CreateTestTemplate(t, db, teamID)
-
-	testutils.CreateTestTemplateAliasWithName(t, db, templateID, "alias-to-invalidate", &teamSlug)
-
-	cache := NewAliasCache(db.SqlcClient, redis)
-	defer cache.Close(ctx)
-
-	// Resolve to populate cache
-	info1, err := cache.Resolve(ctx, "alias-to-invalidate", teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info1)
-
-	// Also lookup by ID to cache that entry
-	_, err = cache.LookupByID(ctx, templateID)
-	require.NoError(t, err)
-
-	// Verify alias key exists in Redis before invalidation
-	aliasKey := cache.cache.RedisKey(buildAliasKey(&teamSlug, "alias-to-invalidate"))
-	exists, err := redis.Exists(ctx, aliasKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(1), exists, "alias key should exist before invalidation")
-
-	// Invalidate by template ID
-	cache.InvalidateByTemplateID(ctx, templateID)
-
-	// Verify alias key is gone from Redis
-	exists, err = redis.Exists(ctx, aliasKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), exists, "alias key should be deleted after invalidation")
-
-	// Verify template ID key is gone from Redis
-	idKey := cache.cache.RedisKey(templateID)
-	exists, err = redis.Exists(ctx, idKey).Result()
-	require.NoError(t, err)
-	assert.Equal(t, int64(0), exists, "template ID key should be deleted after invalidation")
-
-	// Re-resolve should still work (fresh fetch from DB)
-	info3, err := cache.Resolve(ctx, "alias-to-invalidate", teamSlug)
-	require.NoError(t, err)
-	require.NotNil(t, info3)
-	assert.Equal(t, templateID, info3.TemplateID)
-}
-
 // TestTemplateCache_InvalidateDoesNotInvalidateAliases tests that TemplateCache.Invalidate
-// does NOT invalidate alias cache entries (only InvalidateAllTags does)
+// does NOT invalidate alias cache entries (only InvalidateAllTags does metadata)
 func TestTemplateCache_InvalidateDoesNotInvalidateAliases(t *testing.T) {
 	t.Parallel()
 	db := testutils.SetupDatabase(t)
@@ -406,9 +29,9 @@ func TestTemplateCache_InvalidateDoesNotInvalidateAliases(t *testing.T) {
 	defer cache.Close(ctx)
 
 	// Resolve alias to populate alias cache
-	info1, err := cache.ResolveAlias(ctx, "alias-for-template", teamSlug)
+	resolvedID, err := cache.ResolveAlias(ctx, "alias-for-template", teamSlug)
 	require.NoError(t, err)
-	require.NotNil(t, info1)
+	assert.Equal(t, templateID, resolvedID)
 
 	// Verify alias key exists in Redis
 	aliasKey := cache.aliasCache.cache.RedisKey(buildAliasKey(&teamSlug, "alias-for-template"))
@@ -448,23 +71,24 @@ func TestTemplateCache_InvalidateAllTagsDeletesRedisEntries(t *testing.T) {
 	// Verify the entry exists in Redis
 	cacheKey := buildCacheKey(templateID, "default")
 	redisKey := tc.cache.RedisKey(cacheKey)
-	val, err := redisClient.Get(ctx, redisKey).Result()
+	exists, err := redisClient.Exists(ctx, redisKey).Result()
 	require.NoError(t, err)
-	require.NotEmpty(t, val)
+	require.Equal(t, int64(1), exists)
 
 	// InvalidateAllTags should delete the entry from Redis
 	keys := tc.InvalidateAllTags(ctx, templateID)
 	require.NotEmpty(t, keys, "should have deleted at least one key")
 
 	// Verify Redis entry is gone
-	exists, err := redisClient.Exists(ctx, redisKey).Result()
+	exists, err = redisClient.Exists(ctx, redisKey).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), exists, "Redis entry should be deleted after InvalidateAllTags")
 }
 
-// TestTemplateCache_InvalidateAllTagsAlsoInvalidatesAliases tests that
-// TemplateCache.InvalidateAllTags also invalidates the alias cache entries
-func TestTemplateCache_InvalidateAllTagsAlsoInvalidatesAliases(t *testing.T) {
+// TestTemplateCache_InvalidateAllTagsDoesNotInvalidateAliases tests that
+// TemplateCache.InvalidateAllTags does NOT invalidate alias cache entries.
+// Alias entries are only invalidated by InvalidateAlias (alias CRUD).
+func TestTemplateCache_InvalidateAllTagsDoesNotInvalidateAliases(t *testing.T) {
 	t.Parallel()
 	db := testutils.SetupDatabase(t)
 	redis := redis_utils.SetupInstance(t)
@@ -489,11 +113,48 @@ func TestTemplateCache_InvalidateAllTagsAlsoInvalidatesAliases(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), exists, "alias key should exist before invalidation")
 
-	// Invalidate all tags (should also invalidate alias cache)
+	// Invalidate all tags — should NOT invalidate alias cache (alias→templateID mapping is stable)
 	cache.InvalidateAllTags(ctx, templateID)
 
-	// Alias key should be gone from Redis
+	// Alias key should still be present (alias→templateID doesn't change)
 	exists, err = redis.Exists(ctx, aliasKey).Result()
 	require.NoError(t, err)
-	assert.Equal(t, int64(0), exists, "alias key should be deleted after InvalidateAllTags")
+	assert.Equal(t, int64(1), exists, "alias key should survive InvalidateAllTags")
+}
+
+// TestTemplateCache_GetByID tests that GetByID returns correct template info
+func TestTemplateCache_GetByID(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "ready")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "default")
+
+	cache := NewTemplateCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	info, err := cache.GetByID(ctx, templateID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, info)
+	assert.Equal(t, templateID, info.Template.TemplateID)
+	assert.Equal(t, teamID, info.TeamID)
+}
+
+// TestTemplateCache_GetByID_NotFound tests that GetByID returns error for non-existent templates
+func TestTemplateCache_GetByID_NotFound(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	cache := NewTemplateCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	info, err := cache.GetByID(ctx, "non-existent-id", nil)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	require.Nil(t, info)
 }

--- a/packages/api/internal/handlers/auth.go
+++ b/packages/api/internal/handlers/auth.go
@@ -123,16 +123,21 @@ func (a *APIStore) resolveTemplateAndTeam(
 	ctx context.Context,
 	c *gin.Context,
 	identifier string,
-) (*types.Team, *templatecache.AliasInfo, *api.APIError) {
+) (*types.Team, *templatecache.TemplateInfo, *api.APIError) {
 	switch {
 	case c.Value(auth.TeamContextKey) != nil:
 		team := a.GetTeamInfo(c)
-		aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+		templateID, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
 		if err != nil {
 			return nil, nil, templatecache.ErrorToAPIError(err, identifier)
 		}
 
-		if aliasInfo.TeamID != team.ID {
+		info, err := a.templateCache.GetByID(ctx, templateID, nil)
+		if err != nil {
+			return nil, nil, templatecache.ErrorToAPIError(err, identifier)
+		}
+
+		if info.TeamID != team.ID {
 			return nil, nil, &api.APIError{
 				Code:      http.StatusForbidden,
 				ClientMsg: fmt.Sprintf("You don't have access to template '%s'", identifier),
@@ -140,9 +145,9 @@ func (a *APIStore) resolveTemplateAndTeam(
 			}
 		}
 
-		return team, aliasInfo, nil
+		return team, info, nil
 	case c.Value(auth.UserIDContextKey) != nil:
-		aliasInfo, err := a.templateCache.GetByID(ctx, identifier)
+		info, err := a.templateCache.GetByID(ctx, identifier, nil)
 		if err != nil {
 			return nil, nil, templatecache.ErrorToAPIError(err, identifier)
 		}
@@ -153,8 +158,8 @@ func (a *APIStore) resolveTemplateAndTeam(
 		}
 
 		for _, t := range userTeams {
-			if t.Team.ID == aliasInfo.TeamID {
-				return t.Team, aliasInfo, nil
+			if t.Team.ID == info.TeamID {
+				return t.Team, info, nil
 			}
 		}
 

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -79,7 +79,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 	}
 
 	clusterID := clusters.WithClusterFallback(teamInfo.Team.ClusterID)
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Team.Slug)
+	templateID, err := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Team.Slug)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		telemetry.ReportErrorByCode(ctx, apiErr.Code, "error when resolving template alias", apiErr.Err, attribute.String("identifier", identifier))
@@ -88,10 +88,10 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		return
 	}
 
-	env, build, err := a.templateCache.Get(ctx, aliasInfo.TemplateID, tag, teamInfo.Team.ID, clusterID)
+	env, build, err := a.templateCache.Get(ctx, templateID, tag, teamInfo.Team.ID, clusterID)
 	if err != nil {
-		apiErr := templatecache.ErrorToAPIError(err, aliasInfo.TemplateID)
-		telemetry.ReportErrorByCode(ctx, apiErr.Code, "error when getting template", apiErr.Err, telemetry.WithTemplateID(aliasInfo.TemplateID))
+		apiErr := templatecache.ErrorToAPIError(err, templateID)
+		telemetry.ReportErrorByCode(ctx, apiErr.Code, "error when getting template", apiErr.Err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 
 		return

--- a/packages/api/internal/handlers/snapshot_template_create.go
+++ b/packages/api/internal/handlers/snapshot_template_create.go
@@ -68,11 +68,15 @@ func (a *APIStore) PostSandboxesSandboxIDSnapshots(c *gin.Context, sandboxID api
 		}
 
 		// Resolve alias using the cache — same pattern as template builds
-		aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Slug)
+		existingTemplateID, err := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Slug)
+		if err == nil {
+			info, infoErr := a.templateCache.GetByID(ctx, existingTemplateID, nil)
+			if infoErr == nil && info.TeamID == teamID {
+				// Alias exists and is owned by this team — reuse the template
+				opts.ExistingTemplateID = &info.Template.TemplateID
+			}
+		}
 		switch {
-		case err == nil && aliasInfo.TeamID == teamID:
-			// Alias exists and is owned by this team — reuse the template
-			opts.ExistingTemplateID = &aliasInfo.TemplateID
 		case err == nil || errors.Is(err, templatecache.ErrTemplateNotFound):
 			// Not found, or owned by a different team — will create a new template with this alias
 		default:

--- a/packages/api/internal/handlers/template_alias.go
+++ b/packages/api/internal/handlers/template_alias.go
@@ -37,7 +37,15 @@ func (a *APIStore) GetTemplatesAliasesAlias(c *gin.Context, alias string) {
 		return
 	}
 
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	templateID, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	if err != nil {
+		apiErr := templatecache.ErrorToAPIError(err, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+
+		return
+	}
+
+	info, err := a.templateCache.GetByID(ctx, templateID, nil)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
@@ -46,7 +54,7 @@ func (a *APIStore) GetTemplatesAliasesAlias(c *gin.Context, alias string) {
 	}
 
 	// Ownership verification (handles edge case where template was transferred)
-	if aliasInfo.TeamID != team.ID {
+	if info.TeamID != team.ID {
 		a.sendAPIStoreError(c, http.StatusForbidden, "You don't have access to this template alias")
 
 		return
@@ -55,8 +63,8 @@ func (a *APIStore) GetTemplatesAliasesAlias(c *gin.Context, alias string) {
 	// Team is alias owner
 	c.JSON(
 		http.StatusOK, api.TemplateAliasResponse{
-			Public:     aliasInfo.Public,
-			TemplateID: aliasInfo.TemplateID,
+			Public:     info.Template.Public,
+			TemplateID: info.Template.TemplateID,
 		},
 	)
 }

--- a/packages/api/internal/handlers/template_delete.go
+++ b/packages/api/internal/handlers/template_delete.go
@@ -28,7 +28,7 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 	}
 
 	// Resolve template and get the owning team
-	team, aliasInfo, apiErr := a.resolveTemplateAndTeam(ctx, c, identifier)
+	team, info, apiErr := a.resolveTemplateAndTeam(ctx, c, identifier)
 	if apiErr != nil {
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		if apiErr.Code != http.StatusNotFound {
@@ -38,7 +38,7 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 		return
 	}
 
-	templateID := aliasInfo.TemplateID
+	templateID := info.Template.TemplateID
 
 	telemetry.SetAttributes(ctx,
 		attribute.String("env.team.id", team.ID.String()),

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -97,12 +97,17 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	templateID := id.Generate()
 	public := false
 
-	aliasInfo, err := a.templateCache.ResolveAlias(findTemplateCtx, identifier, team.Slug)
+	existingTemplateID, err := a.templateCache.ResolveAlias(findTemplateCtx, identifier, team.Slug)
+	if err == nil {
+		info, err := a.templateCache.GetByID(findTemplateCtx, existingTemplateID, nil)
+		if err == nil && info.TeamID == team.ID {
+			// Template exists and is owned by this team - update it
+			templateID = info.Template.TemplateID
+			public = info.Template.Public
+		}
+		// else: found but owned by different team, or metadata error — team can create their own
+	}
 	switch {
-	case err == nil && aliasInfo.TeamID == team.ID:
-		// Template exists and is owned by this team - update it
-		templateID = aliasInfo.TemplateID
-		public = aliasInfo.Public
 	case err == nil || errors.Is(err, templatecache.ErrTemplateNotFound):
 		// Either alias not found, or found but owned by different team (e.g. promoted template)
 		// Team can create their own template with this alias in their namespace

--- a/packages/api/internal/handlers/template_tags.go
+++ b/packages/api/internal/handlers/template_tags.go
@@ -66,11 +66,20 @@ func (a *APIStore) PostTemplatesTags(c *gin.Context) {
 		targetTagValue = *tag
 	}
 
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	resolvedTemplateID, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 		telemetry.ReportError(ctx, "template not found", apiErr.Err, telemetry.WithTemplateID(identifier))
+
+		return
+	}
+
+	info, err := a.templateCache.GetByID(ctx, resolvedTemplateID, nil)
+	if err != nil {
+		apiErr := templatecache.ErrorToAPIError(err, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		telemetry.ReportError(ctx, "template not found", apiErr.Err, telemetry.WithTemplateID(resolvedTemplateID))
 
 		return
 	}
@@ -86,13 +95,13 @@ func (a *APIStore) PostTemplatesTags(c *gin.Context) {
 
 	// Step 2: Get template with build by ID and tag
 	result, err := client.GetTemplateWithBuildByTag(ctx, queries.GetTemplateWithBuildByTagParams{
-		TemplateID: aliasInfo.TemplateID,
+		TemplateID: resolvedTemplateID,
 		Tag:        &targetTagValue,
 	})
 	if err != nil {
 		if dberrors.IsNotFoundError(err) {
 			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Template '%s' with tag '%s' not found", body.Target, targetTagValue))
-			telemetry.ReportError(ctx, "template tag not found", err, telemetry.WithTemplateID(aliasInfo.TemplateID))
+			telemetry.ReportError(ctx, "template tag not found", err, telemetry.WithTemplateID(resolvedTemplateID))
 
 			return
 		}
@@ -112,7 +121,7 @@ func (a *APIStore) PostTemplatesTags(c *gin.Context) {
 		telemetry.WithTemplateID(template.ID),
 	)
 
-	if aliasInfo.TeamID != team.ID {
+	if info.TeamID != team.ID {
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", identifier))
 		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(template.ID))
 
@@ -239,7 +248,7 @@ func (a *APIStore) DeleteTemplatesTags(c *gin.Context) {
 		return
 	}
 
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	resolvedTemplateID, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
@@ -248,9 +257,18 @@ func (a *APIStore) DeleteTemplatesTags(c *gin.Context) {
 		return
 	}
 
-	if aliasInfo.TeamID != team.ID {
+	info, err := a.templateCache.GetByID(ctx, resolvedTemplateID, nil)
+	if err != nil {
+		apiErr := templatecache.ErrorToAPIError(err, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		telemetry.ReportError(ctx, "template not found", apiErr.Err, telemetry.WithTemplateID(resolvedTemplateID))
+
+		return
+	}
+
+	if info.TeamID != team.ID {
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", identifier))
-		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(aliasInfo.TemplateID))
+		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(resolvedTemplateID))
 
 		return
 	}
@@ -258,12 +276,12 @@ func (a *APIStore) DeleteTemplatesTags(c *gin.Context) {
 	telemetry.SetAttributes(ctx,
 		attribute.String("env.team.id", team.ID.String()),
 		attribute.String("env.team.name", team.Name),
-		telemetry.WithTemplateID(aliasInfo.TemplateID),
+		telemetry.WithTemplateID(resolvedTemplateID),
 	)
 
 	// Delete the tag assignments
 	err = a.sqlcDB.DeleteTemplateTags(ctx, queries.DeleteTemplateTagsParams{
-		TemplateID: aliasInfo.TemplateID,
+		TemplateID: resolvedTemplateID,
 		Tags:       tags,
 	})
 	if err != nil {
@@ -274,17 +292,17 @@ func (a *APIStore) DeleteTemplatesTags(c *gin.Context) {
 	}
 
 	for _, tag := range tags {
-		a.templateCache.Invalidate(context.WithoutCancel(ctx), aliasInfo.TemplateID, &tag)
+		a.templateCache.Invalidate(context.WithoutCancel(ctx), resolvedTemplateID, &tag)
 	}
 
 	telemetry.ReportEvent(ctx, "deleted template tags")
 
 	properties := a.posthog.GetPackageToPosthogProperties(&c.Request.Header)
 	a.posthog.IdentifyAnalyticsTeam(ctx, team.ID.String(), team.Name)
-	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "deleted template tags", properties.Set("environment", aliasInfo.TemplateID).Set("tags", tags))
+	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "deleted template tags", properties.Set("environment", resolvedTemplateID).Set("tags", tags))
 
 	logger.L().Info(ctx, "Deleted template tags",
-		logger.WithTemplateID(aliasInfo.TemplateID),
+		logger.WithTemplateID(resolvedTemplateID),
 		logger.WithTeamID(team.ID.String()),
 	)
 
@@ -315,7 +333,7 @@ func (a *APIStore) GetTemplatesTemplateIDTags(c *gin.Context, templateID api.Tem
 		return
 	}
 
-	aliasInfo, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
+	resolvedTemplateID, err := a.templateCache.ResolveAlias(ctx, identifier, team.Slug)
 	if err != nil {
 		apiErr := templatecache.ErrorToAPIError(err, identifier)
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
@@ -324,14 +342,23 @@ func (a *APIStore) GetTemplatesTemplateIDTags(c *gin.Context, templateID api.Tem
 		return
 	}
 
-	if aliasInfo.TeamID != team.ID {
-		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", templateID))
-		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(aliasInfo.TemplateID))
+	info, err := a.templateCache.GetByID(ctx, resolvedTemplateID, nil)
+	if err != nil {
+		apiErr := templatecache.ErrorToAPIError(err, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		telemetry.ReportError(ctx, "template not found", apiErr.Err, telemetry.WithTemplateID(resolvedTemplateID))
 
 		return
 	}
 
-	tags, err := a.sqlcDB.ListTemplateTags(ctx, aliasInfo.TemplateID)
+	if info.TeamID != team.ID {
+		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You don't have access to sandbox template '%s'", templateID))
+		telemetry.ReportError(ctx, "no access to the template", nil, telemetry.WithTemplateID(resolvedTemplateID))
+
+		return
+	}
+
+	tags, err := a.sqlcDB.ListTemplateTags(ctx, resolvedTemplateID)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when listing template tags")
 		telemetry.ReportCriticalError(ctx, "error when listing template tags", err)

--- a/packages/api/internal/handlers/template_update.go
+++ b/packages/api/internal/handlers/template_update.go
@@ -39,7 +39,7 @@ func (a *APIStore) PatchTemplatesTemplateID(c *gin.Context, aliasOrTemplateID ap
 func (a *APIStore) PatchV2TemplatesTemplateID(c *gin.Context, aliasOrTemplateID api.TemplateID) {
 	ctx := c.Request.Context()
 
-	team, aliasInfo, apiErr := a.updateTemplate(ctx, c, aliasOrTemplateID, false)
+	team, info, apiErr := a.updateTemplate(ctx, c, aliasOrTemplateID, false)
 	if apiErr != nil {
 		telemetry.ReportErrorByCode(ctx, apiErr.Code, apiErr.ClientMsg, apiErr.Err, telemetry.WithTemplateID(aliasOrTemplateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
@@ -47,7 +47,9 @@ func (a *APIStore) PatchV2TemplatesTemplateID(c *gin.Context, aliasOrTemplateID 
 		return
 	}
 
-	template, err := a.sqlcDB.GetTemplateByIDWithAliases(ctx, aliasInfo.TemplateID)
+	templateID := info.Template.TemplateID
+
+	template, err := a.sqlcDB.GetTemplateByIDWithAliases(ctx, templateID)
 	if err != nil {
 		telemetry.ReportError(ctx, "error getting template names after update", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error retrieving template after update")
@@ -60,13 +62,13 @@ func (a *APIStore) PatchV2TemplatesTemplateID(c *gin.Context, aliasOrTemplateID 
 	})
 
 	logger.L().Debug(ctx, "Returned template names after update",
-		logger.WithTemplateID(aliasInfo.TemplateID),
+		logger.WithTemplateID(templateID),
 		logger.WithTeamID(team.ID.String()))
 }
 
 // updateTemplate contains the shared logic for updating a template.
-// Returns the resolved team and aliasInfo on success, or an APIError on failure.
-func (a *APIStore) updateTemplate(ctx context.Context, c *gin.Context, aliasOrTemplateID api.TemplateID, createBackwardCompatAlias bool) (*types.Team, *templatecache.AliasInfo, *api.APIError) {
+// Returns the resolved team and template metadata on success, or an APIError on failure.
+func (a *APIStore) updateTemplate(ctx context.Context, c *gin.Context, aliasOrTemplateID api.TemplateID, createBackwardCompatAlias bool) (*types.Team, *templatecache.TemplateInfo, *api.APIError) {
 	body, err := utils.ParseBody[api.TemplateUpdateRequest](ctx, c)
 	if err != nil {
 		return nil, nil, &api.APIError{
@@ -86,28 +88,30 @@ func (a *APIStore) updateTemplate(ctx context.Context, c *gin.Context, aliasOrTe
 	}
 
 	// Resolve template and get the owning team
-	team, aliasInfo, apiErr := a.resolveTemplateAndTeam(ctx, c, identifier)
+	team, info, apiErr := a.resolveTemplateAndTeam(ctx, c, identifier)
 	if apiErr != nil {
 		return nil, nil, apiErr
 	}
+
+	templateID := info.Template.TemplateID
 
 	telemetry.SetAttributes(ctx,
 		attribute.String("env.team.id", team.ID.String()),
 		attribute.String("env.team.name", team.Name),
 		attribute.String("package_version", c.Request.Header.Get("package_version")),
 		attribute.Bool("create_backward_compat_alias", createBackwardCompatAlias),
-		telemetry.WithTemplateID(aliasInfo.TemplateID),
+		telemetry.WithTemplateID(templateID),
 	)
 
 	// No-op if no update fields provided (empty body is valid per OpenAPI spec)
 	if body.Public == nil {
-		logger.L().Debug(ctx, "Empty PATCH body, no-op", logger.WithTemplateID(aliasInfo.TemplateID))
+		logger.L().Debug(ctx, "Empty PATCH body, no-op", logger.WithTemplateID(templateID))
 
-		return team, aliasInfo, nil
+		return team, info, nil
 	}
 
 	_, err = a.sqlcDB.UpdateTemplate(ctx, queries.UpdateTemplateParams{
-		TemplateIDOrAlias: aliasInfo.TemplateID,
+		TemplateIDOrAlias: templateID,
 		TeamID:            team.ID,
 		Public:            *body.Public,
 	})
@@ -128,12 +132,12 @@ func (a *APIStore) updateTemplate(ctx context.Context, c *gin.Context, aliasOrTe
 	}
 
 	// Invalidate cache immediately after successful DB update
-	a.templateCache.InvalidateAllTags(context.WithoutCancel(ctx), aliasInfo.TemplateID)
+	a.templateCache.InvalidateAllTags(context.WithoutCancel(ctx), templateID)
 
 	// For backward compatibility with older CLIs (v1 endpoint), also create a non-namespaced alias
 	// when publishing a template, so older CLIs can still find it by bare alias name
 	if createBackwardCompatAlias && *body.Public {
-		if apiErr := a.createBackwardCompatibleAlias(ctx, identifier, aliasInfo.TemplateID, team.Slug); apiErr != nil {
+		if apiErr := a.createBackwardCompatibleAlias(ctx, identifier, templateID, team.Slug); apiErr != nil {
 			return nil, nil, apiErr
 		}
 	}
@@ -142,11 +146,11 @@ func (a *APIStore) updateTemplate(ctx context.Context, c *gin.Context, aliasOrTe
 
 	properties := a.posthog.GetPackageToPosthogProperties(&c.Request.Header)
 	a.posthog.IdentifyAnalyticsTeam(ctx, team.ID.String(), team.Name)
-	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "updated environment", properties.Set("environment", aliasInfo.TemplateID))
+	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "updated environment", properties.Set("environment", templateID))
 
-	logger.L().Info(ctx, "Updated template", logger.WithTemplateID(aliasInfo.TemplateID), logger.WithTeamID(team.ID.String()))
+	logger.L().Info(ctx, "Updated template", logger.WithTemplateID(templateID), logger.WithTeamID(team.ID.String()))
 
-	return team, aliasInfo, nil
+	return team, info, nil
 }
 
 // createBackwardCompatibleAlias creates a non-namespaced alias for older CLIs

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -305,7 +305,7 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 		}
 
 		// Step 1: Resolve alias to template ID (using cache with fallback for promoted templates)
-		aliasInfo, err := tm.templateCache.ResolveAlias(ctx, identifier, teamSlug)
+		resolvedTemplateID, err := tm.templateCache.ResolveAlias(ctx, identifier, teamSlug)
 		if err != nil {
 			msg := fmt.Sprintf("error resolving base template '%s'", *fromTemplate)
 			if errors.Is(err, templatecache.ErrTemplateNotFound) {
@@ -318,7 +318,15 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 			}
 		}
 
-		if !aliasInfo.Public && aliasInfo.TeamID != teamID {
+		info, err := tm.templateCache.GetByID(ctx, resolvedTemplateID, nil)
+		if err != nil {
+			return &FromTemplateError{
+				err:     err,
+				message: fmt.Sprintf("error resolving base template '%s'", *fromTemplate),
+			}
+		}
+
+		if !info.Template.Public && info.TeamID != teamID {
 			return &FromTemplateError{
 				err:     nil,
 				message: fmt.Sprintf("you have no access to use '%s' as a base template", *fromTemplate),
@@ -327,7 +335,7 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 
 		// Step 2: Get template with build by ID
 		baseTemplate, err := tm.sqlcDB.GetTemplateWithBuildByTag(ctx, queries.GetTemplateWithBuildByTagParams{
-			TemplateID: aliasInfo.TemplateID,
+			TemplateID: resolvedTemplateID,
 			Tag:        tag,
 		})
 		if err != nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches request-time template resolution and authorization checks across multiple handlers and changes cache invalidation behavior; mistakes could cause incorrect access decisions or stale alias resolution until TTL/invalidation occurs.
> 
> **Overview**
> Simplifies alias resolution so `AliasCache`/`TemplateCache.ResolveAlias` return only a `templateID` string, dropping cached team/public metadata, template-ID backfilling, and bulk alias invalidation-by-templateID logic. All affected handlers now resolve to `templateID` then call `TemplateCache.GetByID` when they need ownership/public checks, and cache invalidation semantics change so `InvalidateAllTags` only clears template+build entries while alias entries are invalidated only via explicit alias CRUD (with updated/additional tests, including new dedicated `alias_cache_test.go`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 842082318fd49aaf85d546592220d20a77252e13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->