### PR TITLE
feat(copy-build): add sql command to connect the build

### DIFF
--- a/packages/orchestrator/README.md
+++ b/packages/orchestrator/README.md
@@ -122,7 +122,7 @@ Flags:
 - `-from <path>` - Source: local path or `gs://bucket`
 - `-to <path>` - Destination: local path or `gs://bucket`
 - `-team <uuid>` - Team UUID (if set, prints SQL to populate DB on stdout)
-- `-envd-version <version>` - Envd version (required if team provided)
+- `-envd-version <version>` - Envd version (required if team provided) — must match the version present in the template
 - `-vcpu <n>` - vCPUs (default: `2`)
 - `-memory <mb>` - Memory in MB (default: `1024`)
 - `-disk <mb>` - Disk in MB (default: `1024`)

--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -202,7 +202,7 @@ func main() {
 	from := flag.String("from", "", "from destination")
 	to := flag.String("to", "", "to destination")
 	teamID := flag.String("team", "", "team UUID (if set, prints SQL to populate DB on stdout)")
-	envdVersion := flag.String("envd-version", "", "envd version (required)")
+	envdVersion := flag.String("envd-version", "", "envd version (required if team provided) — must match the version present in the template")
 	vcpu := flag.Int("vcpu", 2, "vCPUs")
 	memory := flag.Int("memory", 1024, "memory MB")
 	disk := flag.Int("disk", 1024, "disk MB")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the `copy-build` CLI and are gated behind the optional `-team` flag. Main risk is generating incorrect SQL/metadata-derived versions that could seed the database with wrong values if used incorrectly.
> 
> **Overview**
> Extends `copy-build` to optionally generate and print `BEGIN`/`COMMIT`-wrapped SQL that seeds `envs`, `env_builds`, and `env_build_assignments` for a copied build when `-team` is provided (requiring `-envd-version` and using `metadata.json` from the destination to fill kernel/firecracker versions). It also moves progress/log output to stderr so stdout can be safely piped to `psql`, and updates the README to document the new flags and piping workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21a1c86d7c1ff2098868d0370cec4cca11b91904. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->