### PR TITLE
feat(make): add configurable LOCAL_BUILD_TARGET for run-local

### DIFF
--- a/packages/api/Makefile
+++ b/packages/api/Makefile
@@ -1,5 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
+
+LOCAL_BUILD_TARGET ?= build-debug
 PREFIX := $(strip $(subst ",,$(PREFIX)))
 HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
 $(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
@@ -54,8 +56,7 @@ define setup_local_env
 endef
 
 .PHONY: run-local
-run-local:
-	make build-debug
+run-local: $(LOCAL_BUILD_TARGET)
 	$(call setup_local_env)
 	NODE_ID=$(HOSTNAME) ./bin/api --port 3000
 

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -1,5 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
+
+LOCAL_BUILD_TARGET ?= build-debug
 PREFIX := $(strip $(subst ",,$(PREFIX)))
 HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
 $(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
@@ -39,8 +41,7 @@ define setup_local_env
 endef
 
 .PHONY: run-local
-run-local:
-	make build-debug
+run-local: $(LOCAL_BUILD_TARGET)
 	$(call setup_local_env)
 	NODE_ID=$(HOSTNAME) ./bin/client-proxy
 


### PR DESCRIPTION
Allow overriding the build target used by run-local via the `LOCAL_BUILD_TARGET` variable (defaults to build-debug). Can be set in the env file or as an environment variable:
```sh
  export LOCAL_BUILD_TARGET=build
```
---
Simple change in `Makefile` which would make my life slightly easier, as `build-debug` enables features that make the final binaries too memory intensive, especially in long runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk Makefile-only change that just alters which build target `run-local` depends on, with no runtime code changes. Main risk is local developer workflows unexpectedly building a different binary if `LOCAL_BUILD_TARGET` is set incorrectly.
> 
> **Overview**
> Updates local run Makefile targets to depend on a new overridable `LOCAL_BUILD_TARGET` variable (default `build-debug`), allowing developers to choose which build variant is produced before `run-local` starts the binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 560a0d20cf84509311d9c4ee738f8e1518c1db27. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->