### PR TITLE
fix(orchestrator): cleanup running sandboxes on shutdown

### DIFF
--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -492,6 +492,7 @@ func run(config cfg.Config) (success bool) {
 	if err != nil {
 		logger.L().Fatal(ctx, "failed to create orchestrator server", zap.Error(err))
 	}
+	closers = append(closers, closer{"orchestrator service", orchestratorService.Close})
 
 	// template manager sandbox logger
 	tmplSbxLoggerExternal := sbxlogger.NewLogger(

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -2,12 +2,15 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
 	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
@@ -21,6 +24,8 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/service"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -105,4 +110,45 @@ func New(cfg ServiceConfig) (*Server, error) {
 	}
 
 	return server, nil
+}
+
+func (s *Server) Close(ctx context.Context) error {
+	s.uploadedBuilds.Stop()
+
+	sandboxes := s.sandboxFactory.Sandboxes.Items()
+	if len(sandboxes) == 0 {
+		return nil
+	}
+
+	logger.L().Info(ctx, "stopping remaining sandboxes on shutdown", zap.Int("sandbox_count", len(sandboxes)))
+
+	var g errgroup.Group
+	for sandboxID, sbx := range sandboxes {
+		if sbx == nil {
+			continue
+		}
+
+		sandboxID := sandboxID
+		sbx := sbx
+		g.Go(func() error {
+			sbxlogger.E(sbx).Info(ctx, "stopping sandbox during orchestrator shutdown")
+			s.sandboxFactory.Sandboxes.RemoveByLifecycleID(ctx, sandboxID, sbx.LifecycleID)
+
+			if err := sbx.Stop(ctx); err != nil {
+				return fmt.Errorf("failed to stop sandbox %s: %w", sandboxID, err)
+			}
+
+			if err := sbx.Close(ctx); err != nil {
+				return fmt.Errorf("failed to cleanup sandbox %s: %w", sandboxID, err)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return errors.Join(err, ctx.Err())
+	}
+
+	return nil
 }

--- a/packages/orchestrator/pkg/server/sandboxes_test.go
+++ b/packages/orchestrator/pkg/server/sandboxes_test.go
@@ -1,12 +1,15 @@
 package server
 
 import (
+	"context"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -125,4 +128,45 @@ func TestGetSandboxExecutionData(t *testing.T) {
 	assert.Equal(t, int64(512), result["memory_mb"])
 	assert.IsType(t, int64(0), result["execution_time"])
 	assert.Positive(t, result["execution_time"].(int64))
+}
+
+func TestServerClose_EmptyOrNonRunningSandboxes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty sandboxes map", func(t *testing.T) {
+		t.Parallel()
+
+		s := &Server{
+			sandboxFactory: &sandbox.Factory{Sandboxes: sandbox.NewSandboxesMap()},
+			uploadedBuilds: ttlcache.New[string, struct{}](),
+		}
+
+		require.NoError(t, s.Close(t.Context()))
+	})
+
+	t.Run("contains only non-running sandboxes", func(t *testing.T) {
+		t.Parallel()
+
+		sandboxes := sandbox.NewSandboxesMap()
+		sbx := &sandbox.Sandbox{
+			Metadata: &sandbox.Metadata{
+				Config: sandbox.NewConfig(sandbox.Config{}),
+				Runtime: sandbox.RuntimeMetadata{
+					SandboxID: id.Generate(),
+				},
+			},
+			Resources: &sandbox.Resources{
+				Slot: &network.Slot{HostIP: net.IPv4(127, 0, 0, 1)},
+			},
+		}
+
+		sandboxes.Insert(context.Background(), sbx)
+
+		s := &Server{
+			sandboxFactory: &sandbox.Factory{Sandboxes: sandboxes},
+			uploadedBuilds: ttlcache.New[string, struct{}](),
+		}
+
+		require.NoError(t, s.Close(t.Context()))
+	})
 }


### PR DESCRIPTION
## Summary

This fixes orphan Firecracker processes after orchestrator restarts by adding explicit sandbox cleanup during shutdown.

- add `Server.Close()` in orchestrator server to stop/cleanup remaining running sandboxes
- register server close in orchestrator shutdown closers so cleanup is always triggered on process exit
- add unit tests for `Server.Close()` edge cases (empty map and non-running sandboxes)
