### PR TITLE
Fix load current env in set-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ migrate:
 set-env:
 	@ touch .last_used_env
 	@ echo $(ENV) > .last_used_env
-	@ . ${ENV_FILE}
+	@ . ./${ENV_FILE}
 
 .PHONY: switch-env
 switch-env:


### PR DESCRIPTION
Fixes https://github.com/e2b-dev/infra/pull/2001

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to how the Makefile sources the env file; main impact is whether `set-env` succeeds/fails depending on current working directory and `ENV_FILE` contents.
> 
> **Overview**
> Fixes `make set-env` to source the selected `.env.<env>` file via an explicit relative path (`. ./${ENV_FILE}`), avoiding failures when the shell can’t resolve the env file path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 566944811105fec303c31f03bc97b0402364ca53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->