### PR TITLE
Fix downloading all object with `orchestrator` prefix to local folder

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -134,7 +134,9 @@ job "orchestrator-${latest_orchestrator_job_id}" {
       }
 
       artifact {
-        source = "${artifact_source}"
+        source      = "${artifact_source}"
+        destination = "local/orchestrator"
+        mode        = "file"
       }
     }
   }


### PR DESCRIPTION
This change fixes a weird case where Nomad lists all objects with an artifact prefix. If there are more of them (such as orchestrator-special-edition), it switches to folder mode and downloads all files with this prefix to the local dir.

Mode set to file resolves this and tells the Nomad artifacts handler to expect only one file at this exact path.

Mode set to file introduces a new issue where the file in the local directory is named the same as the source URL, which means, in our case, it includes a version query parameter. This is fixed by hardcoding the destination for the downloaded binary.

Relevant function from go getter https://github.com/hashicorp/go-getter/blob/d23bff48fb87c956bb507a03d35a63ee45470e34/get_gcs.go#L39