### PR TITLE
log keepalive failure reasons

### DIFF
--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -56,18 +56,21 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandb
 				logger.WithTeamID(teamID.String()),
 				zap.String("state", string(sbxNotRunningErr.State)),
 			)
+
 			return nil, &api.APIError{Code: http.StatusConflict, ClientMsg: utils.SandboxChangingStateMsg(sandboxID, sbxNotRunningErr.State), Err: err}
 		case errors.As(err, &sbxNotFoundErr):
 			logger.L().Warn(ctx, "Sandbox not found in store during keep alive",
 				logger.WithSandboxID(sandboxID),
 				logger.WithTeamID(teamID.String()),
 			)
+
 			return nil, &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
 		case errors.Is(err, errMaxInstanceLengthExceeded):
 			logger.L().Warn(ctx, "Sandbox max instance length exceeded during keep alive",
 				logger.WithSandboxID(sandboxID),
 				logger.WithTeamID(teamID.String()),
 			)
+
 			return nil, &api.APIError{Code: http.StatusBadRequest, ClientMsg: "Max instance length exceeded", Err: err}
 		default:
 			logger.L().Error(ctx, "Error updating sandbox during keep alive",
@@ -75,6 +78,7 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandb
 				logger.WithSandboxID(sandboxID),
 				logger.WithTeamID(teamID.String()),
 			)
+
 			return nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error when setting sandbox timeout", Err: err}
 		}
 	}
@@ -87,6 +91,7 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandb
 				logger.WithNodeID(sbx.NodeID),
 				logger.WithClusterID(sbx.ClusterID),
 			)
+
 			return nil, &api.APIError{Code: http.StatusNotFound, ClientMsg: utils.SandboxNotFoundMsg(sandboxID), Err: err}
 		}
 
@@ -97,6 +102,7 @@ func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandb
 			logger.WithNodeID(sbx.NodeID),
 			logger.WithClusterID(sbx.ClusterID),
 		)
+
 		return nil, &api.APIError{Code: http.StatusInternalServerError, ClientMsg: "Error when setting sandbox timeout", Err: err}
 	}
 


### PR DESCRIPTION
Logs the reason that keepalive (/timeout) failures happen

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds warning/error logs around existing keep-alive failure paths without changing control flow, but may increase log volume and include additional identifiers in logs.
> 
> **Overview**
> Adds structured warning/error logging in `KeepAliveFor` to record why `/timeout` keep-alive requests fail (sandbox not running, missing in store, max instance length exceeded, missing on node, or generic update errors), including relevant IDs and state for easier debugging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f70a09dadbec5ded590084d2b6aa1c4f8490828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->