### PR TITLE
fix: default BUILD_ARCH to amd64 instead of host architecture

### DIFF
--- a/packages/client-proxy/Dockerfile
+++ b/packages/client-proxy/Dockerfile
@@ -2,6 +2,7 @@ ARG GOLANG_VERSION=1.25.4
 ARG ALPINE_VERSION=3.22
 
 FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION} AS builder
+ARG TARGETARCH
 
 RUN apk add --no-cache make
 
@@ -32,7 +33,8 @@ COPY ./client-proxy/Makefile ./client-proxy/Makefile
 WORKDIR /build/client-proxy
 
 ARG COMMIT_SHA
-RUN --mount=type=cache,target=/root/.cache/go-build make build COMMIT_SHA=${COMMIT_SHA}
+# Use Docker's TARGETARCH so GOARCH matches the container platform.
+RUN --mount=type=cache,target=/root/.cache/go-build make build COMMIT_SHA=${COMMIT_SHA} BUILD_ARCH=${TARGETARCH}
 RUN chmod +x /build/client-proxy/bin/client-proxy
 
 FROM alpine:${ALPINE_VERSION}

--- a/packages/client-proxy/Makefile
+++ b/packages/client-proxy/Makefile
@@ -6,9 +6,9 @@ PREFIX := $(strip $(subst ",,$(PREFIX)))
 HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
 $(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
 
-# Architecture for builds. Defaults to local arch; override for cross-compilation
-# (e.g., BUILD_ARCH=amd64 make build-and-upload from an ARM64 host).
-BUILD_ARCH ?= $(shell go env GOARCH)
+# Architecture for builds. Defaults to amd64; override for ARM64 builds.
+# (e.g., BUILD_ARCH=arm64 make build-and-upload)
+BUILD_ARCH ?= amd64
 # Docker platform string. Override for multi-arch builds:
 #   BUILD_PLATFORM=linux/amd64,linux/arm64 make build-and-upload
 BUILD_PLATFORM ?= linux/$(BUILD_ARCH)

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -7,9 +7,9 @@ LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
-# Architecture for builds. Defaults to local arch; override for cross-compilation
-# (e.g., BUILD_ARCH=amd64 make build from an ARM64 host).
-BUILD_ARCH ?= $(shell go env GOARCH)
+# Architecture for builds. Defaults to amd64; override for ARM64 builds.
+# (e.g., BUILD_ARCH=arm64 make build-local)
+BUILD_ARCH ?= amd64
 # Docker platform string. Override for cross-platform builds:
 #   BUILD_PLATFORM=linux/arm64 make start-docker
 BUILD_PLATFORM ?= linux/$(BUILD_ARCH)

--- a/packages/orchestrator/Dockerfile
+++ b/packages/orchestrator/Dockerfile
@@ -44,7 +44,8 @@ RUN ./orchestrator/scripts/fetch-busybox.sh "${BUSYBOX_VERSION}" "${TARGETARCH}"
 WORKDIR /build/orchestrator
 
 ARG COMMIT_SHA
-RUN --mount=type=cache,target=/root/.cache/go-build make build-local COMMIT_SHA=${COMMIT_SHA}
+# Use Docker's TARGETARCH (set by --platform) so GOARCH matches the container platform.
+RUN --mount=type=cache,target=/root/.cache/go-build make build-local COMMIT_SHA=${COMMIT_SHA} BUILD_ARCH=${TARGETARCH}
 
 FROM scratch
 

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -7,9 +7,9 @@ GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 HOSTNAME := $(shell hostname 2> /dev/null || hostnamectl hostname 2> /dev/null)
 $(if $(HOSTNAME),,$(error Failed to determine hostname: both 'hostname' and 'hostnamectl' failed))
 
-# Architecture for builds. Defaults to local arch; override for cross-compilation
-# (e.g., BUILD_ARCH=amd64 make build from an ARM64 host).
-BUILD_ARCH ?= $(shell go env GOARCH)
+# Architecture for builds. Defaults to amd64; override for ARM64 builds.
+# (e.g., BUILD_ARCH=arm64 make build-local)
+BUILD_ARCH ?= amd64
 # Docker platform string. Override for cross-platform builds:
 #   BUILD_PLATFORM=linux/arm64 make build
 BUILD_PLATFORM ?= linux/$(BUILD_ARCH)


### PR DESCRIPTION
## Summary

Default `BUILD_ARCH` to `amd64` in all three service Makefiles (orchestrator, envd, client-proxy). Previously defaulted to `$(shell go env GOARCH)` which produces arm64 binaries on Apple Silicon Macs, breaking deployments to amd64 clusters.

Override with `BUILD_ARCH=arm64` in `.env.local` or on the command line for ARM64 builds.

## Test plan

- [ ] `make build-and-upload` from Apple Silicon Mac produces amd64 binaries
- [ ] `BUILD_ARCH=arm64 make build-local` still produces arm64 binaries