### PR TITLE
perf(orchestrator): suppress Firecracker FlushMetrics log spam

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -60,7 +60,9 @@ func (f *fcLogFilter) Write(p []byte) (n int, err error) {
 			continue
 		}
 
-		if f.skipResponse.Swap(false) {
+		if f.skipResponse.Load() && bytes.Contains(line, []byte("The request was executed successfully")) {
+			f.skipResponse.Store(false)
+
 			continue
 		}
 


### PR DESCRIPTION
## Summary
Suppress noisy Firecracker log spam from the FlushMetrics action that fires every 5 seconds per sandbox. Each flush produces two log lines (~24 lines/min/sandbox):
- "The API server received a Put request on \"/actions\" with body \"{\"action_type\":\"FlushMetrics\"}\""
- "The request was executed successfully. Status code: 204 No Content."

## Changes
Add `fcLogFilter`, a stateful io.Writer wrapper that filters Firecracker's stdout to suppress FlushMetrics request/response pairs. The filter:
- Drops any write containing "FlushMetrics"
- Sets a flag to also drop the following "The request was executed successfully" response
- Passes all other logs through unchanged

This keeps Firecracker at Info level to preserve other operational messages while targeting only this specific verbose log pair.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to stdout handling that only suppresses specific log lines; main risk is inadvertently filtering unexpected messages if Firecracker log text changes or lines are split across writes.
> 
> **Overview**
> Reduces Firecracker log noise by wrapping the process stdout writer with a small stateful filter that drops `FlushMetrics` request lines and their immediate success responses while passing through all other stdout output unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bed6086bd1fa1529f2eb245eb57e25bc901e5ea3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->