### PR TITLE
fix(orch): clean up orphan firecracker processes on orchestrator shutdown

### DIFF
--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -758,6 +758,12 @@ func run(config cfg.Config, opts Options) (success bool) {
 		}
 	}
 
+	logger.L().Info(ctx, "Stopping all active sandboxes")
+	if err := sandboxFactory.StopAll(closeCtx); err != nil {
+		logger.L().Error(ctx, "error while stopping active sandboxes", zap.Error(err))
+		success = false
+	}
+
 	slices.Reverse(closers)
 	for _, closer := range closers {
 		clog := globalLogger.With(zap.String("service", closer.name), zap.Bool("forced", config.ForceStop))

--- a/packages/orchestrator/pkg/sandbox/fc/process.go
+++ b/packages/orchestrator/pkg/sandbox/fc/process.go
@@ -181,7 +181,8 @@ func NewProcess(
 	)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true, // Create a new session
+		Setsid:    true,
+		Pdeathsig: syscall.SIGKILL,
 	}
 
 	return &Process{

--- a/packages/orchestrator/pkg/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/pkg/sandbox/fc/script_builder.go
@@ -47,7 +47,7 @@ ln -s {{ .HostRootfsPath }} {{ .DeprecatedSandboxRootfsDir }}/{{ .SandboxRootfsF
 mount -t tmpfs tmpfs {{ .SandboxDir }}/{{ .SandboxKernelDir }} -o X-mount.mkdir &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+exec ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
 
 const startScriptV2 = `mount --make-rprivate / &&
 mount -t tmpfs tmpfs {{ .SandboxDir }} -o X-mount.mkdir &&
@@ -57,7 +57,7 @@ ln -s {{ .HostRootfsPath }} {{ .SandboxDir }}/{{ .SandboxRootfsFile }} &&
 mkdir -p {{ .SandboxDir }}/{{ .SandboxKernelDir }} &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+exec ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
 
 // StartScriptBuilder handles the creation and execution of firecracker start scripts
 type StartScriptBuilder struct {

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -273,6 +273,7 @@ type Factory struct {
 	featureFlags      *featureflags.Client
 	hostStatsDelivery hoststats.Delivery
 	cgroupManager     cgroup.Manager
+	activeSandboxes   sync.Map
 }
 
 func NewFactory(
@@ -333,7 +334,11 @@ func (f *Factory) CreateSandbox(
 	}()
 
 	lifecycleID := uuid.NewString()
-	// We want to remove from the map as late as possible
+	cleanup.Add(ctx, func(context.Context) error {
+		f.activeSandboxes.Delete(lifecycleID)
+
+		return nil
+	})
 	cleanup.Add(ctx, func(ctx context.Context) error {
 		f.Sandboxes.Remove(ctx, runtime.SandboxID, lifecycleID)
 
@@ -514,6 +519,8 @@ func (f *Factory) CreateSandbox(
 	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
 	sbx.Checks = NewChecks(sbx, useClickhouseMetrics)
 
+	f.activeSandboxes.Store(sbx.LifecycleID, sbx)
+
 	// Stop the sandbox first if it is still running, otherwise do nothing
 	cleanup.AddPriority(ctx, sbx.Stop)
 
@@ -574,7 +581,11 @@ func (f *Factory) ResumeSandbox(
 	}()
 
 	lifecycleID := uuid.NewString()
-	// We want to remove from the map as late as possible
+	cleanup.Add(ctx, func(context.Context) error {
+		f.activeSandboxes.Delete(lifecycleID)
+
+		return nil
+	})
 	cleanup.Add(ctx, func(ctx context.Context) error {
 		f.Sandboxes.Remove(ctx, runtime.SandboxID, lifecycleID)
 
@@ -884,6 +895,8 @@ func (f *Factory) ResumeSandbox(
 	}
 
 	f.Sandboxes.MarkRunning(ctx, sbx)
+
+	f.activeSandboxes.Store(sbx.LifecycleID, sbx)
 
 	telemetry.ReportEvent(execCtx, "envd initialized")
 
@@ -1387,4 +1400,55 @@ func (f *Factory) GetEnvdInitRequestTimeout(ctx context.Context) time.Duration {
 	envdInitRequestTimeoutMs := f.featureFlags.IntFlag(ctx, featureflags.EnvdInitTimeoutMilliseconds)
 
 	return time.Duration(envdInitRequestTimeoutMs) * time.Millisecond
+}
+
+const stopAllTimeout = 30 * time.Second
+
+// StopAll stops every known active sandbox in parallel.
+// Cleanup (Close) is left to the normal per-sandbox exit-wait goroutine.
+func (f *Factory) StopAll(ctx context.Context) error {
+	var (
+		mu   sync.Mutex
+		errs []error
+		wg   sync.WaitGroup
+	)
+
+	f.activeSandboxes.Range(func(_, value any) bool {
+		sbx, ok := value.(*Sandbox)
+		if !ok || sbx == nil {
+			return true
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			f.Sandboxes.MarkStopping(ctx, sbx.Runtime.SandboxID, sbx.LifecycleID)
+
+			if stopErr := sbx.Stop(ctx); stopErr != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("sandbox %s stop failed: %w",
+					sbx.Runtime.SandboxID, stopErr))
+				mu.Unlock()
+			}
+		}()
+
+		return true
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(stopAllTimeout):
+		mu.Lock()
+		errs = append(errs, fmt.Errorf("timed out after %s waiting for sandboxes to stop", stopAllTimeout))
+		mu.Unlock()
+	}
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Summary

Fix orphan Firecracker process cleanup on orchestrator shutdown.

On orchestrator shutdown/crash, some Firecracker VMs could outlive the orchestrator and remain as orphan processes. This change tightens process lifecycle handling and adds explicit active-sandbox shutdown during drain.

## Root Cause

1. Firecracker was started through `bash -c ...` without replacing the shell process.
2. Firecracker process creation did not enforce a parent-death signal.
3. Shutdown flow did not explicitly stop all active sandboxes before closing dependent services.

## Fix

- Use `exec` in Firecracker start scripts so shell is replaced by Firecracker.
- Set `Pdeathsig: SIGKILL` in Firecracker process `SysProcAttr`.
- Track active sandboxes in `sandbox.Factory` (`activeSandboxes`).
- Add `StopAll(ctx)` in `sandbox.Factory` to stop active sandboxes in parallel with timeout + aggregated errors.
- Call `sandboxFactory.StopAll(closeCtx)` during orchestrator drain phase before running closers.

## Test

- [x] `go test ./pkg/sandbox/... ./pkg/factories/...`
- [x] Manual: create active sandboxes, trigger orchestrator shutdown (`SIGTERM`)
- [x] Manual: verify sandboxes transition to stopping/stopped
- [x] Manual: verify no orphan `firecracker` processes remain after orchestrator exits
