### PR TITLE
Add optimize to testing cmd

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -832,6 +832,7 @@ func (r *runner) collectAndUploadPrefetch(ctx context.Context, opts pauseOptions
 		sbx, err := r.factory.ResumeSandbox(ctx, tmpl, r.sbxConfig, runtime, t0, t0.Add(5*time.Minute), nil)
 		if err != nil {
 			fmt.Println()
+
 			return fmt.Errorf("resume sandbox (run %d): %w", i+1, err)
 		}
 
@@ -848,6 +849,7 @@ func (r *runner) collectAndUploadPrefetch(ctx context.Context, opts pauseOptions
 	commonEntries := computeCommonPrefetchEntries(allPrefetchData)
 	if len(commonEntries) == 0 {
 		fmt.Println("⚠️  No common prefetch blocks found")
+
 		return nil
 	}
 
@@ -870,6 +872,7 @@ func (r *runner) collectAndUploadPrefetch(ctx context.Context, opts pauseOptions
 	r.cache.Invalidate(opts.newBuildID)
 
 	fmt.Printf("✅ Prefetch mapping saved: %d blocks\n", mapping.Count())
+
 	return nil
 }
 
@@ -891,6 +894,7 @@ func computeCommonPrefetchEntries(allData []block.PrefetchData) []block.Prefetch
 			entry, exists := allData[i].BlockEntries[idx]
 			if !exists {
 				allMatch = false
+
 				break
 			}
 			totalOrder += entry.Order


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how build metadata prefetch data is written/cleared and can leave a snapshot with prefetch removed if the optimization run fails or yields no common blocks. It also performs additional sandbox resumes and metadata uploads, which could add load or overwrite expected metadata when pointed at shared storage.
> 
> **Overview**
> Adds a new `-optimize` mode to the `resume-build` command that, after creating/uploading a paused snapshot, resumes that snapshot a couple of times to collect page-fault-based prefetch data, computes a common set of accessed blocks, and uploads an updated metadata prefetch mapping for the new build (clearing any inherited prefetch data first when optimization is enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 734874ec5b65a3c17c5eccb8950152ec8310215e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->