### PR TITLE
fix(consul): scope GCE auto-join zone discovery to instance region

### DIFF
--- a/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
@@ -189,7 +189,7 @@ function generate_consul_config {
   else
     retry_join_json=$(
       cat <<EOF
-"retry_join": ["provider=gce project_name=$project_id tag_value=$cluster_tag_name"],
+"retry_join": ["provider=gce project_name=$project_id tag_value=$cluster_tag_name zone_pattern=$instance_region-.*"],
 EOF
     )
   fi


### PR DESCRIPTION
## Summary
- The Consul `retry_join` GCE cloud auto-join was querying every GCP zone globally (~130+ zones) to discover cluster peers, because no `zone_pattern` was specified.
- Added `zone_pattern=$instance_region-.*` to restrict discovery to only zones within the instance's own region (e.g. `europe-west1-.*`), eliminating ~126 unnecessary GCP API calls and ~80s of startup delay per Consul node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Consul startup config that only narrows discovery scope; main risk is unintended failure to auto-join if a cluster spans regions.
> 
> **Overview**
> Updates Consul’s GCE cloud auto-join `retry_join` configuration to include `zone_pattern=$instance_region-.*`, restricting peer discovery to zones within the current instance region instead of scanning all GCP zones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf6e50f0b15bfdc4c8d64ff32d27dc045e01bd61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->