### PR TITLE
Fixed use of resource arn for cert reference

### DIFF
--- a/iac/provider-aws/alb.tf
+++ b/iac/provider-aws/alb.tf
@@ -73,7 +73,7 @@ resource "aws_lb_listener" "ingress_wildcard" {
   protocol = "HTTPS"
 
   ssl_policy      = "ELBSecurityPolicy-2016-08"
-  certificate_arn = aws_acm_certificate_validation.wildcard.arn
+  certificate_arn = aws_acm_certificate_validation.wildcard.certificate_arn
 
   default_action {
     type             = "forward"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-field Terraform change to a certificate reference; main risk is an infrastructure diff that could force a listener update during apply.
> 
> **Overview**
> Fixes the HTTPS ALB listener’s wildcard certificate reference by using the validated ACM certificate’s `certificate_arn` output instead of the resource ARN, ensuring the listener points at the actual certificate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09afb841245ed81b5911d269b026b75d508df196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->