### PR TITLE
chore(aws): remove Grafana logs secrets from logs collector

### DIFF
--- a/iac/provider-aws/init/secrets.tf
+++ b/iac/provider-aws/init/secrets.tf
@@ -82,13 +82,10 @@ locals {
 
 output "grafana" {
   value = {
-    api_key                  = local.grafana_raw["API_KEY"]
-    otlp_url                 = local.grafana_raw["OTLP_URL"]
-    otel_collector_token     = local.grafana_raw["OTEL_COLLECTOR_TOKEN"]
-    username                 = local.grafana_raw["USERNAME"]
-    logs_user                = local.grafana_raw["LOGS_USER"]
-    logs_url                 = local.grafana_raw["LOGS_URL"]
-    logs_collector_api_token = local.grafana_raw["LOGS_COLLECTOR_API_TOKEN"]
+    api_key              = local.grafana_raw["API_KEY"]
+    otlp_url             = local.grafana_raw["OTLP_URL"]
+    otel_collector_token = local.grafana_raw["OTEL_COLLECTOR_TOKEN"]
+    username             = local.grafana_raw["USERNAME"]
   }
   sensitive = true
 }
@@ -326,4 +323,3 @@ output "redis_cluster_url_secret_name" {
 output "redis_tls_ca_base64_secret_name" {
   value = aws_secretsmanager_secret.redis_tls_ca_base64.name
 }
-

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -178,10 +178,6 @@ module "nomad" {
   grafana_otlp_url             = module.init.grafana.otlp_url
   grafana_username             = module.init.grafana.username
 
-  grafana_logs_user     = module.init.grafana.logs_user
-  grafana_logs_endpoint = module.init.grafana.logs_url
-  grafana_logs_api_key  = module.init.grafana.logs_collector_api_token
-
   api_node_pool          = local.api_pool_name
   clickhouse_node_pool   = local.clickhouse_pool_name
   clickhouse_jobs_prefix = local.clickhouse_jobs_prefix

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -270,10 +270,6 @@ module "logs_collector" {
 
   vector_health_port = var.logs_health_proxy_port
   vector_api_port    = var.logs_proxy_port
-
-  grafana_logs_user     = var.grafana_logs_user
-  grafana_logs_endpoint = var.grafana_logs_endpoint
-  grafana_api_key       = var.grafana_logs_api_key
 }
 
 # ---

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -154,22 +154,6 @@ variable "grafana_username" {
   sensitive = true
 }
 
-variable "grafana_logs_user" {
-  type    = string
-  default = ""
-}
-
-variable "grafana_logs_endpoint" {
-  type    = string
-  default = ""
-}
-
-variable "grafana_logs_api_key" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 # API
 variable "api_port" {
   type    = number


### PR DESCRIPTION
Remove Grafana logs secrets (logs_user, logs_url, logs_collector_api_token)
from the AWS IaC setup — this is a case we don't want to support.