### PR TITLE
feat(ingress): export Traefik metrics to OpenTelemetry collector via gRPC

### DIFF
--- a/iac/modules/job-ingress/jobs/ingress.hcl
+++ b/iac/modules/job-ingress/jobs/ingress.hcl
@@ -93,8 +93,10 @@ job "ingress" {
           "--ping=true",
           "--ping.entryPoint=web",
           "--metrics=true",
-          "--metrics.prometheus=true",
-          "--metrics.prometheus.entryPoint=traefik",
+          "--metrics.otlp=true",
+          "--metrics.otlp.grpc=true",
+          "--metrics.otlp.grpc.endpoint=${otel_collector_grpc_endpoint}",
+          "--metrics.otlp.grpc.insecure=true",
 
           # Traefik Nomad provider
           "--providers.nomad=true",

--- a/iac/modules/job-ingress/main.tf
+++ b/iac/modules/job-ingress/main.tf
@@ -14,5 +14,7 @@ resource "nomad_job" "ingress" {
 
     consul_token    = var.consul_token
     consul_endpoint = var.consul_endpoint
+
+    otel_collector_grpc_endpoint = var.otel_collector_grpc_endpoint
   })
 }

--- a/iac/modules/job-ingress/variables.tf
+++ b/iac/modules/job-ingress/variables.tf
@@ -48,3 +48,8 @@ variable "ingress_memory_mb" {
   type    = number
   default = 512
 }
+
+variable "otel_collector_grpc_endpoint" {
+  type        = string
+  description = "OpenTelemetry collector gRPC endpoint (e.g., localhost:4317)"
+}

--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -223,6 +223,7 @@ processors:
           - "otelcol.exporter.sent.*"
           - "otelcol.receiver.refused.*"
           - "pgxpool.*"
+          - "traefik.*"
 
   filter/only_client_allocs:
     metrics:

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -60,6 +60,8 @@ module "ingress" {
 
   nomad_token  = var.nomad_acl_token_secret
   consul_token = var.consul_acl_token_secret
+
+  otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
 }
 
 resource "nomad_job" "api" {


### PR DESCRIPTION
## Summary
- Configure Traefik ingress to export metrics to the OTEL collector using gRPC instead of Prometheus
- Add `otel_collector_grpc_endpoint` variable to the ingress module for flexible endpoint configuration
- Add `traefik.*` pattern to the OTEL collector metrics filter to include Traefik metrics

## Changes
- `iac/modules/job-ingress/jobs/ingress.hcl` - Replace Prometheus metrics flags with OTLP gRPC configuration
- `iac/modules/job-ingress/main.tf` - Pass OTEL endpoint to job template
- `iac/modules/job-ingress/variables.tf` - Add `otel_collector_grpc_endpoint` variable
- `iac/modules/job-otel-collector/configs/otel-collector.yaml` - Add `traefik.*` to metrics filter
- `iac/provider-gcp/nomad/main.tf` - Wire up the endpoint in module invocation

## Test plan
- [ ] Run `make plan` to verify Terraform changes
- [ ] Deploy to staging and verify Traefik metrics appear in Grafana
- [ ] Check OTEL collector logs for successful metric ingestion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability plumbing and disables Prometheus metrics emission for ingress, so misconfiguration of the OTLP endpoint/allowlist could silently reduce ingress metric coverage without affecting request routing.
> 
> **Overview**
> Switches Traefik ingress metrics export from Prometheus to OTLP-over-gRPC and wires a new `otel_collector_grpc_endpoint` input through the ingress module (set to `localhost:${var.otel_collector_grpc_port}` in GCP) so metrics are sent to the in-cluster OpenTelemetry collector. The OTEL collector’s metrics allowlist is updated to include `traefik.*` so these new metrics are not dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0a28557f19e562ba9275281a7fc4445f56889eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->