### PR TITLE
feat(infra): increase sandbox creation rate limit

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -548,7 +548,7 @@ resource "google_compute_security_policy_rule" "api-throttling-api-key" {
     }
 
     rate_limit_threshold {
-      count        = 1200
+      count        = 1800
       interval_sec = 10
     }
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter infrastructure change to an API rate limit; main risk is increased load/cost if abuse or traffic spikes occur.
> 
> **Overview**
> Increases the GCP Cloud Armor throttle limit for `POST /sandboxes` keyed by `X-API-Key` from 1200 to 1800 requests per 10 seconds to allow higher burst sandbox-creation traffic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84a7060f656ff782a1fb56bf62be9f54b693001d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->