### PR TITLE
pin patch version of python

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -8,5 +8,5 @@ protoc 29.3
 protoc-gen-connect-go 1.18.1
 protoc-gen-go 1.28.1
 protoc-gen-go-grpc 1.6.1
-python 3.13
+python 3.13.11
 terraform 1.5.7


### PR DESCRIPTION
`generated-code-check / run-check` breaks on 3.13.12, pinning to 3.13.11

e.g. https://github.com/e2b-dev/infra/actions/runs/23374131810/job/68003231548

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk change limited to tool version pinning; main impact is that developer/CI environments must have Python `3.13.11` available.
> 
> **Overview**
> Pins Python to the patch version `3.13.11` (instead of the floating `3.13`) in `.tool-versions` to make toolchain resolution and builds more reproducible across machines and CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83f2afa3c62e7d58982ea83c82b4551457d47af8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->