### PR TITLE
fix(deps): use v0.0.0 for shared dependency in clickhouse and db

### DIFF
--- a/packages/clickhouse/go.mod
+++ b/packages/clickhouse/go.mod
@@ -8,7 +8,7 @@ tool github.com/pressly/goose/v3/cmd/goose
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.40.1
-	github.com/e2b-dev/infra/packages/shared v0.0.0-20250811171846-d1cdc9527dec
+	github.com/e2b-dev/infra/packages/shared v0.0.0
 	github.com/google/uuid v1.6.0
 	go.uber.org/zap v1.27.1
 )

--- a/packages/db/go.mod
+++ b/packages/db/go.mod
@@ -10,7 +10,7 @@ tool (
 )
 
 require (
-	github.com/e2b-dev/infra/packages/shared v0.0.0-20250324174051-3fb806938dc1
+	github.com/e2b-dev/infra/packages/shared v0.0.0
 	github.com/exaring/otelpgx v0.9.3
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6


### PR DESCRIPTION
## Summary

- Change `require shared v0.0.0-<old-timestamp>` to `require shared v0.0.0` in clickhouse and db go.mod files

## Problem

The clickhouse and db modules had date-stamped pseudo-versions for the shared package (e.g. `v0.0.0-20250811...`). These modules already use `replace => ../shared`, so locally in infra's workspace everything resolves fine.

However, when external consumers (belt) fetch these modules, Go resolves the published go.mod and sees the old pseudo-version as a real transitive dependency. The old shared version pulls in `prometheus/prometheus@v1.8.2` — a pre-modules pseudo-version that is numerically higher than the modern `v0.309.1` in semver. This breaks packages that depend on `grafana/loki`, which expects the modern prometheus package layout.

## Fix

Use `v0.0.0` in the `require` line. This works because:
- **Locally in infra**: `replace => ../shared` resolves it
- **Externally in belt**: `make update-infra-dependencies` adds a `replace v0.0.0 => v0.0.0-<concrete-commit>` for all infra dependencies

## Test plan

- [x] `go build ./...` passes for clickhouse and db packages