### PR TITLE
Prefix for gcp cluster disk image

### DIFF
--- a/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
@@ -9,10 +9,10 @@ packer {
 }
 
 source "googlecompute" "orch" {
-  image_family = "e2b-orch"
+  image_family = "${var.prefix}orch"
 
   # TODO: Overwrite the image instead of creating timestamped images every time we build its
-  image_name    = "e2b-orch-${formatdate("YYYY-MM-DD-hh-mm-ss", timestamp())}"
+  image_name    = "${var.prefix}orch-${formatdate("YYYY-MM-DD-hh-mm-ss", timestamp())}"
   project_id    = var.gcp_project_id
   source_image  = "ubuntu-2204-jammy-v20251023"
   ssh_username  = "ubuntu"

--- a/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
@@ -10,6 +10,11 @@ variable "network_name" {
   type = string
 }
 
+variable "prefix" {
+  type    = string
+  default = "e2b-"
+}
+
 variable "consul_version" {
   type    = string
   default = "1.16.2"


### PR DESCRIPTION
This is another fix needed to make the infrastructure really prefix-aware. It adds the ability to optionally change the default prefix, but for the back compatibility of open source, we will not use it in the default setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small IaC change limited to image naming; default behavior remains unchanged unless `prefix` is overridden.
> 
> **Overview**
> Makes the GCP Nomad cluster disk image build prefix-aware by parameterizing the image `family` and timestamped `name` with a new `prefix` variable (defaulting to `e2b-`), enabling optional customization without changing existing defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3938dd3cf7bab6527006bbea0b6c1f80e7482c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->