### PR TITLE
Add GCP provider config to orchestrator job module

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -98,6 +98,10 @@ job "orchestrator-${latest_orchestrator_job_id}" {
 %{ if provider == "gcp" }
         ARTIFACTS_REGISTRY_PROVIDER  = "GCP_ARTIFACTS"
         STORAGE_PROVIDER             = "GCPBucket"
+
+        %{ if provider_gcp_config.service_account_key != "" }
+        GOOGLE_SERVICE_ACCOUNT_BASE64 = "${provider_gcp_config.service_account_key}"
+        %{ endif }
 %{ endif }
 %{ if provider == "aws" }
         ARTIFACTS_REGISTRY_PROVIDER  = "AWS_ECR"

--- a/iac/modules/job-orchestrator/main.tf
+++ b/iac/modules/job-orchestrator/main.tf
@@ -26,6 +26,7 @@ locals {
 
     provider            = var.provider_name
     provider_aws_config = var.provider_aws_config
+    provider_gcp_config = var.provider_gcp_config
 
     artifact_source = var.artifact_source
 

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -19,6 +19,15 @@ variable "provider_aws_config" {
   }
 }
 
+variable "provider_gcp_config" {
+  type = object({
+    service_account_key = string
+  })
+  default = {
+    service_account_key = ""
+  }
+}
+
 variable "node_pool" {
   type = string
 }


### PR DESCRIPTION
Pass GCP service account key to the orchestrator job environment via provider_gcp_config variable. This allows the orchestrator to authenticate with GCP services, enabling the merge of template manager and orchestrators into a unified component.

This allows us to optionally pass the service account secret used for presigned URLs for builds. This is useful for deployments in which the orchestrator and template manager are a single service.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces handling of a GCP service account key as an environment variable, which is security-sensitive and could leak via logs/state or improper variable handling. Behavior is gated on `provider == "gcp"` and a non-empty key, but misconfiguration could still impact deployments.
> 
> **Overview**
> Adds a new `provider_gcp_config` input to the job-orchestrator Terraform module and, when running with the GCP provider and a key is provided, injects it into the Nomad job as `GOOGLE_SERVICE_ACCOUNT_BASE64` so the orchestrator can authenticate with GCP services.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cafa94772cfcea6c7e6125007478778b5bb64c70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->