### PR TITLE
fix(proxy): log non-envd sandbox errors as warnings

### DIFF
--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -12,6 +12,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/template"
 	"github.com/e2b-dev/infra/packages/shared/pkg/proxy/tracking"
@@ -135,7 +136,11 @@ func newProxyClient(
 			}
 
 			if err != nil {
-				t.RequestLogger.Error(ctx, "sandbox error handler called", zap.Error(err))
+				if t.SandboxPort == uint64(consts.DefaultEnvdServerPort) {
+					t.RequestLogger.Error(ctx, "sandbox error handler called", zap.Error(err))
+				} else {
+					t.RequestLogger.Warn(ctx, "sandbox error handler called", zap.Error(err))
+				}
 			}
 
 			if t.DefaultToPortError {


### PR DESCRIPTION
## Summary
Downgrade sandbox error handler logs from Error to Warn level for non-envd ports. Errors on envd port (49983) remain at Error level as they indicate infrastructure issues. Other ports frequently encounter expected connection failures when apps aren't running yet, causing unnecessary log noise.

## Changes
- Check `SandboxPort` against `consts.DefaultEnvdServerPort` in the proxy error handler
- Log as Error for envd port, Warn for all other ports
- Reduces alert fatigue from benign connection failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts log severity in the proxy error handler; behavior is otherwise unchanged aside from potentially reduced visibility for non-`DefaultEnvdServerPort` connection failures.
> 
> **Overview**
> Downgrades reverse-proxy sandbox error-handler logs from `Error` to `Warn` for requests targeting non-`DefaultEnvdServerPort` sandbox ports, while keeping `Error` logging for failures on the envd port to preserve signal for likely infrastructure issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5402337574d55dbcf457b173d202ee80c864a6e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->