### PR TITLE
Consul service for clickhouse http

### DIFF
--- a/iac/modules/job-clickhouse/jobs/clickhouse.hcl
+++ b/iac/modules/job-clickhouse/jobs/clickhouse.hcl
@@ -56,6 +56,20 @@ job "clickhouse" {
       }
     }
 
+    service {
+      name = "clickhouse-http"
+      port = "clickhouse-http"
+      tags = ["server-${i + 1}"]
+
+      check {
+        type     = "http"
+        path     = "/ping"
+        port     = "clickhouse-http"
+        interval = "10s"
+        timeout  = "5s"
+      }
+    }
+
     task "clickhouse-server" {
       driver = "docker"
 


### PR DESCRIPTION
Allow us to use consul service discovery for http port.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 256292711e9012a7361ddbebfadc654808ab0cb7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->