### PR TITLE
fix: scope concurrent build cancellation to overlapping tags

### DIFF
--- a/packages/db/pkg/tests/builds/get_concurrent_template_builds_test.go
+++ b/packages/db/pkg/tests/builds/get_concurrent_template_builds_test.go
@@ -1,0 +1,183 @@
+package builds
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	"github.com/e2b-dev/infra/packages/db/queries"
+)
+
+func TestGetConcurrentTemplateBuilds_ReturnsBuildWithSameTag(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	buildA := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v1")
+
+	buildB := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v1")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     templateID,
+		CurrentBuildID: buildA,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 1, "Should return the other build with the same tag")
+	assert.Equal(t, buildB, results[0].ID)
+}
+
+func TestGetConcurrentTemplateBuilds_DoesNotReturnBuildWithDifferentTag(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	buildA := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v1")
+
+	buildB := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v2")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     templateID,
+		CurrentBuildID: buildA,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, results, "Should not return builds with non-overlapping tags")
+}
+
+func TestGetConcurrentTemplateBuilds_ReturnsBuildsWithOverlappingTags(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Build A has tags: v1, v2
+	buildA := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v1")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v2")
+
+	// Build B has tags: v2, v3 (overlaps on v2)
+	buildB := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v2")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v3")
+
+	// Build C has tags: v3 only (no overlap with A)
+	buildC := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildC, "v3")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     templateID,
+		CurrentBuildID: buildA,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 1, "Should return only the build with overlapping tags")
+	assert.Equal(t, buildB, results[0].ID, "Build B overlaps on tag v2")
+}
+
+func TestGetConcurrentTemplateBuilds_DoesNotReturnBuildsFromOtherTemplates(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	template1 := testutils.CreateTestTemplate(t, db, teamID)
+	template2 := testutils.CreateTestTemplate(t, db, teamID)
+
+	buildA := testutils.CreateTestBuild(t, ctx, db, template1, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, template1, buildA, "v1")
+
+	// Same tag, different template
+	buildB := testutils.CreateTestBuild(t, ctx, db, template2, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, template2, buildB, "v1")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     template1,
+		CurrentBuildID: buildA,
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, results, "Should not return builds from other templates")
+}
+
+func TestGetConcurrentTemplateBuilds_OnlyReturnsPendingAndInProgressBuilds(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	currentBuild := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, currentBuild, "v1")
+
+	pendingBuild := testutils.CreateTestBuild(t, ctx, db, templateID, "waiting")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, pendingBuild, "v1")
+
+	inProgressBuild := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, inProgressBuild, "v1")
+
+	readyBuild := testutils.CreateTestBuild(t, ctx, db, templateID, "uploaded")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, readyBuild, "v1")
+
+	failedBuild := testutils.CreateTestBuild(t, ctx, db, templateID, "failed")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, failedBuild, "v1")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     templateID,
+		CurrentBuildID: currentBuild,
+	})
+	require.NoError(t, err)
+
+	resultIDs := make(map[string]bool)
+	for _, r := range results {
+		resultIDs[r.ID.String()] = true
+	}
+
+	assert.True(t, resultIDs[pendingBuild.String()], "Pending build should be returned")
+	assert.True(t, resultIDs[inProgressBuild.String()], "In-progress build should be returned")
+	assert.False(t, resultIDs[readyBuild.String()], "Ready build should NOT be returned")
+	assert.False(t, resultIDs[failedBuild.String()], "Failed build should NOT be returned")
+	assert.Len(t, results, 2)
+}
+
+func TestGetConcurrentTemplateBuilds_NoDuplicatesWithMultipleOverlappingTags(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Both builds share two tags — should still return only one result
+	buildA := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v1")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildA, "v2")
+
+	buildB := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v1")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildB, "v2")
+
+	results, err := db.SqlcClient.GetConcurrentTemplateBuilds(ctx, queries.GetConcurrentTemplateBuildsParams{
+		TemplateID:     templateID,
+		CurrentBuildID: buildA,
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, results, 1, "Should return build B exactly once despite multiple overlapping tags")
+	assert.Equal(t, buildB, results[0].ID)
+}

--- a/packages/db/queries/builds/get_concurrent_template_builds.sql
+++ b/packages/db/queries/builds/get_concurrent_template_builds.sql
@@ -1,7 +1,11 @@
 -- name: GetConcurrentTemplateBuilds :many
-SELECT eb.* FROM env_build_assignments eba
+SELECT DISTINCT eb.* FROM env_build_assignments eba
 JOIN env_builds eb ON eb.id = eba.build_id
 WHERE
     eba.env_id = @template_id
     AND eb.status_group IN ('pending', 'in_progress')
-    AND eb.id != @current_build_id;
+    AND eb.id != @current_build_id
+    AND eba.tag IN (
+        SELECT tag FROM env_build_assignments
+        WHERE build_id = @current_build_id AND env_id = @template_id
+    );

--- a/packages/db/queries/get_concurrent_template_builds.sql.go
+++ b/packages/db/queries/get_concurrent_template_builds.sql.go
@@ -12,12 +12,16 @@ import (
 )
 
 const getConcurrentTemplateBuilds = `-- name: GetConcurrentTemplateBuilds :many
-SELECT eb.id, eb.created_at, eb.updated_at, eb.finished_at, eb.status, eb.dockerfile, eb.start_cmd, eb.vcpu, eb.ram_mb, eb.free_disk_size_mb, eb.total_disk_size_mb, eb.kernel_version, eb.firecracker_version, eb.env_id, eb.envd_version, eb.ready_cmd, eb.cluster_node_id, eb.reason, eb.version, eb.cpu_architecture, eb.cpu_family, eb.cpu_model, eb.cpu_model_name, eb.cpu_flags, eb.status_group, eb.team_id FROM env_build_assignments eba
+SELECT DISTINCT eb.id, eb.created_at, eb.updated_at, eb.finished_at, eb.status, eb.dockerfile, eb.start_cmd, eb.vcpu, eb.ram_mb, eb.free_disk_size_mb, eb.total_disk_size_mb, eb.kernel_version, eb.firecracker_version, eb.env_id, eb.envd_version, eb.ready_cmd, eb.cluster_node_id, eb.reason, eb.version, eb.cpu_architecture, eb.cpu_family, eb.cpu_model, eb.cpu_model_name, eb.cpu_flags, eb.status_group, eb.team_id FROM env_build_assignments eba
 JOIN env_builds eb ON eb.id = eba.build_id
 WHERE
     eba.env_id = $1
     AND eb.status_group IN ('pending', 'in_progress')
     AND eb.id != $2
+    AND eba.tag IN (
+        SELECT tag FROM env_build_assignments
+        WHERE build_id = $2 AND env_id = $1
+    )
 `
 
 type GetConcurrentTemplateBuildsParams struct {


### PR DESCRIPTION
## Summary

- `GetConcurrentTemplateBuilds` previously returned **all** pending/in-progress builds for the same template, regardless of tag. This caused `CheckAndCancelConcurrentBuilds` to cancel builds under different tags when a new build started — breaking concurrent builds of the same template with different tags.
- The query now includes a subquery that only matches builds sharing at least one tag with the current build. `DISTINCT` prevents duplicate rows when multiple tags overlap.
- Unblocks [e2b-dev/E2B#1151](https://github.com/e2b-dev/E2B/pull/1151) which switches SDK tests to use `name:tag` versioning instead of creating new templates per test run.

## Test plan

- [x] Added 6 new tests for `GetConcurrentTemplateBuilds` covering: same-tag match, different-tag isolation, partial tag overlap, cross-template isolation, status filtering, and deduplication with multiple overlapping tags
- [x] All 19 existing + new build tests pass (`go test -race ./packages/db/pkg/tests/builds/...`)
- [x] Linter clean (no new issues)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a SQL query that drives build cancellation behavior; incorrect tag matching could cause missed cancellations or unintended cancellations, though coverage is improved via new tests.
> 
> **Overview**
> Fixes concurrent template build cancellation by scoping `GetConcurrentTemplateBuilds` to only return *other* pending/in-progress builds whose assignment tags overlap with the current build’s tags (and using `DISTINCT` to avoid duplicates when multiple tags match), preventing unrelated tagged builds from being canceled. Adds a focused test suite covering same/different/overlapping tags, cross-template isolation, status-group filtering, and deduplication behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a22d6fc4007bfe67ab027d388fa110a205732587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->