### PR TITLE
fix(lint): disable nolint for race condition

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -104,6 +104,12 @@ linters:
             - pkg: "net/http/pprof"
               desc: "Importing net/http/pprof registers on DefaultServeMux via init(). Use telemetry.NewPprofMux() instead."
 
+    nolintlint:
+      # We are temporarily allowing unused nolints due to apparently
+      # false failures in CI. See
+      # https://github.com/golangci/golangci-lint/issues/3228
+      allow-unused: true
+
     gocritic:
       disabled-checks:
         - appendAssign


### PR DESCRIPTION
https://github.com/e2b-dev/infra/actions/runs/22970133239/job/66691577633?pr=2100
https://github.com/golangci/golangci-lint/issues/3228

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only relaxes lint enforcement by allowing unused `//nolint` directives, which may hide some lint drift but does not affect runtime behavior.
> 
> **Overview**
> Temporarily relaxes `golangci-lint` by enabling `nolintlint.allow-unused`, preventing CI failures caused by erroneous unused `//nolint` reports from an upstream golangci-lint issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bfcf866218230a85b408bb5f33284fbf442f252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->