### PR TITLE
fix(orch): add UserKnownHostsFile=/dev/null to SSH commands in resume-build

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -303,7 +303,7 @@ func (r *runner) interactive(ctx context.Context) error {
 	}
 
 	fmt.Printf("✅ Running (resumed in %s)\n", time.Since(t0))
-	fmt.Printf("   sudo nsenter --net=/var/run/netns/%s ssh -o StrictHostKeyChecking=no root@169.254.0.21\n", sbx.Slot.NamespaceID())
+	fmt.Printf("   sudo nsenter --net=/var/run/netns/%s ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@169.254.0.21\n", sbx.Slot.NamespaceID())
 	fmt.Println("Ctrl+C to stop")
 
 	<-ctx.Done()
@@ -1212,7 +1212,7 @@ func waitForPauseSignal(ctx context.Context, sbx *sandbox.Sandbox, signalName st
 	}
 
 	fmt.Printf("⏳ Waiting for %s signal...\n", signalName)
-	fmt.Printf("   sudo nsenter --net=/var/run/netns/%s ssh -o StrictHostKeyChecking=no root@169.254.0.21\n", sbx.Slot.NamespaceID())
+	fmt.Printf("   sudo nsenter --net=/var/run/netns/%s ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@169.254.0.21\n", sbx.Slot.NamespaceID())
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, sig)


### PR DESCRIPTION
## Summary
- Adds `-o UserKnownHostsFile=/dev/null` to the SSH commands printed by `resume-build` in both the `interactive()` and `waitForPauseSignal()` flows.
- Prevents host key conflicts when connecting to ephemeral VMs that reuse the same IP address (`169.254.0.21`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since it only changes printed SSH instructions, but it encourages bypassing host key verification (via `UserKnownHostsFile=/dev/null` alongside `StrictHostKeyChecking=no`), which increases MITM exposure if used outside the intended ephemeral environment.
> 
> **Overview**
> Updates the `resume-build` CLI’s printed SSH connection hints to add `-o UserKnownHostsFile=/dev/null`, preventing `known_hosts` conflicts when repeatedly connecting to ephemeral sandboxes that reuse the same IP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc686b38846c7a885197d46a3909417703c922fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->