### PR TITLE
Change default alb handler backend to sandbox proxy

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -243,7 +243,7 @@ resource "google_certificate_manager_certificate_map_entry" "subdomains_map_entr
 # Load balancers
 resource "google_compute_url_map" "orch_map" {
   name            = "${var.prefix}orch-map"
-  default_service = google_compute_backend_service.default["nomad"].self_link
+  default_service = google_compute_backend_service.default["session"].self_link
 
   host_rule {
     hosts        = concat(["api.${var.domain_name}"], [for d in var.additional_domains : "api.${d}"])


### PR DESCRIPTION
In case you are making a request to a valid URL address, but "Host"
The header will be manually adjusted, and it will be, for example, different
domain than explicitly supported and/or second-level subdomain load
balancer will skip all rules we have as missed and route to the default
service.

Now default routing backend in case all rules are missed is nomad
control plane. This is unexpected for clients who will for some reason
misconfigure their HTTP client. Routing these requests to the sandbox proxy
looks more.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 146ca4e4f0697913110e1edf22aff4ce1ecb36d7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->