### PR TITLE
chore: allow using code defaults with feature flags

### DIFF
--- a/packages/shared/pkg/feature-flags/client.go
+++ b/packages/shared/pkg/feature-flags/client.go
@@ -103,6 +103,7 @@ func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ld
 type typedFlag[T any] interface {
 	Key() string
 	Fallback() T
+	isSentinel(value T) bool
 }
 
 func getFlag[T any](
@@ -121,6 +122,10 @@ func getFlag[T any](
 	value, err := getFromLaunchDarkly(ctx, flag.Key(), mergeContexts(ctx, contexts), flag.Fallback())
 	if err != nil {
 		logger.L().Warn(ctx, "error evaluating flag", zap.Error(err), zap.String("flag", flag.Key()))
+	}
+
+	if flag.isSentinel(value) {
+		return flag.Fallback()
 	}
 
 	return value

--- a/packages/shared/pkg/feature-flags/client.go
+++ b/packages/shared/pkg/feature-flags/client.go
@@ -103,7 +103,9 @@ func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ld
 type typedFlag[T any] interface {
 	Key() string
 	Fallback() T
-	isSentinel(value T) bool
+	// shouldUseFallback reports whether the value returned by LaunchDarkly is
+	// a sentinel meaning "use the code-level default instead".
+	shouldUseFallback(value T) bool
 }
 
 func getFlag[T any](
@@ -124,7 +126,7 @@ func getFlag[T any](
 		logger.L().Warn(ctx, "error evaluating flag", zap.Error(err), zap.String("flag", flag.Key()))
 	}
 
-	if flag.isSentinel(value) {
+	if flag.shouldUseFallback(value) {
 		return flag.Fallback()
 	}
 

--- a/packages/shared/pkg/feature-flags/client_test.go
+++ b/packages/shared/pkg/feature-flags/client_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,4 +36,74 @@ func TestOfflineDatastore(t *testing.T) {
 	// value is set manually in datastore and should be taken from there
 	flagValue, _ = client.ld.BoolVariation(flagName, clientCtx, false)
 	assert.True(t, flagValue)
+}
+
+func TestSentinelJSONFlag_ReturnsCodeDefault(t *testing.T) {
+	t.Parallel()
+
+	ds := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(ds)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close(t.Context()) })
+
+	fallback := ldvalue.ObjectBuild().Set("key", ldvalue.String("value")).Build()
+	sentinel := JSONFlagSentinel
+	flag := JSONFlag{name: "sentinel-json-test", fallback: fallback, sentinel: &sentinel}
+
+	// LD returns the sentinel (empty object) → getFlag should return the code fallback
+	ds.Update(ds.Flag(flag.name).ValueForAll(sentinel))
+	result := client.JSONFlag(t.Context(), flag)
+	assert.True(t, result.Equal(fallback))
+}
+
+func TestSentinelJSONFlag_NonSentinelPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	ds := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(ds)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close(t.Context()) })
+
+	fallback := ldvalue.ObjectBuild().Set("key", ldvalue.String("value")).Build()
+	sentinel := JSONFlagSentinel
+	flag := JSONFlag{name: "sentinel-json-passthrough", fallback: fallback, sentinel: &sentinel}
+
+	// LD returns a non-sentinel value → it passes through
+	override := ldvalue.ObjectBuild().Set("other", ldvalue.Int(42)).Build()
+	ds.Update(ds.Flag(flag.name).ValueForAll(override))
+	result := client.JSONFlag(t.Context(), flag)
+	assert.True(t, result.Equal(override))
+}
+
+func TestBoolFlag_NoSentinel(t *testing.T) {
+	t.Parallel()
+
+	ds := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(ds)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close(t.Context()) })
+
+	flag := BoolFlag{name: "bool-no-sentinel", fallback: true}
+	ds.Update(ds.Flag(flag.name).VariationForAll(false))
+	result := client.BoolFlag(t.Context(), flag)
+	assert.False(t, result) // bool flags have no sentinel, value passes through
+}
+
+func TestNonSentinelJSONFlag_PassesThroughEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	ds := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(ds)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Close(t.Context()) })
+
+	// A JSONFlag created with newJSONFlag (no sentinel) should pass through
+	// even if LD returns an empty object.
+	fallback := ldvalue.ObjectBuild().Set("key", ldvalue.String("value")).Build()
+	flag := JSONFlag{name: "non-sentinel-json-test", fallback: fallback}
+
+	emptyObj := ldvalue.ObjectBuild().Build()
+	ds.Update(ds.Flag(flag.name).ValueForAll(emptyObj))
+	result := client.JSONFlag(t.Context(), flag)
+	assert.True(t, result.Equal(emptyObj)) // no sentinel, empty object passes through
 }

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -9,6 +9,10 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
+// JSONFlagSentinel is an empty JSON object ({}). When LD returns this value
+// for FirecrackerVersions, the code-level fallback is used instead.
+var JSONFlagSentinel = ldvalue.ObjectBuild().Build()
+
 // kinds
 const (
 	SandboxKind                        ldcontext.Kind = "sandbox"
@@ -31,6 +35,11 @@ const (
 type JSONFlag struct {
 	name     string
 	fallback ldvalue.Value
+	sentinel *ldvalue.Value
+}
+
+func (f JSONFlag) isSentinel(value ldvalue.Value) bool {
+	return f.sentinel != nil && value.Equal(*f.sentinel)
 }
 
 func (f JSONFlag) Key() string {
@@ -53,12 +62,22 @@ func newJSONFlag(name string, fallback ldvalue.Value) JSONFlag {
 	return flag
 }
 
+func newJSONFlagWithSentinel(name string, fallback ldvalue.Value) JSONFlag {
+	flag := newJSONFlag(name, fallback)
+	sentinel := JSONFlagSentinel
+	flag.sentinel = &sentinel
+
+	return flag
+}
+
 var CleanNFSCache = newJSONFlag("clean-nfs-cache", ldvalue.Null())
 
 type BoolFlag struct {
 	name     string
 	fallback bool
 }
+
+func (f BoolFlag) isSentinel(_ bool) bool { return false }
 
 func (f BoolFlag) Key() string {
 	return f.name
@@ -101,6 +120,8 @@ type IntFlag struct {
 	name     string
 	fallback int
 }
+
+func (f IntFlag) isSentinel(_ int) bool { return false }
 
 func (f IntFlag) Key() string {
 	return f.name
@@ -169,6 +190,8 @@ type StringFlag struct {
 	fallback string
 }
 
+func (f StringFlag) isSentinel(_ string) bool { return false }
+
 func (f StringFlag) Key() string {
 	return f.name
 }
@@ -208,7 +231,7 @@ var (
 	BuildIoEngine               = newStringFlag("build-io-engine", "Sync")
 	DefaultPersistentVolumeType = newStringFlag("default-persistent-volume-type", "")
 	BuildNodeInfo               = newJSONFlag("preferred-build-node", ldvalue.Null())
-	FirecrackerVersions         = newJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
+	FirecrackerVersions         = newJSONFlagWithSentinel("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 )
 
 // defaultTrackedTemplates is the default map of template aliases tracked for metrics.

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -38,7 +38,7 @@ type JSONFlag struct {
 	sentinel *ldvalue.Value
 }
 
-func (f JSONFlag) isSentinel(value ldvalue.Value) bool {
+func (f JSONFlag) shouldUseFallback(value ldvalue.Value) bool {
 	return f.sentinel != nil && value.Equal(*f.sentinel)
 }
 
@@ -77,7 +77,7 @@ type BoolFlag struct {
 	fallback bool
 }
 
-func (f BoolFlag) isSentinel(_ bool) bool { return false }
+func (f BoolFlag) shouldUseFallback(_ bool) bool { return false }
 
 func (f BoolFlag) Key() string {
 	return f.name
@@ -121,7 +121,7 @@ type IntFlag struct {
 	fallback int
 }
 
-func (f IntFlag) isSentinel(_ int) bool { return false }
+func (f IntFlag) shouldUseFallback(_ int) bool { return false }
 
 func (f IntFlag) Key() string {
 	return f.name
@@ -190,7 +190,7 @@ type StringFlag struct {
 	fallback string
 }
 
-func (f StringFlag) isSentinel(_ string) bool { return false }
+func (f StringFlag) shouldUseFallback(_ string) bool { return false }
 
 func (f StringFlag) Key() string {
 	return f.name

--- a/packages/shared/pkg/feature-flags/flags.go
+++ b/packages/shared/pkg/feature-flags/flags.go
@@ -9,9 +9,10 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
-// JSONFlagSentinel is an empty JSON object ({}). When LD returns this value
-// for FirecrackerVersions, the code-level fallback is used instead.
-var JSONFlagSentinel = ldvalue.ObjectBuild().Build()
+// JSONFlagSentinel is a JSON object with a unique marker key. When LD returns
+// this value, the code-level fallback is used instead.
+// Value: {"__use_code_default__": true}
+var JSONFlagSentinel = ldvalue.ObjectBuild().Set("__use_code_default__", ldvalue.Bool(true)).Build()
 
 // kinds
 const (
@@ -62,7 +63,7 @@ func newJSONFlag(name string, fallback ldvalue.Value) JSONFlag {
 	return flag
 }
 
-func newJSONFlagWithSentinel(name string, fallback ldvalue.Value) JSONFlag {
+func newJSONFlagWithFallback(name string, fallback ldvalue.Value) JSONFlag {
 	flag := newJSONFlag(name, fallback)
 	sentinel := JSONFlagSentinel
 	flag.sentinel = &sentinel
@@ -231,7 +232,7 @@ var (
 	BuildIoEngine               = newStringFlag("build-io-engine", "Sync")
 	DefaultPersistentVolumeType = newStringFlag("default-persistent-volume-type", "")
 	BuildNodeInfo               = newJSONFlag("preferred-build-node", ldvalue.Null())
-	FirecrackerVersions         = newJSONFlagWithSentinel("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
+	FirecrackerVersions         = newJSONFlagWithFallback("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 )
 
 // defaultTrackedTemplates is the default map of template aliases tracked for metrics.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the shared feature-flag evaluation path and can alter runtime behavior for JSON flags when a sentinel value is configured; mistakes could silently revert to defaults. Limited scope via opt-in sentinel and added tests reduce likelihood of regressions.
> 
> **Overview**
> Adds opt-in support for "use code default" sentinels in feature flag evaluation: `typedFlag` now exposes `shouldUseFallback`, and `getFlag` returns the flag’s fallback when LaunchDarkly returns a sentinel value. Introduces `JSONFlagSentinel` plus `newJSONFlagWithFallback` to enable this behavior for selected JSON flags (currently `FirecrackerVersions`), and adds tests to ensure sentinel JSON values trigger fallback while other flag types and non-sentinel JSON values pass through unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05dfdfc10cce518bada4c21388d5fbbe31a6737a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->