### PR TITLE
fix(orchestrator): validate seekable read ranges

### DIFF
--- a/packages/orchestrator/internal/server/chunks.go
+++ b/packages/orchestrator/internal/server/chunks.go
@@ -108,12 +108,18 @@ func (s *Server) GetBuildFileExists(ctx context.Context, req *orchestrator.GetBu
 // ReadAtBuildSeekable streams a range from a seekable diff file (memfile, rootfs.ext4).
 func (s *Server) ReadAtBuildSeekable(req *orchestrator.ReadAtBuildSeekableRequest, stream orchestrator.ChunkService_ReadAtBuildSeekableServer) error {
 	ctx := stream.Context()
+	offset := req.GetOffset()
+	length := req.GetLength()
+
+	if offset < 0 || length < 0 {
+		return status.Error(codes.InvalidArgument, "offset and length must be non-negative")
+	}
 
 	telemetry.SetAttributes(ctx,
 		telemetry.WithBuildID(req.GetBuildId()),
 		attribute.String("file_name", req.GetFileName()),
-		attribute.Int64("offset", req.GetOffset()),
-		attribute.Int64("length", req.GetLength()),
+		attribute.Int64("offset", offset),
+		attribute.Int64("length", length),
 	)
 
 	if s.uploadedBuilds.Get(req.GetBuildId()) != nil {
@@ -131,7 +137,7 @@ func (s *Server) ReadAtBuildSeekable(req *orchestrator.ReadAtBuildSeekableReques
 		return toGRPCError(err)
 	}
 
-	if err := src.Stream(ctx, req.GetOffset(), req.GetLength(), &seekableStreamSender{stream}); err != nil {
+	if err := src.Stream(ctx, offset, length, &seekableStreamSender{stream}); err != nil {
 		if errors.Is(err, peerserver.ErrNotAvailable) {
 			return stream.Send(&orchestrator.ReadAtBuildSeekableResponse{Availability: peerNotAvailable})
 		}

--- a/packages/orchestrator/internal/server/chunks_test.go
+++ b/packages/orchestrator/internal/server/chunks_test.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	orchestratormocks "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator/mocks"
+)
+
+func TestReadAtBuildSeekable_RejectsNegativeRange(t *testing.T) {
+	t.Parallel()
+
+	stream := orchestratormocks.NewMockChunkService_ReadAtBuildSeekableServer(t)
+	stream.EXPECT().Context().Return(t.Context())
+
+	s := &Server{}
+	err := s.ReadAtBuildSeekable(&orchestrator.ReadAtBuildSeekableRequest{
+		BuildId:  "build-1",
+		FileName: "memfile",
+		Offset:   -1,
+		Length:   1,
+	}, stream)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+}


### PR DESCRIPTION
### Motivation
- Prevent a remote DoS where negative `offset`/`length` values in a peer-to-peer `ReadAtBuildSeekable` gRPC request propagate to `diff.Slice`/`Cache.Slice` and cause a Go slice bounds panic that can crash the orchestrator.

### Description
- Add input validation in `ReadAtBuildSeekable` to reject negative `offset` or `length` and return `codes.InvalidArgument` via `status.Error`.
- Use the validated `offset`/`length` values for telemetry attributes and when invoking the downstream `src.Stream` call to ensure consistent behavior for valid requests.
- Add a focused unit test `TestReadAtBuildSeekable_RejectsNegativeRange` exercising the guard and asserting an `InvalidArgument` status is returned for negative offsets.
- Changes touch `packages/orchestrator/internal/server/chunks.go` and add `packages/orchestrator/internal/server/chunks_test.go`.

### Testing
- Added unit test `TestReadAtBuildSeekable_RejectsNegativeRange` (file `packages/orchestrator/internal/server/chunks_test.go`) to validate negative ranges are rejected.
- Attempted to run the server and peerserver package tests locally (`go test` for `./internal/server` and `./internal/sandbox/template/peerserver`), but the environment aborted package initialization with a runtime panic `cannot find default gateway` before tests could execute, so tests could not complete in this environment.
- The change is minimal and local-runable tests should pass in CI or a developer environment where package init does not panic; the added test exercises only the gRPC handler boundary and does not require network initialization when executed with the mocked server stream.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab626325b88322ba71fa496cdaf6d8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized guard change plus a unit test; main behavioral impact is returning `InvalidArgument` for previously accepted invalid inputs.
> 
> **Overview**
> Adds input validation to `ReadAtBuildSeekable` to reject negative `offset`/`length` values with `InvalidArgument` before streaming, and wires the validated range through telemetry and the downstream `Stream` call. Includes a focused unit test asserting negative ranges are rejected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ade4e0657c1d62be46347e9224104d85a59906a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->