### PR TITLE
chore(orch): increase the max clock drift for logging

### DIFF
--- a/packages/orchestrator/internal/metrics/sandboxes.go
+++ b/packages/orchestrator/internal/metrics/sandboxes.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	maxAcceptableSandboxClockDriftSec = 2
+	maxAcceptableSandboxClockDriftSec = 5
 
 	sbxMemThresholdPct = 80
 	sbxCpuThresholdPct = 80


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only relaxes the warning threshold for sandbox/host clock drift during metrics collection, affecting log noise but not control flow or data handling.
> 
> **Overview**
> Increases the allowed sandbox-to-host clock drift before emitting the "Significant clock drift" warning during sandbox metrics observation, raising the threshold from 2s to 5s to reduce noisy logging from minor time skew.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 436386c267e1cf59e8610841f54a891bbcd7afd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->