### PR TITLE
Replace `hostname` with `hostnamectl`

### DIFF
--- a/packages/api/Makefile
+++ b/packages/api/Makefile
@@ -1,6 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 PREFIX := $(strip $(subst ",,$(PREFIX)))
+HOSTNAME := $(shell hostname || hostnamectl hostname)
 
 expectedMigration := $(shell ./../../scripts/get-latest-migration.sh)
 
@@ -51,7 +52,7 @@ endef
 run-local:
 	make build-debug
 	$(call setup_local_env)
-	NODE_ID=$$(hostname) ./bin/api --port 3000
+	NODE_ID=$(HOSTNAME) ./bin/api --port 3000
 
 # Run the API using air
 .PHONY: dev

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -1,6 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 PREFIX := $(strip $(subst ",,$(PREFIX)))
+HOSTNAME := $(shell hostname || hostnamectl hostname) 
 
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/client-proxy
@@ -40,7 +41,7 @@ endef
 run-local:
 	make build-debug
 	$(call setup_local_env)
-	NODE_ID=$$(hostname) ./bin/client-proxy
+	NODE_ID=$(HOSTNAME) ./bin/client-proxy
 
 .PHONY: generate
 generate:

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -4,6 +4,8 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
+HOSTNAME := $(shell hostname || hostnamectl hostname)
+
 .PHONY: init
 init:
 	brew install protobuf
@@ -51,7 +53,7 @@ endef
 .PHONY: run-local
 run-local:
 	$(call setup_local_env)
-	NODE_ID=$$(hostname) ./bin/orchestrator
+	NODE_ID=$(HOSTNAME) ./bin/orchestrator
 
 .PHONY: upload/clean-nfs-cache
 upload/clean-nfs-cache:


### PR DESCRIPTION
This is mainly a quality of life improvement for people not using Ubuntu. Many distros ship hostnamectl instead of the older hostname tool. Any modern distro should ship hostnamectl so this should be a drop-in replacement.