### PR TITLE
fix(orch): set mmds early to fix a race condition for snapshot templates

### DIFF
--- a/packages/orchestrator/internal/sandbox/fc/process.go
+++ b/packages/orchestrator/internal/sandbox/fc/process.go
@@ -554,13 +554,6 @@ func (p *Process) Resume(
 	}
 	telemetry.ReportEvent(ctx, "configured tx rate limit")
 
-	err = p.client.resumeVM(ctx)
-	if err != nil {
-		fcStopErr := p.Stop(ctx)
-
-		return errors.Join(fmt.Errorf("error resuming vm: %w", err), fcStopErr)
-	}
-
 	meta := &MmdsMetadata{
 		SandboxID:            sbxMetadata.SandboxID,
 		TemplateID:           sbxMetadata.TemplateID,
@@ -573,11 +566,19 @@ func (p *Process) Resume(
 		meta.AccessTokenHash = keys.HashAccessToken("")
 	}
 
+	// Set mmds before resuming the VM so the data are available as soon as the VM is up
 	err = p.client.setMmds(ctx, meta)
 	if err != nil {
 		fcStopErr := p.Stop(ctx)
 
 		return errors.Join(fmt.Errorf("error setting mmds: %w", err), fcStopErr)
+	}
+
+	err = p.client.resumeVM(ctx)
+	if err != nil {
+		fcStopErr := p.Stop(ctx)
+
+		return errors.Join(fmt.Errorf("error resuming vm: %w", err), fcStopErr)
 	}
 
 	telemetry.SetAttributes(


### PR DESCRIPTION
TODO: 
- [ ] try to find reproducer
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the ordering of snapshot resume steps, which can affect VM bring-up timing and failure modes if MMDS or resume calls behave differently than expected. Risk is limited in scope to the Firecracker snapshot resume path.
> 
> **Overview**
> Fixes a race during snapshot-based VM resume by moving the MMDS metadata write (`setMmds`) to occur *before* `resumeVM`, ensuring sandbox/template/logging metadata (and access-token hash) is available immediately when the VM comes up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0954b5a1ff092f84f2dceb6f3b750ca4e611bb5c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->