### PR TITLE
fix(dashboard-api): strip quotes and whitespace from PREFIX in Makefile

### DIFF
--- a/packages/dashboard-api/Makefile
+++ b/packages/dashboard-api/Makefile
@@ -1,5 +1,6 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
+PREFIX := $(strip $(subst ",,$(PREFIX)))
 
 expectedMigration := $(shell ./../../scripts/get-latest-migration.sh)
 


### PR DESCRIPTION
## Summary
- The `.env` files define `PREFIX="e2b-"` with literal double quotes. When Make includes these files, `PREFIX` becomes `"e2b-" ` (with quotes and a trailing space from the comment delimiter).
- Every other package Makefile (`api`, `client-proxy`, `db`, `clickhouse`, `docker-reverse-proxy`) sanitizes this with `$(strip $(subst ",,$(PREFIX)))`, but `dashboard-api` was missing this line.
- The unstripped value caused `IMAGE_REGISTRY` to contain a space, splitting the `--tag` argument and breaking `docker buildx build` with `"requires 1 argument"`.

## Test plan
- [ ] Run `make build-and-upload/dashboard-api` and verify the docker build succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Makefile-only change that trims/strips quotes from `PREFIX` to prevent malformed `IMAGE_REGISTRY`/Docker tag values; main risk is unexpected behavior if someone relied on quoted prefixes.
> 
> **Overview**
> Normalizes `PREFIX` in the `dashboard-api` Makefile by stripping quotes and surrounding whitespace after loading env files, preventing spaces/quotes from leaking into `IMAGE_REGISTRY` and breaking Docker build tagging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f7da2ac0890282f4f4ab9dfe84dd3212e41e2f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->