### PR TITLE
fix(api): prevent template deletion when running sandboxes reference it

### DIFF
--- a/packages/api/internal/handlers/template_delete.go
+++ b/packages/api/internal/handlers/template_delete.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -46,8 +47,8 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 		telemetry.WithTemplateID(templateID),
 	)
 
-	// Check across all teams for running sandboxes that use this template as their base
-	hasRunningSandboxes, err := a.orchestrator.HasRunningSandboxesForBaseTemplate(ctx, templateID)
+	// Check if there are running sandboxes that use this template as their base
+	sandboxes, err := a.orchestrator.GetSandboxes(ctx, team.ID, []sandbox.State{sandbox.StateRunning, sandbox.StatePausing, sandbox.StateSnapshotting})
 	if err != nil {
 		telemetry.ReportError(ctx, "error when checking for running sandboxes", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when checking for running sandboxes")
@@ -55,10 +56,12 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 		return
 	}
 
-	if hasRunningSandboxes {
-		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("cannot delete template '%s' because there are running sandboxes using it", templateID))
+	for _, sbx := range sandboxes {
+		if sbx.BaseTemplateID == templateID {
+			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("cannot delete template '%s' because there are running sandboxes using it", templateID))
 
-		return
+			return
+		}
 	}
 
 	// check if base template has snapshots

--- a/packages/api/internal/orchestrator/list_instances.go
+++ b/packages/api/internal/orchestrator/list_instances.go
@@ -15,23 +15,3 @@ func (o *Orchestrator) GetSandboxes(ctx context.Context, teamID uuid.UUID, state
 
 	return o.sandboxStore.TeamItems(ctx, teamID, states)
 }
-
-// HasRunningSandboxesForBaseTemplate reports whether any active sandbox
-// (across all teams) uses the given template as its BaseTemplateID.
-func (o *Orchestrator) HasRunningSandboxesForBaseTemplate(ctx context.Context, baseTemplateID string) (bool, error) {
-	ctx, childSpan := tracer.Start(ctx, "has-running-sandboxes-for-base-template")
-	defer childSpan.End()
-
-	sandboxes, err := o.sandboxStore.AllItems(ctx, []sandbox.State{sandbox.StateRunning, sandbox.StatePausing, sandbox.StateSnapshotting, sandbox.StateKilling})
-	if err != nil {
-		return false, err
-	}
-
-	for _, sbx := range sandboxes {
-		if sbx.BaseTemplateID == baseTemplateID {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}


### PR DESCRIPTION
## Summary
- Adds a check in the `DELETE /templates/{templateID}` handler to block deletion when running sandboxes (in Running, Pausing, or Snapshotting state) still reference the template as their `BaseTemplateID`.
- This prevents the foreign key violation (`snapshots_envs_base_env_id`) that occurred when auto-pause tried to insert a snapshot for a sandbox whose base template had been deleted.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion behavior for templates by introducing a runtime dependency check against the orchestrator; incorrect state filtering or template matching could prevent legitimate deletions or still allow deletions that later fail.
> 
> **Overview**
> Prevents deleting a template if any non-stopped sandbox in `Running`, `Pausing`, or `Snapshotting` state still references it as `BaseTemplateID`, returning a `400` instead of proceeding and risking later snapshot/foreign-key failures. Also fixes `Orchestrator.GetSandboxes` tracing to propagate the span context by using the returned `ctx` from `tracer.Start`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ade3cdafe07d8b38c95cffc9fa043f3e815663f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->