### PR TITLE
Increase start-client DNS wait timeouts from 10s to 60s

### DIFF
--- a/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
+++ b/iac/provider-aws/modules/nodepool-client/scripts/start-client.sh
@@ -201,13 +201,13 @@ echo $overcommitment_hugepages >/proc/sys/vm/nr_overcommit_hugepages
 
 # Give Consul a moment to start its DNS server on port 8600
 echo "- Waiting for Consul DNS to start on port 8600..."
-for i in {1..10}; do
+for i in {1..60}; do
   if nc -z 127.0.0.1 8600 2>/dev/null; then
-    echo "- Consul DNS is ready (attempt $i/10)"
+    echo "- Consul DNS is ready (attempt $i/60)"
     break
   fi
-  if [ $i -eq 10 ]; then
-    echo "- ERROR: Consul DNS not responding after 10 seconds, exiting..."
+  if [ $i -eq 60 ]; then
+    echo "- ERROR: Consul DNS not responding after 60 seconds, exiting..."
     exit 1
   fi
   sleep 1
@@ -224,13 +224,13 @@ echo "- Waiting for systemd-resolved to settle"
 
 # Give Consul a moment to start its DNS server on port 8600
 echo "- Waiting for Systemd-resolved to start..."
-for i in {1..10}; do
+for i in {1..60}; do
   if host google.com 2>/dev/null; then
-    echo "- DNS resolving is ready (attempt $i/10)"
+    echo "- DNS resolving is ready (attempt $i/60)"
     break
   fi
-  if [ $i -eq 10 ]; then
-    echo "- ERROR: Systemd-resolved not responding after 10 seconds, exiting..."
+  if [ $i -eq 60 ]; then
+    echo "- ERROR: Systemd-resolved not responding after 60 seconds, exiting..."
     exit 1
   fi
   sleep 1

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -304,13 +304,13 @@ GCE_DNS=$(curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/c
 
 # Give Consul a moment to start its DNS server on port 8600
 echo "- Waiting for Consul DNS to start on port 8600..."
-for i in {1..10}; do
+for i in {1..60}; do
   if nc -z 127.0.0.1 8600 2>/dev/null; then
-    echo "- Consul DNS is ready (attempt $i/10)"
+    echo "- Consul DNS is ready (attempt $i/60)"
     break
   fi
-  if [ $i -eq 10 ]; then
-    echo "- ERROR: Consul DNS not responding after 10 seconds, exiting..."
+  if [ $i -eq 60 ]; then
+    echo "- ERROR: Consul DNS not responding after 60 seconds, exiting..."
     exit 1
   fi
   sleep 1
@@ -327,13 +327,13 @@ echo "- Waiting for systemd-resolved to settle"
 
 # Give Consul a moment to start its DNS server on port 8600
 echo "- Waiting for Systemd-resolved to start..."
-for i in {1..10}; do
+for i in {1..60}; do
   if host google.com 2>/dev/null; then
-    echo "- DNS resolving is ready (attempt $i/10)"
+    echo "- DNS resolving is ready (attempt $i/60)"
     break
   fi
-  if [ $i -eq 10 ]; then
-    echo "- ERROR: Systemd-resolved not responding after 10 seconds, exiting..."
+  if [ $i -eq 60 ]; then
+    echo "- ERROR: Systemd-resolved not responding after 60 seconds, exiting..."
     exit 1
   fi
   sleep 1


### PR DESCRIPTION
Consul DNS and systemd-resolved can take longer than 10 seconds to become ready, causing the user-data script to exit before Nomad starts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to boot-time retry timing only; primary risk is slightly slower node startup when DNS is genuinely broken, but no security-sensitive logic is modified.
> 
> **Overview**
> In both AWS and GCP client `start-client.sh` boot scripts, increases the readiness wait loops for Consul DNS (port 8600) and subsequent `systemd-resolved` DNS resolution checks from 10 to 60 attempts/seconds, updating log messages and failure thresholds so the scripts don’t exit prematurely before starting Nomad.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f0642ac36380729a5f4c7ac87193f342c3a7813. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->