### PR TITLE
feat(api): add gRPC timeout middleware for API

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -59,7 +59,7 @@ const (
 	// Must be less than maxWriteTimeout so the context cancels before the
 	// server's write deadline kills the connection (WriteTimeout does NOT
 	// cancel r.Context(); see https://github.com/golang/go/issues/59602).
-	requestTimeout = 60 * time.Second
+	requestTimeout = customMiddleware.DefaultRequestTimeout
 
 	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
@@ -385,7 +385,7 @@ func run() int {
 		l.Fatal(ctx, "failed to create proxy grpc listener", zap.Error(err))
 	}
 
-	grpcServer := e2bgrpc.NewGRPCServer(tel)
+	grpcServer := e2bgrpc.NewGRPCServer(tel, e2bgrpc.UnaryTimeoutInterceptor(requestTimeout))
 	proxygrpc.RegisterSandboxServiceServer(grpcServer, handlers.NewSandboxService(apiStore))
 
 	// pass the signal context so that handlers know when shutdown is happening.

--- a/packages/shared/pkg/grpc/interceptor.go
+++ b/packages/shared/pkg/grpc/interceptor.go
@@ -1,0 +1,20 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// UnaryTimeoutInterceptor returns a gRPC unary server interceptor that applies
+// the given timeout to each request context.
+func UnaryTimeoutInterceptor(timeout time.Duration) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		ctx, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("request timed out"))
+		defer cancel()
+
+		return handler(ctx, req)
+	}
+}

--- a/packages/shared/pkg/grpc/server.go
+++ b/packages/shared/pkg/grpc/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-func NewGRPCServer(tel *telemetry.Client) *grpc.Server {
+func NewGRPCServer(tel *telemetry.Client, extraUnaryInterceptors ...grpc.UnaryServerInterceptor) *grpc.Server {
 	opts := []logging.Option{
 		logging.WithLogOnEvents(logging.StartCall, logging.PayloadReceived, logging.PayloadSent, logging.FinishCall),
 		logging.WithLevels(logging.DefaultServerCodeToLevel),
@@ -27,6 +27,14 @@ func NewGRPCServer(tel *telemetry.Client) *grpc.Server {
 		"/TemplateService/HealthStatus",
 		"/InfoService/ServiceInfo",
 	)
+
+	defaultInterceptors := []grpc.UnaryServerInterceptor{
+		recovery.UnaryServerInterceptor(),
+		selector.UnaryServerInterceptor(
+			logging.UnaryServerInterceptor(logger.GRPCLogger(logger.L()), opts...),
+			ignoredLoggingRoutes,
+		),
+	}
 
 	return grpc.NewServer(
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
@@ -44,11 +52,10 @@ func NewGRPCServer(tel *telemetry.Client) *grpc.Server {
 					otelgrpc.WithMeterProvider(tel.MeterProvider),
 				))),
 		grpc.ChainUnaryInterceptor(
-			recovery.UnaryServerInterceptor(),
-			selector.UnaryServerInterceptor(
-				logging.UnaryServerInterceptor(logger.GRPCLogger(logger.L()), opts...),
-				ignoredLoggingRoutes,
-			),
+			append(
+				defaultInterceptors,
+				extraUnaryInterceptors...,
+			)...,
 		),
 		grpc.ChainStreamInterceptor(
 			selector.StreamServerInterceptor(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Applies a hard deadline to all API gRPC unary calls, which can change behavior for long-running requests and introduce new cancellations if timeouts are mis-sized.
> 
> **Overview**
> Adds a reusable unary gRPC timeout interceptor and updates the shared `NewGRPCServer` helper to accept optional extra unary interceptors. The API now uses the same `DefaultRequestTimeout` value for both HTTP and gRPC by wiring the timeout interceptor into its gRPC server setup, causing unary gRPC handlers to run under a per-request context deadline with an explicit timeout cause.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8578c6da3e586aa0e5f7ff1fc3b7c13323d3d50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->