### PR TITLE
fix(deps): use v0.0.0 for shared dependency in clickhouse and db modules

### DIFF
--- a/packages/clickhouse/go.mod
+++ b/packages/clickhouse/go.mod
@@ -8,7 +8,7 @@ tool github.com/pressly/goose/v3/cmd/goose
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
-	github.com/e2b-dev/infra/packages/shared v0.0.0-20250811171846-d1cdc9527dec
+	github.com/e2b-dev/infra/packages/shared v0.0.0
 	github.com/google/uuid v1.6.0
 	go.uber.org/zap v1.27.1
 )

--- a/packages/db/go.mod
+++ b/packages/db/go.mod
@@ -10,7 +10,7 @@ tool (
 )
 
 require (
-	github.com/e2b-dev/infra/packages/shared v0.0.0-20250324174051-3fb806938dc1
+	github.com/e2b-dev/infra/packages/shared v0.0.0
 	github.com/exaring/otelpgx v0.9.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6


### PR DESCRIPTION
The clickhouse and db go.mod files had date-stamped pseudo-versions for the shared package (e.g. v0.0.0-20250811...) instead of plain v0.0.0. While this works locally thanks to the `replace => ../shared` directive, external consumers (such as company-private repos) resolve the published go.mod and see the old pseudo-version as a real dependency. Go's MVS then pulls both the old and new shared versions, and the old shared transitively requires prometheus/prometheus@v1.8.2 — a pre-modules pseudo-version that is higher than the modern v0.309.1 in semver. This breaks packages that depend on grafana/loki, which expects the modern prometheus package layout.

Using v0.0.0 ensures external consumers only see the version they explicitly replace, avoiding phantom transitive dependencies.