### PR TITLE
feat(orchestrator): configurable base rootfs size limit via feature flag

### DIFF
--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -22,6 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -34,9 +35,6 @@ var files embed.FS
 var fileTemplates = template.Must(template.ParseFS(files, "files/*"))
 
 const (
-	// Max size of the rootfs file in MB.
-	maxRootfsSize = 25000 << constants.ToMBShift
-
 	BusyBoxPath     = "usr/bin/busybox"
 	BusyBoxInitPath = "usr/bin/init"
 
@@ -50,6 +48,7 @@ type Rootfs struct {
 	buildContext        buildcontext.BuildContext
 	artifactRegistry    artifactsregistry.ArtifactsRegistry
 	dockerhubRepository dockerhub.RemoteRepository
+	featureFlags        *featureflags.Client
 }
 
 type MultiWriter struct {
@@ -71,11 +70,13 @@ func New(
 	artifactRegistry artifactsregistry.ArtifactsRegistry,
 	dockerhubRepository dockerhub.RemoteRepository,
 	buildContext buildcontext.BuildContext,
+	featureFlags *featureflags.Client,
 ) *Rootfs {
 	return &Rootfs{
 		buildContext:        buildContext,
 		artifactRegistry:    artifactRegistry,
 		dockerhubRepository: dockerhubRepository,
+		featureFlags:        featureFlags,
 	}
 }
 
@@ -130,6 +131,7 @@ func (r *Rootfs) CreateExt4Filesystem(
 	telemetry.ReportEvent(childCtx, "set up filesystem")
 
 	l.Info(ctx, "Creating file system and pulling Docker image")
+	maxRootfsSize := int64(r.featureFlags.IntFlag(ctx, featureflags.BuildBaseRootfsSizeLimitMB)) << constants.ToMBShift
 	ext4Size, err := oci.ToExt4(ctx, l, img, rootfsPath, maxRootfsSize, template.RootfsBlockSize())
 	if err != nil {
 		return containerregistry.Config{}, fmt.Errorf("error converting oci to ext4: %w", err)

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -179,7 +179,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 	// Created here to be able to pass it to CreateSandbox for populating COW cache
 	rootfsPath := filepath.Join(templateBuildDir, rootfsBuildFileName)
 
-	rootfs, memfile, envsImg, err := constructLayerFilesFromOCI(ctx, userLogger, bb.BuildContext, bb.Metadata(), baseMetadata.Template.BuildID, bb.artifactRegistry, bb.dockerhubRepository, rootfsPath)
+	rootfs, memfile, envsImg, err := constructLayerFilesFromOCI(ctx, userLogger, bb.BuildContext, bb.Metadata(), baseMetadata.Template.BuildID, bb.artifactRegistry, bb.dockerhubRepository, bb.featureFlags, rootfsPath)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("error building environment: %w", err)
 	}

--- a/packages/orchestrator/internal/template/build/phases/base/files.go
+++ b/packages/orchestrator/internal/template/build/phases/base/files.go
@@ -16,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
+	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -28,6 +29,7 @@ func constructLayerFilesFromOCI(
 	baseBuildID string,
 	artifactRegistry artifactsregistry.ArtifactsRegistry,
 	dockerhubRepository dockerhub.RemoteRepository,
+	featureFlags *featureflags.Client,
 	rootfsPath string,
 ) (r *block.Local, m block.ReadonlyDevice, c containerregistry.Config, e error) {
 	ctx, span := tracer.Start(ctx, "template-build")
@@ -38,6 +40,7 @@ func constructLayerFilesFromOCI(
 		artifactRegistry,
 		dockerhubRepository,
 		buildContext,
+		featureFlags,
 	)
 	provisionScript, err := getProvisionScript(ctx, ProvisionScriptParams{
 		BusyBox:    rootfs.SandboxBusyBoxPath,

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -159,6 +159,9 @@ var (
 	// SandboxMaxIncomingConnections is the maximum number of concurrent HTTP proxy
 	// connections allowed per sandbox. Negative means no limit.
 	SandboxMaxIncomingConnections = newIntFlag("sandbox-max-incoming-connections", -1)
+
+	// BuildBaseRootfsSizeLimitMB is the maximum size of the base rootfs filesystem created from the OCI image, in MB.
+	BuildBaseRootfsSizeLimitMB = newIntFlag("build-base-rootfs-size-limit-mb", 25000)
 )
 
 type StringFlag struct {


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `maxRootfsSize` constant (25 GB) with a LaunchDarkly feature flag (`build-base-rootfs-size-limit-mb`, fallback: 25000 MB)
- Allows per-team overrides of the base rootfs size limit when creating the filesystem from the OCI image — team context is already embedded in `ctx` from `builder.go` during template builds
- Threads the feature flags client through `Rootfs` struct and `constructLayerFilesFromOCI`
