### PR TITLE
wait for existing sandboxes to become runnable before returning

### DIFF
--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -104,36 +104,49 @@ func (o *Orchestrator) CreateSandbox(
 	// Calculate total concurrent instances including addons
 	totalConcurrentInstances := team.Limits.SandboxConcurrency
 
-	// Check if team has reached max instances
-	finishStart, waitForStart, err := o.sandboxStore.Reserve(ctx, team.Team.ID, sandboxID, int(totalConcurrentInstances))
-	if err != nil {
-		var limitErr *sandbox.LimitExceededError
+	var err error
+	var finishStart func(sandbox.Sandbox, error)
+	for {
+		// Check if team has reached max instances
+		var waitForStart func(ctx context.Context) (sandbox.Sandbox, error)
+		finishStart, waitForStart, err = o.sandboxStore.Reserve(ctx, team.Team.ID, sandboxID, int(totalConcurrentInstances))
+		if err != nil {
+			var limitErr *sandbox.LimitExceededError
 
-		switch {
-		case errors.As(err, &limitErr):
-			return sandbox.Sandbox{}, &api.APIError{
-				Code: http.StatusTooManyRequests,
-				ClientMsg: fmt.Sprintf(
-					"you have reached the maximum number of concurrent E2B sandboxes (%d). If you need more, "+
-						"please visit 'https://e2b.dev/docs/billing'", totalConcurrentInstances),
-				Err: fmt.Errorf("team '%s' has reached the maximum number of instances (%d)", team.ID, totalConcurrentInstances),
-			}
-		default:
-			logger.L().Error(ctx, "failed to reserve sandbox for team", logger.WithSandboxID(sandboxID), zap.Error(err))
+			switch {
+			case errors.As(err, &limitErr):
+				return sandbox.Sandbox{}, &api.APIError{
+					Code: http.StatusTooManyRequests,
+					ClientMsg: fmt.Sprintf(
+						"you have reached the maximum number of concurrent E2B sandboxes (%d). If you need more, "+
+							"please visit 'https://e2b.dev/docs/billing'", totalConcurrentInstances),
+					Err: fmt.Errorf("team '%s' has reached the maximum number of instances (%d)", team.ID, totalConcurrentInstances),
+				}
+			default:
+				logger.L().Error(ctx, "failed to reserve sandbox for team", logger.WithSandboxID(sandboxID), zap.Error(err))
 
-			return sandbox.Sandbox{}, &api.APIError{
-				Code:      http.StatusInternalServerError,
-				ClientMsg: fmt.Sprintf("Failed to create sandbox: %s", err),
-				Err:       err,
+				return sandbox.Sandbox{}, &api.APIError{
+					Code:      http.StatusInternalServerError,
+					ClientMsg: fmt.Sprintf("Failed to create sandbox: %s", err),
+					Err:       err,
+				}
 			}
 		}
-	}
 
-	if waitForStart != nil {
+		if waitForStart == nil {
+			break
+		}
+
 		logger.L().Info(ctx, "sandbox is already being started, waiting for it to be ready", logger.WithSandboxID(sandboxID))
 
 		sbx, err = waitForStart(ctx)
 		if err != nil {
+			if errors.Is(err, sandbox.ErrNotFound) {
+				logger.L().Info(ctx, "sandbox disappeared while waiting for readiness, retrying reservation", logger.WithSandboxID(sandboxID))
+
+				continue
+			}
+
 			logger.L().Warn(ctx, "Error waiting for sandbox to start", zap.Error(err), logger.WithSandboxID(sandboxID))
 
 			var apiErr *api.APIError

--- a/packages/api/internal/sandbox/store.go
+++ b/packages/api/internal/sandbox/store.go
@@ -168,13 +168,37 @@ func (s *Store) Sync(ctx context.Context, sandboxes []Sandbox, nodeID string) {
 	}
 }
 
+func (s *Store) waitForExistingSandbox(ctx context.Context, teamID uuid.UUID, sandboxID string) (Sandbox, error) {
+	for {
+		sbx, err := s.storage.Get(ctx, teamID, sandboxID)
+		if err != nil {
+			return Sandbox{}, err
+		}
+
+		if sbx.State == StateRunning {
+			return sbx, nil
+		}
+
+		logger.L().Info(ctx, "Sandbox exists but is not ready, waiting for state change",
+			logger.WithSandboxID(sandboxID),
+			zap.String("state", string(sbx.State)),
+		)
+
+		err = s.storage.WaitForStateChange(ctx, teamID, sandboxID)
+		if err != nil {
+			return Sandbox{}, err
+		}
+	}
+}
+
 func (s *Store) Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(Sandbox, error), waitForStart func(ctx context.Context) (Sandbox, error), err error) {
 	finishStart, waitForStart, err = s.reservations.Reserve(ctx, teamID, sandboxID, limit)
 	if err != nil {
 		if errors.Is(err, ErrAlreadyExists) {
-			// Try to get the sandbox from the storage if already exists
+			// Sandbox exists in storage already. Wait for it to become runnable or disappear,
+			// then let the caller decide whether to retry the reservation path.
 			return nil, func(ctx context.Context) (Sandbox, error) {
-				return s.storage.Get(ctx, teamID, sandboxID)
+				return s.waitForExistingSandbox(ctx, teamID, sandboxID)
 			}, nil
 		}
 

--- a/packages/api/internal/sandbox/store_test.go
+++ b/packages/api/internal/sandbox/store_test.go
@@ -143,6 +143,85 @@ func (m *MockStorage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
 	return m.Storage.Add(ctx, sbx)
 }
 
+type reserveResponse struct {
+	finishStart  func(sandbox.Sandbox, error)
+	waitForStart func(context.Context) (sandbox.Sandbox, error)
+	err          error
+}
+
+type ScriptedReservationStorage struct {
+	mu        sync.Mutex
+	responses []reserveResponse
+	calls     int
+}
+
+func (s *ScriptedReservationStorage) Reserve(_ context.Context, _ uuid.UUID, _ string, _ int) (func(sandbox.Sandbox, error), func(context.Context) (sandbox.Sandbox, error), error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.calls >= len(s.responses) {
+		return nil, nil, fmt.Errorf("unexpected Reserve call %d", s.calls+1)
+	}
+
+	resp := s.responses[s.calls]
+	s.calls++
+
+	return resp.finishStart, resp.waitForStart, resp.err
+}
+
+func (s *ScriptedReservationStorage) Release(_ context.Context, _ uuid.UUID, _ string) error {
+	return nil
+}
+
+type StatefulStorage struct {
+	sandbox.Storage
+
+	mu        sync.Mutex
+	current   *sandbox.Sandbox
+	waitCalls int
+	waitErr   error
+	onWait    func()
+}
+
+func NewStatefulStorage(current *sandbox.Sandbox) *StatefulStorage {
+	return &StatefulStorage{
+		Storage: memory.NewStorage(),
+		current: current,
+	}
+}
+
+func (s *StatefulStorage) Get(_ context.Context, teamID uuid.UUID, sandboxID string) (sandbox.Sandbox, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.current == nil || s.current.TeamID != teamID || s.current.SandboxID != sandboxID {
+		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+	}
+
+	return *s.current, nil
+}
+
+func (s *StatefulStorage) WaitForStateChange(_ context.Context, _ uuid.UUID, _ string) error {
+	s.mu.Lock()
+	s.waitCalls++
+	onWait := s.onWait
+	waitErr := s.waitErr
+	s.mu.Unlock()
+
+	if onWait != nil {
+		onWait()
+	}
+
+	return waitErr
+}
+
+func (s *StatefulStorage) WaitCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.waitCalls
+}
+
 // createTestSandbox creates a test sandbox with default values
 func createTestSandbox() sandbox.Sandbox {
 	return sandbox.NewSandbox(
@@ -532,5 +611,67 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 		stored, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, err)
 		assert.Equal(t, sbx.SandboxID, stored.SandboxID)
+	})
+}
+
+func TestReserve_ExistingSandbox(t *testing.T) {
+	t.Parallel()
+
+	t.Run("running sandbox is returned immediately", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		sbx := createTestSandbox()
+		storage := NewStatefulStorage(&sbx)
+		reservations := &ScriptedReservationStorage{
+			responses: []reserveResponse{
+				{err: sandbox.ErrAlreadyExists},
+			},
+		}
+		store := sandbox.NewStore(storage, reservations, sandbox.Callbacks{})
+
+		finishStart, waitForStart, err := store.Reserve(ctx, sbx.TeamID, sbx.SandboxID, 1)
+		require.NoError(t, err)
+		assert.Nil(t, finishStart)
+		require.NotNil(t, waitForStart)
+
+		got, err := waitForStart(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, sbx.SandboxID, got.SandboxID)
+		assert.Equal(t, sandbox.StateRunning, got.State)
+		assert.Equal(t, 0, storage.WaitCalls())
+		assert.Equal(t, 1, reservations.calls)
+	})
+
+	t.Run("pausing sandbox waits for state change and then disappears", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+
+		sbx := createTestSandbox()
+		sbx.State = sandbox.StatePausing
+
+		storage := NewStatefulStorage(&sbx)
+		storage.onWait = func() {
+			storage.mu.Lock()
+			defer storage.mu.Unlock()
+			storage.current = nil
+		}
+
+		reservations := &ScriptedReservationStorage{
+			responses: []reserveResponse{
+				{err: sandbox.ErrAlreadyExists},
+			},
+		}
+		store := sandbox.NewStore(storage, reservations, sandbox.Callbacks{})
+
+		_, waitForStart, err := store.Reserve(ctx, sbx.TeamID, sbx.SandboxID, 1)
+		require.NoError(t, err)
+		require.NotNil(t, waitForStart)
+
+		_, err = waitForStart(ctx)
+		require.Error(t, err)
+		require.ErrorIs(t, err, sandbox.ErrNotFound)
+		assert.Equal(t, 1, storage.WaitCalls())
+		assert.Equal(t, 1, reservations.calls)
 	})
 }


### PR DESCRIPTION
draft [wip]: fix connect/readiness gap leading to post-connect run failures during pause/autopause transitions.

When reserve hits ErrAlreadyExists, do not treat storage presence as readiness. Wait for the existing sandbox to reach running, and if it disappears while that wait is in flight, retry reservation/start instead of returning early.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox reservation/startup flow and adds retry loops, which could impact sandbox creation latency or introduce unexpected waits if state transitions don’t fire as expected.
> 
> **Overview**
> Fixes a readiness gap when `Reserve` encounters `ErrAlreadyExists` by waiting for the existing sandbox to transition to `StateRunning` (via `WaitForStateChange`) instead of immediately returning a potentially non-runnable record, and updates `CreateSandbox` to retry the reservation path if the sandbox disappears while waiting; adds tests covering immediate-return for running sandboxes and wait-then-`ErrNotFound` behavior during pause transitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d43f71704a8d617e39d1174344a3e2aaab201b0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->