### PR TITLE
Remove noisy connection limit exceeded log

### DIFF
--- a/packages/orchestrator/internal/tcpfirewall/proxy.go
+++ b/packages/orchestrator/internal/tcpfirewall/proxy.go
@@ -182,9 +182,6 @@ func (t *connectionHandler) HandleConn(conn net.Conn) {
 	maxLimit := t.featureFlags.IntFlag(ctx, featureflags.TCPFirewallMaxConnectionsPerSandbox)
 	count, acquired := t.limiter.TryAcquire(sandboxID, maxLimit)
 	if !acquired {
-		sbxLogger.Warn(ctx, "connection limit exceeded for sandbox",
-			zap.Int64("current_connections", count),
-			zap.Int("max_limit", maxLimit))
 		t.metrics.RecordError(ctx, ErrorTypeLimitExceeded, t.protocol)
 		conn.Close()
 


### PR DESCRIPTION
## Summary
Removes the excessive warning log that was triggered every time a sandbox's TCP connection limit was exceeded. The metric recording is preserved to track these limit events.

## Changes
- Remove `sbxLogger.Warn()` call in TCP firewall proxy when connection limit is hit
- Error metrics continue to be recorded for observability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only reduces logging on a known limit-exceeded path while keeping metric emission and connection-closing behavior unchanged. Main risk is reduced per-sandbox diagnostic detail if metrics are insufficient during incident triage.
> 
> **Overview**
> Stops emitting the `sbxLogger.Warn` message every time a sandbox hits the TCP connection limit, while preserving the `limit_exceeded` error metric and the existing behavior of closing the connection when the limit is exceeded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87b0ec185787f8bca468ed645d5d0de67a22ad4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->