### PR TITLE
chore(api): add sandboxID to traces

### DIFF
--- a/packages/api/internal/handlers/sandbox_connect.go
+++ b/packages/api/internal/handlers/sandbox_connect.go
@@ -59,6 +59,8 @@ func (a *APIStore) PostSandboxesSandboxIDConnect(c *gin.Context, sandboxID api.S
 		return
 	}
 
+	span.SetAttributes(telemetry.WithSandboxID(sandboxID))
+
 	// It could happen that after sandbox transition, it'll be again transitioning, retry up to maxConnectRetries times.
 	const maxConnectRetries = 3
 

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -113,8 +113,9 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 
 	alias := firstAlias(env.Aliases)
 	telemetry.SetAttributes(ctx,
-		attribute.String("env.team.id", teamInfo.Team.ID.String()),
+		telemetry.WithSandboxID(sandboxID),
 		telemetry.WithTemplateID(env.TemplateID),
+		telemetry.WithBuildID(build.ID.String()),
 		attribute.String("env.alias", alias),
 		telemetry.WithKernelVersion(build.KernelVersion),
 		telemetry.WithFirecrackerVersion(build.FirecrackerVersion),

--- a/packages/api/internal/handlers/sandbox_kill.go
+++ b/packages/api/internal/handlers/sandbox_kill.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/e2b-dev/infra/packages/api/internal/db"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator"
@@ -59,7 +58,7 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	teamID := team.ID
 
 	telemetry.SetAttributes(ctx,
-		attribute.String("instance.id", sandboxID),
+		telemetry.WithSandboxID(sandboxID),
 		telemetry.WithTeamID(teamID.String()),
 	)
 

--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -37,6 +37,8 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 	}
 
 	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(telemetry.WithSandboxID(sandboxID))
+
 	traceID := span.SpanContext().TraceID().String()
 	c.Set("traceID", traceID)
 

--- a/packages/api/internal/handlers/sandbox_refresh.go
+++ b/packages/api/internal/handlers/sandbox_refresh.go
@@ -29,6 +29,8 @@ func (a *APIStore) PostSandboxesSandboxIDRefreshes(
 		return
 	}
 
+	telemetry.SetAttributes(ctx, telemetry.WithSandboxID(sandboxID))
+
 	team := auth.MustGetTeamInfo(c)
 	var duration time.Duration
 

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -33,7 +33,14 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	traceID := span.SpanContext().TraceID().String()
 	c.Set("traceID", traceID)
 
-	telemetry.ReportEvent(ctx, "Parsed body")
+	sandboxID, err := utils.ShortID(sandboxID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid sandbox ID")
+
+		return
+	}
+
+	span.SetAttributes(telemetry.WithSandboxID(sandboxID))
 
 	body, err := ginutils.ParseBody[api.PostSandboxesSandboxIDResumeJSONRequestBody](ctx, c)
 	if err != nil {
@@ -43,6 +50,8 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 
 		return
 	}
+
+	telemetry.ReportEvent(ctx, "Parsed body")
 
 	timeout := sandbox.SandboxTimeoutDefault
 	if body.Timeout != nil {
@@ -56,14 +65,6 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	}
 
 	teamID := teamInfo.Team.ID
-
-	sandboxID, err = utils.ShortID(sandboxID)
-	if err != nil {
-		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid sandbox ID")
-
-		return
-	}
-
 	sandboxData, err := a.orchestrator.GetSandbox(ctx, teamID, sandboxID)
 	if err == nil {
 		if sandboxData.TeamID != teamID {

--- a/packages/api/internal/handlers/sandbox_timeout.go
+++ b/packages/api/internal/handlers/sandbox_timeout.go
@@ -28,6 +28,8 @@ func (a *APIStore) PostSandboxesSandboxIDTimeout(
 		return
 	}
 
+	telemetry.SetAttributes(ctx, telemetry.WithSandboxID(sandboxID))
+
 	team := auth.MustGetTeamInfo(c)
 
 	var duration time.Duration

--- a/packages/api/internal/handlers/snapshot_template_create.go
+++ b/packages/api/internal/handlers/snapshot_template_create.go
@@ -45,6 +45,8 @@ func (a *APIStore) PostSandboxesSandboxIDSnapshots(c *gin.Context, sandboxID api
 		return
 	}
 
+	span.SetAttributes(telemetry.WithSandboxID(sandboxID))
+
 	body, err := ginutils.ParseBody[api.PostSandboxesSandboxIDSnapshotsJSONRequestBody](ctx, c)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk instrumentation-only changes; main risk is minor attribute inconsistency (e.g., `snapshot_template_create` sets `WithSandboxID` before normalizing via `ShortID`) which could fragment trace filtering.
> 
> **Overview**
> Adds consistent OpenTelemetry span attributes for `sandboxID` across sandbox lifecycle endpoints (connect/pause/resume/refresh/timeout/kill/snapshot), and includes `buildID` when creating sandboxes, improving trace correlation and debugging without changing the underlying sandbox behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65ba58a57279640b13d1e6df49b733fa0c87e068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->