### PR TITLE
docs(envd): document version bump requirement on behavioral changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ Client → Client-Proxy → API (REST) ⟷ PostgreSQL
 - Process management API: `/spec/process/process.proto`
 - Filesystem API: `/spec/filesystem/filesystem.proto`
 - Port: 49983
+- **Version in `pkg/version.go` must be bumped on every behavioral change** (not comments/docs-only changes)
 
 **Client Proxy (`packages/client-proxy/`)** - Edge routing layer
 - Service discovery via Consul

--- a/packages/envd/README.md
+++ b/packages/envd/README.md
@@ -4,6 +4,12 @@ Daemon that runs inside a sandbox that allows interacting with the sandbox via c
 
 ## Development
 
+### Versioning
+
+The envd version in `pkg/version.go` must be bumped on every change that affects behavior (code changes, dependency updates, etc.). Pure comment or documentation changes that don't affect the compiled binary don't require a version bump.
+
+### Running locally
+
 Run the following command to (re)build the envd daemon and start a Docker container with envd running inside:
 
 ```bash


### PR DESCRIPTION
The envd version in pkg/version.go must be bumped on every behavioral
change, but this was only tribal knowledge. Document it in the envd
README and CLAUDE.md so contributors and AI assistants are aware of
the requirement.