### PR TITLE
chore(api): log reason for failing to connect, resume sandboxes on state change

### DIFF
--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -77,7 +77,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		// Sandbox exists but isn't running → check which transitional state.
 		var notRunningErr *sandbox.NotRunningError
 		if !errors.As(apiErr.Err, &notRunningErr) {
-			telemetry.ReportCriticalError(ctx, "error keeping sandbox alive", apiErr.Err,
+			telemetry.ReportErrorByCode(ctx, apiErr.Code, "error keeping sandbox alive", apiErr.Err,
 				telemetry.WithSandboxID(sandboxID),
 				telemetry.WithTeamID(teamID.String()),
 			)
@@ -157,7 +157,7 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 	if snap.EnvSecure {
 		accessToken, tokenErr := a.getEnvdAccessToken(build.EnvdVersion, sandboxID)
 		if tokenErr != nil {
-			telemetry.ReportCriticalError(ctx, "Secure envd access token error", tokenErr.Err,
+			telemetry.ReportErrorByCode(ctx, tokenErr.Code, "Secure envd access token error", tokenErr.Err,
 				telemetry.WithTemplateID(snap.EnvID),
 				telemetry.WithBuildID(build.ID.String()),
 				telemetry.WithSandboxID(sandboxID),

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -166,7 +166,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	if snap.EnvSecure {
 		accessToken, tokenErr := a.getEnvdAccessToken(build.EnvdVersion, sandboxID)
 		if tokenErr != nil {
-			telemetry.ReportCriticalError(ctx, "Secure envd access token error", tokenErr.Err,
+			telemetry.ReportErrorByCode(ctx, tokenErr.Code, "Secure envd access token error", tokenErr.Err,
 				telemetry.WithTemplateID(snap.EnvID),
 				telemetry.WithBuildID(build.ID.String()),
 				telemetry.WithSandboxID(sandboxID),


### PR DESCRIPTION
currently, we drop the `err` from `err = a.orchestrator.WaitForStateChange(ctx, teamID, sandboxID)`. This makes it hard for us to know why requests during pausing errored. 

This change logs the dropped `err` so we can get better confidence in why we're gettign 500 errors during state transitions.

also updates the error logging to use the telemetry.reportCriticalError to maintain `Error` text while helping with the spans


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-path telemetry/logging while keeping existing control flow and responses largely the same, with added visibility into `WaitForStateChange` failures and snapshot/token errors.
> 
> **Overview**
> Improves observability for sandbox `connect` and `resume` during state transitions by reporting previously dropped `WaitForStateChange` errors and standardizing several failure logs to `telemetry.ReportCriticalError`/`ReportErrorByCode` with sandbox/team (and where relevant template/build) metadata, making 500s and other failures easier to diagnose without changing the happy-path behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2894837ba71e1336bbfa91e8fafacb0096b7d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->