### PR TITLE
feat(api): add snapshot routes to metrics middleware

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -94,6 +94,7 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 			"/sandboxes/:sandboxID/pause",
 			"/sandboxes/:sandboxID/connect",
 			"/sandboxes/:sandboxID/resume",
+			"/sandboxes/:sandboxID/snapshots",
 		),
 		gin.Recovery(),
 	)


### PR DESCRIPTION
## Summary
Include `/sandboxes/:sandboxID/snapshots` in the metrics middleware for observability parity with other sandbox operations like pause, connect, and resume.

## Changes
- Added snapshot creation route to the `IncludeRoutes` metrics middleware configuration in the API server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands OpenTelemetry metrics instrumentation to an additional route with no functional, auth, or data-path changes; main risk is a small increase in metrics volume/cardinality for snapshot calls.
> 
> **Overview**
> Adds `/sandboxes/:sandboxID/snapshots` to the routes covered by the metrics middleware so snapshot operations emit the same OpenTelemetry request metrics as other sandbox endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb76432d6cc6a1b8693ed4cb4ea000db43794ebf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->