### PR TITLE
Pass domain to launchdarkly in API

### DIFF
--- a/iac/provider-gcp/nomad/jobs/api.hcl
+++ b/iac/provider-gcp/nomad/jobs/api.hcl
@@ -103,6 +103,7 @@ job "api" {
 
       env {
         ENVIRONMENT                    = "${environment}"
+        DOMAIN_NAME                    = "${domain_name}"
         NODE_ID                        = "$${node.unique.id}"
         NOMAD_TOKEN                    = "${nomad_acl_token}"
         ORCHESTRATOR_PORT              = "${orchestrator_port}"

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -77,6 +77,7 @@ resource "nomad_job" "api" {
     memory_mb = var.api_resources_memory_mb
     cpu_count = var.api_resources_cpu_count
 
+    domain_name                             = var.domain_name
     orchestrator_port                       = var.orchestrator_port
     otel_collector_grpc_endpoint            = "localhost:${var.otel_collector_grpc_port}"
     logs_collector_address                  = "http://localhost:${var.logs_proxy_port.port}"

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -60,6 +60,8 @@ type Config struct {
 	// SandboxStorageBackend selects the sandbox storage implementation.
 	// "redis" uses Redis directly; "populate_redis" uses in-memory with Redis shadow writes.
 	SandboxStorageBackend string `env:"SANDBOX_STORAGE_BACKEND" envDefault:"memory"`
+
+	DomainName string `env:"DOMAIN_NAME" envDefault:""`
 }
 
 func Parse() (Config, error) {

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -130,6 +130,8 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, config cfg.Config) 
 		logger.L().Fatal(ctx, "failed to create feature flags client", zap.Error(err))
 	}
 
+	featureFlags.SetDeploymentName(config.DomainName)
+
 	accessTokenGenerator, err := sandbox.NewAccessTokenGenerator(config.SandboxAccessTokenHashSeed)
 	if err != nil {
 		logger.L().Fatal(ctx, "Initializing access token generator failed", zap.Error(err))

--- a/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/internal/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -374,7 +374,7 @@ func (u *Userfaultfd) faultPage(
 		span.RecordError(joinedErr)
 		u.logger.Error(ctx, "UFFD serve uffdio copy error", zap.Error(joinedErr))
 
-		return fmt.Errorf("failed uffdio copy %w", joinedErr)
+		return fmt.Errorf("failed uffdio copy: %w", joinedErr)
 	}
 
 	// Add the offset to the missing requests tracker with metadata.

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -283,9 +283,7 @@ func run(config cfg.Config) (success bool) {
 	}
 	closers = append(closers, closer{"feature flags", featureFlags.Close})
 
-	if config.DomainName != "" {
-		featureFlags.SetDeploymentName(config.DomainName)
-	}
+	featureFlags.SetDeploymentName(config.DomainName)
 
 	// gcp concurrent upload limiter
 	limiter, err := limit.New(ctx, featureFlags)


### PR DESCRIPTION
This lets us target feature flags to custom clusters that are all "dev", or "staging", etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily wires an existing `DOMAIN_NAME` value through config and deployment to scope LaunchDarkly evaluations; main downside would be mis-targeted flags if the env var is wrong or empty.
> 
> **Overview**
> Propagates `DOMAIN_NAME` into the API deployment/config and always sets it on the feature-flags client so LaunchDarkly evaluations can be targeted per deployment/cluster domain; also tweaks a UFFD copy error message for clearer wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3472f98e77cfcbb9824f95699c535c1a092ada34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->