### PR TITLE
fix: disable memory.peak per-FD reset (requires kernel 6.12+)

### DIFF
--- a/packages/clickhouse/pkg/hoststats/hoststats.go
+++ b/packages/clickhouse/pkg/hoststats/hoststats.go
@@ -30,7 +30,7 @@ type SandboxHostStat struct {
 	CgroupCPUUserUsec   uint64 `ch:"cgroup_cpu_user_usec"`      // cumulative, microseconds
 	CgroupCPUSystemUsec uint64 `ch:"cgroup_cpu_system_usec"`    // cumulative, microseconds
 	CgroupMemoryUsage   uint64 `ch:"cgroup_memory_usage_bytes"` // current, bytes
-	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // interval peak, bytes (reset after each sample)
+	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // lifetime peak, bytes
 }
 
 // Delivery is the interface for delivering host stats to storage backend


### PR DESCRIPTION
The per-FD peak reset (write to memory.peak) was introduced in kernel commit c6f53ed8f213 ("mm, memcg: cg2 memory{.swap,}.peak write handlers") which landed in 6.12. Our hosts don't run 6.12 yet, so the reset does not work, memory.peak reports a lifetime peak instead of an interval peak, and every failed write produces a debug log message per sandbox per collection interval.

Disable the reset write and open memory.peak as read-only. The FD-based read infrastructure is preserved so re-enabling is straightforward when the fleet upgrades to kernel 6.12+.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to memory peak accounting and reduces logging; main risk is downstream consumers expecting interval peaks and needing to adjust dashboards/alerts.
> 
> **Overview**
> Disables the per-FD `memory.peak` reset behavior (and associated debug-noise on older kernels) by switching the cgroup `memory.peak` file descriptor to read-only, removing the reset write, and updating stats semantics/documentation to treat `MemoryPeakBytes`/`CgroupMemoryPeak` as a *lifetime* peak. Tests are updated to assert monotonic lifetime peak behavior instead of interval-reset behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51d11508d6a10f1b0dc1c1a7857e3a2ad06ba930. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->