### PR TITLE
chore(api): refactor get last snapshot query

### DIFF
--- a/packages/db/queries/get_last_snapshot.sql.go
+++ b/packages/db/queries/get_last_snapshot.sql.go
@@ -12,8 +12,15 @@ import (
 const getLastSnapshot = `-- name: GetLastSnapshot :one
 SELECT COALESCE(ea.aliases, ARRAY[]::text[])::text[] AS aliases, COALESCE(ea.names, ARRAY[]::text[])::text[] AS names, s.created_at, s.env_id, s.sandbox_id, s.id, s.metadata, s.base_env_id, s.sandbox_started_at, s.env_secure, s.origin_node_id, s.allow_internet_access, s.auto_pause, s.team_id, s.config, eb.id, eb.created_at, eb.updated_at, eb.finished_at, eb.status, eb.dockerfile, eb.start_cmd, eb.vcpu, eb.ram_mb, eb.free_disk_size_mb, eb.total_disk_size_mb, eb.kernel_version, eb.firecracker_version, eb.env_id, eb.envd_version, eb.ready_cmd, eb.cluster_node_id, eb.reason, eb.version, eb.cpu_architecture, eb.cpu_family, eb.cpu_model, eb.cpu_model_name, eb.cpu_flags, eb.status_group, eb.team_id
 FROM "public"."snapshots" s
-JOIN "public"."env_build_assignments" eba ON eba.env_id = s.env_id AND eba.tag = 'default'
-JOIN "public"."env_builds" eb ON eb.id = eba.build_id
+JOIN LATERAL (
+    SELECT eba.build_id
+    FROM "public"."env_build_assignments" eba
+    JOIN "public"."env_builds" eb_inner ON eb_inner.id = eba.build_id AND eb_inner.status_group = 'ready'
+    WHERE eba.env_id = s.env_id AND eba.tag = 'default'
+    ORDER BY eba.created_at DESC
+    LIMIT 1
+) latest_eba ON TRUE
+JOIN "public"."env_builds" eb ON eb.id = latest_eba.build_id
 LEFT JOIN LATERAL (
     SELECT
         ARRAY_AGG(alias ORDER BY alias) AS aliases,
@@ -21,9 +28,7 @@ LEFT JOIN LATERAL (
     FROM "public"."env_aliases"
     WHERE env_id = s.base_env_id
 ) ea ON TRUE
-WHERE s.sandbox_id = $1 AND eb.status_group = 'ready'
-ORDER BY eba.created_at DESC
-LIMIT 1
+WHERE s.sandbox_id = $1
 `
 
 type GetLastSnapshotRow struct {

--- a/packages/db/queries/snapshots/get_last_snapshot.sql
+++ b/packages/db/queries/snapshots/get_last_snapshot.sql
@@ -1,8 +1,15 @@
 -- name: GetLastSnapshot :one
 SELECT COALESCE(ea.aliases, ARRAY[]::text[])::text[] AS aliases, COALESCE(ea.names, ARRAY[]::text[])::text[] AS names, sqlc.embed(s), sqlc.embed(eb)
 FROM "public"."snapshots" s
-JOIN "public"."env_build_assignments" eba ON eba.env_id = s.env_id AND eba.tag = 'default'
-JOIN "public"."env_builds" eb ON eb.id = eba.build_id
+JOIN LATERAL (
+    SELECT eba.build_id
+    FROM "public"."env_build_assignments" eba
+    JOIN "public"."env_builds" eb_inner ON eb_inner.id = eba.build_id AND eb_inner.status_group = 'ready'
+    WHERE eba.env_id = s.env_id AND eba.tag = 'default'
+    ORDER BY eba.created_at DESC
+    LIMIT 1
+) latest_eba ON TRUE
+JOIN "public"."env_builds" eb ON eb.id = latest_eba.build_id
 LEFT JOIN LATERAL (
     SELECT
         ARRAY_AGG(alias ORDER BY alias) AS aliases,
@@ -10,6 +17,4 @@ LEFT JOIN LATERAL (
     FROM "public"."env_aliases"
     WHERE env_id = s.base_env_id
 ) ea ON TRUE
-WHERE s.sandbox_id = $1 AND eb.status_group = 'ready'
-ORDER BY eba.created_at DESC
-LIMIT 1;
+WHERE s.sandbox_id = $1;


### PR DESCRIPTION
This should prevent iterating over all `env_build_assignments` and improving the performance for snapshots with a lot of iterations of pause/resume