### PR TITLE
chore(orch): add observability for cmux

### DIFF
--- a/packages/orchestrator/internal/factories/cmux.go
+++ b/packages/orchestrator/internal/factories/cmux.go
@@ -6,9 +6,15 @@ import (
 	"net"
 
 	"github.com/soheilhy/cmux"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
-func NewCMUXServer(ctx context.Context, port uint16) (cmux.CMux, error) {
+func NewCMUXServer(ctx context.Context, port uint16, meterProvider metric.MeterProvider) (cmux.CMux, error) {
 	var lisCfg net.ListenConfig
 	lis, err := lisCfg.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
@@ -16,6 +22,16 @@ func NewCMUXServer(ctx context.Context, port uint16) (cmux.CMux, error) {
 	}
 
 	m := cmux.New(lis)
+
+	meter := meterProvider.Meter("orchestrator.cmux")
+	errCounter := utils.Must(telemetry.GetCounter(meter, telemetry.CmuxErrorsTotal))
+
+	m.HandleError(func(err error) bool {
+		logger.L().Warn(ctx, "cmux connection error", zap.Error(err))
+		errCounter.Add(ctx, 1)
+
+		return true // keep serving
+	})
 
 	return m, nil
 }

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -579,7 +579,7 @@ func run(config cfg.Config) (success bool) {
 	grpc_health_v1.RegisterHealthServer(grpcServer, grpcHealth)
 
 	// cmux server, allows us to reuse the same TCP port between grpc and HTTP requests
-	cmuxServer, err := factories.NewCMUXServer(ctx, config.GRPCPort)
+	cmuxServer, err := factories.NewCMUXServer(ctx, config.GRPCPort, tel.MeterProvider)
 	if err != nil {
 		logger.L().Fatal(ctx, "failed to create cmux server", zap.Error(err))
 	}

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -89,6 +89,9 @@ const (
 	// Ingress proxy counters
 	IngressProxyConnectionsBlockedTotal CounterType = "orchestrator.proxy.connections.blocked.total"
 
+	// cmux counters
+	CmuxErrorsTotal CounterType = "orchestrator.cmux.errors.total"
+
 	// Firecracker net counters — global totals, no sandbox_id (low cardinality).
 	// All carry a direction=tx/rx attribute. Per-sandbox distributions are histograms below.
 	SandboxFCNetFails         CounterType = "orchestrator.sandbox.fc.net.fails"
@@ -138,6 +141,7 @@ var counterDesc = map[CounterType]string{
 	TCPFirewallDecisionsTotal:       "Total number of TCP firewall allow/block decisions",
 
 	IngressProxyConnectionsBlockedTotal: "Total number of ingress proxy connections blocked by connection limit",
+	CmuxErrorsTotal:                     "Total number of cmux connection multiplexer errors",
 
 	SandboxFCNetFails:         "Total Firecracker VMM errors transmitting or receiving data (direction=tx/rx)",
 	SandboxFCNetNoAvailBuffer: "Total Firecracker VMM events where no virtqueue buffer was available (direction=tx/rx)",
@@ -156,6 +160,7 @@ var counterUnits = map[CounterType]string{
 	TCPFirewallDecisionsTotal:       "{decision}",
 
 	IngressProxyConnectionsBlockedTotal: "{connection}",
+	CmuxErrorsTotal:                     "{error}",
 
 	SandboxFCNetFails:         "{error}",
 	SandboxFCNetNoAvailBuffer: "{event}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds logging/metrics instrumentation and a cmux error handler; main concern is potential log/metric volume if errors spike.
> 
> **Overview**
> Adds observability to the orchestrator’s `cmux` listener by wiring in an OpenTelemetry meter, registering a `CmuxErrorsTotal` counter, and logging + incrementing the counter on `cmux` connection errors while continuing to serve.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b76db7269c133de6948ca12d1e7d2a91f1a67f87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->