### PR TITLE
fix(iac): pass persistent volume vars to Terraform via Makefile

### DIFF
--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -99,6 +99,11 @@ REDIS_SHARD_COUNT=
 # Template bucket name (if you want to use a different bucket for templates then the default one)
 # TEMPLATE_BUCKET_NAME=
 
+# Default persistent volume type (default: "")
+DEFAULT_PERSISTENT_VOLUME_TYPE=
+# Persistent volume types (default: {})
+PERSISTENT_VOLUME_TYPES=
+
 # -------------------------------------- Variables for integration tests -----------------------------------------------
 # Hash seed used for generating sandbox access tokens, not needed if you are not using them
 SANDBOX_ACCESS_TOKEN_HASH_SEED=abcdefghijklmnopqrstuvwxyz

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -75,7 +75,9 @@ tf_vars := \
 	$(call tfvar, BUCKET_PREFIX) \
 	$(call tfvar, LOKI_BOOT_DISK_TYPE) \
 	$(call tfvar, LOKI_USE_V13_SCHEMA_FROM) \
-	$(call tfvar, DASHBOARD_API_COUNT)
+	$(call tfvar, DASHBOARD_API_COUNT) \
+	$(call tfvar, DEFAULT_PERSISTENT_VOLUME_TYPE) \
+	$(call tfvar, PERSISTENT_VOLUME_TYPES)
 
 .PHONY: init
 init:


### PR DESCRIPTION
## Summary
- `TF_VAR_default_persistent_volume_type` and `TF_VAR_persistent_volume_types` were not being picked up by `make plan` because they were defined with the `TF_VAR_` prefix directly in the env file. Make's `-include` sets them as Make variables but does not export them as environment variables to subprocesses (Terraform).
- Adds `DEFAULT_PERSISTENT_VOLUME_TYPE` and `PERSISTENT_VOLUME_TYPES` to the `tf_vars` block in `iac/provider-gcp/Makefile` so they follow the same `tfvar` macro convention as all other variables.
- Adds both variables to `.env.gcp.template` under the optional block.

## Notes
Existing env files that use the old `TF_VAR_*` naming (e.g. `.env.stagingdobrac`) need to be updated to use `DEFAULT_PERSISTENT_VOLUME_TYPE` and `PERSISTENT_VOLUME_TYPES` (without the `TF_VAR_` prefix).

## Test plan
- [x] Verify `make plan` picks up `DEFAULT_PERSISTENT_VOLUME_TYPE` and `PERSISTENT_VOLUME_TYPES` from the env file
- [x] Verify plan output includes the expected persistent volume configuration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only affects Terraform variable wiring and env templates, but misconfigured/renamed env vars could change planned infrastructure if operators don’t update existing env files consistently.
> 
> **Overview**
> Fixes GCP IaC env propagation so persistent volume settings are actually provided to Terraform by adding `DEFAULT_PERSISTENT_VOLUME_TYPE` and `PERSISTENT_VOLUME_TYPES` to the Makefile’s exported `TF_VAR_*` set and documenting these env keys in `.env.gcp.template`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf103116667685c9b7d646404d8c02eb9104cac0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->