### PR TITLE
chore(orch): decrease healthcheck failed log level

### DIFF
--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -92,7 +92,7 @@ func (c *Checks) Healthcheck(ctx context.Context, alwaysReport bool) {
 
 	if !ok && c.healthy.CompareAndSwap(true, false) {
 		sbxlogger.E(c.sandbox).Healthcheck(ctx, sbxlogger.Fail)
-		sbxlogger.I(c.sandbox).Error(ctx, "healthcheck failed", zap.Error(err))
+		sbxlogger.I(c.sandbox).Warn(ctx, "healthcheck failed", zap.Error(err))
 
 		return
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Log-level only change with no impact on healthcheck behavior or control flow; the main risk is reduced alerting/visibility if downstream systems rely on error-level logs.
> 
> **Overview**
> Downgrades the log level for sandbox healthcheck failures from `Error` to `Warn` when a sandbox first transitions from healthy to unhealthy, reducing noise while keeping explicit error logging for the `alwaysReport` control-path failures unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c5fad7806649a41e46322bc89e6ea863a57131b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->