### PR TITLE
chore(orch): improve envd init logs

### DIFF
--- a/packages/orchestrator/internal/sandbox/envd.go
+++ b/packages/orchestrator/internal/sandbox/envd.go
@@ -74,12 +74,6 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 			return response, requestCount, nil
 		}
 
-		logger.L().Debug(ctx, "failed to do request to envd, retrying",
-			logger.WithSandboxID(s.Runtime.SandboxID),
-			logger.WithEnvdVersion(s.Config.Envd.Version),
-			zap.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()),
-			zap.Error(err))
-
 		select {
 		case <-ctx.Done():
 			return nil, requestCount, fmt.Errorf("%w with cause: %w", ctx.Err(), context.Cause(ctx))
@@ -119,6 +113,14 @@ func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
 
 	response, count, err := s.doRequestWithInfiniteRetries(ctx, http.MethodPost, address)
 	if err != nil {
+		logger.L().Error(ctx, "failed to init envd after retries",
+			logger.WithSandboxID(s.Runtime.SandboxID),
+			logger.WithEnvdVersion(s.Config.Envd.Version),
+			zap.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()),
+			zap.Int64("attempts", count),
+			zap.Error(err),
+		)
+
 		envdInitCalls.Add(ctx, count, metric.WithAttributes(attributesFail...))
 
 		return fmt.Errorf("failed to init envd: %w", err)
@@ -148,6 +150,13 @@ func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
 
 		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
 	}
+
+	logger.L().Debug(ctx, "succeeded to init envd",
+		logger.WithSandboxID(s.Runtime.SandboxID),
+		logger.WithEnvdVersion(s.Config.Envd.Version),
+		zap.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()),
+		zap.Int64("attempts", count),
+	)
 
 	span.SetStatus(codes.Ok, fmt.Sprintf("envd init returned %d", response.StatusCode))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk logging-only change around envd init; behavior is unchanged aside from log emission timing and added attempt counts.
> 
> **Overview**
> Tweaks `envd` init retry logging by removing per-retry debug messages and instead logging a single error when retries ultimately fail (including total `attempts`) plus a debug message when init succeeds (also including `attempts` and the configured timeout), while keeping the existing init metrics behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2d6a83ad5607ce5099fd1fe96a5f425a5f2f393. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->