### PR TITLE
chore(clickhouse): decrease TTL for internal logs

### DIFF
--- a/iac/modules/job-clickhouse/configs/config.xml
+++ b/iac/modules/job-clickhouse/configs/config.xml
@@ -75,10 +75,6 @@
 
     <processors_profile_log remove="1"/>
 
-    <asynchronous_metric_log>
-        <ttl>event_date + INTERVAL 1 DAY</ttl>
-    </asynchronous_metric_log>
-
     <part_log>
         <ttl>event_date + INTERVAL 1 DAY</ttl>
     </part_log>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk infra config change, but it may reduce observability by retaining internal diagnostic logs for only 1 day and disabling `trace_log`/`processors_profile_log`.
> 
> **Overview**
> Reduces ClickHouse internal log retention from 7 days to 1 day for most system logs, adds a 1-day TTL for `query_views_log`, and disables `trace_log` and `processors_profile_log` via `remove="1"` in the ClickHouse config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b770b50b48e78be6b844ec9ba53b81957d06e08e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->