### PR TITLE
fix(db): backport fix for snapshot metadata null

### DIFF
--- a/packages/db/migrations/20260312120000_fix_snapshots_jsonb_null_metadata.sql
+++ b/packages/db/migrations/20260312120000_fix_snapshots_jsonb_null_metadata.sql
@@ -39,7 +39,7 @@ DROP PROCEDURE fix_snapshots_jsonb_null_metadata();
 CREATE OR REPLACE FUNCTION fix_snapshots_metadata_json_null()
 RETURNS trigger AS $$
 BEGIN
-  IF NEW.metadata = 'null'::jsonb THEN
+  IF NEW.metadata IS NULL OR NEW.metadata = 'null'::jsonb THEN
     NEW.metadata := '{}'::jsonb;
   END IF;
   RETURN NEW;

--- a/packages/db/migrations/20260314120000_fix_snapshots_metadata_sql_null_trigger.sql
+++ b/packages/db/migrations/20260314120000_fix_snapshots_metadata_sql_null_trigger.sql
@@ -22,7 +22,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION fix_snapshots_metadata_json_null()
 RETURNS trigger AS $$
 BEGIN
-  IF NEW.metadata = 'null'::jsonb THEN
+  IF NEW.metadata IS NULL OR NEW.metadata = 'null'::jsonb THEN
     NEW.metadata := '{}'::jsonb;
   END IF;
   RETURN NEW;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes database trigger behavior for all inserts/updates to `snapshots.metadata`, which could mask unexpected NULL writes and affects production write paths. Migration behavior should be validated against any assumptions about distinguishing missing metadata vs empty objects.
> 
> **Overview**
> Updates the `snapshots.metadata` normalizing trigger so it converts both SQL `NULL` and JSONB `'null'` values to `'{}'::jsonb` on insert/update, preventing constraint/query failures from legacy writes and ensuring the rollback migration keeps the same behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0eccfe266ffcc32c22bf564ae1d4d30836efd38a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->