### PR TITLE
chore(orch): clean up gcs grpc env vars

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -108,14 +108,6 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         %{ if provider_gcp_config.gcs_grpc_connection_pool_size != 0 }
         GCS_GRPC_CONNECTION_POOL_SIZE = "${provider_gcp_config.gcs_grpc_connection_pool_size}"
         %{ endif }
-
-        %{ if !provider_gcp_config.gcs_enable_direct_path }
-        GCS_ENABLE_DIRECT_PATH = "false"
-        %{ endif }
-
-        %{ if !provider_gcp_config.gcs_disable_telemetry }
-        GCS_DISABLE_TELEMETRY = "false"
-        %{ endif }
 %{ endif }
 %{ if provider == "aws" }
         ARTIFACTS_REGISTRY_PROVIDER  = "AWS_ECR"

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -23,14 +23,10 @@ variable "provider_gcp_config" {
   type = object({
     service_account_key           = optional(string, "")
     gcs_grpc_connection_pool_size = optional(number, 0)
-    gcs_enable_direct_path        = optional(bool, true)
-    gcs_disable_telemetry         = optional(bool, true)
   })
   default = {
     service_account_key           = ""
     gcs_grpc_connection_pool_size = 0
-    gcs_enable_direct_path        = true
-    gcs_disable_telemetry         = true
   }
 }
 

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -106,14 +106,6 @@ job "template-manager" {
         %{ if provider_gcp_config.gcs_grpc_connection_pool_size != 0 }
         GCS_GRPC_CONNECTION_POOL_SIZE = "${provider_gcp_config.gcs_grpc_connection_pool_size}"
         %{ endif }
-
-        %{ if !provider_gcp_config.gcs_enable_direct_path }
-        GCS_ENABLE_DIRECT_PATH = "false"
-        %{ endif }
-
-        %{ if !provider_gcp_config.gcs_disable_telemetry }
-        GCS_DISABLE_TELEMETRY = "false"
-        %{ endif }
 %{ endif }
 %{ if provider == "aws" }
         ARTIFACTS_REGISTRY_PROVIDER   = "AWS_ECR"

--- a/iac/modules/job-template-manager/variables.tf
+++ b/iac/modules/job-template-manager/variables.tf
@@ -15,8 +15,6 @@ variable "provider_gcp_config" {
     region                        = optional(string, "")
     docker_registry               = optional(string, "")
     gcs_grpc_connection_pool_size = optional(number, 0)
-    gcs_enable_direct_path        = optional(bool, true)
-    gcs_disable_telemetry         = optional(bool, true)
   })
   default = {
     service_account_key           = ""
@@ -24,8 +22,6 @@ variable "provider_gcp_config" {
     region                        = ""
     docker_registry               = ""
     gcs_grpc_connection_pool_size = 0
-    gcs_enable_direct_path        = true
-    gcs_disable_telemetry         = true
   }
 }
 

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -82,9 +82,7 @@ tf_vars := \
 	$(call tfvar, DB_MIN_IDLE_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MAX_OPEN_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS) \
-	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE) \
-	$(call tfvar, GCS_ENABLE_DIRECT_PATH) \
-	$(call tfvar, GCS_DISABLE_TELEMETRY)
+	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE)
 
 .PHONY: init
 init:

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -305,8 +305,6 @@ module "nomad" {
   volume_token_duration         = var.volume_token_valid_for
 
   gcs_grpc_connection_pool_size = var.gcs_grpc_connection_pool_size
-  gcs_enable_direct_path        = var.gcs_enable_direct_path
-  gcs_disable_telemetry         = var.gcs_disable_telemetry
 }
 
 

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -409,8 +409,6 @@ module "orchestrator" {
   provider_name = "gcp"
   provider_gcp_config = {
     gcs_grpc_connection_pool_size = var.gcs_grpc_connection_pool_size
-    gcs_enable_direct_path        = var.gcs_enable_direct_path
-    gcs_disable_telemetry         = var.gcs_disable_telemetry
   }
 
   node_pool  = var.orchestrator_node_pool
@@ -479,8 +477,6 @@ module "template_manager" {
     region                        = var.gcp_region
     docker_registry               = var.custom_envs_repository_name
     gcs_grpc_connection_pool_size = var.gcs_grpc_connection_pool_size
-    gcs_enable_direct_path        = var.gcs_enable_direct_path
-    gcs_disable_telemetry         = var.gcs_disable_telemetry
   }
 
   update_stanza = var.template_manages_clusters_size_gt_1

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -477,13 +477,3 @@ variable "gcs_grpc_connection_pool_size" {
   description = "Number of gRPC connections in the GCS connection pool"
   type        = number
 }
-
-variable "gcs_enable_direct_path" {
-  description = "Enable DirectPath for GCS gRPC client"
-  type        = bool
-}
-
-variable "gcs_disable_telemetry" {
-  description = "Disable telemetry for GCS gRPC client"
-  type        = bool
-}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -726,15 +726,3 @@ variable "gcs_grpc_connection_pool_size" {
     error_message = "gcs_grpc_connection_pool_size must be a positive integer or 0 for using default specified in code."
   }
 }
-
-variable "gcs_enable_direct_path" {
-  description = "Enable DirectPath for GCS gRPC client"
-  type        = bool
-  default     = true
-}
-
-variable "gcs_disable_telemetry" {
-  description = "Disable telemetry for GCS gRPC client"
-  type        = bool
-  default     = true
-}

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -38,8 +38,7 @@ const (
 	googleBackoffMultiplier        = 2
 	googleMaxAttempts              = 10
 	defaultGRPCConnectionPoolSize  = 4
-	defaultGCSEnableDirectPath     = "true"
-	defaultGCSDisableTelemetry     = "false"
+	defaultGCSEnableDirectPath     = false
 	gcloudDefaultUploadConcurrency = 16
 
 	gcsOperationAttr                           = "operation"
@@ -95,21 +94,11 @@ func NewGCP(ctx context.Context, bucketName string, limiter *limit.Limiter) (Sto
 		return nil, fmt.Errorf("failed to parse GCS_GRPC_CONNECTION_POOL_SIZE: %w", err)
 	}
 
-	enableDirectPath := env.GetEnv("GCS_ENABLE_DIRECT_PATH", defaultGCSEnableDirectPath) == "true"
-	disableTelemetry := env.GetEnv("GCS_DISABLE_TELEMETRY", defaultGCSDisableTelemetry) == "true"
-
 	opts := []option.ClientOption{
 		option.WithGRPCConnectionPool(grpcPoolSize),
 		option.WithGRPCDialOption(grpc.WithInitialConnWindowSize(32 * megabyte)),
 		option.WithGRPCDialOption(grpc.WithInitialWindowSize(4 * megabyte)),
-		internaloption.EnableDirectPath(enableDirectPath),
-	}
-
-	if disableTelemetry {
-		opts = append(opts,
-			option.WithTelemetryDisabled(),
-			storage.WithDisabledClientMetrics(),
-		)
+		internaloption.EnableDirectPath(defaultGCSEnableDirectPath),
 	}
 
 	client, err := storage.NewGRPCClient(ctx, opts...)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removes previously supported Terraform/env toggles for GCS DirectPath and telemetry; deployments that relied on those variables may see behavior/observability changes or fail if their automation still sets them. Also changes GCS client initialization defaults, which could impact storage performance and metrics collection.
> 
> **Overview**
> This PR drops the `gcs_enable_direct_path` and `gcs_disable_telemetry` configuration knobs across the GCP IaC (variables, Nomad job env wiring, and `provider-gcp` Makefile/module inputs) and simplifies the Go GCS client setup to only honor `GCS_GRPC_CONNECTION_POOL_SIZE`, always using a fixed DirectPath default and no longer conditionally disabling telemetry/client metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a04ca33e9321cafb83fd47a1d886c5345aec62e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->