### PR TITLE
chore(api): disable request timeout

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -59,7 +59,7 @@ const (
 	// Must be less than maxWriteTimeout so the context cancels before the
 	// server's write deadline kills the connection (WriteTimeout does NOT
 	// cancel r.Context(); see https://github.com/golang/go/issues/59602).
-	requestTimeout = 60 * time.Second
+	// requestTimeout = 60 * time.Second
 
 	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removing per-request context deadlines can allow handlers to block indefinitely (e.g., on DB pool acquisition), increasing the risk of goroutine buildup and degraded availability under load. It also shifts timeout behavior to upstream/proxy and server write deadlines, which may be less predictable for long-running requests.
> 
> **Overview**
> Disables the API’s per-request context timeout by commenting out the `requestTimeout` constant and the `customMiddleware.RequestTimeout(...)` Gin middleware, so requests no longer get an enforced 60s cancellation/408 behavior and may run until other server or upstream timeouts intervene.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2144d21c8520e198a13befac29598b74dee870ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->