### PR TITLE
move logging middleware before auth check

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -130,6 +130,30 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 	}
 	r.Use(cors.New(corsConfig))
 
+	r.Use(sharedmiddleware.LoggingMiddleware(l, sharedmiddleware.Config{
+		TimeFormat:   time.RFC3339Nano,
+		UTC:          true,
+		DefaultLevel: zap.InfoLevel,
+		Skipper: func(c *gin.Context) bool {
+			switch c.FullPath() {
+			case "/health",
+				"/sandboxes/:sandboxID/refreshes",
+				"/templates/:templateID/builds/:buildID/logs",
+				"/templates/:templateID/builds/:buildID/status":
+				return true
+			}
+
+			return false
+		},
+		Context: func(c *gin.Context) []zapcore.Field {
+			if teamInfo, ok := auth.GetTeamInfo(c); ok {
+				return []zapcore.Field{logger.WithTeamID(teamInfo.ID.String())}
+			}
+
+			return nil
+		},
+	}))
+
 	// Create a team API Key auth validator
 	AuthenticationFunc := auth.CreateAuthenticationFunc(
 		[]auth.Authenticator{
@@ -163,32 +187,6 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 	)
 
 	r.Use(customMiddleware.InitLaunchDarklyContext)
-
-	// Request logging must be executed after authorization (if required) is done,
-	// so that we can log team ID.
-	r.Use(sharedmiddleware.LoggingMiddleware(l, sharedmiddleware.Config{
-		TimeFormat:   time.RFC3339Nano,
-		UTC:          true,
-		DefaultLevel: zap.InfoLevel,
-		Skipper: func(c *gin.Context) bool {
-			switch c.FullPath() {
-			case "/health",
-				"/sandboxes/:sandboxID/refreshes",
-				"/templates/:templateID/builds/:buildID/logs",
-				"/templates/:templateID/builds/:buildID/status":
-				return true
-			}
-
-			return false
-		},
-		Context: func(c *gin.Context) []zapcore.Field {
-			if teamInfo, ok := auth.GetTeamInfo(c); ok {
-				return []zapcore.Field{logger.WithTeamID(teamInfo.ID.String())}
-			}
-
-			return nil
-		},
-	}))
 
 	// We now register our store above as the handler for the interface
 	api.RegisterHandlersWithOptions(r, apiStore, api.GinServerOptions{


### PR DESCRIPTION
moves the logging middleware before auth, allowing us to capture request logs when the authentication fails.

it was moved down in https://github.com/e2b-dev/infra/commit/13a41c8d54fd8e86e748cf4e929a474161b00657 to get team id into the request logs, but current behavior just adds it anyway (we log after c.next() returns) so moving it back up still gets us team.id and the request logs


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk reorder of Gin middleware; main impact is increased logging coverage for rejected/unauthorized requests, with a small chance of changing log volume or missing `team_id` when auth fails early.
> 
> **Overview**
> Moves `sharedmiddleware.LoggingMiddleware` to run before the OpenAPI request validator/authentication middleware so requests that fail auth/validation (and previously short-circuited the chain) are still captured in logs, while keeping the same skip routes and optional `team_id` context when available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9fcdc0b35c43fe2a41ccdaf6e4448c44b15c65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->