### PR TITLE
Increase timeouts for the LB backend

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -43,7 +43,7 @@ resource "google_compute_backend_service" "ingress" {
   session_affinity = null
   health_checks    = [google_compute_health_check.ingress.id]
 
-  timeout_sec = 65
+  timeout_sec = 80
 
   load_balancing_scheme = "EXTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -56,7 +56,7 @@ locals {
       protocol                        = "HTTP"
       port                            = var.api_port.port
       port_name                       = var.api_port.name
-      timeout_sec                     = 65
+      timeout_sec                     = 80
       connection_draining_timeout_sec = 1
       http_health_check = {
         request_path       = var.api_port.health_path


### PR DESCRIPTION
Previously they were lower than the api write timeouts, causing 504 where it should have been errors from the API.