### PR TITLE
fix(ingress): resolve Cloudflare zone lookup for subdomain-based domain names

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -1,17 +1,5 @@
 locals {
-  domains    = toset(concat(var.additional_domains, [var.domain_name]))
   subdomains = ["dashboard-api"]
-
-  // Extract root domain (Cloudflare zone) and prefix from each domain.
-  // e.g. "sub.example.com" -> root_domain = "example.com", prefix = "sub"
-  //      "example.dev"     -> root_domain = "example.dev", prefix = ""
-  domain_parts = { for d in local.domains : d => split(".", d) }
-  domain_info = {
-    for d, parts in local.domain_parts : d => {
-      root_domain = join(".", slice(parts, length(parts) - 2, length(parts)))
-      prefix      = join(".", slice(parts, 0, max(length(parts) - 2, 0)))
-    }
-  }
 
   ingress_zones = toset([for info in local.domain_info : info.root_domain])
 

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -18,12 +18,24 @@ provider "cloudflare" {
 locals {
   domain_map = { for d in var.additional_domains : replace(d, ".", "-") => d }
 
-  parts        = split(".", var.domain_name)
-  is_subdomain = length(local.parts) > 2
-  // Take everything except last 2 parts
-  subdomain = local.is_subdomain ? join(".", slice(local.parts, 0, length(local.parts) - 2)) : ""
-  // Take last 2 parts (1 dot)
-  root_domain = local.is_subdomain ? join(".", slice(local.parts, length(local.parts) - 2, length(local.parts))) : var.domain_name
+  // All domains (primary + additional)
+  domains = toset(concat(var.additional_domains, [var.domain_name]))
+
+  // Extract root domain (Cloudflare zone) and prefix from each domain.
+  // e.g. "sub.example.com" -> root_domain = "example.com", prefix = "sub"
+  //      "example.dev"     -> root_domain = "example.dev", prefix = ""
+  domain_parts = { for d in local.domains : d => split(".", d) }
+  domain_info = {
+    for d, parts in local.domain_parts : d => {
+      root_domain = length(parts) >= 2 ? join(".", slice(parts, length(parts) - 2, length(parts))) : d
+      prefix      = join(".", slice(parts, 0, max(length(parts) - 2, 0)))
+    }
+  }
+
+  // Primary domain parsing
+  is_subdomain = local.domain_info[var.domain_name].prefix != ""
+  subdomain    = local.domain_info[var.domain_name].prefix
+  root_domain  = local.domain_info[var.domain_name].root_domain
 
   backends = {
     session = {


### PR DESCRIPTION
## Summary
- The `cloudflare_zone` data source in `ingress.tf` was using the full `domain_name` as the zone name, which fails when it's a subdomain (e.g. `sub.example.com`) since the Cloudflare zone is the apex domain (`example.com`).
- Extracts the root domain (last 2 parts) for zone lookups and prepends the domain prefix to DNS record names, producing the correct FQDN (e.g. `dashboard-api.sub.example.com`).
- Backward compatible: apex domains (e.g. `example.dev`) still work as before with an empty prefix.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small Terraform logic change limited to Cloudflare zone selection and record naming; main risk is mis-targeted DNS records if domain parsing is wrong.
> 
> **Overview**
> Fixes ingress Cloudflare DNS creation for subdomain-based domains by deriving the apex `root_domain` for zone lookups and generating DNS record names that include the domain prefix, ensuring records like `dashboard-api.sub.example.com` are created in the `example.com` zone (while keeping apex-domain behavior unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a83e1c07b5fa45cfcb540416533432965a35b321. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->