### PR TITLE
fix: add missing `make destroy` target to top-level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,11 @@ move:
 	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
 	$(MAKE) -C iac/provider-$(PROVIDER) move
 
+.PHONY: destroy
+destroy:
+	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
+	$(MAKE) -C iac/provider-$(PROVIDER) destroy
+
 .PHONY: version
 version:
 	./scripts/increment-version.sh


### PR DESCRIPTION
## Summary
- The self-host docs (`self-host.md`) reference `make destroy` but the target only existed in the provider-specific Makefiles (`iac/provider-gcp/Makefile`, `iac/provider-aws/Makefile`), not the top-level `Makefile`.
- Adds the `destroy` target following the same delegation pattern used by `plan`, `apply`, `import`, and `move` — with the `confirm.sh` safety prompt.

## Test plan
- [ ] Run `make destroy` from the repo root and verify it delegates to the correct provider Makefile
- [ ] Verify the confirmation prompt appears before Terraform runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)