### PR TITLE
chore(api): log lifecycle properties when creating a sandbox

### DIFF
--- a/packages/api/internal/handlers/sandbox.go
+++ b/packages/api/internal/handlers/sandbox.go
@@ -178,16 +178,19 @@ func (a *APIStore) startSandboxInternal(
 		attribute.String("instance.id", sbx.SandboxID),
 	)
 
-	sbxlogger.E(&sbxlogger.SandboxMetadata{
+	logMetadata := &sbxlogger.SandboxMetadata{
 		SandboxID:  sbx.SandboxID,
 		TemplateID: sbx.TemplateID,
 		TeamID:     team.ID.String(),
-	}).Info(
+	}
+	sbxlogger.E(logMetadata).Info(ctx, "Sandbox created", zap.String("end_time", endTime.Format("2006-01-02 15:04:05 -07:00")))
+	sbxlogger.I(logMetadata).Info(
 		ctx,
-		"Sandbox created",
+		"Sandbox created details",
 		zap.String("end_time", endTime.Format("2006-01-02 15:04:05 -07:00")),
-		zap.Bool("auto_pause", autoPause),
 		zap.String("auto_resume_policy", autoResumePolicy),
+		zap.Bool("auto_pause", autoPause),
+		zap.String("parent_template_id", baseTemplateID),
 	)
 
 	return sbx, nil


### PR DESCRIPTION
when creating a sandbox, logs the lifecycle properties so we can pull if it was supposed to pause/die on timeout easily in grafana

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds additional structured logging during sandbox creation, without changing sandbox lifecycle behavior or data flows.
> 
> **Overview**
> Extends sandbox creation logging to include key lifecycle properties so operators can quickly confirm intended timeout behavior. When a sandbox is created, it now logs `auto_pause`, the resolved `auto_resume_policy` (or `unset`), and `parent_template_id` alongside the existing end-time message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21a61bb0cdfc1075f94ef5866f6345516909a9f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->