### PR TITLE
Small fixes in chrony service

### DIFF
--- a/packages/envd/debug.Dockerfile
+++ b/packages/envd/debug.Dockerfile
@@ -55,15 +55,6 @@ RUN echo ' \n\
 makestep 1 -1 \n\
 ' >/etc/chrony/chrony.conf
 
-RUN mkdir -p /etc/systemd/system/chrony.service.d
-RUN echo ' \n\
-[Service] \n\
-ExecStart= \n\
-ExecStart=/usr/sbin/chronyd \n\
-User=root \n\
-Group=root \n\
-' >/etc/systemd/system/chrony.service.d/override.conf
-
 RUN systemctl enable chrony 2>&1
 
 COPY bin/envd /usr/bin/envd

--- a/packages/orchestrator/internal/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/internal/template/build/phases/base/provision.sh
@@ -15,7 +15,7 @@ is_package_installed() {
 }
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony linuxptp socat curl ca-certificates fuse3 iptables git nfs-common"
+PACKAGES="systemd systemd-sysv openssh-server sudo chrony socat curl ca-certificates fuse3 iptables git nfs-common"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""
@@ -54,16 +54,6 @@ EOF
 
 # Add a proxy config, as some environments expects it there (e.g. timemaster in Node Dockerimage)
 echo "include /etc/chrony/chrony.conf" >/etc/chrony.conf
-
-# Set chrony to run as root
-mkdir -p /etc/systemd/system/chrony.service.d
-cat <<EOF >/etc/systemd/system/chrony.service.d/override.conf
-[Service]
-ExecStart=
-ExecStart=/usr/sbin/chronyd
-User=root
-Group=root
-EOF
 
 echo "Setting up SSH"
 mkdir -p /etc/ssh

--- a/tests/integration/internal/tests/api/templates/build_template_test.go
+++ b/tests/integration/internal/tests/api/templates/build_template_test.go
@@ -1014,7 +1014,6 @@ func TestTemplateBuildInstalledPackagesAvailable(t *testing.T) {
 		"openssh-server",
 		"sudo",
 		"chrony",
-		"linuxptp",
 		"socat",
 		"curl",
 		"ca-certificates",


### PR DESCRIPTION
c9502302 tried to make sure that we are launching chronyd as root. Apparently, this does launch the service using the root user but chronyd then drops privileges and continues working as the _chrony user. However, it does not change the owner of /run/chrony to _chrony which causes chronyd itself to complain and close the UDS socket over which we can interact with it.

This is not a problem per se, since we don't actually interact with chronyd at the moment. However, we can avoid the issue and adhere to best practices by not running chrony as root.

Moreover, we noticed that the `chrony.service` races with the `timemaster.service`. Some times chronyd is handled by the latter than the former. We don't really need timemsater, so we can just remove it from the sandbox and avoid the race and the noise it adds to the system.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit dc7bb39df49f9b6e337ff699523a29008fc65b0b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->