### PR TITLE
Add a tracing helper

### DIFF
--- a/packages/shared/pkg/telemetry/fields.go
+++ b/packages/shared/pkg/telemetry/fields.go
@@ -28,6 +28,10 @@ func WithNodeID(nodeID string) attribute.KeyValue {
 	return zapFieldToOTELAttribute(logger.WithNodeID(nodeID))
 }
 
+func WithServiceInstanceID(serviceInstanceID string) attribute.KeyValue {
+	return zapFieldToOTELAttribute(logger.WithServiceInstanceID(serviceInstanceID))
+}
+
 func WithClusterID(clusterID uuid.UUID) attribute.KeyValue {
 	return zapFieldToOTELAttribute(logger.WithClusterID(clusterID))
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive change in telemetry field helpers with no behavior changes beyond emitting an extra optional attribute.
> 
> **Overview**
> Adds a new telemetry helper `WithServiceInstanceID` that converts the existing logger field into an OpenTelemetry attribute, enabling traces/spans to be tagged with `service.instance.id` consistently alongside other common identifiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 222280e9c54bab52726b332a75bb0e5bfd63dea2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->