### PR TITLE
fix: remove ^orphan_file ext4 flag unsupported by older e2fsprogs

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -55,12 +55,6 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 			"huge_file",
 			"large_file",
 			"sparse_super2",
-
-			// Disabled for compatibility with older guest e2fsprogs (Ubuntu 22.04, Debian 11).
-			// orphan_file was added as default in e2fsprogs >= 1.47.0; without disabling it,
-			// guest tools fail with "unsupported read-only feature(s)".
-			// See https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.47.0
-			"^orphan_file",
 		}, ","),
 		"-b", strconv.FormatInt(blockSize, 10),
 		"-m", strconv.FormatInt(reservedBlocksPercentage, 10),


### PR DESCRIPTION
Production orchestrators run e2fsprogs < 1.47.0 which does not recognize the `orphan_file` feature. Passing `^orphan_file` to `mkfs.ext4` on these older versions causes an "Invalid filesystem option set" error because the feature is entirely unknown, not just unsupported. Since orphan_file is only a default in `e2fsprogs` >= 1.47.0.

Fixes: 5adcb7ad6aa2 ("feat: reserve disk space for guest OS during template build (#2082)")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to template filesystem creation flags; main impact is ext4 feature set selection during `mkfs.ext4` runs.
> 
> **Overview**
> Removes the `^orphan_file` feature toggle from the `mkfs.ext4` invocation during template ext4 creation so template builds work with older e2fsprogs versions where `orphan_file` is an unknown option and would otherwise cause `mkfs.ext4` to fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a75a20d3557c3129ffa81c5ef59940820086f1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->