### PR TITLE
chore(api): increase Redis connection count

### DIFF
--- a/packages/shared/pkg/factories/redis.go
+++ b/packages/shared/pkg/factories/redis.go
@@ -25,6 +25,11 @@ type RedisConfig struct {
 	RedisTLSCABase64 string
 }
 
+const (
+	clusterNodeConnectionSizePerCPU = 20
+	minIdleConnectionsPerCPU        = 5
+)
+
 func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalClient, error) {
 	var redisClient redis.UniversalClient
 
@@ -38,8 +43,8 @@ func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalCli
 		numCPU := runtime.GOMAXPROCS(0)
 		clusterOpts := &redis.ClusterOptions{
 			Addrs:        []string{config.RedisClusterURL},
-			PoolSize:     50 * numCPU,
-			MinIdleConns: 10 * numCPU,
+			PoolSize:     clusterNodeConnectionSizePerCPU * numCPU,
+			MinIdleConns: minIdleConnectionsPerCPU * numCPU,
 		}
 
 		if config.RedisTLSCABase64 != "" {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Redis cluster connection pool sizing, which can change runtime resource usage (connections/memory) and behavior under load; impact is limited to Redis cluster mode.
> 
> **Overview**
> Scales Redis *cluster* connection pooling based on available CPU by introducing per-CPU `PoolSize` and `MinIdleConns` defaults (instead of a fixed idle count), increasing capacity on larger runtimes while keeping TLS, tracing/metrics instrumentation, and non-cluster client settings unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d55dac71478c8cc16123af2f603471109c2e9169. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->