### PR TITLE
Only set NFS proxy log level once

### DIFF
--- a/packages/orchestrator/internal/nfsproxy/logged/handler.go
+++ b/packages/orchestrator/internal/nfsproxy/logged/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/willscott/go-nfs"
@@ -16,8 +17,12 @@ type loggedHandler struct {
 
 var _ nfs.Handler = (*loggedHandler)(nil)
 
+var setLogLevelOnce sync.Once
+
 func WrapWithLogging(ctx context.Context, handler nfs.Handler) nfs.Handler {
-	nfs.Log.SetLevel(nfs.TraceLevel)
+	setLogLevelOnce.Do(func() {
+		nfs.Log.SetLevel(nfs.TraceLevel)
+	})
 
 	return loggedHandler{ctx: ctx, inner: handler}
 }


### PR DESCRIPTION
avoid a race condition in tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to log initialization; main risk is reduced/unchanged log level behavior if different callers expected to reconfigure it later.
> 
> **Overview**
> Updates the NFS proxy logging wrapper so `nfs.Log.SetLevel(nfs.TraceLevel)` is applied only once per process via `sync.Once`, avoiding races when multiple handlers are created (notably in concurrent tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4330955508ca7a01ed5dcad371bf4b3065d95618. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->