### PR TITLE
Remove .env file that is relative to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ENV := $(shell cat .last_used_env || echo "not-set")
-ENV_FILE := $(PWD)/.env.${ENV}
+ENV_FILE := .env.${ENV}
 PROVIDER ?= gcp
 
 -include ${ENV_FILE}


### PR DESCRIPTION
Using PWD causes issues with scripting that executes Ingra makefile commands from a non-root infra directory.
Other makefiles here or in our other projects are not using PWD.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to Makefile environment file resolution; main impact is that running `make` from other working directories may now load a different `.env.<env>` than before if callers relied on `$PWD` behavior.
> 
> **Overview**
> Updates Makefile env loading to resolve `.env.<ENV>` relative to the Makefile/repo instead of using `$PWD`, improving reliability when `make` is invoked from scripts or subdirectories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ace4116d63111203fb14259b68814aa48240659. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->