### PR TITLE
fix(otel-collector-nomad-server): don't set service.instance.id to otel collector's host name

### DIFF
--- a/iac/modules/job-otel-collector-nomad-server/configs/otel-collector-nomad-server.yaml
+++ b/iac/modules/job-otel-collector-nomad-server/configs/otel-collector-nomad-server.yaml
@@ -118,7 +118,8 @@ processors:
 
   transform/set-name:
     metric_statements:
-      - set(datapoint.attributes["service.instance.id"], resource.attributes["host.name"])
+      # We don't want to set host name here as we want to report the nomad server, not the otel collector's host
+      # - set(datapoint.attributes["service.instance.id"], resource.attributes["host.name"])
       - set(datapoint.attributes["deployment.environment"], resource.attributes["cloud.account.id"])
       - delete_key(resource.attributes, "service.name")
 


### PR DESCRIPTION
In otel collector we set this to keep the information on which node the code was running, but the otel collector for nomad server doesn't run on the same node