### PR TITLE
feat(aws): add SSM agent for remote shell access to cluster nodes

### DIFF
--- a/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
@@ -159,6 +159,14 @@ build {
     ]
   }
 
+  // Install SSM Agent for remote shell access
+  provisioner "shell" {
+    inline = [
+      "sudo snap install amazon-ssm-agent --classic",
+      "sudo systemctl enable snap.amazon-ssm-agent.amazon-ssm-agent.service",
+    ]
+  }
+
   provisioner "shell" {
     inline = [
       # Increase the maximum number of open files

--- a/iac/provider-aws/nomad-cluster/main.tf
+++ b/iac/provider-aws/nomad-cluster/main.tf
@@ -170,6 +170,19 @@ data "aws_iam_policy_document" "cluster_node_policy" {
     ]
     resources = ["*"]
   }
+
+  // SSM Session Manager for remote shell access
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel",
+      "ssm:UpdateInstanceInformation",
+    ]
+    resources = ["*"]
+  }
 }
 
 data "aws_iam_policy_document" "cluster_node_ec2_policy" {


### PR DESCRIPTION
## Summary

- AWS cluster nodes have no public IPs and no SSH keys, making debugging impossible without a bastion host
- Adds AWS SSM Session Manager support so operators can connect with `aws ssm start-session --target <instance-id>`
- **Packer AMI**: installs `amazon-ssm-agent` via snap
- **IAM policy**: grants `ssmmessages:*` + `ssm:UpdateInstanceInformation` to the shared cluster node policy

## Test plan

- [ ] Build new AMI with `make build` in `iac/provider-aws/nomad-cluster-disk-image`
- [ ] Apply IAM changes with `make plan-without-jobs && make apply`
- [ ] Cycle instances (terminate, let ASG replace)
- [ ] Verify `aws ssm start-session --target <instance-id>` connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)