### PR TITLE
Remove package check from goose warm step in PR tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Warm goose tool
         working-directory: ${{ matrix.package }}
         run: go tool goose --version
-        if: matrix.package == 'packages/db'
 
       - name: Setup envd tests
         run: |


### PR DESCRIPTION
Remove the `if: matrix.package == 'packages/db'` condition from the goose warm-up step in the PR tests workflow. This allows the tool to be warmed up for all packages in the matrix instead of only the database package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes CI behavior by running `go tool goose --version` for every matrix entry; main potential issue is added CI time or unexpected failures in packages where `goose` isn’t available via `go tool`.
> 
> **Overview**
> Removes the matrix-package guard so the PR test workflow always runs the `goose` warm-up command (`go tool goose --version`) for every package in the test matrix, instead of only for `packages/db`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37d4acccac2a260efd38ae0eb324cf3d32608abe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->