### PR TITLE
chore: add minimum idle connections in Redis

### DIFF
--- a/packages/shared/pkg/factories/redis.go
+++ b/packages/shared/pkg/factories/redis.go
@@ -49,7 +49,7 @@ func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalCli
 		poolSize := clusterNodeConnectionSizePerCPU * numCPU
 		minIdleConns := minIdleConnectionsPerCPU * numCPU
 		if config.PoolSize > 0 {
-			poolSize = config.PoolSize
+			poolSize = max(minIdleConnections, config.PoolSize)
 			minIdleConns = max(minIdleConnections, config.PoolSize/4)
 		}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts Redis cluster connection pool sizing and `MinIdleConns`, which could increase connection/resource usage and subtly change runtime behavior under load.
> 
> **Overview**
> When `PoolSize` is explicitly set for Redis Cluster, the client now enforces a minimum of 10 connections for both the overall pool size and the computed `MinIdleConns` (previously `PoolSize` and `PoolSize/4` could be very small).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58182e5a5797075c02125ac4c96d203a38df8088. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->