### PR TITLE
fix(db): make env_builds team_id backfill resumable

### DIFF
--- a/packages/db/migrations/20260218120000_add_team_id_to_env_builds.sql
+++ b/packages/db/migrations/20260218120000_add_team_id_to_env_builds.sql
@@ -66,6 +66,11 @@ BEGIN
   ORDER BY eb.created_at DESC, eb.id DESC
   LIMIT 1;
 
+  IF NOT FOUND THEN
+    last_created_at := '1970-01-01 00:00:00+00';
+    last_id := '00000000-0000-0000-0000-000000000000';
+  END IF;
+
   RAISE NOTICE 'backfill_env_builds_team_id: resuming from cursor (%, %)', last_created_at, last_id;
 
   LOOP


### PR DESCRIPTION
## Summary
- Makes the `backfill_env_builds_team_id` procedure resumable on restart by probing for the first unprocessed row (`team_id IS NULL` with a matching assignment) and setting the cursor there instead of re-scanning from epoch.
- On a fresh run all rows are NULL so behavior is unchanged; on restart after interruption, already-committed batches are skipped efficiently via `idx_env_builds_created_at` (backward scan) + `idx_env_build_assignments_build`.
- No new indexes required — the resume query is covered by existing indexes available at procedure execution time.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes database migration/backfill control flow and cursor positioning; mistakes could skip or reprocess rows and impact data correctness or migration runtime.
> 
> **Overview**
> Updates the `backfill_env_builds_team_id` migration backfill to be resumable: on restart it finds the first `env_builds` row still missing `team_id` (with a valid assignment) and sets the cursor just before it so already-committed batches are skipped rather than rescanned from epoch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59fe9b08a52abc5e43e19e3ed05589b0dc60762. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->