### PR TITLE
fix(iac): make performance config optional

### DIFF
--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -683,9 +683,9 @@ variable "persistent_volume_types" {
     protocol       = optional(string)
     nfs_version    = optional(string)
     mount_options  = optional(list(string))
-    performance_config = object({
+    performance_config = optional(object({
       max_iops = optional(number)
-    })
+    }))
   }))
 
   default = {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Terraform type change that relaxes input validation; main risk is unintentionally allowing missing performance settings where they were previously required.
> 
> **Overview**
> Updates the `persistent_volume_types` variable schema so `performance_config` is optional, allowing volume definitions to omit IOPS-related configuration while keeping existing `max_iops` support when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71b0c0fb3316ff118b2cc6fd49166d491c4f5336. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->