### PR TITLE
Use consistent workflow dependencies

### DIFF
--- a/.github/workflows/build-and-upload-job.yml
+++ b/.github/workflows/build-and-upload-job.yml
@@ -42,6 +42,13 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
 
+      - name: Checkout actions
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions
+          path: actions
+
       - name: Setup environment
         uses: ./.github/actions/deploy-setup
         with:

--- a/.github/workflows/build-and-upload-job.yml
+++ b/.github/workflows/build-and-upload-job.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions
-          path: actions
+          path: actions-from-ref
 
       - name: Setup environment
-        uses: ./.github/actions/deploy-setup
+        uses: ./actions-from-ref/.github/actions/deploy-setup
         with:
           environment: ${{ inputs.environment }}
           install_gcloud: "true"

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions
-          path: actions
+          path: actions-from-ref
 
       - name: Setup environment
-        uses: ./.github/actions/deploy-setup
+        uses: ./actions-from-ref/.github/actions/deploy-setup
         with:
           environment: ${{ inputs.environment }}
           install_gcloud: "true"

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -40,6 +40,13 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
 
+      - name: Checkout actions
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions
+          path: actions
+
       - name: Setup environment
         uses: ./.github/actions/deploy-setup
         with:

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
 
+      - name: Checkout actions
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: |
+            .github/actions
+          path: actions
+
       - name: Setup environment
         uses: ./.github/actions/deploy-setup
         with:

--- a/.github/workflows/deploy-job.yml
+++ b/.github/workflows/deploy-job.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions
-          path: actions
+          path: actions-from-ref
 
       - name: Setup environment
-        uses: ./.github/actions/deploy-setup
+        uses: ./actions-from-ref/.github/actions/deploy-setup
         with:
           environment: ${{ inputs.environment }}
           infisical_machine_identity_id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.commit_sha }}
 
       - name: Setup Go
         uses: ./.github/actions/go-setup-cache


### PR DESCRIPTION
Deploys are executed against a ref ("main") and a sha ("HEAD-3", for example. the workflow is executed from "main", which checks out "HEAD-3", which can cause inconsistencies in inputs and side effects. this PR checks out the actions before they're read