### PR TITLE
fix(template): handle OCI whiteout when unpacking image layers

### DIFF
--- a/packages/orchestrator/internal/template/build/core/oci/oci.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci.go
@@ -427,7 +427,7 @@ func createExport(ctx context.Context, logger logger.Logger, srcImage containerr
 
 			err = archive.Untar(rc, layerPath, &archive.TarOptions{
 				IgnoreChownErrors: true,
-				WhiteoutFormat: archive.OverlayWhiteoutFormat,
+				WhiteoutFormat:    archive.OverlayWhiteoutFormat,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to untar layer %d: %w", i, err)

--- a/packages/orchestrator/internal/template/build/core/oci/oci_test.go
+++ b/packages/orchestrator/internal/template/build/core/oci/oci_test.go
@@ -108,6 +108,7 @@ func createLayerWithWhiteout(t *testing.T, whiteoutPath string) *bytes.Buffer {
 	})
 	require.NoError(t, err)
 	require.NoError(t, tw.Close())
+
 	return &buf
 }
 
@@ -158,7 +159,7 @@ func TestCreateExportHandlesOCIWhiteout(t *testing.T) {
 	upperWhiteoutPath := filepath.Join(upperLayerDir, "stale-file.txt")
 	info, err := os.Stat(upperWhiteoutPath)
 	require.NoError(t, err, "upper layer must contain whiteout device at stale-file.txt so overlay merge hides lower layer's file")
-	assert.True(t, info.Mode()&os.ModeCharDevice != 0, "stale-file.txt in upper layer must be a character device (OCI whiteout), got %s", info.Mode())
+	assert.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeCharDevice, "stale-file.txt in upper layer must be a character device (OCI whiteout), got %s", info.Mode())
 }
 
 // authHandler wraps a registry handler with basic authentication


### PR DESCRIPTION
**Summary**

Fix incorrect handling of OCI layer whiteout during template build that caused the template rootfs to diverge from the source Docker image. Paths deleted in upper image layers (via `.wh.<name>` whiteout) were still visible from lower layers in the merged view, so the template could contain stale files or wrong package versions (e.g. pydantic 1.x instead of 2.x from the image). Snapshot/restore or sandbox runs from such templates then saw inconsistent filesystem state compared to `docker run` of the same image.

**Root Cause**

Layers were untarred with `archive.Untar` without setting `TarOptions.WhiteoutFormat`. So OCI whiteout entries in the tar were either written as plain files or not applied. The subsequent overlay merge (multiple lowerdirs, no upper) did not treat those as “deleted” paths; lower-layer content for those paths remained visible. On images that use multi-layer builds with deletions (e.g. replacing a venv or package dir), the template rootfs therefore did not match the image.

**Fix**

Set `WhiteoutFormat: archive.OverlayWhiteoutFormat` in the Untar `TarOptions` when extracting each layer in `createExport`. The containers/storage archive then processes whiteout during unpack so that overlay merge correctly hides deleted paths from lower layers. The final rsync from the overlay mount to the template rootfs now matches the image’s merged view.

**Test**

Built a template from a Docker image that has upper layers removing/replacing content (e.g. conda env with pydantic 2.x). Before: template showed old pydantic 1.x from a lower layer. After: template shows pydantic 2.x consistent with `docker run` of the image. Template build and sandbox creation from the template complete successfully.