### PR TITLE
fix(api): race condition in TeamsWithSandboxCount

### DIFF
--- a/packages/api/internal/sandbox/storage/memory/sandbox.go
+++ b/packages/api/internal/sandbox/storage/memory/sandbox.go
@@ -50,10 +50,12 @@ func (i *memorySandbox) State() sandbox.State {
 	return i._data.State
 }
 
+// SandboxID returns the sandbox ID, safe to use without lock, it's immutable
 func (i *memorySandbox) SandboxID() string {
 	return i._data.SandboxID
 }
 
+// TeamID returns the team ID, safe to use without lock, it's immutable
 func (i *memorySandbox) TeamID() uuid.UUID {
 	return i._data.TeamID
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line change in non-persistent in-memory aggregation logic; low chance of broad impact beyond sandbox count reporting.
> 
> **Overview**
> Updates the in-memory sandbox storage implementation so `TeamsWithSandboxCount` increments counts using the underlying cached sandbox data’s `TeamID` field (`item._data.TeamID`) instead of the `TeamID()` accessor, aligning counting with the stored state used elsewhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f196923a41250e6c0e0e674e7755ac1c20a06a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->