### PR TITLE
chore: rename feature-flags package to featureflags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ Client → Client-Proxy → API (REST) ⟷ PostgreSQL
 - Database: `pkg/db/` (ent ORM)
 - Models: `pkg/models/`
 - Storage: `pkg/storage/` (GCS/S3 clients)
-- Feature flags: `pkg/feature-flags/` (LaunchDarkly)
+- Feature flags: `pkg/featureflags/` (LaunchDarkly)
 
 **Database (`packages/db/`)** - PostgreSQL layer
 - Migrations: `migrations/*.sql` (goose)

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -12,7 +12,7 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/golang-jwt/jwt/v5"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 const (

--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -16,7 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/templates"

--- a/packages/api/internal/handlers/deprecated_template_start_build.go
+++ b/packages/api/internal/handlers/deprecated_template_start_build.go
@@ -19,7 +19,7 @@ import (
 	dbtypes "github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	apiutils "github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/templates"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"

--- a/packages/api/internal/handlers/mocks/mockfeatureflagsclient.go
+++ b/packages/api/internal/handlers/mocks/mockfeatureflagsclient.go
@@ -7,7 +7,7 @@ package handlersmocks
 import (
 	"context"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -40,7 +40,7 @@ func (_m *MockFeatureFlagsClient) EXPECT() *MockFeatureFlagsClient_Expecter {
 }
 
 // BoolFlag provides a mock function for the type MockFeatureFlagsClient
-func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flagName feature_flags.BoolFlag, contexts ...ldcontext.Context) bool {
+func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flagName featureflags.BoolFlag, contexts ...ldcontext.Context) bool {
 	var tmpRet mock.Arguments
 	if len(contexts) > 0 {
 		tmpRet = _mock.Called(ctx, flagName, contexts)
@@ -54,7 +54,7 @@ func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flagName feat
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(context.Context, feature_flags.BoolFlag, ...ldcontext.Context) bool); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, featureflags.BoolFlag, ...ldcontext.Context) bool); ok {
 		r0 = returnFunc(ctx, flagName, contexts...)
 	} else {
 		r0 = ret.Get(0).(bool)
@@ -69,22 +69,22 @@ type MockFeatureFlagsClient_BoolFlag_Call struct {
 
 // BoolFlag is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flagName feature_flags.BoolFlag
+//   - flagName featureflags.BoolFlag
 //   - contexts ...ldcontext.Context
 func (_e *MockFeatureFlagsClient_Expecter) BoolFlag(ctx interface{}, flagName interface{}, contexts ...interface{}) *MockFeatureFlagsClient_BoolFlag_Call {
 	return &MockFeatureFlagsClient_BoolFlag_Call{Call: _e.mock.On("BoolFlag",
 		append([]interface{}{ctx, flagName}, contexts...)...)}
 }
 
-func (_c *MockFeatureFlagsClient_BoolFlag_Call) Run(run func(ctx context.Context, flagName feature_flags.BoolFlag, contexts ...ldcontext.Context)) *MockFeatureFlagsClient_BoolFlag_Call {
+func (_c *MockFeatureFlagsClient_BoolFlag_Call) Run(run func(ctx context.Context, flagName featureflags.BoolFlag, contexts ...ldcontext.Context)) *MockFeatureFlagsClient_BoolFlag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 feature_flags.BoolFlag
+		var arg1 featureflags.BoolFlag
 		if args[1] != nil {
-			arg1 = args[1].(feature_flags.BoolFlag)
+			arg1 = args[1].(featureflags.BoolFlag)
 		}
 		var arg2 []ldcontext.Context
 		var variadicArgs []ldcontext.Context
@@ -106,7 +106,7 @@ func (_c *MockFeatureFlagsClient_BoolFlag_Call) Return(b bool) *MockFeatureFlags
 	return _c
 }
 
-func (_c *MockFeatureFlagsClient_BoolFlag_Call) RunAndReturn(run func(ctx context.Context, flagName feature_flags.BoolFlag, contexts ...ldcontext.Context) bool) *MockFeatureFlagsClient_BoolFlag_Call {
+func (_c *MockFeatureFlagsClient_BoolFlag_Call) RunAndReturn(run func(ctx context.Context, flagName featureflags.BoolFlag, contexts ...ldcontext.Context) bool) *MockFeatureFlagsClient_BoolFlag_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -28,7 +28,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"

--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )

--- a/packages/api/internal/handlers/sandboxes_list_metrics.go
+++ b/packages/api/internal/handlers/sandboxes_list_metrics.go
@@ -15,7 +15,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -32,7 +32,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/pool"
 	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/factories"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs/loki"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"

--- a/packages/api/internal/handlers/team_metrics.go
+++ b/packages/api/internal/handlers/team_metrics.go
@@ -10,7 +10,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	clickhouseUtils "github.com/e2b-dev/infra/packages/clickhouse/pkg/utils"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )

--- a/packages/api/internal/handlers/team_metrics_max.go
+++ b/packages/api/internal/handlers/team_metrics_max.go
@@ -12,7 +12,7 @@ import (
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	clickhouseUtils "github.com/e2b-dev/infra/packages/clickhouse/pkg/utils"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -13,7 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/template"
 	apiutils "github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/templates"

--- a/packages/api/internal/handlers/template_start_build_v2.go
+++ b/packages/api/internal/handlers/template_start_build_v2.go
@@ -18,7 +18,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/templates"

--- a/packages/api/internal/handlers/volume_create.go
+++ b/packages/api/internal/handlers/volume_create.go
@@ -16,7 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	clustershared "github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	feature_flags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -37,7 +37,7 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 		telemetry.WithTeamID(team.ID.String()),
 	)
 
-	if !a.featureFlags.BoolFlag(ctx, feature_flags.PersistentVolumesFlag) {
+	if !a.featureFlags.BoolFlag(ctx, featureflags.PersistentVolumesFlag) {
 		a.sendAPIStoreError(c, http.StatusForbidden, "use of volumes is not enabled")
 
 		return
@@ -63,7 +63,7 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 		return
 	}
 
-	ctx = feature_flags.AddToContext(ctx, feature_flags.VolumeContext(body.Name))
+	ctx = featureflags.AddToContext(ctx, featureflags.VolumeContext(body.Name))
 
 	volumeType := a.getVolumeType(ctx)
 	if volumeType == "" {
@@ -158,7 +158,7 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 }
 
 func (a *APIStore) getVolumeType(ctx context.Context) string {
-	volumeType := a.featureFlags.StringFlag(ctx, feature_flags.DefaultPersistentVolumeType)
+	volumeType := a.featureFlags.StringFlag(ctx, featureflags.DefaultPersistentVolumeType)
 	if volumeType == "" {
 		volumeType = a.config.DefaultPersistentVolumeType
 	}

--- a/packages/api/internal/middleware/launchdarkly.go
+++ b/packages/api/internal/middleware/launchdarkly.go
@@ -5,7 +5,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 func InitLaunchDarklyContext(c *gin.Context) {

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -22,7 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
-	feature_flags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
@@ -169,7 +169,7 @@ func (o *Orchestrator) CreateSandbox(
 	}
 
 	hasHugePages := fcSemver.HasHugePages()
-	firecrackerVersion := feature_flags.ResolveFirecrackerVersion(ctx, o.featureFlagsClient, build.FirecrackerVersion)
+	firecrackerVersion := featureflags.ResolveFirecrackerVersion(ctx, o.featureFlagsClient, build.FirecrackerVersion)
 	telemetry.ReportEvent(ctx, "Got FC info")
 
 	var sbxDomain *string
@@ -256,7 +256,7 @@ func (o *Orchestrator) CreateSandbox(
 	nodeClusterID := clusters.WithClusterFallback(team.ClusterID)
 	clusterNodes := o.GetClusterNodes(nodeClusterID)
 
-	labelFilteringEnabled := o.featureFlagsClient.BoolFlag(ctx, feature_flags.SandboxLabelBasedSchedulingFlag, feature_flags.TeamContext(team.ID.String()), feature_flags.SandboxContext(sandboxID))
+	labelFilteringEnabled := o.featureFlagsClient.BoolFlag(ctx, featureflags.SandboxLabelBasedSchedulingFlag, featureflags.TeamContext(team.ID.String()), featureflags.SandboxContext(sandboxID))
 
 	node, err = placement.PlaceSandbox(ctx, o.placementAlgorithm, clusterNodes, node, sbxRequest, builds.ToMachineInfo(build), labelFilteringEnabled, team.SandboxSchedulingLabels)
 	if err != nil {

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -27,7 +27,7 @@ import (
 	redisbackend "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	e2bcatalog "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-catalog"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"

--- a/packages/api/internal/template-manager/template_manager.go
+++ b/packages/api/internal/template-manager/template_manager.go
@@ -18,7 +18,7 @@ import (
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	clustersshared "github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	templatemanagergrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/machineinfo"

--- a/packages/clickhouse/pkg/events/delivery.go
+++ b/packages/clickhouse/pkg/events/delivery.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/clickhouse/pkg/batcher"
 	"github.com/e2b-dev/infra/packages/shared/pkg/events"
-	flags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -47,12 +47,12 @@ type ClickhouseDelivery struct {
 	conn    driver.Conn
 }
 
-func NewDefaultClickhouseSandboxEventsDelivery(ctx context.Context, conn driver.Conn, featureFlags *flags.Client) (*ClickhouseDelivery, error) {
-	maxBatchSize := featureFlags.IntFlag(ctx, flags.ClickhouseBatcherMaxBatchSize)
+func NewDefaultClickhouseSandboxEventsDelivery(ctx context.Context, conn driver.Conn, featureFlags *featureflags.Client) (*ClickhouseDelivery, error) {
+	maxBatchSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherMaxBatchSize)
 
-	maxDelay := time.Duration(featureFlags.IntFlag(ctx, flags.ClickhouseBatcherMaxDelay)) * time.Millisecond
+	maxDelay := time.Duration(featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherMaxDelay)) * time.Millisecond
 
-	batcherQueueSize := featureFlags.IntFlag(ctx, flags.ClickhouseBatcherQueueSize, flags.SandboxContext("clickhouse-batcher"))
+	batcherQueueSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherQueueSize, featureflags.SandboxContext("clickhouse-batcher"))
 
 	return NewClickhouseSandboxEventsDelivery(
 		ctx, conn, batcher.BatcherOptions{

--- a/packages/clickhouse/pkg/hoststats/delivery.go
+++ b/packages/clickhouse/pkg/hoststats/delivery.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/clickhouse/pkg/batcher"
-	flags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -44,11 +44,11 @@ type ClickhouseDelivery struct {
 func NewDefaultClickhouseHostStatsDelivery(
 	ctx context.Context,
 	conn driver.Conn,
-	featureFlags *flags.Client,
+	featureFlags *featureflags.Client,
 ) (*ClickhouseDelivery, error) {
-	maxBatchSize := featureFlags.IntFlag(ctx, flags.ClickhouseBatcherMaxBatchSize)
-	maxDelay := time.Duration(featureFlags.IntFlag(ctx, flags.ClickhouseBatcherMaxDelay)) * time.Millisecond
-	batcherQueueSize := featureFlags.IntFlag(ctx, flags.ClickhouseBatcherQueueSize)
+	maxBatchSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherMaxBatchSize)
+	maxDelay := time.Duration(featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherMaxDelay)) * time.Millisecond
+	batcherQueueSize := featureFlags.IntFlag(ctx, featureflags.ClickhouseBatcherQueueSize)
 
 	return NewClickhouseHostStatsDelivery(
 		ctx, conn, batcher.BatcherOptions{

--- a/packages/client-proxy/internal/proxy/proxy.go
+++ b/packages/client-proxy/internal/proxy/proxy.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	proxygrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"

--- a/packages/client-proxy/internal/proxy/proxy_test.go
+++ b/packages/client-proxy/internal/proxy/proxy_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
 	catalog "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-catalog"
 )

--- a/packages/client-proxy/main.go
+++ b/packages/client-proxy/main.go
@@ -24,7 +24,7 @@ import (
 	e2bproxy "github.com/e2b-dev/infra/packages/proxy/internal/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/factories"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	e2bcatalog "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-catalog"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"

--- a/packages/orchestrator/benchmark_test.go
+++ b/packages/orchestrator/benchmark_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"

--- a/packages/orchestrator/cmd/clean-nfs-cache/main.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/main.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/cmd/clean-nfs-cache/cleaner"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/metrics"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"

--- a/packages/orchestrator/cmd/mount-build-rootfs/main.go
+++ b/packages/orchestrator/cmd/mount-build-rootfs/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/cmd/internal/cmdutil"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd/testutils"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -35,7 +35,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/core/rootfs"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/envd/process"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/envd/process/processconnect"

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/metrics"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"

--- a/packages/orchestrator/internal/proxy/proxy.go
+++ b/packages/orchestrator/internal/proxy/proxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/connlimit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	reverseproxy "github.com/e2b-dev/infra/packages/shared/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/pool"

--- a/packages/orchestrator/internal/sandbox/block/chunk.go
+++ b/packages/orchestrator/internal/sandbox/block/chunk.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block/metrics"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"

--- a/packages/orchestrator/internal/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/internal/sandbox/block/streaming_chunk.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block/metrics"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )

--- a/packages/orchestrator/internal/sandbox/build/cache.go
+++ b/packages/orchestrator/internal/sandbox/build/cache.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/cfg"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/orchestrator/internal/sandbox/build/cache_test.go
+++ b/packages/orchestrator/internal/sandbox/build/cache_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/cfg"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 const (

--- a/packages/orchestrator/internal/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/internal/sandbox/build/storage_diff.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	blockmetrics "github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block/metrics"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )

--- a/packages/orchestrator/internal/sandbox/nbd/path_direct_test.go
+++ b/packages/orchestrator/internal/sandbox/nbd/path_direct_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd/testutils"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 

--- a/packages/orchestrator/internal/sandbox/nbd/testutils/nbd_device.go
+++ b/packages/orchestrator/internal/sandbox/nbd/testutils/nbd_device.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
-	feature_flags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
-func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *feature_flags.Client) (nbd.DevicePath, *Cleaner, error) {
+func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *featureflags.Client) (nbd.DevicePath, *Cleaner, error) {
 	var cleaner Cleaner
 
 	devicePool, err := nbd.NewDevicePool()

--- a/packages/orchestrator/internal/sandbox/nbd/testutils/template_rootfs.go
+++ b/packages/orchestrator/internal/sandbox/nbd/testutils/template_rootfs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/cfg"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block/metrics"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/build"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )

--- a/packages/orchestrator/internal/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/internal/sandbox/rootfs/nbd.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/nbd"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"

--- a/packages/orchestrator/internal/sandbox/sandbox.go
+++ b/packages/orchestrator/internal/sandbox/sandbox.go
@@ -31,7 +31,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/uffd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/uffd/prefetch"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"

--- a/packages/orchestrator/internal/sandbox/template/cache.go
+++ b/packages/orchestrator/internal/sandbox/template/cache.go
@@ -19,7 +19,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template/peerclient"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"

--- a/packages/orchestrator/internal/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/internal/sandbox/uffd/prefetch/prefetcher.go
@@ -12,7 +12,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/uffd"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"

--- a/packages/orchestrator/internal/server/main.go
+++ b/packages/orchestrator/internal/server/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/template/peerclient"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/service"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"

--- a/packages/orchestrator/internal/server/sandboxes.go
+++ b/packages/orchestrator/internal/server/sandboxes.go
@@ -25,7 +25,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/fc"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
 	"github.com/e2b-dev/infra/packages/shared/pkg/events"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"

--- a/packages/orchestrator/internal/tcpfirewall/proxy.go
+++ b/packages/orchestrator/internal/tcpfirewall/proxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/sandbox/network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/connlimit"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -34,7 +34,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"

--- a/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/internal/template/build/core/rootfs/rootfs.go
@@ -23,7 +23,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"

--- a/packages/orchestrator/internal/template/build/phases/base/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/base/builder.go
@@ -30,7 +30,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"

--- a/packages/orchestrator/internal/template/build/phases/base/files.go
+++ b/packages/orchestrator/internal/template/build/phases/base/files.go
@@ -16,7 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/constants"
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/orchestrator/internal/template/build/phases/base/hash.go
+++ b/packages/orchestrator/internal/template/build/phases/base/hash.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/phases"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/storage/cache"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 

--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -23,7 +23,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/sandboxtools"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/storage/cache"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/templates"

--- a/packages/orchestrator/internal/template/server/main.go
+++ b/packages/orchestrator/internal/template/server/main.go
@@ -21,7 +21,7 @@ import (
 	artifactsregistry "github.com/e2b-dev/infra/packages/shared/pkg/artifacts-registry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/dockerhub"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -52,7 +52,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	event "github.com/e2b-dev/infra/packages/shared/pkg/events"
 	sharedFactories "github.com/e2b-dev/infra/packages/shared/pkg/factories"
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	e2bgrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	orchestratorinfo "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"

--- a/packages/shared/pkg/featureflags/client.go
+++ b/packages/shared/pkg/featureflags/client.go
@@ -1,4 +1,4 @@
-package feature_flags
+package featureflags
 
 import (
 	"context"

--- a/packages/shared/pkg/featureflags/client_test.go
+++ b/packages/shared/pkg/featureflags/client_test.go
@@ -1,4 +1,4 @@
-package feature_flags
+package featureflags
 
 import (
 	"testing"

--- a/packages/shared/pkg/featureflags/context.go
+++ b/packages/shared/pkg/featureflags/context.go
@@ -1,4 +1,4 @@
-package feature_flags
+package featureflags
 
 import (
 	"context"

--- a/packages/shared/pkg/featureflags/context_test.go
+++ b/packages/shared/pkg/featureflags/context_test.go
@@ -1,4 +1,4 @@
-package feature_flags
+package featureflags
 
 import (
 	"context"

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -1,4 +1,4 @@
-package feature_flags
+package featureflags
 
 import (
 	"context"

--- a/packages/shared/pkg/limit/gcloud.go
+++ b/packages/shared/pkg/limit/gcloud.go
@@ -3,7 +3,7 @@ package limit
 import (
 	"context"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 

--- a/packages/shared/pkg/limit/limiter.go
+++ b/packages/shared/pkg/limit/limiter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 

--- a/packages/shared/pkg/limit/upload.go
+++ b/packages/shared/pkg/limit/upload.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/shared/pkg/sandbox-catalog/catalog_redis.go
+++ b/packages/shared/pkg/sandbox-catalog/catalog_redis.go
@@ -11,7 +11,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/shared/pkg/sandbox-catalog/catalog_redis_test.go
+++ b/packages/shared/pkg/sandbox-catalog/catalog_redis_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 

--- a/packages/shared/pkg/storage/mocks/mockfeatureflagsclient.go
+++ b/packages/shared/pkg/storage/mocks/mockfeatureflagsclient.go
@@ -7,7 +7,7 @@ package storagemocks
 import (
 	"context"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -40,7 +40,7 @@ func (_m *MockFeatureFlagsClient) EXPECT() *MockFeatureFlagsClient_Expecter {
 }
 
 // BoolFlag provides a mock function for the type MockFeatureFlagsClient
-func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flag feature_flags.BoolFlag, ldctx ...ldcontext.Context) bool {
+func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flag featureflags.BoolFlag, ldctx ...ldcontext.Context) bool {
 	var tmpRet mock.Arguments
 	if len(ldctx) > 0 {
 		tmpRet = _mock.Called(ctx, flag, ldctx)
@@ -54,7 +54,7 @@ func (_mock *MockFeatureFlagsClient) BoolFlag(ctx context.Context, flag feature_
 	}
 
 	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(context.Context, feature_flags.BoolFlag, ...ldcontext.Context) bool); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, featureflags.BoolFlag, ...ldcontext.Context) bool); ok {
 		r0 = returnFunc(ctx, flag, ldctx...)
 	} else {
 		r0 = ret.Get(0).(bool)
@@ -69,22 +69,22 @@ type MockFeatureFlagsClient_BoolFlag_Call struct {
 
 // BoolFlag is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flag feature_flags.BoolFlag
+//   - flag featureflags.BoolFlag
 //   - ldctx ...ldcontext.Context
 func (_e *MockFeatureFlagsClient_Expecter) BoolFlag(ctx interface{}, flag interface{}, ldctx ...interface{}) *MockFeatureFlagsClient_BoolFlag_Call {
 	return &MockFeatureFlagsClient_BoolFlag_Call{Call: _e.mock.On("BoolFlag",
 		append([]interface{}{ctx, flag}, ldctx...)...)}
 }
 
-func (_c *MockFeatureFlagsClient_BoolFlag_Call) Run(run func(ctx context.Context, flag feature_flags.BoolFlag, ldctx ...ldcontext.Context)) *MockFeatureFlagsClient_BoolFlag_Call {
+func (_c *MockFeatureFlagsClient_BoolFlag_Call) Run(run func(ctx context.Context, flag featureflags.BoolFlag, ldctx ...ldcontext.Context)) *MockFeatureFlagsClient_BoolFlag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 feature_flags.BoolFlag
+		var arg1 featureflags.BoolFlag
 		if args[1] != nil {
-			arg1 = args[1].(feature_flags.BoolFlag)
+			arg1 = args[1].(featureflags.BoolFlag)
 		}
 		var arg2 []ldcontext.Context
 		var variadicArgs []ldcontext.Context
@@ -106,13 +106,13 @@ func (_c *MockFeatureFlagsClient_BoolFlag_Call) Return(b bool) *MockFeatureFlags
 	return _c
 }
 
-func (_c *MockFeatureFlagsClient_BoolFlag_Call) RunAndReturn(run func(ctx context.Context, flag feature_flags.BoolFlag, ldctx ...ldcontext.Context) bool) *MockFeatureFlagsClient_BoolFlag_Call {
+func (_c *MockFeatureFlagsClient_BoolFlag_Call) RunAndReturn(run func(ctx context.Context, flag featureflags.BoolFlag, ldctx ...ldcontext.Context) bool) *MockFeatureFlagsClient_BoolFlag_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // IntFlag provides a mock function for the type MockFeatureFlagsClient
-func (_mock *MockFeatureFlagsClient) IntFlag(ctx context.Context, flag feature_flags.IntFlag, ldctx ...ldcontext.Context) int {
+func (_mock *MockFeatureFlagsClient) IntFlag(ctx context.Context, flag featureflags.IntFlag, ldctx ...ldcontext.Context) int {
 	var tmpRet mock.Arguments
 	if len(ldctx) > 0 {
 		tmpRet = _mock.Called(ctx, flag, ldctx)
@@ -126,7 +126,7 @@ func (_mock *MockFeatureFlagsClient) IntFlag(ctx context.Context, flag feature_f
 	}
 
 	var r0 int
-	if returnFunc, ok := ret.Get(0).(func(context.Context, feature_flags.IntFlag, ...ldcontext.Context) int); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, featureflags.IntFlag, ...ldcontext.Context) int); ok {
 		r0 = returnFunc(ctx, flag, ldctx...)
 	} else {
 		r0 = ret.Get(0).(int)
@@ -141,22 +141,22 @@ type MockFeatureFlagsClient_IntFlag_Call struct {
 
 // IntFlag is a helper method to define mock.On call
 //   - ctx context.Context
-//   - flag feature_flags.IntFlag
+//   - flag featureflags.IntFlag
 //   - ldctx ...ldcontext.Context
 func (_e *MockFeatureFlagsClient_Expecter) IntFlag(ctx interface{}, flag interface{}, ldctx ...interface{}) *MockFeatureFlagsClient_IntFlag_Call {
 	return &MockFeatureFlagsClient_IntFlag_Call{Call: _e.mock.On("IntFlag",
 		append([]interface{}{ctx, flag}, ldctx...)...)}
 }
 
-func (_c *MockFeatureFlagsClient_IntFlag_Call) Run(run func(ctx context.Context, flag feature_flags.IntFlag, ldctx ...ldcontext.Context)) *MockFeatureFlagsClient_IntFlag_Call {
+func (_c *MockFeatureFlagsClient_IntFlag_Call) Run(run func(ctx context.Context, flag featureflags.IntFlag, ldctx ...ldcontext.Context)) *MockFeatureFlagsClient_IntFlag_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 feature_flags.IntFlag
+		var arg1 featureflags.IntFlag
 		if args[1] != nil {
-			arg1 = args[1].(feature_flags.IntFlag)
+			arg1 = args[1].(featureflags.IntFlag)
 		}
 		var arg2 []ldcontext.Context
 		var variadicArgs []ldcontext.Context
@@ -178,7 +178,7 @@ func (_c *MockFeatureFlagsClient_IntFlag_Call) Return(n int) *MockFeatureFlagsCl
 	return _c
 }
 
-func (_c *MockFeatureFlagsClient_IntFlag_Call) RunAndReturn(run func(ctx context.Context, flag feature_flags.IntFlag, ldctx ...ldcontext.Context) int) *MockFeatureFlagsClient_IntFlag_Call {
+func (_c *MockFeatureFlagsClient_IntFlag_Call) RunAndReturn(run func(ctx context.Context, flag featureflags.IntFlag, ldctx ...ldcontext.Context) int) *MockFeatureFlagsClient_IntFlag_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/shared/pkg/storage/storage_cache.go
+++ b/packages/shared/pkg/storage/storage_cache.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 

--- a/packages/shared/pkg/storage/storage_cache_blob.go
+++ b/packages/shared/pkg/storage/storage_cache_blob.go
@@ -10,7 +10,7 @@ import (
 
 	"go.opentelemetry.io/otel/trace"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/lock"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
-	featureflags "github.com/e2b-dev/infra/packages/shared/pkg/feature-flags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/lock"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"


### PR DESCRIPTION
Rename the `shared/pkg/feature-flags` directory to `featureflags` so the Go package name matches the import alias used by nearly every consumer. This eliminates the need for import aliases across 62 files and unifies the inconsistent `feature_flags` / `featureflags` / `flags` aliases into a single canonical name.

This is a purely mechanical rename with no behavioral changes. All packages build successfully and tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical rename of a shared package and import paths; main risk is build breakage if any references were missed or downstream modules pin the old path.
> 
> **Overview**
> Renames the shared LaunchDarkly feature flags code so the directory/package name matches the canonical `featureflags` import, updating references across services, tests, and generated mocks to remove inconsistent aliases and use the unified package name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8baab5560643721ea0b4eddb3c1539d4de751fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->