### PR TITLE
Add env var for ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -82,7 +82,8 @@ tf_vars := \
 	$(call tfvar, DB_MIN_IDLE_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MAX_OPEN_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS) \
-	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE)
+	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE) \
+	$(call tfvar, ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS)
 
 .PHONY: init
 init:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adds wiring for a new Terraform variable in the GCP Makefile and does not change runtime application logic.
> 
> **Overview**
> Adds support for configuring extra API paths handled by ingress by exporting `ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS` as a Terraform variable during GCP IaC `make` workflows, alongside the existing `GCS_GRPC_CONNECTION_POOL_SIZE` variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a432df76ad240169b50dd88331db3d6d62f74256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->