### PR TITLE
fix(logging): record canceled contexts as 499

### DIFF
--- a/packages/shared/pkg/middleware/logging.go
+++ b/packages/shared/pkg/middleware/logging.go
@@ -73,6 +73,9 @@ func LoggingMiddleware(logger logger.Logger, conf Config) gin.HandlerFunc {
 			}
 
 			status := c.Writer.Status()
+			if errors.Is(ctx.Err(), context.Canceled) {
+				status = 499
+			}
 
 			fields := []zapcore.Field{
 				zap.Int("status", status),
@@ -102,7 +105,7 @@ func LoggingMiddleware(logger logger.Logger, conf Config) gin.HandlerFunc {
 
 			level := conf.DefaultLevel
 			switch {
-			case status >= http.StatusInternalServerError && !errors.Is(ctx.Err(), context.Canceled):
+			case status >= http.StatusInternalServerError:
 				level = zapcore.ErrorLevel
 			case status >= http.StatusBadRequest:
 				level = zapcore.WarnLevel


### PR DESCRIPTION
## Summary

When a context is canceled, the logging middleware now sets the status code to 499 to match the pattern already used in tracing and metrics middlewares. This ensures consistency across all three observability layers.

The redundant canceled context check in the error-level condition has been removed since 499 won't trigger error-level logging anyway.

## Related Issues

Fixes the status code inconsistency for canceled requests across logging, metrics, and traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: logging-only behavior change that adjusts the recorded status code for canceled requests and slightly alters log severity decisions without affecting request handling.
> 
> **Overview**
> Updates the Gin logging middleware to record client-canceled requests as HTTP `499` and simplifies severity selection by removing the special-case canceled-context check, aligning logged status/severity with other observability layers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddc5e709b35b237361eeac34d0df88ec2aa8be95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->