### PR TITLE
fix: remove GCP-specific arg from AWS orchestrator module

### DIFF
--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -166,8 +166,6 @@ module "orchestrator" {
   domain_name             = var.domain_name
   build_cache_bucket_name = var.build_cache_bucket_name
   launch_darkly_api_key   = var.launch_darkly_api_key
-
-  gcs_grpc_connection_pool_size = var.gcs_grpc_connection_pool_size
 }
 
 data "aws_s3_object" "template_manager" {


### PR DESCRIPTION
## Summary
- Removes `gcs_grpc_connection_pool_size` from the AWS provider's orchestrator module call in `iac/provider-aws/nomad/main.tf`
- This argument was introduced in #2174 but is GCP-specific — the orchestrator module only accepts it inside `provider_gcp_config`, not as a top-level variable
- Causes `terraform plan` to fail on the AWS provider with: `An argument named "gcs_grpc_connection_pool_size" is not expected here`

## Test plan
- [x] Verified `terraform plan` fails on AWS provider without this fix
- [ ] Run `terraform plan` on AWS provider after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)