### PR TITLE
Removed `additional_api_path_rules` value replaced by new `additional_api_paths_handled_by_ingress`

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -39,7 +39,6 @@ tf_vars := \
 	$(call tfvar, GCP_REGION) \
 	$(call tfvar, GCP_ZONE) \
 	$(call tfvar, DOMAIN_NAME) \
-	$(call tfvar, ADDITIONAL_API_SERVICES_JSON) \
 	$(call tfvar, PREFIX) \
 	$(call tfvar, SANDBOX_STORAGE_BACKEND) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -51,12 +51,6 @@ data "google_secret_manager_secret_version" "routing_domains" {
 
 locals {
   additional_domains = nonsensitive(jsondecode(data.google_secret_manager_secret_version.routing_domains.secret_data))
-  additional_api_services = (
-    length(var.additional_api_services) > 0 ? var.additional_api_services :
-    var.additional_api_services_json != "" ? jsondecode(var.additional_api_services_json) :
-    []
-  )
-
 
   // Check if all clusters has size greater than 1
   template_manages_clusters_size_gt_1 = alltrue([for c in var.build_clusters_config : (c.cluster_size > 1)])
@@ -158,7 +152,6 @@ module "cluster" {
   domain_name                  = var.domain_name
 
   additional_domains                      = local.additional_domains
-  additional_api_services                 = local.additional_api_services
   additional_api_paths_handled_by_ingress = var.additional_api_paths_handled_by_ingress
 
   docker_contexts_bucket_name = module.init.envs_docker_context_bucket_name

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -130,15 +130,6 @@ module "network" {
 
   labels = var.labels
   prefix = var.prefix
-
-  additional_api_path_rules = [
-    for service in var.additional_api_services : {
-      paths      = service.paths
-      service_id = service.service_id
-    }
-  ]
-
-  additional_ports = [for service in var.additional_api_services : service.api_node_group_port]
 }
 
 module "filestore" {

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -277,14 +277,6 @@ resource "google_compute_url_map" "orch_map" {
         service = google_compute_backend_service.ingress.self_link
       }
     }
-
-    dynamic "path_rule" {
-      for_each = var.additional_api_path_rules
-      content {
-        paths   = path_rule.value.paths
-        service = path_rule.value.service_id
-      }
-    }
   }
 
   path_matcher {
@@ -462,15 +454,6 @@ resource "google_compute_firewall" "default-hc" {
   allow {
     protocol = "tcp"
     ports    = [var.ingress_port.port]
-  }
-
-  dynamic "allow" {
-    for_each = toset(var.additional_ports)
-
-    content {
-      protocol = "tcp"
-      ports    = [allow.value]
-    }
   }
 }
 

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -106,16 +106,3 @@ variable "labels" {
 variable "additional_api_paths_handled_by_ingress" {
   type = list(string)
 }
-
-variable "additional_api_path_rules" {
-  description = "Additional path rules to add to the load balancer routing."
-  type = list(object({
-    paths      = list(string)
-    service_id = string
-  }))
-}
-
-variable "additional_ports" {
-  description = "Additional ports to expose on the load balancer."
-  type        = list(number)
-}

--- a/iac/provider-gcp/nomad-cluster/nodepool-api.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-api.tf
@@ -1,11 +1,5 @@
 locals {
   api_pool_name = "${var.prefix}orch-api"
-  api_additional_ports = [
-    for service in var.additional_api_services : {
-      name = service.api_node_group_port_name
-      port = service.api_node_group_port
-    }
-  ]
 
   api_startup_script = templatefile("${path.module}/scripts/start-api.sh", {
     CLUSTER_TAG_NAME             = var.cluster_tag_name
@@ -74,14 +68,6 @@ resource "google_compute_instance_group_manager" "api_pool" {
   named_port {
     name = var.ingress_port.name
     port = var.ingress_port.port
-  }
-
-  dynamic "named_port" {
-    for_each = local.api_additional_ports
-    content {
-      name = "${var.prefix}${named_port.value.name}"
-      port = named_port.value.port
-    }
   }
 
   auto_healing_policies {

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -270,17 +270,6 @@ variable "clickhouse_health_port" {
   })
 }
 
-variable "additional_api_services" {
-  description = "Additional path rules to add to the load balancer routing."
-  type = list(object({
-    paths      = list(string)
-    service_id = string
-
-    api_node_group_port_name = string
-    api_node_group_port      = number
-  }))
-}
-
 variable "filestore_cache_enabled" {
   type    = bool
   default = false

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -317,37 +317,6 @@ variable "domain_name" {
   description = "The domain name where e2b will run"
 }
 
-variable "additional_api_services_json" {
-  type        = string
-  description = <<EOT
-Deprecated. Use `additional_api_services` instead.
-
-Additional path rules to add to the API path matcher.
-Format: json string of an array of objects with 'path' and 'service' keys.
-Example:
-[
-  {
-    "paths": ["/api/v1"],
-    "service_id": "projects/e2b/global/backendServices/example",
-    "api_node_group_port_name": "example-port",
-    "api_node_group_port": 8080
-  }
-]
-EOT
-  default     = ""
-}
-
-variable "additional_api_services" {
-  type = list(object({
-    paths                    = list(string)
-    service_id               = string
-    api_node_group_port_name = string
-    api_node_group_port      = number
-  }))
-  description = "Additional path rules to add to the API path matcher."
-  default     = []
-}
-
 variable "prefix" {
   type        = string
   description = "The prefix to use for all resources in this module"


### PR DESCRIPTION
This change removes the legacy way of propagating additional backends for api paths. There is a new, prettier way that uses our ingress so GCP backend and VM group port propagation is not needed.

All services are already exposed via Traefik, so we can deploy this.