### PR TITLE
ci: warmup goose before tests to avoid ETXTBSY race

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -48,16 +48,6 @@ jobs:
             ${{ matrix.package }}/go.mod
             ${{ matrix.package }}/go.sum
 
-      - name: Cache Go build cache (db)
-        id: db-gobuild-cache
-        if: matrix.package == 'packages/db'
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/go-build
-          key: ${{ runner.os }}-db-gobuild-${{ hashFiles('go.work', 'packages/db/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-db-gobuild-
-
       - name: Warm goose tool
         working-directory: ${{ matrix.package }}
         run: go tool goose --version


### PR DESCRIPTION
Warms up goose before running tests to avoid ETXTBSY races on tests.

Getting sporadic failing unit tests due to "text file busy" when applying goose migrations, e.g. https://github.com/e2b-dev/infra/actions/runs/22504612582/job/65200077694
```
=== NAME  TestTwoTeamsCanHaveSameAliasName
    namespace_resolution_test.go:92: 
        	Error Trace:	/home/runner/work/infra/infra/packages/db/pkg/testutils/db.go:120
        	            				/home/runner/work/infra/infra/packages/db/pkg/testutils/db.go:71
        	            				/home/runner/work/infra/infra/packages/db/pkg/tests/template_aliases/namespace_resolution_test.go:92
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestTwoTeamsCanHaveSameAliasName
        	Messages:   	Migration failed: go tool goose: fork/exec /home/runner/.cache/go-build/6c/6c75c36c9707abd699068d8788342657f21a57a03cf02bec308c2246dbfcb44e-d/goose: text file busy

```

Also saves us about 20 seconds on the unit tests looks like - 
- with warming up goose, https://github.com/e2b-dev/infra/actions/runs/22508711630/job/65213064548, down to 8 second goose warmup, ~20 second tests)
example prior
- https://github.com/e2b-dev/infra/actions/runs/22503343183/job/65195766662 57s
- https://github.com/e2b-dev/infra/actions/runs/22508077731/job/65211144607 56s



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that adds a pre-run step to compile/cache `goose` for the DB test job; main risk is only potential workflow flakiness if the tool invocation fails in CI.
> 
> **Overview**
> Updates the PR test workflow to pre-warm the `goose` Go tool (via `go tool goose --version`) before running `packages/db` tests, aiming to avoid intermittent `ETXTBSY` failures when migrations run and to speed up the test job by caching the compiled binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8990e32695a5bf40115696ee394c83a37ba0bb6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->