### PR TITLE
chore(api): enable request timeout

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -63,7 +63,7 @@ const (
 	// Must be less than maxWriteTimeout so the context cancels before the
 	// server's write deadline kills the connection (WriteTimeout does NOT
 	// cancel r.Context(); see https://github.com/golang/go/issues/59602).
-	// requestTimeout = 60 * time.Second
+	requestTimeout = 60 * time.Second
 
 	// This timeout should be > 600 (GCP LB upstream idle timeout) to prevent race condition
 	// https://cloud.google.com/load-balancing/docs/https#timeouts_and_retries%23:~:text=The%20load%20balancer%27s%20backend%20keepalive,is%20greater%20than%20600%20seconds
@@ -133,7 +133,7 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 			},
 		}),
 		gin.Recovery(),
-		// customMiddleware.RequestTimeout(requestTimeout), //nolint:contextcheck // Gin middleware sets context via c.Request.WithContext
+		customMiddleware.RequestTimeout(requestTimeout), //nolint:contextcheck // Gin middleware sets context via c.Request.WithContext
 	)
 
 	corsConfig := cors.DefaultConfig()


### PR DESCRIPTION
Reverts e2b-dev/infra#2156

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enabling a hard 60s request context deadline can cause previously-long requests to start failing with 408s and may surface cancellation-related bugs in downstream calls that weren’t context-aware.
> 
> **Overview**
> Re-enables a global 60s per-request context timeout in the API by defining `requestTimeout` and wiring `customMiddleware.RequestTimeout` into the Gin middleware chain, so handlers and blocking upstream calls are canceled on deadline and requests can return `408 Request Timeout` when no response was written.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99e50a44e01f8399750d9270e0bbf9ccdfb45cf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->