### PR TITLE
fix(api): return 503 -> 408 on timeout, reorder middleware

### DIFF
--- a/packages/api/internal/middleware/timeout.go
+++ b/packages/api/internal/middleware/timeout.go
@@ -15,7 +15,7 @@ import (
 // when the connection pool is saturated.
 //
 // If the deadline is exceeded and the handler has not yet written a response,
-// the middleware responds with 503 Service Unavailable.
+// the middleware responds with 408 Request Timeout.
 //
 // Routes matching any of the excludedRoutes patterns are skipped (useful for
 // health checks and long-polling endpoints).
@@ -34,7 +34,7 @@ func RequestTimeout(timeout time.Duration, excludedRoutes ...string) gin.Handler
 		c.Next()
 
 		if ctx.Err() == context.DeadlineExceeded && !c.Writer.Written() {
-			c.String(http.StatusServiceUnavailable, "request timed out")
+			c.String(http.StatusRequestTimeout, "request timed out")
 			c.Abort()
 		}
 	}

--- a/packages/api/internal/middleware/timeout_test.go
+++ b/packages/api/internal/middleware/timeout_test.go
@@ -35,7 +35,7 @@ func TestRequestTimeout_SetsDeadline(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestRequestTimeout_Returns503WhenHandlerDoesNotWrite(t *testing.T) {
+func TestRequestTimeout_Returns408WhenHandlerDoesNotWrite(t *testing.T) {
 	t.Parallel()
 
 	r := gin.New()
@@ -52,7 +52,7 @@ func TestRequestTimeout_Returns503WhenHandlerDoesNotWrite(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, 500*time.Millisecond, "should have timed out promptly")
-	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Equal(t, http.StatusRequestTimeout, w.Code)
 	assert.Equal(t, "request timed out", w.Body.String())
 }
 

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -88,6 +88,23 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 	r.Use(gin.Recovery())
 
 	r.Use(
+		// We use custom otel gin middleware because we want to log 4xx errors in the otel
+		customMiddleware.ExcludeRoutes(
+			tracingMiddleware.Middleware(tel.TracerProvider, serviceName), //nolint:contextcheck // TODO: fix this later
+			"/health",
+			"/sandboxes/:sandboxID/refreshes",
+			"/templates/:templateID/builds/:buildID/logs",
+			"/templates/:templateID/builds/:buildID/status",
+		),
+		customMiddleware.IncludeRoutes(
+			metricsMiddleware.Middleware(tel.MeterProvider, serviceName), //nolint:contextcheck // TODO: fix this later
+			"/sandboxes",
+			"/sandboxes/:sandboxID",
+			"/sandboxes/:sandboxID/pause",
+			"/sandboxes/:sandboxID/connect",
+			"/sandboxes/:sandboxID/resume",
+			"/sandboxes/:sandboxID/snapshots",
+		),
 		sharedmiddleware.LoggingMiddleware(l, sharedmiddleware.Config{
 			TimeFormat:   time.RFC3339Nano,
 			UTC:          true,
@@ -111,23 +128,6 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 				return nil
 			},
 		}),
-		// We use custom otel gin middleware because we want to log 4xx errors in the otel
-		customMiddleware.ExcludeRoutes(
-			tracingMiddleware.Middleware(tel.TracerProvider, serviceName), //nolint:contextcheck // TODO: fix this later
-			"/health",
-			"/sandboxes/:sandboxID/refreshes",
-			"/templates/:templateID/builds/:buildID/logs",
-			"/templates/:templateID/builds/:buildID/status",
-		),
-		customMiddleware.IncludeRoutes(
-			metricsMiddleware.Middleware(tel.MeterProvider, serviceName), //nolint:contextcheck // TODO: fix this later
-			"/sandboxes",
-			"/sandboxes/:sandboxID",
-			"/sandboxes/:sandboxID/pause",
-			"/sandboxes/:sandboxID/connect",
-			"/sandboxes/:sandboxID/resume",
-			"/sandboxes/:sandboxID/snapshots",
-		),
 		gin.Recovery(),
 		customMiddleware.RequestTimeout(requestTimeout), //nolint:contextcheck // Gin middleware sets context via c.Request.WithContext
 	)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the HTTP status code returned on request deadline expiry and reorders Gin middleware, which can affect client behavior and what gets logged/recorded in tracing/metrics.
> 
> **Overview**
> Updates the request-timeout middleware to return **`408 Request Timeout`** (instead of `503`) when a handler hasn’t written a response before the context deadline, and aligns the unit test accordingly. It also reorders the Gin middleware chain so the custom OpenTelemetry tracing/metrics wrappers run earlier relative to logging and the timeout middleware.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8512b9f51ae16014a4ca999118cd9d624fa777e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->