### PR TITLE
Add additional 120s for consul when health check shows VM is healthy

### DIFF
--- a/iac/provider-gcp/.terraform.lock.hcl
+++ b/iac/provider-gcp/.terraform.lock.hcl
@@ -66,6 +66,26 @@ provider "registry.terraform.io/hashicorp/google" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "6.50.0"
+  hashes = [
+    "h1:uxh4ME3hhSzVjmiWgA1IQqYqg25MV6FMVArHyA6Ki5o=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/nomad" {
   version     = "2.1.0"
   constraints = "2.1.0"

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -30,10 +30,11 @@ data "google_compute_zones" "region_zones" {
 }
 
 resource "google_compute_region_instance_group_manager" "server_pool" {
+  provider = google-beta
+
   region             = var.gcp_region
   name               = "${local.server_pool_name}-rig"
   base_instance_name = local.server_pool_name
-
 
   target_pools                     = []
   target_size                      = var.server_cluster_size
@@ -57,8 +58,13 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
     // We want to keep the instance distribution even
     instance_redistribution_type = "PROACTIVE"
     max_unavailable_fixed        = 0
+
     // The number has to be a multiple of the number of zones in the region
     max_surge_fixed = length(data.google_compute_zones.region_zones.names)
+
+    // Wait 120s after instance is "healthy" before considering it truly ready
+    // Gives Consul time to join Raft before GCP proceeds to kill old instances
+    min_ready_sec = 120
   }
 
   auto_healing_policies {


### PR DESCRIPTION
This change will add an additional 120-second wait after a newly initialized instance is spawned and marked as healthy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout timing and provider selection for GCP instance group management, which can affect upgrade behavior and cluster availability if misconfigured.
> 
> **Overview**
> Adds a 120-second `min_ready_sec` delay to the Nomad server regional instance group manager rollout so GCP waits after a VM becomes healthy before proceeding with replacement, reducing the chance of Consul being disrupted during rolling updates. This also switches that MIG resource to use the `google-beta` provider and locks `hashicorp/google-beta` in Terraform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d5952a8bd4a3f017c05907b68dd6e21fef45645. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->