### PR TITLE
Silence hostname missing red herring warning

### DIFF
--- a/packages/api/Makefile
+++ b/packages/api/Makefile
@@ -1,7 +1,8 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 PREFIX := $(strip $(subst ",,$(PREFIX)))
-HOSTNAME := $(shell hostname || hostnamectl hostname)
+HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
+$(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
 
 expectedMigration := $(shell ./../../scripts/get-latest-migration.sh)
 

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -1,7 +1,8 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 PREFIX := $(strip $(subst ",,$(PREFIX)))
-HOSTNAME := $(shell hostname || hostnamectl hostname) 
+HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
+$(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
 
 ifeq ($(PROVIDER),aws)
 	IMAGE_REGISTRY := $(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com/$(PREFIX)core/client-proxy

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -4,7 +4,8 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
-HOSTNAME := $(shell hostname || hostnamectl hostname)
+HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
+$(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
 
 .PHONY: init
 init:


### PR DESCRIPTION
We're trying `hostname` and then fall-back to `hostnamectl`. If the former fails it prints out a warning even though the latter succeeds. The failure logs something in stderr which sometimes is confusing. Redirect it stderr to /dev/null, and check the HOSTNAME variable to see if it's set and if not, fail.