### PR TITLE
chore(db): migrate users_teams PK from bigint to UUID for replication

### DIFF
--- a/packages/api/internal/db/teams.go
+++ b/packages/api/internal/db/teams.go
@@ -29,7 +29,7 @@ func GetTeamsByUser(ctx context.Context, db *authdb.Client, userID uuid.UUID) ([
 	for _, team := range teams {
 		teamsWithLimits = append(teamsWithLimits, &types.TeamWithDefault{
 			Team:      types.NewTeam(&team.Team, &team.TeamLimit),
-			IsDefault: team.UsersTeam.IsDefault,
+			IsDefault: team.IsDefault,
 		})
 	}
 

--- a/packages/api/internal/handlers/teams.go
+++ b/packages/api/internal/handlers/teams.go
@@ -39,7 +39,7 @@ func (a *APIStore) GetTeams(c *gin.Context) {
 			TeamID:    row.Team.ID.String(),
 			Name:      row.Team.Name,
 			ApiKey:    apiKey.RawAPIKey,
-			IsDefault: row.UsersTeam.IsDefault,
+			IsDefault: row.IsDefault,
 		}
 	}
 

--- a/packages/db/migrations/20260316120000_users_teams_uuid_pkey.sql
+++ b/packages/db/migrations/20260316120000_users_teams_uuid_pkey.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- 1. Add new UUID column with default (existing rows get auto-populated)
+ALTER TABLE public.users_teams ADD COLUMN IF NOT EXISTS uuid_id UUID DEFAULT gen_random_uuid() NOT NULL;
+
+-- 2. Build unique index concurrently to avoid holding ACCESS EXCLUSIVE lock during index scan
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS users_teams_uuid_id_idx
+  ON public.users_teams (uuid_id);
+
+-- 3. Swap primary key using the pre-built index (brief metadata lock only)
+ALTER TABLE public.users_teams
+  DROP CONSTRAINT users_teams_pkey,
+  ADD CONSTRAINT users_teams_pkey PRIMARY KEY USING INDEX users_teams_uuid_id_idx;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- 1. Build unique index on old bigint id concurrently
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS users_teams_id_idx
+  ON public.users_teams (id);
+
+-- 2. Swap primary key back to bigint id
+ALTER TABLE public.users_teams
+  DROP CONSTRAINT users_teams_pkey,
+  ADD CONSTRAINT users_teams_pkey PRIMARY KEY USING INDEX users_teams_id_idx;
+
+-- 3. Drop the uuid column
+ALTER TABLE public.users_teams DROP COLUMN IF EXISTS uuid_id;

--- a/packages/db/pkg/auth/queries/get_team.sql.go
+++ b/packages/db/pkg/auth/queries/get_team.sql.go
@@ -133,7 +133,7 @@ func (q *Queries) GetTeamWithTierByTeamID(ctx context.Context, id uuid.UUID) (Ge
 }
 
 const getTeamsWithUsersTeamsWithTier = `-- name: GetTeamsWithUsersTeamsWithTier :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.id, ut.user_id, ut.team_id, ut.is_default, ut.added_by, ut.created_at, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id
@@ -142,7 +142,7 @@ WHERE ut.user_id = $1
 
 type GetTeamsWithUsersTeamsWithTierRow struct {
 	Team      Team
-	UsersTeam UsersTeam
+	IsDefault bool
 	TeamLimit TeamLimit
 }
 
@@ -167,12 +167,7 @@ func (q *Queries) GetTeamsWithUsersTeamsWithTier(ctx context.Context, userID uui
 			&i.Team.ClusterID,
 			&i.Team.SandboxSchedulingLabels,
 			&i.Team.Slug,
-			&i.UsersTeam.ID,
-			&i.UsersTeam.UserID,
-			&i.UsersTeam.TeamID,
-			&i.UsersTeam.IsDefault,
-			&i.UsersTeam.AddedBy,
-			&i.UsersTeam.CreatedAt,
+			&i.IsDefault,
 			&i.TeamLimit.ID,
 			&i.TeamLimit.MaxLengthHours,
 			&i.TeamLimit.ConcurrentSandboxes,

--- a/packages/db/pkg/auth/queries/models.go
+++ b/packages/db/pkg/auth/queries/models.go
@@ -227,6 +227,7 @@ type UsersTeam struct {
 	IsDefault bool
 	AddedBy   *uuid.UUID
 	CreatedAt pgtype.Timestamp
+	UuidID    uuid.UUID
 }
 
 type Volume struct {

--- a/packages/db/pkg/auth/queries/teams_usersteams_join.sql.go
+++ b/packages/db/pkg/auth/queries/teams_usersteams_join.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getTeamsWithUsersTeams = `-- name: GetTeamsWithUsersTeams :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.id, ut.user_id, ut.team_id, ut.is_default, ut.added_by, ut.created_at
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.is_default
 FROM "public"."teams" t
 JOIN "public"."users_teams" ut ON ut.team_id = t.id
 WHERE ut.user_id = $1
@@ -20,7 +20,7 @@ WHERE ut.user_id = $1
 
 type GetTeamsWithUsersTeamsRow struct {
 	Team      Team
-	UsersTeam UsersTeam
+	IsDefault bool
 }
 
 func (q *Queries) GetTeamsWithUsersTeams(ctx context.Context, userID uuid.UUID) ([]GetTeamsWithUsersTeamsRow, error) {
@@ -44,12 +44,7 @@ func (q *Queries) GetTeamsWithUsersTeams(ctx context.Context, userID uuid.UUID) 
 			&i.Team.ClusterID,
 			&i.Team.SandboxSchedulingLabels,
 			&i.Team.Slug,
-			&i.UsersTeam.ID,
-			&i.UsersTeam.UserID,
-			&i.UsersTeam.TeamID,
-			&i.UsersTeam.IsDefault,
-			&i.UsersTeam.AddedBy,
-			&i.UsersTeam.CreatedAt,
+			&i.IsDefault,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/auth/sql_queries/teams/get_team.sql
+++ b/packages/db/pkg/auth/sql_queries/teams/get_team.sql
@@ -19,7 +19,7 @@ FROM "public"."teams" t
 WHERE t.id = $1;
 
 -- name: GetTeamsWithUsersTeamsWithTier :many
-SELECT sqlc.embed(t), sqlc.embed(ut), sqlc.embed(tl)
+SELECT sqlc.embed(t), ut.is_default, sqlc.embed(tl)
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id

--- a/packages/db/pkg/auth/sql_queries/users_teams/teams_usersteams_join.sql
+++ b/packages/db/pkg/auth/sql_queries/users_teams/teams_usersteams_join.sql
@@ -1,5 +1,5 @@
 -- name: GetTeamsWithUsersTeams :many
-SELECT sqlc.embed(t), sqlc.embed(ut)
+SELECT sqlc.embed(t), ut.is_default
 FROM "public"."teams" t
 JOIN "public"."users_teams" ut ON ut.team_id = t.id
 WHERE ut.user_id = $1;

--- a/packages/db/queries/models.go
+++ b/packages/db/queries/models.go
@@ -227,6 +227,7 @@ type UsersTeam struct {
 	IsDefault bool
 	AddedBy   *uuid.UUID
 	CreatedAt pgtype.Timestamp
+	UuidID    uuid.UUID
 }
 
 type Volume struct {


### PR DESCRIPTION
Change `users_teams` primary column from ID to UUID. This is a migration path to prevent issues with replication.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a primary key swap on `users_teams`, which can impact replication and any hidden foreign key/ORM assumptions, and the migration runs without a transaction so partial application is possible if it fails mid-way.
> 
> **Overview**
> Migrates `users_teams` to use a new `uuid_id` UUID primary key (added with `gen_random_uuid()`, indexed concurrently, then promoted to the PK with a reversible down migration). Updates sqlc queries and API team listing code to stop depending on the `users_teams` join model fields and instead project only `ut.is_default`, aligning the read paths with the new schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33048eca3debc542041393f1771c9085b6ffebef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->