### PR TITLE
fix(api): remove an extra line

### DIFF
--- a/packages/api/internal/middleware/otel/tracing/middleware.go
+++ b/packages/api/internal/middleware/otel/tracing/middleware.go
@@ -19,6 +19,7 @@ package tracing // import "go.opentelemetry.io/contrib/instrumentation/github.co
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -115,7 +116,7 @@ func Middleware(tracerProvider oteltrace.TracerProvider, service string) gin.Han
 		span.SetAttributes(attrs...)
 		span.SetStatus(spanStatus, spanMessage)
 		if len(c.Errors) > 0 {
-			span.SetAttributes(attribute.String("gin.errors", c.Errors.String()))
+			span.SetAttributes(attribute.String("gin.errors", strings.TrimSpace(c.Errors.String())))
 		}
 	}
 }


### PR DESCRIPTION
gin appends an extra newline at the end of errors
```
gin.errors | "Error #01: Error killing sandbox: sandbox operation failed\n"
```
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts formatting of the `gin.errors` span attribute by trimming surrounding whitespace; no request handling or tracing semantics change beyond the reported error string.
> 
> **Overview**
> Trims surrounding whitespace from the `gin.errors` OpenTelemetry span attribute in the Gin tracing middleware to avoid emitting error strings with extra newlines/spaces.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d5329a20860a399405ac85322ae985c22699125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->