### PR TITLE
fix(db): make status_group trigger creation idempotent

### DIFF
--- a/packages/db/migrations/20260210120002_add_status_group_column.sql
+++ b/packages/db/migrations/20260210120002_add_status_group_column.sql
@@ -16,7 +16,7 @@ END;
 $$ LANGUAGE plpgsql;
 -- +goose StatementEnd
 
-CREATE TRIGGER trg_compute_status_group
+CREATE OR REPLACE TRIGGER trg_compute_status_group
   BEFORE INSERT OR UPDATE OF status ON public.env_builds
   FOR EACH ROW EXECUTE FUNCTION compute_status_group();
 


### PR DESCRIPTION
## Summary
- Changed `CREATE TRIGGER` to `CREATE OR REPLACE TRIGGER` in the `add_status_group_column` migration, making it safe to re-run without failing on "trigger already exists"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line migration change to make trigger creation idempotent; low risk as it doesn’t alter schema or trigger logic.
> 
> **Overview**
> Makes the `add_status_group_column` migration safe to re-run by changing the trigger creation to `CREATE OR REPLACE TRIGGER`, avoiding failures when `trg_compute_status_group` already exists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68c3fb2f98a9677af14f556ea560ee1f8eb6c406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->