### PR TITLE
chore(orch): add envd version to healthcheck

### DIFF
--- a/packages/orchestrator/internal/sandbox/checks.go
+++ b/packages/orchestrator/internal/sandbox/checks.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 )
 
@@ -92,7 +93,7 @@ func (c *Checks) Healthcheck(ctx context.Context, alwaysReport bool) {
 
 	if !ok && c.healthy.CompareAndSwap(true, false) {
 		sbxlogger.E(c.sandbox).Healthcheck(ctx, sbxlogger.Fail)
-		sbxlogger.I(c.sandbox).Warn(ctx, "healthcheck failed", zap.Error(err))
+		sbxlogger.I(c.sandbox).Warn(ctx, "healthcheck failed", zap.Error(err), logger.WithEnvdVersion(c.sandbox.Config.Envd.Version))
 
 		return
 	}
@@ -108,7 +109,7 @@ func (c *Checks) Healthcheck(ctx context.Context, alwaysReport bool) {
 			sbxlogger.E(c.sandbox).Healthcheck(ctx, sbxlogger.ReportSuccess)
 		} else {
 			sbxlogger.E(c.sandbox).Healthcheck(ctx, sbxlogger.ReportFail)
-			sbxlogger.I(c.sandbox).Error(ctx, "control healthcheck failed", zap.Error(err))
+			sbxlogger.I(c.sandbox).Error(ctx, "control healthcheck failed", zap.Error(err), logger.WithEnvdVersion(c.sandbox.Config.Envd.Version))
 		}
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only enriches healthcheck warning/error logs with an additional `envd.version` field and doesn’t change healthcheck behavior or control flow.
> 
> **Overview**
> Healthcheck failure logging now includes the sandbox `envd.version` field on warning/error entries, making it easier to correlate healthcheck issues with the running envd release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a4e4c6a4595207be27c85052de11e6bdd09d5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->