### PR TITLE
fix(envd): prevent exit event loss on HTTP/2 context cancel

### DIFF
--- a/packages/envd/internal/services/process/connect.go
+++ b/packages/envd/internal/services/process/connect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -92,9 +93,17 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 			}
 		}
 
+		// We MUST deliver the end event if the process has exited.
+		// The data channel closing means all stdout/stderr is drained,
+		// so the process is done or nearly done. Use a generous timeout
+		// rather than racing against ctx.Done(), which can fire due to
+		// transient network issues (proxy reset, NAT rebinding, etc).
+		endCtx, endCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer endCancel()
+
 		select {
-		case <-ctx.Done():
-			cancel(ctx.Err())
+		case <-endCtx.Done():
+			cancel(fmt.Errorf("timed out waiting for process end event after data channel closed"))
 
 			return
 		case event, ok := <-end:
@@ -110,8 +119,6 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 				},
 			})
 			if streamErr != nil {
-				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
-
 				return
 			}
 		}

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -155,7 +155,7 @@ func New(
 		cancel:    cancel,
 		outCtx:    outCtx,
 		outCancel: outCancel,
-		EndEvent:  NewMultiplexedChannel[rpc.ProcessEvent_End](0),
+		EndEvent:  NewMultiplexedChannel[rpc.ProcessEvent_End](1),
 		logger:    logger,
 	}
 

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -179,9 +179,17 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 			}
 		}
 
+		// We MUST deliver the end event if the process has exited.
+		// The data channel closing means all stdout/stderr is drained,
+		// so the process is done or nearly done. Use a generous timeout
+		// rather than racing against ctx.Done(), which can fire due to
+		// transient network issues (proxy reset, NAT rebinding, etc).
+		endCtx, endCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer endCancel()
+
 		select {
-		case <-ctx.Done():
-			cancel(ctx.Err())
+		case <-endCtx.Done():
+			cancel(fmt.Errorf("timed out waiting for process end event after data channel closed"))
 
 			return
 		case event, ok := <-end:
@@ -197,7 +205,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				},
 			})
 			if streamErr != nil {
-				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
+				handlerL.Warn().Err(streamErr).Msg("failed to send end event to client")
 
 				return
 			}


### PR DESCRIPTION
## Summary

- Fix race condition in `Start` and `Connect` streaming handlers where the final `select` races `ctx.Done()` against `<-end` — if the HTTP/2 context cancels between stdout EOF and process exit, the exit event is silently dropped, causing clients to hang until timeout
- Replace `ctx.Done()` with a 30s timeout on `context.Background()` to decouple end-event delivery from the HTTP/2 stream lifecycle
- Buffer the `EndEvent` multiplexed channel (0→1) so `handler.Wait()` doesn't block on send if the consumer hasn't reached the final select yet

## Test plan

- [ ] Verify `go build ./...` passes (Linux — macOS has pre-existing syscall errors)
- [ ] Run `echo "done" && sleep 2` and cancel the HTTP/2 context during the sleep — end event should still be delivered
- [ ] Run `commands.run("echo done")` in a loop to check for intermittent failures