### PR TITLE
fix: update test.Dockerfile after internal/ → pkg/ migration

### DIFF
--- a/packages/orchestrator/test.Dockerfile
+++ b/packages/orchestrator/test.Dockerfile
@@ -16,7 +16,7 @@ COPY .shared/pkg pkg
 
 WORKDIR /build/clickhouse
 
-# Copy clickhouse package dependencies  
+# Copy clickhouse package dependencies
 COPY .clickhouse/go.mod .clickhouse/go.sum ./
 RUN go mod download
 
@@ -30,7 +30,9 @@ RUN go mod download
 
 # Copy source code
 COPY main.go Makefile ./
-COPY internal internal
+COPY scripts scripts
+COPY pkg pkg
+COPY cmd cmd
 
 FROM base AS runner
 


### PR DESCRIPTION
## Summary

- Replace `COPY internal internal` with `COPY pkg pkg`, `COPY cmd cmd`, `COPY scripts scripts`
- The orchestrator code moved from `internal/` to `pkg/` in #2184 but `test.Dockerfile` was not updated
- Also adds `scripts/` (needed for `fetch-busybox` once #2281 lands) and `cmd/` for full coverage

## Test plan

- [ ] `make test-docker` completes successfully