### PR TITLE
feat(orchestrator): add configurable build timeout flag to create-build

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -62,6 +62,7 @@ func main() {
 	startCmd := flag.String("start-cmd", "", "start command")
 	setupCmd := flag.String("setup-cmd", "", "setup command to run during build (e.g., install deps)")
 	readyCmd := flag.String("ready-cmd", "", "ready check command")
+	timeout := flag.Int("timeout", 5, "build timeout in minutes")
 	verbose := flag.Bool("v", false, "verbose output")
 	flag.Parse()
 
@@ -95,7 +96,7 @@ func main() {
 		log.Fatalf("network config: %v", err)
 	}
 
-	err = doBuild(ctx, *templateID, *toBuild, *fromBuild, *kernel, *fc, *vcpu, *memory, *disk, *hugePages, *startCmd, *setupCmd, *readyCmd, localMode, *verbose, builderConfig, networkConfig)
+	err = doBuild(ctx, *templateID, *toBuild, *fromBuild, *kernel, *fc, *vcpu, *memory, *disk, *hugePages, *startCmd, *setupCmd, *readyCmd, localMode, *verbose, *timeout, builderConfig, networkConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -178,10 +179,11 @@ func doBuild(
 	hugePages bool,
 	startCmd, setupCmd, readyCmd string,
 	localMode, verbose bool,
+	timeout int,
 	builderConfig cfg.BuilderConfig,
 	networkConfig network.Config,
 ) error {
-	ctx, cancel := context.WithTimeout(parentCtx, 5*time.Minute)
+	ctx, cancel := context.WithTimeout(parentCtx, time.Duration(timeout)*time.Minute)
 	defer cancel()
 
 	var cores []zapcore.Core


### PR DESCRIPTION
Add `-timeout` flag (default 5 minutes) to allow overriding the build timeout without code changes.

---

Sometimes it can take longer, especially on slow internet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only parameterizes an existing fixed 5-minute `context.WithTimeout` in the `create-build` CLI; main risk is misconfiguration (e.g., `-timeout 0`/negative) causing premature cancellation or unexpectedly long-running builds.
> 
> **Overview**
> Adds a `-timeout` flag (default 5 minutes) to `cmd/create-build` and threads it into `doBuild` so the build context deadline is configurable instead of being hard-coded to 5 minutes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 871ccb60351d7fe864330727cfa39732fe4fa209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->