### PR TITLE
Remove unused ctx arg from logger constructor

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -251,7 +251,7 @@ func run() int {
 		}
 	}()
 
-	l := sharedutils.Must(logger.NewLogger(ctx, logger.LoggerConfig{
+	l := sharedutils.Must(logger.NewLogger(logger.LoggerConfig{
 		ServiceName:   serviceName,
 		IsInternal:    true,
 		IsDebug:       env.IsDebug(),

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -71,15 +71,13 @@ func run() int {
 	}()
 
 	l := utils.Must(
-		logger.NewLogger(
-			ctx, logger.LoggerConfig{
-				ServiceName:   serviceName,
-				IsInternal:    true,
-				IsDebug:       env.IsDebug(),
-				Cores:         []zapcore.Core{logger.GetOTELCore(tel.LogsProvider, serviceName)},
-				EnableConsole: true,
-			},
-		),
+		logger.NewLogger(logger.LoggerConfig{
+			ServiceName:   serviceName,
+			IsInternal:    true,
+			IsDebug:       env.IsDebug(),
+			Cores:         []zapcore.Core{logger.GetOTELCore(tel.LogsProvider, serviceName)},
+			EnableConsole: true,
+		}),
 	)
 
 	defer func() {

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -73,7 +73,7 @@ func run() int {
 		}
 	}()
 
-	l, err := logger.NewLogger(ctx, logger.LoggerConfig{
+	l, err := logger.NewLogger(logger.LoggerConfig{
 		ServiceName:   serviceName,
 		IsInternal:    true,
 		IsDebug:       e2benv.IsDebug(),

--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -174,7 +174,7 @@ func preRun(ctx context.Context) (cleaner.Options, logger.Logger, telemetry.LogP
 		cores = append(cores, otelCore)
 	}
 
-	l := utils.Must(logger.NewLogger(ctx, logger.LoggerConfig{
+	l := utils.Must(logger.NewLogger(logger.LoggerConfig{
 		ServiceName:   serviceName,
 		IsInternal:    true,
 		IsDebug:       env.IsDebug(),

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -193,7 +193,7 @@ func doBuild(
 		))
 	}
 
-	l, err := logger.NewLogger(ctx, logger.LoggerConfig{
+	l, err := logger.NewLogger(logger.LoggerConfig{
 		ServiceName:   "build-template",
 		IsInternal:    true,
 		IsDebug:       verbose,

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -195,7 +195,7 @@ func run(config cfg.Config) (success bool) {
 		}
 	}()
 
-	globalLogger := utils.Must(logger.NewLogger(ctx, logger.LoggerConfig{
+	globalLogger := utils.Must(logger.NewLogger(logger.LoggerConfig{
 		ServiceName:   serviceName,
 		IsInternal:    true,
 		IsDebug:       env.IsDebug(),

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -31,7 +31,7 @@ type LoggerConfig struct {
 	EnableConsole bool
 }
 
-func NewLogger(_ context.Context, loggerConfig LoggerConfig) (Logger, error) {
+func NewLogger(loggerConfig LoggerConfig) (Logger, error) {
 	var level zap.AtomicLevel
 	if loggerConfig.IsDebug {
 		level = zap.NewAtomicLevelAt(zap.DebugLevel)

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -39,7 +39,7 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 		enableConsole = true
 	}
 
-	lg, err := logger.NewLogger(ctx, logger.LoggerConfig{
+	lg, err := logger.NewLogger(logger.LoggerConfig{
 		ServiceName:       config.ServiceName,
 		IsInternal:        config.IsInternal,
 		IsDebug:           true,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk mechanical signature change that affects service startup wiring for logging; failures would show up at compile time and are unlikely to alter runtime behavior.
> 
> **Overview**
> Removes the unused `context.Context` parameter from `logger.NewLogger` and updates service entrypoints and sandbox logger creation to call the constructor with only `LoggerConfig`, simplifying logger initialization without changing logging behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c887f1155d505c20805c66215a75420c4ae9764e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->