### PR TITLE
Disable cloud.provider and cloud.platform in AWS otel resource detection

### DIFF
--- a/iac/modules/job-otel-collector-nomad-server/configs/otel-collector-nomad-server.yaml
+++ b/iac/modules/job-otel-collector-nomad-server/configs/otel-collector-nomad-server.yaml
@@ -100,6 +100,10 @@ processors:
     override: true
     ec2:
       resource_attributes:
+        cloud.provider:
+          enabled: false
+        cloud.platform:
+          enabled: false
         cloud.account.id:
           enabled: true
         cloud.region:

--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -325,6 +325,10 @@ processors:
     override: true
     ec2:
       resource_attributes:
+        cloud.provider:
+          enabled: false
+        cloud.platform:
+          enabled: false
         cloud.account.id:
           enabled: true
         cloud.region:


### PR DESCRIPTION
Explicitly disable cloud.provider and cloud.platform attributes in ec2 resource detection for both otel-collector and otel-collector-nomad-server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes emitted OpenTelemetry resource attributes for AWS, which can break existing dashboards/alerts or downstream processors that query `cloud.provider`/`cloud.platform`. No material security or performance risk beyond potential label/cardinality shifts.
> 
> **Overview**
> Disables emitting `cloud.provider` and `cloud.platform` from AWS `ec2` `resourcedetection` in the OpenTelemetry Collector configs so telemetry from AWS no longer includes those resource attributes (potentially affecting any queries or alerts that rely on them).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2492bb9423769646116e0fec286ad680c5cb35da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->