### PR TITLE
fix(db): prevent race condition in snapshots metadata migration

### DIFF
--- a/packages/db/migrations/20260310120000_add_snapshots_metadata_gin_index.sql
+++ b/packages/db/migrations/20260310120000_add_snapshots_metadata_gin_index.sql
@@ -4,6 +4,26 @@
 -- Set default first so new rows never get NULL metadata while backfill runs.
 ALTER TABLE public.snapshots ALTER COLUMN metadata SET DEFAULT '{}'::jsonb;
 
+-- Install a trigger that converts SQL NULL and JSON 'null' to '{}' on insert/update,
+-- so concurrent writes during the backfill can't re-introduce NULLs.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION fix_snapshots_metadata_json_null()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.metadata IS NULL OR NEW.metadata = 'null'::jsonb THEN
+    NEW.metadata := '{}'::jsonb;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS trg_snapshots_fix_json_null_metadata ON public.snapshots;
+CREATE TRIGGER trg_snapshots_fix_json_null_metadata
+  BEFORE INSERT OR UPDATE OF metadata ON public.snapshots
+  FOR EACH ROW
+  EXECUTE FUNCTION fix_snapshots_metadata_json_null();
+
 -- Backfill NULL metadata to empty jsonb in batches.
 -- Each iteration picks an arbitrary batch of NULLs (no ordering on random UUIDs).
 -- +goose StatementBegin
@@ -48,3 +68,6 @@ DROP INDEX CONCURRENTLY IF EXISTS idx_snapshots_team_metadata_gin;
 
 ALTER TABLE public.snapshots ALTER COLUMN metadata DROP NOT NULL;
 ALTER TABLE public.snapshots ALTER COLUMN metadata DROP DEFAULT;
+
+DROP TRIGGER IF EXISTS trg_snapshots_fix_json_null_metadata ON public.snapshots;
+DROP FUNCTION IF EXISTS fix_snapshots_metadata_json_null();


### PR DESCRIPTION
## Summary
- Migration `20260310120000` failed with `SQLSTATE 23502` because concurrent INSERTs with explicit `NULL` metadata slipped in between the backfill completing and `SET NOT NULL` being applied.
- Adds a `BEFORE INSERT OR UPDATE` trigger **before** the backfill that converts SQL NULL and JSON `'null'` to `'{}'::jsonb`, closing the race window entirely.
- The trigger is the same one created in later migrations (`20260312120000`, `20260314120000`), which will be no-ops since they use `CREATE OR REPLACE` / `DROP TRIGGER IF EXISTS`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a production database migration by adding a write-path trigger and new objects, which could affect insert/update behavior on `public.snapshots` and must be validated under load and with existing application write patterns.
> 
> **Overview**
> Updates the `20260310120000` snapshots metadata migration to prevent concurrent writes from reintroducing `NULL`/JSON `null` during the backfill by adding a `BEFORE INSERT OR UPDATE` trigger that coerces those values to `'{}'::jsonb` before applying `SET NOT NULL`, and ensures the new trigger/function are removed on rollback while keeping the concurrent GIN index creation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e04d5dd6457a2be3faa23617d859e4bbf0f275b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->