### PR TITLE
move the reservation up to when updating envd

### DIFF
--- a/packages/orchestrator/internal/template/build/builder.go
+++ b/packages/orchestrator/internal/template/build/builder.go
@@ -262,6 +262,7 @@ func runBuild(
 	layerExecutor := layer.NewLayerExecutor(
 		bc,
 		builder.logger,
+		builder.featureFlags,
 		builder.templateCache,
 		builder.proxy,
 		builder.sandboxes,

--- a/packages/orchestrator/internal/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/internal/template/build/layer/layer_executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/sandboxtools"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/build/storage/cache"
 	"github.com/e2b-dev/infra/packages/orchestrator/internal/template/metadata"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
@@ -25,7 +26,8 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/interna
 type LayerExecutor struct {
 	buildcontext.BuildContext
 
-	logger logger.Logger
+	logger       logger.Logger
+	featureFlags *featureflags.Client
 
 	templateCache   *sbxtemplate.Cache
 	proxy           *proxy.SandboxProxy
@@ -39,6 +41,7 @@ type LayerExecutor struct {
 func NewLayerExecutor(
 	buildContext buildcontext.BuildContext,
 	logger logger.Logger,
+	featureFlags *featureflags.Client,
 	templateCache *sbxtemplate.Cache,
 	proxy *proxy.SandboxProxy,
 	sandboxes *sandbox.Map,
@@ -50,7 +53,8 @@ func NewLayerExecutor(
 	return &LayerExecutor{
 		BuildContext: buildContext,
 
-		logger: logger,
+		logger:       logger,
+		featureFlags: featureFlags,
 
 		templateCache:   templateCache,
 		proxy:           proxy,
@@ -111,6 +115,30 @@ func (lb *LayerExecutor) BuildLayer(
 			)
 
 			return metadata.Template{}, fmt.Errorf("update envd: %w", err)
+		}
+
+		// Apply guest-side reserved blocks on the resumed-template path so older
+		// cached templates get the reservation before subsequent build actions run.
+		if reservedDiskSpaceMB := int64(lb.featureFlags.IntFlag(ctx, featureflags.BuildReservedDiskSpaceMB)); reservedDiskSpaceMB > 0 {
+			err = sandboxtools.SetReservedBlocksInGuest(
+				ctx,
+				lb.proxy,
+				userLogger,
+				sbx.Runtime.SandboxID,
+				reservedDiskSpaceMB,
+				lb.Config.RootfsBlockSize(),
+			)
+			if err != nil {
+				lb.logger.Error(
+					ctx,
+					"error setting reserved disk space in guest",
+					logger.WithSandboxID(sbx.Runtime.SandboxID),
+					logger.WithExecutionID(sbx.Runtime.ExecutionID),
+					zap.Error(err),
+				)
+
+				return metadata.Template{}, fmt.Errorf("set reserved disk space in guest: %w", err)
+			}
 		}
 	}
 

--- a/packages/orchestrator/internal/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/internal/template/build/phases/finalize/builder.go
@@ -219,16 +219,6 @@ func (ppb *PostProcessingBuilder) postProcessingFn(userLogger logger.Logger) lay
 				return
 			}
 
-			// Set reserved disk space for the guest OS before syncing
-			if reservedDiskSpaceMB := int64(ppb.featureFlags.IntFlag(ctx, featureflags.BuildReservedDiskSpaceMB)); reservedDiskSpaceMB > 0 {
-				err := sandboxtools.SetReservedBlocksInGuest(ctx, ppb.proxy, userLogger, sbx.Runtime.SandboxID, reservedDiskSpaceMB, ppb.Config.RootfsBlockSize())
-				if err != nil {
-					e = fmt.Errorf("error setting reserved disk space: %w", err)
-
-					return
-				}
-			}
-
 			// Ensure all changes are synchronized to disk so the sandbox can be restarted
 			err := sandboxtools.SyncChangesToDisk(
 				ctx,


### PR DESCRIPTION
Moves guest-side reserved disk setup earlier for cached template builds. No change to fresh builds.

relates to: https://github.com/e2b-dev/infra/pull/2082#discussion_r2962641835


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves reserved disk space setup to run immediately after `envd` updates on resumed/cached builds, affecting guest filesystem behavior before subsequent actions. Risk is moderate because it changes build-time disk reservation timing and relies on feature-flag configuration during layer execution.
> 
> **Overview**
> Moves guest-side reserved disk block configuration from the final post-processing step to immediately after `envd` is updated when resuming from a cached template, ensuring older cached templates get the reservation applied before later build actions run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b22ec8a16b132b8f0905daef110127c2ec7886. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->