### PR TITLE
chore(metrics): turn feature flags on by default

### DIFF
--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -97,8 +97,8 @@ func newBoolFlag(name string, fallback bool) BoolFlag {
 }
 
 var (
-	MetricsWriteFlag                    = newBoolFlag("sandbox-metrics-write", env.IsDevelopment())
-	MetricsReadFlag                     = newBoolFlag("sandbox-metrics-read", env.IsDevelopment())
+	MetricsWriteFlag                    = newBoolFlag("sandbox-metrics-write", true)
+	MetricsReadFlag                     = newBoolFlag("sandbox-metrics-read", true)
 	SnapshotFeatureFlag                 = newBoolFlag("use-nfs-for-snapshots", env.IsDevelopment())
 	TemplateFeatureFlag                 = newBoolFlag("use-nfs-for-templates", env.IsDevelopment())
 	EnableWriteThroughCacheFlag         = newBoolFlag("write-to-cache-on-writes", false)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the default behavior of metrics reads/writes, which can increase ClickHouse/query/write load and affect observability costs or stability if the backend isn’t ready. No auth or data integrity logic is modified beyond enabling the metrics paths.
> 
> **Overview**
> This PR flips the default fallbacks for the `sandbox-metrics-read` and `sandbox-metrics-write` feature flags to `true`, enabling the ClickHouse-backed sandbox/team metrics read paths and sandbox metrics write/checks by default even when LaunchDarkly flags aren’t explicitly set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6585d32c41f28caeaa0eadc1d059f75d066c4115. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->