### PR TITLE
chore(otel-collector): add disk metrics

### DIFF
--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -291,6 +291,25 @@ processors:
             new_value: blocked
             aggregation_type: sum
 
+  transform/aggregate_nvme:
+    metric_statements:
+      - context: datapoint
+        statements:
+          - replace_pattern(attributes["device"], "^nvme.*$$", "nvme")
+
+  metricstransform/aggregate_disks:
+    transforms:
+      - include: "system.disk.*"
+        match_type: regexp
+        action: update
+        operations:
+          - action: aggregate_labels
+            label_set:
+              - service.instance.id
+              - device
+              - direction
+              - deployment.environment
+            aggregation_type: sum
 
   resourcedetection:
     # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
@@ -480,6 +499,8 @@ service:
         - resourcedetection
         - transform/set-name
         - metricstransform/single_cpu
+        - transform/aggregate_nvme
+        - metricstransform/aggregate_disks
         - batch
       exporters:
         - otlp_http/grafana_cloud


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes telemetry collection/processing and adds new disk metrics, which can increase ingest volume/cost or alter dashboards/alerts if aggregation is incorrect.
> 
> **Overview**
> This updates the `otel-collector.yaml` host metrics pipeline to start collecting `system.disk.*` I/O metrics for `sd*` and `nvme*` devices, and adds processors to normalize NVMe device names and aggregate disk datapoints by a reduced label set to limit cardinality before exporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e84c9a2d3d51d91823bc64c9e42f62237e6f86e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->