### PR TITLE
refactor(storage): FrameTable - per-build instead of per-mapping

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -96,15 +96,16 @@ func (b *File) ReadAt(ctx context.Context, p []byte, off int64) (n int, err erro
 		}
 
 		size := b.buildFileSize(h, mappedToBuild.BuildId)
-		mappedBuild, err := b.getBuild(ctx, mappedToBuild.BuildId, size, mappedToBuild.FrameTable.CompressionType())
+		ft := h.GetBuildFrameData(mappedToBuild.BuildId)
+		layer, err := b.getBuild(ctx, mappedToBuild.BuildId, size, ft.CompressionType())
 		if err != nil {
 			return 0, fmt.Errorf("failed to get build: %w", err)
 		}
 
-		buildN, err := mappedBuild.ReadAt(ctx,
+		buildN, err := layer.ReadAt(ctx,
 			p[n:int64(n)+readLength],
 			int64(mappedToBuild.Offset),
-			mappedToBuild.FrameTable,
+			ft,
 		)
 		if err != nil {
 			var transErr *storage.PeerTransitionedError
@@ -145,12 +146,13 @@ func (b *File) Slice(ctx context.Context, off, _ int64) ([]byte, error) {
 		}
 
 		size := b.buildFileSize(h, mappedBuild.BuildId)
-		diff, err := b.getBuild(ctx, mappedBuild.BuildId, size, mappedBuild.FrameTable.CompressionType())
+		ft := h.GetBuildFrameData(mappedBuild.BuildId)
+		diff, err := b.getBuild(ctx, mappedBuild.BuildId, size, ft.CompressionType())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get build: %w", err)
 		}
 
-		result, err := diff.Slice(ctx, int64(mappedBuild.Offset), int64(h.Metadata.BlockSize), mappedBuild.FrameTable)
+		result, err := diff.Slice(ctx, int64(mappedBuild.Offset), int64(h.Metadata.BlockSize), ft)
 		if err != nil {
 			var transErr *storage.PeerTransitionedError
 			if errors.As(err, &transErr) && transitionRetries < maxTransitionRetries {
@@ -199,12 +201,14 @@ func (b *File) swapHeader(transErr *storage.PeerTransitionedError) error {
 	return nil
 }
 
-// buildFileSize returns the uncompressed file size for buildID from the
-// header's BuildFiles map. Returns 0 for V3 headers (no BuildFiles), which
-// signals the read path to fall back to a Size() RPC.
+// buildFileSize returns the uncompressed file size for a build. Returns 0 for
+// V3 headers, which signals the read path to fall back to a Size() RPC.
 func (b *File) buildFileSize(h *header.Header, buildID uuid.UUID) int64 {
-	if info, ok := h.BuildFiles[buildID]; ok {
-		return info.Size
+	if h.Builds == nil {
+		return 0
+	}
+	if bd, ok := h.Builds[buildID]; ok {
+		return bd.Size
 	}
 
 	return 0

--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -97,12 +97,12 @@ func (b *File) ReadAt(ctx context.Context, p []byte, off int64) (n int, err erro
 
 		size := b.buildFileSize(h, mappedToBuild.BuildId)
 		ft := h.GetBuildFrameData(mappedToBuild.BuildId)
-		layer, err := b.getBuild(ctx, mappedToBuild.BuildId, size, ft.CompressionType())
+		mappedBuild, err := b.getBuild(ctx, mappedToBuild.BuildId, size, ft.CompressionType())
 		if err != nil {
 			return 0, fmt.Errorf("failed to get build: %w", err)
 		}
 
-		buildN, err := layer.ReadAt(ctx,
+		buildN, err := mappedBuild.ReadAt(ctx,
 			p[n:int64(n)+readLength],
 			int64(mappedToBuild.Offset),
 			ft,
@@ -204,9 +204,6 @@ func (b *File) swapHeader(transErr *storage.PeerTransitionedError) error {
 // buildFileSize returns the uncompressed file size for a build. Returns 0 for
 // V3 headers, which signals the read path to fall back to a Size() RPC.
 func (b *File) buildFileSize(h *header.Header, buildID uuid.UUID) int64 {
-	if h.Builds == nil {
-		return 0
-	}
 	if bd, ok := h.Builds[buildID]; ok {
 		return bd.Size
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -1,8 +1,10 @@
 package sandbox
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/google/uuid"
@@ -144,18 +146,14 @@ func (b *buildUploader) scheduleAlwaysUploads(eg *errgroup.Group, ctx context.Co
 	})
 }
 
-// pendingBuildInfo pairs a FrameTable with the uncompressed file size and
-// uncompressed-data checksum so all can be stored in the header after uploads complete.
 type pendingBuildInfo struct {
 	ft       *storage.FrameTable
 	fileSize int64
 	checksum [32]byte
 }
 
-// PendingBuildInfo collects FrameTables and file sizes from compressed data
-// uploads across all layers. After all data files are uploaded, the collected
-// tables are applied to headers before the compressed headers are serialized
-// and uploaded. Safe for concurrent use from errgroup goroutines.
+// PendingBuildInfo collects frame tables and file sizes from compressed
+// uploads, applied to headers before serialization. Safe for concurrent use.
 type PendingBuildInfo struct {
 	mu sync.Mutex
 	m  map[string]pendingBuildInfo
@@ -192,39 +190,40 @@ func (p *PendingBuildInfo) get(key string) *pendingBuildInfo {
 	return &info
 }
 
-func (p *PendingBuildInfo) applyToHeader(h *headers.Header, fileType string) error {
+func (p *PendingBuildInfo) applyToHeader(h *headers.Header, fileType string) {
 	if h == nil {
-		return nil
+		return
 	}
 
-	// Track frame cursor per build to avoid O(N²) rescanning.
-	cursors := make(map[string]int)
-
+	var buildIDs []uuid.UUID
 	for _, mapping := range h.Mapping {
-		key := pendingBuildInfoKey(mapping.BuildId.String(), fileType)
+		if _, found := slices.BinarySearchFunc(buildIDs, mapping.BuildId, func(a, b uuid.UUID) int {
+			return bytes.Compare(a[:], b[:])
+		}); !found {
+			buildIDs = append(buildIDs, mapping.BuildId)
+			slices.SortFunc(buildIDs, func(a, b uuid.UUID) int { return bytes.Compare(a[:], b[:]) })
+		}
+	}
+
+	for _, buildID := range buildIDs {
+		key := pendingBuildInfoKey(buildID.String(), fileType)
 		info := p.get(key)
 
 		if info == nil {
 			continue
 		}
 
-		cursor := cursors[key]
-		next, err := mapping.SetFrames(info.ft, cursor)
-		if err != nil {
-			return fmt.Errorf("apply frames to mapping at offset %d for build %s: %w",
-				mapping.Offset, mapping.BuildId.String(), err)
+		if h.Builds == nil {
+			h.Builds = make(map[uuid.UUID]headers.BuildData)
 		}
-		cursors[key] = next
 
-		// Populate BuildFiles with size and checksum for this build.
-		if h.BuildFiles == nil {
-			h.BuildFiles = make(map[uuid.UUID]headers.BuildFileInfo)
-		}
-		h.BuildFiles[mapping.BuildId] = headers.BuildFileInfo{
+		bd := headers.BuildData{
 			Size:     info.fileSize,
 			Checksum: info.checksum,
 		}
+		if info.ft != nil && info.ft.IsCompressed() {
+			bd.FrameData = info.ft
+		}
+		h.Builds[buildID] = bd
 	}
-
-	return nil
 }

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -164,10 +164,6 @@ func pendingBuildInfoKey(buildID, fileType string) string {
 }
 
 func (p *PendingBuildInfo) add(key string, ft *storage.FrameTable, fileSize int64, checksum [32]byte) {
-	if ft == nil {
-		return
-	}
-
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -195,21 +191,21 @@ func (p *PendingBuildInfo) applyToHeader(h *headers.Header, fileType string) {
 		return
 	}
 
-	var buildIDs []uuid.UUID
-	for _, mapping := range h.Mapping {
-		if _, found := slices.BinarySearchFunc(buildIDs, mapping.BuildId, func(a, b uuid.UUID) int {
-			return bytes.Compare(a[:], b[:])
-		}); !found {
-			buildIDs = append(buildIDs, mapping.BuildId)
-			slices.SortFunc(buildIDs, func(a, b uuid.UUID) int { return bytes.Compare(a[:], b[:]) })
-		}
+	buildIDs := make([]uuid.UUID, len(h.Mapping))
+	for i, m := range h.Mapping {
+		buildIDs[i] = m.BuildId
 	}
+	slices.SortFunc(buildIDs, func(a, b uuid.UUID) int { return bytes.Compare(a[:], b[:]) })
+	buildIDs = slices.CompactFunc(buildIDs, func(a, b uuid.UUID) bool { return a == b })
 
 	for _, buildID := range buildIDs {
 		key := pendingBuildInfoKey(buildID.String(), fileType)
 		info := p.get(key)
 
 		if info == nil {
+			// Parent builds and uuid.Nil (empty blocks) have no pending entry.
+			// Parent builds are either already in h.Builds (copied by ToDiffHeader),
+			// or h.Builds is nil (V3 base with no Builds map at all).
 			continue
 		}
 

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -93,9 +93,7 @@ func (c *compressedUploader) FinalizeHeaders(ctx context.Context) (memfileHeader
 		eg.Go(func() error {
 			h := c.snapshot.MemfileDiffHeader.CloneForUpload()
 
-			if err := c.pending.applyToHeader(h, storage.MemfileName); err != nil {
-				return fmt.Errorf("apply frames to memfile header: %w", err)
-			}
+			c.pending.applyToHeader(h, storage.MemfileName)
 
 			h.Metadata.Version = headers.MetadataVersionCompressed
 
@@ -114,9 +112,7 @@ func (c *compressedUploader) FinalizeHeaders(ctx context.Context) (memfileHeader
 		eg.Go(func() error {
 			h := c.snapshot.RootfsDiffHeader.CloneForUpload()
 
-			if err := c.pending.applyToHeader(h, storage.RootfsName); err != nil {
-				return fmt.Errorf("apply frames to rootfs header: %w", err)
-			}
+			c.pending.applyToHeader(h, storage.RootfsName)
 
 			h.Metadata.Version = headers.MetadataVersionCompressed
 

--- a/packages/shared/pkg/storage/compress_frame_table.go
+++ b/packages/shared/pkg/storage/compress_frame_table.go
@@ -35,13 +35,14 @@ func (r Range) String() string {
 	return fmt.Sprintf("%d/%d", r.Offset, r.Length)
 }
 
-// frameEntry stores one frame as absolute [Start, End) byte offsets in both
-// address spaces.
+// frameEntry stores one frame as an absolute start offset plus size in both
+// address spaces. Fields must be exported for encoding/binary (Read/Write use reflection).
+// Field order chosen for optimal alignment: two int64 then two uint32 = 24 bytes, no padding.
 type frameEntry struct {
 	StartU int64
-	EndU   int64
 	StartC int64
-	EndC   int64
+	SizeU  int32
+	SizeC  int32
 }
 
 // FrameTable is the decompression index for a compressed diff file.
@@ -65,9 +66,9 @@ func NewFrameTable(ct CompressionType, sizes []FrameSize) *FrameTable {
 	for i, s := range sizes {
 		entries[i] = frameEntry{
 			StartU: u,
-			EndU:   u + int64(s.U),
 			StartC: c,
-			EndC:   c + int64(s.C),
+			SizeU:  s.U,
+			SizeC:  s.C,
 		}
 		u += int64(s.U)
 		c += int64(s.C)
@@ -85,10 +86,9 @@ func (ft *FrameTable) CompressionType() CompressionType {
 	return ft.compressionType
 }
 
-// IsCompressed reports whether ft is non-nil, has a compression type set, and
-// contains at least one frame.
+// IsCompressed reports whether ft is non-nil and has a compression type set.
 func (ft *FrameTable) IsCompressed() bool {
-	return ft != nil && ft.compressionType != CompressionNone && len(ft.entries) > 0
+	return ft != nil && ft.compressionType != CompressionNone
 }
 
 func (ft *FrameTable) NumFrames() int {
@@ -99,17 +99,20 @@ func (ft *FrameTable) NumFrames() int {
 	return len(ft.entries)
 }
 
+func (e frameEntry) endU() int64 { return e.StartU + int64(e.SizeU) }
+func (e frameEntry) endC() int64 { return e.StartC + int64(e.SizeC) }
+
 func (ft *FrameTable) FrameAt(i int) (startU, endU, startC, endC int64) {
 	e := ft.entries[i]
 
-	return e.StartU, e.EndU, e.StartC, e.EndC
+	return e.StartU, e.endU(), e.StartC, e.endC()
 }
 
 // UncompressedSize returns the total uncompressed size across all frames.
 func (ft *FrameTable) UncompressedSize() int64 {
 	var total int64
 	for _, e := range ft.entries {
-		total += e.EndU - e.StartU
+		total += int64(e.SizeU)
 	}
 
 	return total
@@ -119,7 +122,7 @@ func (ft *FrameTable) UncompressedSize() int64 {
 func (ft *FrameTable) CompressedSize() int64 {
 	var total int64
 	for _, e := range ft.entries {
-		total += e.EndC - e.StartC
+		total += int64(e.SizeC)
 	}
 
 	return total
@@ -141,7 +144,7 @@ func (ft *FrameTable) locate(offset int64) (frameEntry, error) {
 	}
 
 	e := ft.entries[i]
-	if offset >= e.EndU {
+	if offset >= e.endU() {
 		return frameEntry{}, fmt.Errorf("offset %d is in a gap (not covered by any frame)", offset)
 	}
 
@@ -156,7 +159,7 @@ func (ft *FrameTable) LocateCompressed(offset int64) (Range, error) {
 		return Range{}, err
 	}
 
-	return Range{Offset: e.StartC, Length: int(e.EndC - e.StartC)}, nil
+	return Range{Offset: e.StartC, Length: int(e.SizeC)}, nil
 }
 
 // LocateUncompressed returns the uncompressed byte range for the frame
@@ -167,7 +170,7 @@ func (ft *FrameTable) LocateUncompressed(offset int64) (Range, error) {
 		return Range{}, err
 	}
 
-	return Range{Offset: e.StartU, Length: int(e.EndU - e.StartU)}, nil
+	return Range{Offset: e.StartU, Length: int(e.SizeU)}, nil
 }
 
 // Serialize writes the frame table to w in binary little-endian format.
@@ -212,11 +215,14 @@ func DeserializeFrameTable(r io.Reader) (*FrameTable, error) {
 		return nil, fmt.Errorf("read frame count: %w", err)
 	}
 
+	if ct == 0 && n > 0 {
+		return nil, fmt.Errorf("compression type is 0 but frame count is %d: corrupted header", n)
+	}
 	if ct == 0 || n == 0 {
 		return nil, nil
 	}
 
-	// Cap to prevent OOM from corrupted headers. 1<<20 frames × 32 bytes = 32 MiB.
+	// Cap to prevent OOM from corrupted headers. 1<<20 frames × 24 bytes = 24 MiB.
 	const maxFrames = 1 << 20
 	if n > maxFrames {
 		return nil, fmt.Errorf("frame count %d exceeds maximum %d", n, maxFrames)
@@ -226,6 +232,15 @@ func DeserializeFrameTable(r io.Reader) (*FrameTable, error) {
 	for i := range n {
 		if err := binary.Read(r, binary.LittleEndian, &entries[i]); err != nil {
 			return nil, fmt.Errorf("read frame entry %d: %w", i, err)
+		}
+		if entries[i].SizeU <= 0 || entries[i].SizeC <= 0 {
+			return nil, fmt.Errorf("frame %d has zero or negative size: SizeU=%d SizeC=%d", i, entries[i].SizeU, entries[i].SizeC)
+		}
+		if i > 0 && entries[i].StartU < entries[i-1].endU() {
+			return nil, fmt.Errorf("frame %d StartU %d < previous endU %d: U-entries not sorted", i, entries[i].StartU, entries[i-1].endU())
+		}
+		if i > 0 && entries[i].StartC < entries[i-1].endC() {
+			return nil, fmt.Errorf("frame %d StartC %d < previous endC %d: C-entries not sorted", i, entries[i].StartC, entries[i-1].endC())
 		}
 	}
 
@@ -247,7 +262,7 @@ func (ft *FrameTable) TrimToRanges(ranges [][2]int64) *FrameTable {
 
 		// Binary search: first frame whose EndU > startU.
 		lo := sort.Search(len(ft.entries), func(i int) bool {
-			return ft.entries[i].EndU > startU
+			return ft.entries[i].endU() > startU
 		})
 
 		for i := lo; i < len(ft.entries) && ft.entries[i].StartU < endU; i++ {

--- a/packages/shared/pkg/storage/compress_frame_table.go
+++ b/packages/shared/pkg/storage/compress_frame_table.go
@@ -1,7 +1,10 @@
 package storage
 
 import (
+	"encoding/binary"
 	"fmt"
+	"io"
+	"sort"
 )
 
 type CompressionType byte
@@ -11,60 +14,6 @@ const (
 	CompressionZstd
 	CompressionLZ4
 )
-
-// # Compression Layout
-//
-// Dirty blocks (4 KiB rootfs, 2 MiB memfile) are packed into a diff file,
-// grouped into frames (default 2 MiB), and each frame compressed independently.
-// Two address spaces describe the same data:
-//
-//     |blk|...|blk | blk|...|blk |
-//     |- f0 (2M) - | ---  f1 --- |
-//	U: 0             2M            4M
-//     |- f0 -|- f1 -|- f2 -|
-//	C: 0     .6M    1.3M   1.7M
-//
-// # BuildMaps and FrameTable Subsets
-//
-// The header maps virtual offsets to builds via BuildMap entries. Each
-// mapping carries a FrameTable subset covering just its byte range:
-//
-//	Virtual:  ──[━━━━ M0 ━━━━]──[━━━━━━ M1 ━━━━━━]──[━━ M2 ━━]──
-//	            BuildId=aa         BuildId=bb            BuildId=aa
-//	            BuildStorageOffset=0  BuildStorageOffset=0  BuildStorageOffset=8M
-//	            Length=4M          Length=6M            Length=2M
-//	            ft: frames 0-1  ft: frames 0-2       ft: frames 4-4
-//
-// # Read Path: Virtual Offset → C-Space Fetch
-//
-//	read virtual offset V=5M
-//	  │
-//	  ├─ find mapping: M1 {Build=bb, BuildStorageOffset=0, Length=6M}
-//	  │
-//	  ├─ diff offset = V - M1.Offset + M1.BuildStorageOffset = 5M
-//	  │
-//	  ├─ M1.ft: frame 0: U:[0,2M)  frame 1: U:[2M,4M)  frame 2: U:[4M,6M)
-//    │  LocateCompressed(5M) → frame2, C:[2.0M, 3.3M)
-//	  ├─ fetch C bytes [2.0M, 3.3M) from build "bb"
-//	  ├─ decompress → 2 MiB frame, cache
-//	  └─ return block at offset 5M - 4M = 1M within frame
-
-// FrameOffset holds a position in both address spaces.
-// U is the byte offset in the uncompressed diff file.
-// C is the byte offset in the compressed diff file.
-type FrameOffset struct {
-	U int64
-	C int64
-}
-
-func (o *FrameOffset) String() string {
-	return fmt.Sprintf("U:%d/C:%d", o.U, o.C)
-}
-
-func (o *FrameOffset) Add(f FrameSize) {
-	o.U += int64(f.U)
-	o.C += int64(f.C)
-}
 
 // FrameSize holds the uncompressed (U) and compressed (C) byte size of a
 // single frame.
@@ -86,18 +35,45 @@ func (r Range) String() string {
 	return fmt.Sprintf("%d/%d", r.Offset, r.Length)
 }
 
-// FrameTable is the decompression index for a compressed diff file (or a
-// contiguous subset of one). Offset is the position of the first frame in
-// both address spaces; Frames lists each frame's U and C sizes in order.
-type FrameTable struct {
-	compressionType CompressionType
-	Offset          FrameOffset
-	Frames          []FrameSize
+// frameEntry stores one frame as absolute [Start, End) byte offsets in both
+// address spaces.
+type frameEntry struct {
+	StartU int64
+	EndU   int64
+	StartC int64
+	EndC   int64
 }
 
-// NewFrameTable creates a FrameTable with the given compression type.
-func NewFrameTable(ct CompressionType) *FrameTable {
-	return &FrameTable{compressionType: ct}
+// FrameTable is the decompression index for a compressed diff file.
+// Immutable after construction; safe to share across goroutines.
+// Sparse tables (gaps between entries) are supported.
+type FrameTable struct {
+	compressionType CompressionType
+	entries         []frameEntry // sorted by StartU
+}
+
+// NewFrameTable creates a FrameTable from consecutive frame sizes, computing
+// absolute offsets starting from zero.
+func NewFrameTable(ct CompressionType, sizes []FrameSize) *FrameTable {
+	if len(sizes) == 0 {
+		return &FrameTable{compressionType: ct}
+	}
+
+	entries := make([]frameEntry, len(sizes))
+
+	var u, c int64
+	for i, s := range sizes {
+		entries[i] = frameEntry{
+			StartU: u,
+			EndU:   u + int64(s.U),
+			StartC: c,
+			EndC:   c + int64(s.C),
+		}
+		u += int64(s.U)
+		c += int64(s.C)
+	}
+
+	return &FrameTable{compressionType: ct, entries: entries}
 }
 
 // CompressionType returns the compression type. Nil-safe: returns CompressionNone for nil.
@@ -109,118 +85,191 @@ func (ft *FrameTable) CompressionType() CompressionType {
 	return ft.compressionType
 }
 
-// IsCompressed reports whether ft is non-nil and has a compression type set.
+// IsCompressed reports whether ft is non-nil, has a compression type set, and
+// contains at least one frame.
 func (ft *FrameTable) IsCompressed() bool {
-	return ft != nil && ft.compressionType != CompressionNone
+	return ft != nil && ft.compressionType != CompressionNone && len(ft.entries) > 0
 }
 
-// UncompressedSize returns the total uncompressed byte size across all frames.
+func (ft *FrameTable) NumFrames() int {
+	if ft == nil {
+		return 0
+	}
+
+	return len(ft.entries)
+}
+
+func (ft *FrameTable) FrameAt(i int) (startU, endU, startC, endC int64) {
+	e := ft.entries[i]
+
+	return e.StartU, e.EndU, e.StartC, e.EndC
+}
+
+// UncompressedSize returns the total uncompressed size across all frames.
 func (ft *FrameTable) UncompressedSize() int64 {
 	var total int64
-	for _, frame := range ft.Frames {
-		total += int64(frame.U)
+	for _, e := range ft.entries {
+		total += e.EndU - e.StartU
 	}
 
 	return total
 }
 
-// Subset extracts frames overlapping range r, starting the scan at frame
-// index `from`. It returns the index of the first included frame (not one
-// past it) so that consecutive calls re-check the boundary frame — this is
-// correct because a frame straddling two ranges must appear in both subsets.
-func (ft *FrameTable) Subset(r Range, from int) (*FrameTable, int) {
-	if ft == nil || r.Length == 0 {
-		return nil, from
+// CompressedSize returns the total compressed size across all frames.
+func (ft *FrameTable) CompressedSize() int64 {
+	var total int64
+	for _, e := range ft.entries {
+		total += e.EndC - e.StartC
 	}
 
-	result := &FrameTable{
-		compressionType: ft.compressionType,
-	}
-
-	// Advance currentOffset to frame `from`.
-	currentOffset := ft.Offset
-	for i := range from {
-		if i >= len(ft.Frames) {
-			break
-		}
-		currentOffset.Add(ft.Frames[i])
-	}
-
-	startSet := false
-	requestedEnd := r.Offset + int64(r.Length)
-	nextFrom := from
-
-	for i := from; i < len(ft.Frames); i++ {
-		frame := ft.Frames[i]
-		frameEnd := currentOffset.U + int64(frame.U)
-
-		if frameEnd <= r.Offset {
-			currentOffset.Add(frame)
-			nextFrom = i + 1
-
-			continue
-		}
-		if currentOffset.U >= requestedEnd {
-			break
-		}
-
-		if !startSet {
-			result.Offset = currentOffset
-			startSet = true
-			nextFrom = i
-		}
-		result.Frames = append(result.Frames, frame)
-		currentOffset.Add(frame)
-	}
-
-	if !startSet {
-		return nil, nextFrom
-	}
-
-	return result, nextFrom
+	return total
 }
 
-// locate finds the frame containing the given uncompressed offset and returns
-// its start position (in both address spaces) and full size.
-func (ft *FrameTable) locate(offset int64) (frameOffset FrameOffset, frameSize FrameSize, err error) {
+// locate finds the frame containing the given uncompressed offset.
+func (ft *FrameTable) locate(offset int64) (frameEntry, error) {
 	if ft == nil {
-		return FrameOffset{}, FrameSize{}, fmt.Errorf("locate called with nil frame table - data is not compressed")
+		return frameEntry{}, fmt.Errorf("locate called with nil frame table — data is not compressed")
 	}
 
-	currentOffset := ft.Offset
-	for _, frame := range ft.Frames {
-		frameEnd := currentOffset.U + int64(frame.U)
-		if offset >= currentOffset.U && offset < frameEnd {
-			return currentOffset, frame, nil
-		}
-		currentOffset.Add(frame)
+	// Binary search: find the last entry whose StartU <= offset.
+	i := sort.Search(len(ft.entries), func(i int) bool {
+		return ft.entries[i].StartU > offset
+	}) - 1
+
+	if i < 0 || i >= len(ft.entries) {
+		return frameEntry{}, fmt.Errorf("offset %d not found in frame table", offset)
 	}
 
-	return FrameOffset{}, FrameSize{}, fmt.Errorf("offset %d is beyond the end of the frame table", offset)
+	e := ft.entries[i]
+	if offset >= e.EndU {
+		return frameEntry{}, fmt.Errorf("offset %d is in a gap (not covered by any frame)", offset)
+	}
+
+	return e, nil
 }
 
-// LocateCompressed returns the compressed (C-space) byte range for the frame
-// containing the given uncompressed offset. Use this when you need to fetch
-// raw compressed bytes from storage.
+// LocateCompressed returns the compressed byte range for the frame containing
+// the given uncompressed offset.
 func (ft *FrameTable) LocateCompressed(offset int64) (Range, error) {
-	start, size, err := ft.locate(offset)
+	e, err := ft.locate(offset)
 	if err != nil {
 		return Range{}, err
 	}
 
-	return Range{Offset: start.C, Length: int(size.C)}, nil
+	return Range{Offset: e.StartC, Length: int(e.EndC - e.StartC)}, nil
 }
 
-// LocateUncompressed returns the uncompressed (U-space) byte range for the
-// frame containing the given uncompressed offset. Use this when you need to
-// know the logical frame boundaries for cache alignment or chunk management.
+// LocateUncompressed returns the uncompressed byte range for the frame
+// containing the given uncompressed offset.
 func (ft *FrameTable) LocateUncompressed(offset int64) (Range, error) {
-	start, size, err := ft.locate(offset)
+	e, err := ft.locate(offset)
 	if err != nil {
 		return Range{}, err
 	}
 
-	return Range{Offset: start.U, Length: int(size.U)}, nil
+	return Range{Offset: e.StartU, Length: int(e.EndU - e.StartU)}, nil
+}
+
+// Serialize writes the frame table to w in binary little-endian format.
+// Nil-safe: writes zeros for type and count.
+func (ft *FrameTable) Serialize(w io.Writer) error {
+	if !ft.IsCompressed() {
+		z := [8]byte{} // two uint32 zeros: CompressionType=0, NumFrames=0
+		_, err := w.Write(z[:])
+
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, uint32(ft.compressionType)); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(ft.entries))); err != nil {
+		return err
+	}
+
+	for _, e := range ft.entries {
+		if err := binary.Write(w, binary.LittleEndian, e); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// DeserializeFrameTable reads a FrameTable from r. Returns nil for
+// uncompressed builds (compressionType=0 or numFrames=0).
+func DeserializeFrameTable(r io.Reader) (*FrameTable, error) {
+	var ct uint32
+
+	if err := binary.Read(r, binary.LittleEndian, &ct); err != nil {
+		return nil, fmt.Errorf("read compression type: %w", err)
+	}
+
+	var n uint32
+
+	if err := binary.Read(r, binary.LittleEndian, &n); err != nil {
+		return nil, fmt.Errorf("read frame count: %w", err)
+	}
+
+	if ct == 0 || n == 0 {
+		return nil, nil
+	}
+
+	// Cap to prevent OOM from corrupted headers. 1<<20 frames × 32 bytes = 32 MiB.
+	const maxFrames = 1 << 20
+	if n > maxFrames {
+		return nil, fmt.Errorf("frame count %d exceeds maximum %d", n, maxFrames)
+	}
+
+	entries := make([]frameEntry, n)
+	for i := range n {
+		if err := binary.Read(r, binary.LittleEndian, &entries[i]); err != nil {
+			return nil, fmt.Errorf("read frame entry %d: %w", i, err)
+		}
+	}
+
+	return &FrameTable{compressionType: CompressionType(ct), entries: entries}, nil
+}
+
+// TrimToRanges returns a new FrameTable containing only the frames that
+// overlap with at least one of the given [startU, endU) byte ranges.
+func (ft *FrameTable) TrimToRanges(ranges [][2]int64) *FrameTable {
+	if ft == nil || len(ft.entries) == 0 || len(ranges) == 0 {
+		return ft
+	}
+
+	keep := make([]bool, len(ft.entries))
+	kept := 0
+
+	for _, r := range ranges {
+		startU, endU := r[0], r[1]
+
+		// Binary search: first frame whose EndU > startU.
+		lo := sort.Search(len(ft.entries), func(i int) bool {
+			return ft.entries[i].EndU > startU
+		})
+
+		for i := lo; i < len(ft.entries) && ft.entries[i].StartU < endU; i++ {
+			if !keep[i] {
+				keep[i] = true
+				kept++
+			}
+		}
+	}
+
+	if kept == len(ft.entries) {
+		return ft // nothing trimmed
+	}
+
+	trimmed := make([]frameEntry, 0, kept)
+	for i, e := range ft.entries {
+		if keep[i] {
+			trimmed = append(trimmed, e)
+		}
+	}
+
+	return &FrameTable{compressionType: ft.compressionType, entries: trimmed}
 }
 
 func (ct CompressionType) Suffix() string {

--- a/packages/shared/pkg/storage/compress_frame_table.go
+++ b/packages/shared/pkg/storage/compress_frame_table.go
@@ -13,7 +13,64 @@ const (
 	CompressionNone = CompressionType(iota)
 	CompressionZstd
 	CompressionLZ4
+
+	// maxDeserializedFrames caps the number of frames read from a serialized
+	// FrameTable to prevent OOM from corrupted headers. 1M frames = 2 TiB
+	// uncompressed at 2 MiB frame size.
+	maxDeserializedFrames = 1024 * 1024
 )
+
+// # Compression: files, frames, and two address spaces (U/C)
+//
+// Dirty blocks (4 KiB rootfs, 2 MiB memfile) are packed into a diff file,
+// grouped into frames (default 2 MiB), and each frame compressed independently.
+// Two address spaces describe the same data:
+//
+//	U-space (uncompressed):  |-- frame 0 (2M) --|-- frame 1 (2M) --| ...
+//	C-space (compressed):    |-- f0 (.6M) --|-- f1 (.7M) --| ...
+//
+// Each frame's position is recorded as a frameEntry with absolute offsets
+// (StartU, StartC) and sizes (SizeU, SizeC). A FrameTable is a sorted
+// slice of these entries — lookups are a single binary search on StartU.
+//
+// # Read path: virtual offset → build mapping → frame lookup → C-space fetch
+//
+// The header maps virtual offsets to builds via BuildMap entries. Each
+// mapping says "virtual range [Offset, Offset+Length) lives in build X
+// starting at BuildStorageOffset". The read path:
+//
+//  1. GetShiftedMapping(virtualOff) → {BuildId, U-offset within build, length}
+//  2. header.GetBuildFrameData(BuildId) → build's FrameTable
+//  3. ft.LocateCompressed(U-offset) → C-space byte range
+//  4. Fetch compressed bytes from GCS, decompress, cache, return block
+//
+// # Build chain: how Builds propagates through layered templates
+//
+// Each V4 header carries a Builds map (Header.Builds) with per-build
+// metadata: file size, checksum, and FrameTable. When a child template
+// is built on a parent, ToDiffHeader merges mappings and copies the
+// parent's Builds entries for all still-referenced build IDs. Then
+// applyToHeader adds the current build's own entry:
+//
+//	base (build=aa)          → Builds: {aa: {ft, size, checksum}}
+//	  └─ child (build=bb)    → Builds: {aa: ..., bb: ...}
+//	       └─ grandchild (cc)→ Builds: {aa: ..., bb: ..., cc: ...}
+//
+// # Sparse trimming: serialization compacts frame tables
+//
+// During V4 header serialization, each build's FrameTable is trimmed to
+// only the frames overlapping that build's mappings (TrimToRanges). This
+// keeps headers compact when a build has many frames but only a few are
+// referenced in the current layer.
+//
+// # V3/V4 interop: uncompressed layers in the chain
+//
+// V3 (uncompressed) headers have Builds == nil and do not serialize build
+// metadata. A V3 layer in the middle of a chain drops all ancestor build
+// metadata. The read path degrades gracefully: nil FrameTable means read
+// uncompressed; missing build size falls back to a Size() RPC. In
+// practice all layers use the same format (all V3 or all V4); mixed
+// chains arise only during transitions.
 
 // FrameSize holds the uncompressed (U) and compressed (C) byte size of a
 // single frame.
@@ -53,11 +110,16 @@ type FrameTable struct {
 	entries         []frameEntry // sorted by StartU
 }
 
+// newFrameTableFromEntries creates a FrameTable from pre-computed absolute-offset entries.
+func newFrameTableFromEntries(ct CompressionType, entries []frameEntry) *FrameTable {
+	return &FrameTable{compressionType: ct, entries: entries}
+}
+
 // NewFrameTable creates a FrameTable from consecutive frame sizes, computing
 // absolute offsets starting from zero.
 func NewFrameTable(ct CompressionType, sizes []FrameSize) *FrameTable {
 	if len(sizes) == 0 {
-		return &FrameTable{compressionType: ct}
+		return newFrameTableFromEntries(ct, nil)
 	}
 
 	entries := make([]frameEntry, len(sizes))
@@ -74,7 +136,7 @@ func NewFrameTable(ct CompressionType, sizes []FrameSize) *FrameTable {
 		c += int64(s.C)
 	}
 
-	return &FrameTable{compressionType: ct, entries: entries}
+	return newFrameTableFromEntries(ct, entries)
 }
 
 // CompressionType returns the compression type. Nil-safe: returns CompressionNone for nil.
@@ -176,23 +238,23 @@ func (ft *FrameTable) LocateUncompressed(offset int64) (Range, error) {
 // Serialize writes the frame table to w in binary little-endian format.
 // Nil-safe: writes zeros for type and count.
 func (ft *FrameTable) Serialize(w io.Writer) error {
-	if !ft.IsCompressed() {
-		z := [8]byte{} // two uint32 zeros: CompressionType=0, NumFrames=0
-		_, err := w.Write(z[:])
+	var ct CompressionType
+	var n int
+	if ft != nil && ft.compressionType != CompressionNone {
+		ct = ft.compressionType
+		n = len(ft.entries)
+	}
 
+	if err := binary.Write(w, binary.LittleEndian, uint32(ct)); err != nil {
 		return err
 	}
 
-	if err := binary.Write(w, binary.LittleEndian, uint32(ft.compressionType)); err != nil {
+	if err := binary.Write(w, binary.LittleEndian, uint32(n)); err != nil {
 		return err
 	}
 
-	if err := binary.Write(w, binary.LittleEndian, uint32(len(ft.entries))); err != nil {
-		return err
-	}
-
-	for _, e := range ft.entries {
-		if err := binary.Write(w, binary.LittleEndian, e); err != nil {
+	for i := range n {
+		if err := binary.Write(w, binary.LittleEndian, ft.entries[i]); err != nil {
 			return err
 		}
 	}
@@ -222,10 +284,8 @@ func DeserializeFrameTable(r io.Reader) (*FrameTable, error) {
 		return nil, nil
 	}
 
-	// Cap to prevent OOM from corrupted headers. 1<<20 frames × 24 bytes = 24 MiB.
-	const maxFrames = 1 << 20
-	if n > maxFrames {
-		return nil, fmt.Errorf("frame count %d exceeds maximum %d", n, maxFrames)
+	if n > maxDeserializedFrames {
+		return nil, fmt.Errorf("frame count %d exceeds maximum %d", n, maxDeserializedFrames)
 	}
 
 	entries := make([]frameEntry, n)
@@ -244,7 +304,7 @@ func DeserializeFrameTable(r io.Reader) (*FrameTable, error) {
 		}
 	}
 
-	return &FrameTable{compressionType: CompressionType(ct), entries: entries}, nil
+	return newFrameTableFromEntries(CompressionType(ct), entries), nil
 }
 
 // TrimToRanges returns a new FrameTable containing only the frames that
@@ -284,7 +344,7 @@ func (ft *FrameTable) TrimToRanges(ranges [][2]int64) *FrameTable {
 		}
 	}
 
-	return &FrameTable{compressionType: ft.compressionType, entries: trimmed}
+	return newFrameTableFromEntries(ft.compressionType, trimmed)
 }
 
 func (ct CompressionType) Suffix() string {

--- a/packages/shared/pkg/storage/compress_frame_table.go
+++ b/packages/shared/pkg/storage/compress_frame_table.go
@@ -139,7 +139,7 @@ func (ft *FrameTable) locate(offset int64) (frameEntry, error) {
 		return ft.entries[i].StartU > offset
 	}) - 1
 
-	if i < 0 || i >= len(ft.entries) {
+	if i < 0 {
 		return frameEntry{}, fmt.Errorf("offset %d not found in frame table", offset)
 	}
 

--- a/packages/shared/pkg/storage/compress_frame_table_test.go
+++ b/packages/shared/pkg/storage/compress_frame_table_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,17 +10,23 @@ import (
 // threeFrameFT returns a FrameTable with three 1MB uncompressed frames
 // and varying compressed sizes, starting at the given offset.
 func threeFrameFT(startU, startC int64) *FrameTable {
-	ft := &FrameTable{
+	return &FrameTable{
 		compressionType: CompressionLZ4,
-		Offset:          FrameOffset{U: startU, C: startC},
-		Frames: []FrameSize{
-			{U: 1 << 20, C: 500_000}, // frame 0
-			{U: 1 << 20, C: 600_000}, // frame 1
-			{U: 1 << 20, C: 400_000}, // frame 2
+		entries: []frameEntry{
+			{
+				StartU: startU, EndU: startU + 1<<20,
+				StartC: startC, EndC: startC + 500_000,
+			},
+			{
+				StartU: startU + 1<<20, EndU: startU + 2<<20,
+				StartC: startC + 500_000, EndC: startC + 1_100_000,
+			},
+			{
+				StartU: startU + 2<<20, EndU: startU + 3<<20,
+				StartC: startC + 1_100_000, EndC: startC + 1_500_000,
+			},
 		},
 	}
-
-	return ft
 }
 
 func TestLocate(t *testing.T) {
@@ -74,7 +81,7 @@ func TestLocate(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("respects Offset", func(t *testing.T) {
+	t.Run("non-zero start offset", func(t *testing.T) {
 		t.Parallel()
 		sub := threeFrameFT(1<<20, 500_000)
 
@@ -86,8 +93,142 @@ func TestLocate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(500_000), r.Offset)
 
-		// Before Offset — no frame should contain offset 0.
+		// Before first entry — no frame should contain offset 0.
 		_, err = sub.LocateUncompressed(0)
 		require.Error(t, err)
+	})
+}
+
+func TestNewFrameTable(t *testing.T) {
+	t.Parallel()
+
+	ft := NewFrameTable(CompressionZstd, []FrameSize{
+		{U: 1 << 20, C: 500_000},
+		{U: 1 << 20, C: 600_000},
+	})
+
+	require.Equal(t, 2, ft.NumFrames())
+	require.Equal(t, CompressionZstd, ft.CompressionType())
+	require.True(t, ft.IsCompressed())
+	require.Equal(t, int64(2<<20), ft.UncompressedSize())
+	require.Equal(t, int64(1_100_000), ft.CompressedSize())
+
+	startU, endU, startC, endC := ft.FrameAt(0)
+	require.Equal(t, int64(0), startU)
+	require.Equal(t, int64(1<<20), endU)
+	require.Equal(t, int64(0), startC)
+	require.Equal(t, int64(500_000), endC)
+
+	startU, _, startC, _ = ft.FrameAt(1)
+	require.Equal(t, int64(1<<20), startU)
+	require.Equal(t, int64(500_000), startC)
+}
+
+func TestFrameTable_TrimToRanges(t *testing.T) {
+	t.Parallel()
+
+	ft := NewFrameTable(CompressionLZ4, []FrameSize{
+		{U: 1 << 20, C: 500_000},
+		{U: 1 << 20, C: 600_000},
+		{U: 1 << 20, C: 400_000},
+		{U: 1 << 20, C: 700_000},
+	})
+
+	t.Run("all frames retained", func(t *testing.T) {
+		t.Parallel()
+		trimmed := ft.TrimToRanges([][2]int64{{0, 4 << 20}})
+		require.Same(t, ft, trimmed)
+	})
+
+	t.Run("single range trims to subset", func(t *testing.T) {
+		t.Parallel()
+		trimmed := ft.TrimToRanges([][2]int64{{1 << 20, 3 << 20}})
+		require.Equal(t, 2, trimmed.NumFrames())
+
+		startU, _, _, _ := trimmed.FrameAt(0)
+		require.Equal(t, int64(1<<20), startU)
+
+		startU, _, _, _ = trimmed.FrameAt(1)
+		require.Equal(t, int64(2<<20), startU)
+	})
+
+	t.Run("two disjoint ranges", func(t *testing.T) {
+		t.Parallel()
+		trimmed := ft.TrimToRanges([][2]int64{
+			{0, 1 << 20},
+			{3 << 20, 4 << 20},
+		})
+		require.Equal(t, 2, trimmed.NumFrames())
+
+		startU, _, _, _ := trimmed.FrameAt(0)
+		require.Equal(t, int64(0), startU)
+
+		startU, _, _, _ = trimmed.FrameAt(1)
+		require.Equal(t, int64(3<<20), startU)
+	})
+
+	t.Run("nil table", func(t *testing.T) {
+		t.Parallel()
+		var nilFT *FrameTable
+		require.Nil(t, nilFT.TrimToRanges([][2]int64{{0, 100}}))
+	})
+
+	t.Run("sparse lookup works", func(t *testing.T) {
+		t.Parallel()
+		trimmed := ft.TrimToRanges([][2]int64{
+			{0, 1 << 20},
+			{3 << 20, 4 << 20},
+		})
+
+		r, err := trimmed.LocateCompressed(0)
+		require.NoError(t, err)
+		require.Equal(t, int64(0), r.Offset)
+
+		r, err = trimmed.LocateCompressed(3 << 20)
+		require.NoError(t, err)
+		require.Equal(t, int64(500_000+600_000+400_000), r.Offset)
+
+		// Gap lookup fails
+		_, err = trimmed.LocateCompressed(1 << 20)
+		require.Error(t, err)
+	})
+}
+
+func TestSerializeDeserializeFrameTable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round-trip", func(t *testing.T) {
+		t.Parallel()
+		ft := NewFrameTable(CompressionZstd, []FrameSize{
+			{U: 2048, C: 1024},
+			{U: 4096, C: 3500},
+		})
+
+		var buf bytes.Buffer
+		require.NoError(t, ft.Serialize(&buf))
+
+		got, err := DeserializeFrameTable(&buf)
+		require.NoError(t, err)
+		require.Equal(t, ft.NumFrames(), got.NumFrames())
+		require.Equal(t, ft.CompressionType(), got.CompressionType())
+
+		for i := range ft.NumFrames() {
+			wSU, wEU, wSC, wEC := ft.FrameAt(i)
+			gSU, gEU, gSC, gEC := got.FrameAt(i)
+			require.Equal(t, wSU, gSU, "frame %d StartU", i)
+			require.Equal(t, wEU, gEU, "frame %d EndU", i)
+			require.Equal(t, wSC, gSC, "frame %d StartC", i)
+			require.Equal(t, wEC, gEC, "frame %d EndC", i)
+		}
+	})
+
+	t.Run("nil writes zeros", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		require.NoError(t, (*FrameTable)(nil).Serialize(&buf))
+
+		got, err := DeserializeFrameTable(&buf)
+		require.NoError(t, err)
+		require.Nil(t, got)
 	})
 }

--- a/packages/shared/pkg/storage/compress_frame_table_test.go
+++ b/packages/shared/pkg/storage/compress_frame_table_test.go
@@ -13,18 +13,9 @@ func threeFrameFT(startU, startC int64) *FrameTable {
 	return &FrameTable{
 		compressionType: CompressionLZ4,
 		entries: []frameEntry{
-			{
-				StartU: startU, EndU: startU + 1<<20,
-				StartC: startC, EndC: startC + 500_000,
-			},
-			{
-				StartU: startU + 1<<20, EndU: startU + 2<<20,
-				StartC: startC + 500_000, EndC: startC + 1_100_000,
-			},
-			{
-				StartU: startU + 2<<20, EndU: startU + 3<<20,
-				StartC: startC + 1_100_000, EndC: startC + 1_500_000,
-			},
+			{StartU: startU, StartC: startC, SizeU: 1 << 20, SizeC: 500_000},                     // frame 0
+			{StartU: startU + 1<<20, StartC: startC + 500_000, SizeU: 1 << 20, SizeC: 600_000},   // frame 1
+			{StartU: startU + 2<<20, StartC: startC + 1_100_000, SizeU: 1 << 20, SizeC: 400_000}, // frame 2
 		},
 	}
 }

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -238,7 +238,7 @@ func compressStream(ctx context.Context, in io.Reader, cfg *CompressConfig, uplo
 
 	copy(checksum[:], hasher.Sum(nil))
 
-	ft = &FrameTable{compressionType: cfg.CompressionType(), Frames: frames}
+	ft = NewFrameTable(cfg.CompressionType(), frames)
 
 	return ft, checksum, nil
 }

--- a/packages/shared/pkg/storage/compress_upload_test.go
+++ b/packages/shared/pkg/storage/compress_upload_test.go
@@ -64,14 +64,16 @@ func (t *ThrottledPartUploader) UploadPart(ctx context.Context, partIndex int, d
 // concatenated compressed blob, returning the original uncompressed data.
 func decompressAll(ft *FrameTable, compressed []byte) ([]byte, error) {
 	var result []byte
-	var cOff int64
 
-	for i, fs := range ft.Frames {
-		if cOff+int64(fs.C) > int64(len(compressed)) {
-			return nil, fmt.Errorf("frame %d: compressed data truncated (need %d, have %d)", i, cOff+int64(fs.C), len(compressed))
+	for i := range ft.NumFrames() {
+		_, _, startC, endC := ft.FrameAt(i)
+		cLen := endC - startC
+
+		if startC+cLen > int64(len(compressed)) {
+			return nil, fmt.Errorf("frame %d: compressed data truncated (need %d, have %d)", i, startC+cLen, len(compressed))
 		}
 
-		frameData := compressed[cOff : cOff+int64(fs.C)]
+		frameData := compressed[startC:endC]
 
 		var frame []byte
 		var err error
@@ -93,7 +95,6 @@ func decompressAll(ft *FrameTable, compressed []byte) ([]byte, error) {
 			return nil, fmt.Errorf("frame %d: %w", i, err)
 		}
 		result = append(result, frame...)
-		cOff += int64(fs.C)
 	}
 
 	return result, nil
@@ -169,7 +170,7 @@ func TestCompressStreamRoundTrip(t *testing.T) {
 			require.NoError(t, err)
 
 			if tc.dataSize == 0 {
-				require.Empty(t, ft.Frames)
+				require.Equal(t, 0, ft.NumFrames())
 				require.Equal(t, sha256.Sum256(nil), checksum)
 
 				return
@@ -177,7 +178,7 @@ func TestCompressStreamRoundTrip(t *testing.T) {
 
 			// Verify frame count.
 			expectedFrames := (tc.dataSize + tc.frameSize - 1) / tc.frameSize
-			require.Len(t, ft.Frames, expectedFrames)
+			require.Equal(t, expectedFrames, ft.NumFrames())
 
 			// Verify checksum.
 			require.Equal(t, sha256.Sum256(original), checksum)
@@ -422,11 +423,7 @@ func BenchmarkStoreFile(b *testing.B) {
 						b.Fatal(err)
 					}
 
-					var cSize int64
-					for _, f := range ft.Frames {
-						cSize += int64(f.C)
-					}
-					b.ReportMetric(float64(cSize)/float64(ft.UncompressedSize()), "ratio")
+					b.ReportMetric(float64(ft.CompressedSize())/float64(ft.UncompressedSize()), "ratio")
 				}
 			})
 		}

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -12,41 +12,34 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-// BuildFileInfo holds metadata about a build's data file, stored in the header
-// so the read path can avoid network round-trips (e.g. Size() calls to GCS).
-type BuildFileInfo struct {
-	Size     int64    // uncompressed file size
-	Checksum [32]byte // SHA-256 of uncompressed data; zero value means unknown
+// BuildData holds per-build metadata stored in V4 headers.
+type BuildData struct {
+	Size      int64               // uncompressed file size
+	Checksum  [32]byte            // SHA-256 of uncompressed data; zero value means unknown
+	FrameData *storage.FrameTable // nil for uncompressed builds
 }
 
 const NormalizeFixVersion = 3
 
 type Header struct {
 	Metadata *Metadata
-	// BuildFiles maps build IDs to their file metadata (size + checksum).
-	// Each layer's upload adds its own entry via applyToHeader, and inherits
-	// all parent entries via ToDiffHeader (which copies originalHeader.BuildFiles).
-	// This means every V4 header has a complete map of all builds referenced
-	// in its Mapping. V3 headers have no BuildFiles; the read path falls back
-	// to a Size() RPC for those.
-	BuildFiles  map[uuid.UUID]BuildFileInfo
+	// Builds maps build IDs to per-build metadata. V3 headers have nil Builds;
+	// the read path falls back to a Size() RPC for those.
+	Builds      map[uuid.UUID]BuildData
 	blockStarts *bitset.BitSet
 	startMap    map[int64]*BuildMap
 
 	Mapping []*BuildMap
 }
 
-// CloneForUpload returns a clone with copied Mapping and BuildFiles, safe to
-// mutate for serialization without racing with concurrent readers of the
-// original. Only serialization-relevant fields are populated (Metadata,
-// Mapping, BuildFiles); lookup indices (blockStarts, startMap) are left nil.
+// CloneForUpload returns a shallow clone safe for serialization without
+// racing with concurrent readers.
 func (t *Header) CloneForUpload() *Header {
 	mappings := make([]*BuildMap, len(t.Mapping))
-	for i, m := range t.Mapping {
-		mappings[i] = m.Copy()
-	}
+	copy(mappings, t.Mapping)
 
 	metaCopy := *t.Metadata
 	clone := &Header{
@@ -54,9 +47,9 @@ func (t *Header) CloneForUpload() *Header {
 		Mapping:  mappings,
 	}
 
-	if t.BuildFiles != nil {
-		clone.BuildFiles = make(map[uuid.UUID]BuildFileInfo, len(t.BuildFiles))
-		maps.Copy(clone.BuildFiles, t.BuildFiles)
+	if t.Builds != nil {
+		clone.Builds = make(map[uuid.UUID]BuildData, len(t.Builds))
+		maps.Copy(clone.Builds, t.Builds)
 	}
 
 	return clone
@@ -125,10 +118,9 @@ func (t *Header) GetShiftedMapping(ctx context.Context, offset int64) (BuildMap,
 	mappedLength := int64(mapping.Length) - shift
 
 	b := BuildMap{
-		Offset:     mapping.BuildStorageOffset + uint64(shift),
-		Length:     uint64(mappedLength),
-		BuildId:    mapping.BuildId,
-		FrameTable: mapping.FrameTable,
+		Offset:  mapping.BuildStorageOffset + uint64(shift),
+		Length:  uint64(mappedLength),
+		BuildId: mapping.BuildId,
 	}
 
 	if mappedLength < 0 {
@@ -145,6 +137,15 @@ func (t *Header) GetShiftedMapping(ctx context.Context, offset int64) (BuildMap,
 	}
 
 	return b, nil
+}
+
+// GetBuildFrameData returns the frame table for a build, or nil.
+func (t *Header) GetBuildFrameData(buildID uuid.UUID) *storage.FrameTable {
+	if t.Builds == nil {
+		return nil
+	}
+
+	return t.Builds[buildID].FrameData
 }
 
 // TODO: Maybe we can optimize mapping by automatically assuming the mapping is uuid.Nil if we don't find it + stopping storing the nil mapping.

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -35,8 +35,9 @@ type Header struct {
 	Mapping []*BuildMap
 }
 
-// CloneForUpload returns a shallow clone safe for serialization without
-// racing with concurrent readers.
+// CloneForUpload returns a shallow clone safe for serialization without racing
+// with concurrent readers. BuildMap pointers and BuildData.FrameData pointers
+// are shared (both are immutable after construction).
 func (t *Header) CloneForUpload() *Header {
 	mappings := make([]*BuildMap, len(t.Mapping))
 	copy(mappings, t.Mapping)

--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/bits-and-blooms/bitset"
 	"github.com/google/uuid"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 // Offset, Length and BuildStorage are in bytes of the data file
@@ -19,42 +17,6 @@ type BuildMap struct {
 	Length             uint64
 	BuildId            uuid.UUID
 	BuildStorageOffset uint64
-	FrameTable         *storage.FrameTable
-}
-
-func (mapping *BuildMap) Copy() *BuildMap {
-	return &BuildMap{
-		Offset:             mapping.Offset,
-		Length:             mapping.Length,
-		BuildId:            mapping.BuildId,
-		BuildStorageOffset: mapping.BuildStorageOffset,
-		FrameTable:         mapping.FrameTable,
-	}
-}
-
-// SetFrames associates compression frame information with this mapping,
-// starting the scan from frame index `from` and
-// returning the next cursor position. Use this when applying frames to a
-// sorted sequence of mappings to avoid O(N²) rescanning.
-func (mapping *BuildMap) SetFrames(frameTable *storage.FrameTable, from int) (int, error) {
-	if frameTable == nil {
-		return from, nil
-	}
-
-	mappedRange := storage.Range{
-		Offset: int64(mapping.BuildStorageOffset),
-		Length: int(mapping.Length),
-	}
-
-	subset, next := frameTable.Subset(mappedRange, from)
-	if subset == nil && mapping.Length > 0 {
-		return next, fmt.Errorf("mapping at virtual offset %d (storage offset %d, length %d): no frames found from index %d",
-			mapping.Offset, mapping.BuildStorageOffset, mapping.Length, from)
-	}
-
-	mapping.FrameTable = subset
-
-	return next, nil
 }
 
 func CreateMapping(
@@ -181,22 +143,12 @@ func MergeMappings(
 		if diff.Offset >= base.Offset && diff.Offset+diff.Length <= base.Offset+base.Length {
 			leftBaseLength := int64(diff.Offset) - int64(base.Offset)
 
-			// Track frame cursor so the right split starts scanning where the left stopped,
-			// avoiding O(N²) rescanning of the base's FrameTable.
-			frameCursor := 0
-
 			if leftBaseLength > 0 {
 				leftBase := &BuildMap{
-					Offset:  base.Offset,
-					Length:  uint64(leftBaseLength),
-					BuildId: base.BuildId,
-					// the build storage offset is the same as the base mapping
+					Offset:             base.Offset,
+					Length:             uint64(leftBaseLength),
+					BuildId:            base.BuildId,
 					BuildStorageOffset: base.BuildStorageOffset,
-				}
-				var err error
-				frameCursor, err = leftBase.SetFrames(base.FrameTable, 0)
-				if err != nil {
-					return nil, fmt.Errorf("set frames for left split at offset %d: %w", leftBase.Offset, err)
 				}
 
 				mappings = append(mappings, leftBase)
@@ -215,9 +167,6 @@ func MergeMappings(
 					Length:             uint64(rightBaseLength),
 					BuildId:            base.BuildId,
 					BuildStorageOffset: base.BuildStorageOffset + uint64(rightBaseShift),
-				}
-				if _, err := rightBase.SetFrames(base.FrameTable, frameCursor); err != nil {
-					return nil, fmt.Errorf("set frames for right split at offset %d: %w", rightBase.Offset, err)
 				}
 
 				baseMapping[baseIdx] = rightBase
@@ -246,9 +195,6 @@ func MergeMappings(
 					BuildId:            base.BuildId,
 					BuildStorageOffset: base.BuildStorageOffset + uint64(rightBaseShift),
 				}
-				if _, err := rightBase.SetFrames(base.FrameTable, 0); err != nil {
-					return nil, fmt.Errorf("set frames for right split at offset %d: %w", rightBase.Offset, err)
-				}
 
 				baseMapping[baseIdx] = rightBase
 			} else {
@@ -270,9 +216,6 @@ func MergeMappings(
 					BuildId:            base.BuildId,
 					BuildStorageOffset: base.BuildStorageOffset,
 				}
-				if _, err := leftBase.SetFrames(base.FrameTable, 0); err != nil {
-					return nil, fmt.Errorf("set frames for left split at offset %d: %w", leftBase.Offset, err)
-				}
 
 				mappings = append(mappings, leftBase)
 			}
@@ -292,8 +235,6 @@ func MergeMappings(
 }
 
 // NormalizeMappings joins adjacent mappings that have the same buildId.
-// When merging mappings, FrameTables are also merged by extending the first
-// mapping's FrameTable with frames from subsequent mappings.
 func NormalizeMappings(mappings []*BuildMap) []*BuildMap {
 	if len(mappings) == 0 {
 		return nil
@@ -301,30 +242,25 @@ func NormalizeMappings(mappings []*BuildMap) []*BuildMap {
 
 	result := make([]*BuildMap, 0, len(mappings))
 
-	// Start with a copy of the first mapping (Copy() now includes FrameTable)
-	current := mappings[0].Copy()
+	current := &BuildMap{
+		Offset:             mappings[0].Offset,
+		Length:             mappings[0].Length,
+		BuildId:            mappings[0].BuildId,
+		BuildStorageOffset: mappings[0].BuildStorageOffset,
+	}
 
 	for i := 1; i < len(mappings); i++ {
 		mp := mappings[i]
 		if mp.BuildId != current.BuildId {
-			// BuildId changed, add the current map to results and start a new one
 			result = append(result, current)
-			current = mp.Copy() // New copy (includes FrameTable)
-		} else {
-			// Same BuildId, merge: add the length and extend FrameTable
-			current.Length += mp.Length
-
-			// Extend FrameTable if the mapping being merged has one
-			if mp.FrameTable != nil {
-				if current.FrameTable == nil {
-					// Current has no FrameTable but merged one does - take it
-					current.FrameTable = mp.FrameTable
-				} else {
-					// Both have FrameTables - extend current's with mp's frames
-					// The frames are contiguous subsets, so we append non-overlapping frames
-					current.FrameTable = mergeFrameTables(current.FrameTable, mp.FrameTable)
-				}
+			current = &BuildMap{
+				Offset:             mp.Offset,
+				Length:             mp.Length,
+				BuildId:            mp.BuildId,
+				BuildStorageOffset: mp.BuildStorageOffset,
 			}
+		} else {
+			current.Length += mp.Length
 		}
 	}
 
@@ -332,64 +268,4 @@ func NormalizeMappings(mappings []*BuildMap) []*BuildMap {
 	result = append(result, current)
 
 	return result
-}
-
-// mergeFrameTables extends ft1 with frames from ft2. The FrameTables are
-// assumed to be contiguous subsets from the same original, so ft2's frames
-// follow ft1's frames (with possible overlap at the boundary). this function
-// returns either an reference to one of the input tables, unchanged, or a new
-// FrameTable with frames from both tables.
-func mergeFrameTables(ft1, ft2 *storage.FrameTable) *storage.FrameTable {
-	if ft1 == nil {
-		return ft2
-	}
-	if ft2 == nil {
-		return ft1
-	}
-
-	// Calculate where ft1 ends (uncompressed offset)
-	ft1EndU := ft1.Offset.U
-	for _, frame := range ft1.Frames {
-		ft1EndU += int64(frame.U)
-	}
-
-	// Find where to start appending from ft2 (skip frames already covered by ft1)
-	ft2CurrentU := ft2.Offset.U
-	startIdx := 0
-	for i, frame := range ft2.Frames {
-		frameEndU := ft2CurrentU + int64(frame.U)
-		if frameEndU <= ft1EndU {
-			// This frame is already covered by ft1
-			ft2CurrentU = frameEndU
-			startIdx = i + 1
-
-			continue
-		}
-		if ft2CurrentU < ft1EndU {
-			// This frame overlaps with ft1's last frame - it's the same frame, skip it
-			ft2CurrentU = frameEndU
-			startIdx = i + 1
-
-			continue
-		}
-		// This frame is beyond ft1's coverage
-		break
-	}
-
-	// Append remaining frames from ft2
-	if startIdx < len(ft2.Frames) {
-		// Create a new FrameTable with extended frames
-		newFrames := make([]storage.FrameSize, len(ft1.Frames), len(ft1.Frames)+len(ft2.Frames)-startIdx)
-		copy(newFrames, ft1.Frames)
-		newFrames = append(newFrames, ft2.Frames[startIdx:]...)
-
-		result := storage.NewFrameTable(ft1.CompressionType())
-		result.Offset = ft1.Offset
-		result.Frames = newFrames
-
-		return result
-	}
-
-	// All of ft2's frames were already covered by ft1
-	return ft1
 }

--- a/packages/shared/pkg/storage/header/mapping_test.go
+++ b/packages/shared/pkg/storage/header/mapping_test.go
@@ -1,14 +1,11 @@
 package header
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 var (
@@ -715,56 +712,22 @@ func TestNormalizeMappingsDoesNotModifyInput(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// makeFrameTable builds a FrameTable with n frames of uniform uncompressed size
-// frameU, compressed size frameC, starting at offset 0.
-func makeFrameTable(n int, frameU, frameC int32) *storage.FrameTable {
-	ft := storage.NewFrameTable(storage.CompressionZstd)
-	ft.Offset = storage.FrameOffset{U: 0, C: 0}
-	for range n {
-		ft.Frames = append(ft.Frames, storage.FrameSize{U: frameU, C: frameC})
-	}
-
-	return ft
-}
-
-func assertFrameTable(t *testing.T, label string, m *BuildMap, startU, startC int64, nFrames int, frameU, frameC int32) {
-	t.Helper()
-
-	require.NotNil(t, m.FrameTable, "%s: FrameTable should not be nil", label)
-	assert.Equal(t, startU, m.FrameTable.Offset.U, "%s: Offset.U", label)
-	assert.Equal(t, startC, m.FrameTable.Offset.C, "%s: Offset.C", label)
-	require.Len(t, m.FrameTable.Frames, nFrames, "%s: frame count", label)
-	for i, f := range m.FrameTable.Frames {
-		assert.Equal(t, frameU, f.U, "%s: frame[%d].U", label, i)
-		assert.Equal(t, frameC, f.C, "%s: frame[%d].C", label, i)
-	}
-}
-
-func TestMergeMappings_FrameTableSplits(t *testing.T) {
+func TestMergeMappings_Splits(t *testing.T) {
 	t.Parallel()
-
-	// Frame geometry: each frame = 1 block uncompressed, compressed to 1 MiB.
-	frameU := int32(blockSize)
-	frameC := int32(1 << 20)
 
 	compBaseID := uuid.New()
 	compDiffID := uuid.New()
 	plainID := uuid.New()
-
-	// 6-frame base FrameTable covering blocks [0..6).
-	//   frame i: U=[i*2M, (i+1)*2M)  C=[i*1M, (i+1)*1M)
-	baseFT := makeFrameTable(6, frameU, frameC)
 
 	tests := map[string]struct {
 		base     []*BuildMap
 		diff     []*BuildMap
 		validate func(t *testing.T, merged []*BuildMap)
 	}{
-		"diff inside base — left and right get correct frame subsets": {
+		"diff inside base — left and right split correctly": {
 			base: []*BuildMap{{
 				Offset: 0, Length: 6 * blockSize,
 				BuildId: compBaseID, BuildStorageOffset: 0,
-				FrameTable: baseFT,
 			}},
 			diff: []*BuildMap{{
 				Offset: 2 * blockSize, Length: 2 * blockSize,
@@ -776,24 +739,22 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 
 				assert.Equal(t, uint64(0), m[0].Offset)
 				assert.Equal(t, 2*blockSize, m[0].Length)
-				assertFrameTable(t, "left", m[0], 0, 0, 2, frameU, frameC)
+				assert.Equal(t, compBaseID, m[0].BuildId)
 
 				assert.Equal(t, compDiffID, m[1].BuildId)
 
 				assert.Equal(t, 4*blockSize, m[2].Offset)
 				assert.Equal(t, 4*blockSize, m[2].BuildStorageOffset)
-				assertFrameTable(t, "right", m[2],
-					4*int64(frameU), 4*int64(frameC), 2, frameU, frameC)
+				assert.Equal(t, compBaseID, m[2].BuildId)
 			},
 		},
 
-		"base after diff with overlap — right split keeps tail frames": {
+		"base after diff with overlap — right split keeps tail": {
 			base: []*BuildMap{
 				{Offset: 0, Length: 1 * blockSize, BuildId: plainID},
 				{
 					Offset: 1 * blockSize, Length: 4 * blockSize,
 					BuildId: compBaseID, BuildStorageOffset: 0,
-					FrameTable: makeFrameTable(4, frameU, frameC),
 				},
 			},
 			diff: []*BuildMap{{
@@ -808,17 +769,15 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 
 				assert.Equal(t, 3*blockSize, m[1].Offset)
 				assert.Equal(t, 2*blockSize, m[1].BuildStorageOffset)
-				assertFrameTable(t, "right-tail", m[1],
-					2*int64(frameU), 2*int64(frameC), 2, frameU, frameC)
+				assert.Equal(t, compBaseID, m[1].BuildId)
 			},
 		},
 
-		"diff after base with overlap — left split keeps head frames": {
+		"diff after base with overlap — left split keeps head": {
 			base: []*BuildMap{
 				{
 					Offset: 0, Length: 4 * blockSize,
 					BuildId: compBaseID, BuildStorageOffset: 0,
-					FrameTable: makeFrameTable(4, frameU, frameC),
 				},
 				{Offset: 4 * blockSize, Length: 2 * blockSize, BuildId: plainID},
 			},
@@ -832,7 +791,7 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 
 				assert.Equal(t, uint64(0), m[0].Offset)
 				assert.Equal(t, 2*blockSize, m[0].Length)
-				assertFrameTable(t, "left-head", m[0], 0, 0, 2, frameU, frameC)
+				assert.Equal(t, compBaseID, m[0].BuildId)
 
 				assert.Equal(t, compDiffID, m[1].BuildId)
 			},
@@ -842,7 +801,6 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 			base: []*BuildMap{{
 				Offset: 0, Length: 6 * blockSize,
 				BuildId: compBaseID, BuildStorageOffset: 0,
-				FrameTable: baseFT,
 			}},
 			diff: []*BuildMap{
 				{Offset: 1 * blockSize, Length: 1 * blockSize, BuildId: compDiffID},
@@ -852,37 +810,24 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 				t.Helper()
 				require.Len(t, m, 5)
 
-				assertFrameTable(t, "piece-0", m[0], 0, 0, 1, frameU, frameC)
+				assert.Equal(t, compBaseID, m[0].BuildId)
+				assert.Equal(t, 1*blockSize, m[0].Length)
+
 				assert.Equal(t, compDiffID, m[1].BuildId)
-				assertFrameTable(t, "piece-2", m[2],
-					2*int64(frameU), 2*int64(frameC), 2, frameU, frameC)
+
+				assert.Equal(t, compBaseID, m[2].BuildId)
+				assert.Equal(t, 2*blockSize, m[2].Length)
+				assert.Equal(t, 2*blockSize, m[2].BuildStorageOffset)
+
 				assert.Equal(t, compDiffID, m[3].BuildId)
-				assertFrameTable(t, "piece-4", m[4],
-					5*int64(frameU), 5*int64(frameC), 1, frameU, frameC)
+
+				assert.Equal(t, compBaseID, m[4].BuildId)
+				assert.Equal(t, 1*blockSize, m[4].Length)
+				assert.Equal(t, 5*blockSize, m[4].BuildStorageOffset)
 			},
 		},
 
-		"nil FrameTable base — splits work without frames": {
-			base: []*BuildMap{{
-				Offset: 0, Length: 4 * blockSize,
-				BuildId: compBaseID, BuildStorageOffset: 0,
-			}},
-			diff: []*BuildMap{{
-				Offset: 1 * blockSize, Length: 2 * blockSize,
-				BuildId: compDiffID,
-			}},
-			validate: func(t *testing.T, m []*BuildMap) {
-				t.Helper()
-				require.Len(t, m, 3)
-				assert.Nil(t, m[0].FrameTable)
-				assert.Nil(t, m[2].FrameTable)
-			},
-		},
-
-		"multi-layer base with three compressed builds — diff splits middle build": {
-			// Simulates a real multi-layer header: three builds (A, B, C) each
-			// with their own FrameTable. A diff lands inside build B, splitting
-			// it. Builds A and C must pass through with FrameTables intact.
+		"multi-layer base — diff splits middle build": {
 			base: func() []*BuildMap {
 				buildA := uuid.New()
 				buildB := compBaseID
@@ -892,17 +837,14 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 					{
 						Offset: 0, Length: 2 * blockSize,
 						BuildId: buildA, BuildStorageOffset: 0,
-						FrameTable: makeFrameTable(2, frameU, frameC),
 					},
 					{
 						Offset: 2 * blockSize, Length: 4 * blockSize,
 						BuildId: buildB, BuildStorageOffset: 0,
-						FrameTable: makeFrameTable(4, frameU, frameC),
 					},
 					{
 						Offset: 6 * blockSize, Length: 2 * blockSize,
 						BuildId: buildC, BuildStorageOffset: 0,
-						FrameTable: makeFrameTable(2, frameU, frameC),
 					},
 				}
 			}(),
@@ -912,31 +854,20 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 			}},
 			validate: func(t *testing.T, m []*BuildMap) {
 				t.Helper()
-				// Expected: A(untouched) | B-left[0..1) | diff | B-right[3..4) | C(untouched)
 				require.Len(t, m, 5)
 
-				// Build A: untouched, full 2-frame FT.
-				assertFrameTable(t, "build-A", m[0], 0, 0, 2, frameU, frameC)
-
-				// Build B left: block [2*bs..3*bs), storage offset 0, frame 0 only.
+				// Build B left
 				assert.Equal(t, 2*blockSize, m[1].Offset)
 				assert.Equal(t, 1*blockSize, m[1].Length)
 				assert.Equal(t, uint64(0), m[1].BuildStorageOffset)
-				assertFrameTable(t, "build-B-left", m[1], 0, 0, 1, frameU, frameC)
 
 				// Diff
 				assert.Equal(t, compDiffID, m[2].BuildId)
 
-				// Build B right: block [5*bs..6*bs), storage offset 3*bs, frame 3.
+				// Build B right
 				assert.Equal(t, 5*blockSize, m[3].Offset)
 				assert.Equal(t, 1*blockSize, m[3].Length)
 				assert.Equal(t, 3*blockSize, m[3].BuildStorageOffset)
-				assertFrameTable(t, "build-B-right", m[3],
-					3*int64(frameU), 3*int64(frameC), 1, frameU, frameC)
-
-				// Build C: untouched, full 2-frame FT.
-				assert.Equal(t, 6*blockSize, m[4].Offset)
-				assertFrameTable(t, "build-C", m[4], 0, 0, 2, frameU, frameC)
 			},
 		},
 	}
@@ -949,36 +880,6 @@ func TestMergeMappings_FrameTableSplits(t *testing.T) {
 			require.NoError(t, err)
 
 			tc.validate(t, merged)
-
-			// Verify the invariant that the read path depends on:
-			// for every mapping with a FrameTable, LocateCompressed must be
-			// able to find frames at both the start and end of the mapping's
-			// storage range. This is what GetShiftedMapping + Chunker.fetch
-			// rely on.
-			for i, m := range merged {
-				ft := m.FrameTable
-				if ft == nil {
-					continue
-				}
-
-				label := fmt.Sprintf("mapping[%d] offset=%d storage=%d len=%d",
-					i, m.Offset, m.BuildStorageOffset, m.Length)
-
-				// Offset must be at or before the mapping's storage offset.
-				require.LessOrEqual(t, ft.Offset.U, int64(m.BuildStorageOffset),
-					"%s: FrameTable.Offset.U must be <= BuildStorageOffset", label)
-
-				// LocateCompressed must find the first block.
-				_, err := ft.LocateCompressed(int64(m.BuildStorageOffset))
-				require.NoError(t, err, "%s: LocateCompressed(start)", label)
-
-				// LocateCompressed must find the last block.
-				if m.Length > 0 {
-					lastByte := int64(m.BuildStorageOffset + m.Length - 1)
-					_, err := ft.LocateCompressed(lastByte)
-					require.NoError(t, err, "%s: LocateCompressed(last byte)", label)
-				}
-			}
 		})
 	}
 }

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -157,15 +157,17 @@ func (d *DiffMetadata) ToDiffHeader(
 		return nil, fmt.Errorf("failed to create header: %w", err)
 	}
 
-	// Copy only BuildFiles referenced by the merged mappings.
-	referenced := make(map[uuid.UUID]struct{}, len(m))
-	for _, mapping := range m {
-		referenced[mapping.BuildId] = struct{}{}
-	}
-	header.BuildFiles = make(map[uuid.UUID]BuildFileInfo, len(referenced))
-	for id := range referenced {
-		if info, ok := originalHeader.BuildFiles[id]; ok {
-			header.BuildFiles[id] = info
+	// Copy Builds referenced by the merged mappings.
+	if originalHeader.Builds != nil {
+		referenced := make(map[uuid.UUID]struct{}, len(m))
+		for _, mapping := range m {
+			referenced[mapping.BuildId] = struct{}{}
+		}
+		header.Builds = make(map[uuid.UUID]BuildData, len(referenced))
+		for id := range referenced {
+			if bd, ok := originalHeader.Builds[id]; ok {
+				header.Builds[id] = bd
+			}
 		}
 	}
 

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -10,13 +10,13 @@ import (
 // SerializeHeader serializes a header, dispatching to the version-specific format.
 //
 // V3 (Version <= 3): [Metadata] [v3 mappings…]
-// V4 (Version >= 4): [Metadata] [uint32 uncompressedSize] [LZ4( BuildFiles + v4 mappings + FrameTables )]
+// V4 (Version >= 4): [Metadata] [uint32 uncompressedSize] [LZ4( Builds + v4 mappings )]
 func SerializeHeader(h *Header) ([]byte, error) {
 	if h.Metadata.Version <= 3 {
 		return serializeV3(h.Metadata, h.Mapping)
 	}
 
-	return serializeV4(h.Metadata, h.BuildFiles, h.Mapping)
+	return serializeV4(h.Metadata, h.Builds, h.Mapping)
 }
 
 // DeserializeBytes auto-detects the header version and deserializes accordingly.

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -10,15 +10,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-// newFT creates a FrameTable for test fixtures.
-func newFT(ct storage.CompressionType, offset storage.FrameOffset, frames []storage.FrameSize) *storage.FrameTable {
-	ft := storage.NewFrameTable(ct)
-	ft.Offset = offset
-	ft.Frames = frames
-
-	return ft
-}
-
 func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -66,8 +57,8 @@ func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 	require.Equal(t, baseID, got.Mapping[1].BuildId)
 	require.Equal(t, uint64(123), got.Mapping[1].BuildStorageOffset)
 
-	// V3 headers have no BuildFiles
-	require.Nil(t, got.BuildFiles)
+	// V3 headers have no Builds
+	require.Nil(t, got.Builds)
 }
 
 func TestDeserialize_TruncatedMetadata(t *testing.T) {
@@ -143,10 +134,6 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 			Length:             4096,
 			BuildId:            buildID,
 			BuildStorageOffset: 0,
-			FrameTable: newFT(storage.CompressionLZ4, storage.FrameOffset{U: 0, C: 0}, []storage.FrameSize{
-				{U: 2048, C: 1024},
-				{U: 2048, C: 900},
-			}),
 		},
 		{
 			Offset:             4096,
@@ -157,16 +144,20 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 	}
 
 	checksum := sha256.Sum256([]byte("test-data"))
-	buildFiles := map[uuid.UUID]BuildFileInfo{
-		buildID: {Size: 12345, Checksum: checksum},
-		baseID:  {Size: 67890},
-	}
 
 	h, err := NewHeader(metadata, mappings)
 	require.NoError(t, err)
-	h.BuildFiles = buildFiles
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {
+			Size: 12345, Checksum: checksum,
+			FrameData: storage.NewFrameTable(storage.CompressionLZ4, []storage.FrameSize{
+				{U: 2048, C: 1024},
+				{U: 2048, C: 900},
+			}),
+		},
+		baseID: {Size: 67890},
+	}
 
-	// Test with Serialize + Deserialize (unified path)
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
 
@@ -175,38 +166,36 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
 	require.Len(t, got.Mapping, 2)
+	require.Equal(t, buildID, got.Mapping[0].BuildId)
+	require.Equal(t, baseID, got.Mapping[1].BuildId)
 
-	// First mapping has FrameTable
-	m0 := got.Mapping[0]
-	require.Equal(t, uint64(0), m0.Offset)
-	require.Equal(t, uint64(4096), m0.Length)
-	require.Equal(t, buildID, m0.BuildId)
-	require.NotNil(t, m0.FrameTable)
-	require.Equal(t, storage.CompressionLZ4, m0.FrameTable.CompressionType())
-	require.Equal(t, int64(0), m0.FrameTable.Offset.U)
-	require.Equal(t, int64(0), m0.FrameTable.Offset.C)
-	require.Len(t, m0.FrameTable.Frames, 2)
-	require.Equal(t, int32(2048), m0.FrameTable.Frames[0].U)
-	require.Equal(t, int32(1024), m0.FrameTable.Frames[0].C)
-	require.Equal(t, int32(2048), m0.FrameTable.Frames[1].U)
-	require.Equal(t, int32(900), m0.FrameTable.Frames[1].C)
+	// Builds round-trip
+	require.Len(t, got.Builds, 2)
+	require.Equal(t, int64(12345), got.Builds[buildID].Size)
+	require.Equal(t, checksum, got.Builds[buildID].Checksum)
+	require.Equal(t, int64(67890), got.Builds[baseID].Size)
 
-	// Second mapping has no FrameTable
-	m1 := got.Mapping[1]
-	require.Equal(t, uint64(4096), m1.Offset)
-	require.Equal(t, uint64(4096), m1.Length)
-	require.Equal(t, baseID, m1.BuildId)
-	require.Nil(t, m1.FrameTable)
+	// Frame data round-trip
+	fd := got.Builds[buildID].FrameData
+	require.NotNil(t, fd)
+	require.Equal(t, storage.CompressionLZ4, fd.CompressionType())
+	require.Equal(t, 2, fd.NumFrames())
 
-	// BuildFiles round-trip
-	require.Len(t, got.BuildFiles, 2)
-	require.Equal(t, int64(12345), got.BuildFiles[buildID].Size)
-	require.Equal(t, checksum, got.BuildFiles[buildID].Checksum)
-	require.Equal(t, int64(67890), got.BuildFiles[baseID].Size)
-	require.Equal(t, [32]byte{}, got.BuildFiles[baseID].Checksum)
+	r, err := fd.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 1024, r.Length)
+
+	r, err = fd.LocateCompressed(2048)
+	require.NoError(t, err)
+	require.Equal(t, int64(1024), r.Offset)
+	require.Equal(t, 900, r.Length)
+
+	// baseID has no frames
+	require.Nil(t, got.Builds[baseID].FrameData)
 }
 
-func TestSerializeDeserialize_V4_Zstd_NonZeroStartAt(t *testing.T) {
+func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 	t.Parallel()
 
 	buildID := uuid.New()
@@ -225,16 +214,22 @@ func TestSerializeDeserialize_V4_Zstd_NonZeroStartAt(t *testing.T) {
 			Length:             4096,
 			BuildId:            buildID,
 			BuildStorageOffset: 8192,
-			FrameTable: newFT(storage.CompressionZstd, storage.FrameOffset{U: 8192, C: 4000}, []storage.FrameSize{
-				{U: 4096, C: 3500},
-			}),
 		},
 	}
 
 	h, err := NewHeader(metadata, mappings)
 	require.NoError(t, err)
+	// 3 frames; only the third [8192, 12288) overlaps the mapping.
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {
+			FrameData: storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+				{U: 4096, C: 2000},
+				{U: 4096, C: 3000},
+				{U: 4096, C: 3500},
+			}),
+		},
+	}
 
-	// Test with Serialize + Deserialize (unified path)
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
 
@@ -242,24 +237,21 @@ func TestSerializeDeserialize_V4_Zstd_NonZeroStartAt(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, got.Mapping, 1)
-	m := got.Mapping[0]
-	require.NotNil(t, m.FrameTable)
-	require.Equal(t, storage.CompressionZstd, m.FrameTable.CompressionType())
-	require.Equal(t, int64(8192), m.FrameTable.Offset.U)
-	require.Equal(t, int64(4000), m.FrameTable.Offset.C)
-	require.Len(t, m.FrameTable.Frames, 1)
-	require.Equal(t, int32(4096), m.FrameTable.Frames[0].U)
-	require.Equal(t, int32(3500), m.FrameTable.Frames[0].C)
+	require.Equal(t, uint64(8192), got.Mapping[0].BuildStorageOffset)
 
-	// No BuildFiles set
-	require.Nil(t, got.BuildFiles)
+	require.Len(t, got.Builds, 1)
+	fd := got.Builds[buildID].FrameData
+	require.NotNil(t, fd)
+	require.Equal(t, storage.CompressionZstd, fd.CompressionType())
+	require.Equal(t, 1, fd.NumFrames())
+
+	r, err := fd.LocateCompressed(8192)
+	require.NoError(t, err)
+	require.Equal(t, int64(2000+3000), r.Offset)
+	require.Equal(t, 3500, r.Length)
 }
 
-// TestSerializeDeserialize_V4_CompressionNone_EmptyFrames verifies that a
-// FrameTable with CompressionNone and zero frames does not corrupt the stream.
-// Before the fix, the serializer wrote a Offset offset (16 bytes) but the
-// deserializer skipped it because the packed value was 0.
-func TestSerializeDeserialize_V4_CompressionNone_EmptyFrames(t *testing.T) {
+func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 	t.Parallel()
 
 	buildID := uuid.New()
@@ -279,8 +271,6 @@ func TestSerializeDeserialize_V4_CompressionNone_EmptyFrames(t *testing.T) {
 			Length:             4096,
 			BuildId:            buildID,
 			BuildStorageOffset: 0,
-			// FrameTable with CompressionNone and no frames — packed value is 0.
-			FrameTable: newFT(storage.CompressionNone, storage.FrameOffset{U: 100, C: 50}, nil),
 		},
 		{
 			Offset:             4096,
@@ -293,7 +283,6 @@ func TestSerializeDeserialize_V4_CompressionNone_EmptyFrames(t *testing.T) {
 	h, err := NewHeader(metadata, mappings)
 	require.NoError(t, err)
 
-	// Test with Serialize + Deserialize (unified path)
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
 
@@ -301,14 +290,7 @@ func TestSerializeDeserialize_V4_CompressionNone_EmptyFrames(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, got.Mapping, 2)
-
-	// First mapping: FrameTable was effectively empty, deserializer should treat as nil.
-	require.Nil(t, got.Mapping[0].FrameTable)
-
-	// Second mapping must not be corrupted by stray Offset bytes.
-	require.Equal(t, uint64(4096), got.Mapping[1].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[1].Length)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
+	require.Nil(t, got.Builds)
 }
 
 func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
@@ -336,14 +318,15 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 			Length:             4096 * numFrames,
 			BuildId:            buildID,
 			BuildStorageOffset: 0,
-			FrameTable:         newFT(storage.CompressionLZ4, storage.FrameOffset{U: 0, C: 0}, frames),
 		},
 	}
 
 	h, err := NewHeader(metadata, mappings)
 	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {FrameData: storage.NewFrameTable(storage.CompressionLZ4, frames)},
+	}
 
-	// Test with Serialize + Deserialize (unified path)
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
 
@@ -351,17 +334,22 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, got.Mapping, 1)
-	require.NotNil(t, got.Mapping[0].FrameTable)
-	require.Len(t, got.Mapping[0].FrameTable.Frames, numFrames)
+	require.NotNil(t, got.Builds)
+	fd := got.Builds[buildID].FrameData
+	require.NotNil(t, fd)
+	require.Equal(t, numFrames, fd.NumFrames())
 
-	// Spot-check first and last frame
-	require.Equal(t, int32(4096), got.Mapping[0].FrameTable.Frames[0].U)
-	require.Equal(t, int32(2000), got.Mapping[0].FrameTable.Frames[0].C)
-	require.Equal(t, int32(4096), got.Mapping[0].FrameTable.Frames[numFrames-1].U)
-	require.Equal(t, int32(2000+numFrames-1), got.Mapping[0].FrameTable.Frames[numFrames-1].C)
+	r, err := fd.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 2000, r.Length)
+
+	r, err = fd.LocateCompressed(int64(4096 * (numFrames - 1)))
+	require.NoError(t, err)
+	require.Equal(t, 2000+numFrames-1, r.Length)
 }
 
-func TestSerializeDeserialize_V4_EmptyBuildFiles(t *testing.T) {
+func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	t.Parallel()
 
 	buildID := uuid.New()
@@ -384,7 +372,7 @@ func TestSerializeDeserialize_V4_EmptyBuildFiles(t *testing.T) {
 
 	h, err := NewHeader(metadata, mappings)
 	require.NoError(t, err)
-	// No BuildFiles set (nil map)
+	// No Builds set (nil map)
 
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
@@ -393,5 +381,130 @@ func TestSerializeDeserialize_V4_EmptyBuildFiles(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, got.Mapping, 1)
-	require.Nil(t, got.BuildFiles) // numBuilds=0 → nil
+	require.Nil(t, got.Builds)
+}
+
+func TestFrameTable_LocateCompressed(t *testing.T) {
+	t.Parallel()
+
+	fd := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 2048, C: 1024},
+		{U: 2048, C: 900},
+		{U: 4096, C: 3500},
+	})
+
+	// Frame 0: U=[0,2048), C=[0,1024)
+	r, err := fd.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 1024, r.Length)
+
+	r, err = fd.LocateCompressed(2047)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 1024, r.Length)
+
+	// Frame 1: U=[2048,4096), C=[1024,1924)
+	r, err = fd.LocateCompressed(2048)
+	require.NoError(t, err)
+	require.Equal(t, int64(1024), r.Offset)
+	require.Equal(t, 900, r.Length)
+
+	// Frame 2: U=[4096,8192), C=[1924,5424)
+	r, err = fd.LocateCompressed(4096)
+	require.NoError(t, err)
+	require.Equal(t, int64(1924), r.Offset)
+	require.Equal(t, 3500, r.Length)
+
+	// Beyond end
+	_, err = fd.LocateCompressed(8192)
+	require.Error(t, err)
+}
+
+func TestFrameTable_LocateUncompressed(t *testing.T) {
+	t.Parallel()
+
+	fd := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 2048, C: 1024},
+		{U: 4096, C: 3500},
+	})
+
+	// Frame 0: U=[0,2048)
+	r, err := fd.LocateUncompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 2048, r.Length)
+
+	// Frame 1: U=[2048,6144)
+	r, err = fd.LocateUncompressed(2048)
+	require.NoError(t, err)
+	require.Equal(t, int64(2048), r.Offset)
+	require.Equal(t, 4096, r.Length)
+
+	// Beyond end
+	_, err = fd.LocateUncompressed(6144)
+	require.Error(t, err)
+}
+
+func TestSerializeDeserialize_V4_SparseTrimming(t *testing.T) {
+	t.Parallel()
+
+	buildID := uuid.New()
+	otherID := uuid.New()
+
+	ft := storage.NewFrameTable(storage.CompressionLZ4, []storage.FrameSize{
+		{U: 4096, C: 2000},
+		{U: 4096, C: 3000},
+		{U: 4096, C: 2500},
+		{U: 4096, C: 1800},
+	})
+
+	metadata := &Metadata{
+		Version:     4,
+		BlockSize:   4096,
+		Size:        4096 * 4,
+		Generation:  0,
+		BuildId:     buildID,
+		BaseBuildId: buildID,
+	}
+
+	// Mapping only references frames 0 and 3 (gap at 1,2 due to otherID).
+	mappings := []*BuildMap{
+		{Offset: 0, Length: 4096, BuildId: buildID, BuildStorageOffset: 0},
+		{Offset: 4096, Length: 8192, BuildId: otherID, BuildStorageOffset: 0},
+		{Offset: 12288, Length: 4096, BuildId: buildID, BuildStorageOffset: 12288},
+	}
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {FrameData: ft, Size: 16384},
+		otherID: {Size: 8192},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	gotFT := got.Builds[buildID].FrameData
+	require.NotNil(t, gotFT)
+	require.Equal(t, 2, gotFT.NumFrames())
+
+	// Frame 0
+	r, err := gotFT.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 2000, r.Length)
+
+	// Frame 3
+	r, err = gotFT.LocateCompressed(12288)
+	require.NoError(t, err)
+	require.Equal(t, int64(2000+3000+2500), r.Offset)
+	require.Equal(t, 1800, r.Length)
+
+	// Gap
+	_, err = gotFT.LocateCompressed(4096)
+	require.Error(t, err)
 }

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -384,6 +384,196 @@ func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	require.Nil(t, got.Builds)
 }
 
+func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
+	t.Parallel()
+
+	buildA := uuid.New()
+	buildB := uuid.New()
+
+	// Build A: 3 frames, each 4096 uncompressed.
+	//   Frame 0: U=[0,4096)   C=[0,1000)
+	//   Frame 1: U=[4096,8192) C=[1000,2800)
+	//   Frame 2: U=[8192,12288) C=[2800,5100)
+	ftA := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 4096, C: 1000},
+		{U: 4096, C: 1800},
+		{U: 4096, C: 2300},
+	})
+
+	// Build B: 2 frames, each 4096 uncompressed.
+	//   Frame 0: U=[0,4096)   C=[0,500)
+	//   Frame 1: U=[4096,8192) C=[500,1700)
+	ftB := storage.NewFrameTable(storage.CompressionLZ4, []storage.FrameSize{
+		{U: 4096, C: 500},
+		{U: 4096, C: 1200},
+	})
+
+	// Virtual layout (20480 bytes total):
+	//   [0,4096)     → buildA offset 0
+	//   [4096,12288) → buildB offset 0 (8192 bytes = both frames of B)
+	//   [12288,20480)→ buildA offset 4096 (8192 bytes = frames 1..2 of A)
+	metadata := &Metadata{
+		Version:     4,
+		BlockSize:   4096,
+		Size:        20480,
+		Generation:  2,
+		BuildId:     buildA,
+		BaseBuildId: buildA,
+	}
+
+	mappings := []*BuildMap{
+		{Offset: 0, Length: 4096, BuildId: buildA, BuildStorageOffset: 0},
+		{Offset: 4096, Length: 8192, BuildId: buildB, BuildStorageOffset: 0},
+		{Offset: 12288, Length: 8192, BuildId: buildA, BuildStorageOffset: 4096},
+	}
+
+	checksumA := sha256.Sum256([]byte("build-a"))
+	checksumB := sha256.Sum256([]byte("build-b"))
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		buildA: {Size: 12288, Checksum: checksumA, FrameData: ftA},
+		buildB: {Size: 8192, Checksum: checksumB, FrameData: ftB},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(4), got.Metadata.Version)
+	require.Len(t, got.Mapping, 3)
+	require.Len(t, got.Builds, 2)
+
+	// Verify checksums round-trip.
+	require.Equal(t, checksumA, got.Builds[buildA].Checksum)
+	require.Equal(t, checksumB, got.Builds[buildB].Checksum)
+
+	// --- Build A frame lookups via GetBuildFrameData ---
+	fdA := got.GetBuildFrameData(buildA)
+	require.NotNil(t, fdA)
+	require.Equal(t, storage.CompressionZstd, fdA.CompressionType())
+	// All 3 frames should survive trimming: frame 0 referenced by mapping 0,
+	// frames 1-2 referenced by mapping 2.
+	require.Equal(t, 3, fdA.NumFrames())
+
+	// Frame 0 of A: U=0, C offset=0, C length=1000.
+	r, err := fdA.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 1000, r.Length)
+
+	// Frame 1 of A: U=4096, C offset=1000, C length=1800.
+	r, err = fdA.LocateCompressed(4096)
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), r.Offset)
+	require.Equal(t, 1800, r.Length)
+
+	// Frame 2 of A: U=8192, C offset=2800, C length=2300.
+	r, err = fdA.LocateCompressed(8192)
+	require.NoError(t, err)
+	require.Equal(t, int64(2800), r.Offset)
+	require.Equal(t, 2300, r.Length)
+
+	// --- Build B frame lookups via GetBuildFrameData ---
+	fdB := got.GetBuildFrameData(buildB)
+	require.NotNil(t, fdB)
+	require.Equal(t, storage.CompressionLZ4, fdB.CompressionType())
+	require.Equal(t, 2, fdB.NumFrames())
+
+	// Frame 0 of B: U=0, C offset=0, C length=500.
+	r, err = fdB.LocateCompressed(0)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), r.Offset)
+	require.Equal(t, 500, r.Length)
+
+	// Frame 1 of B: U=4096, C offset=500, C length=1200.
+	r, err = fdB.LocateCompressed(4096)
+	require.NoError(t, err)
+	require.Equal(t, int64(500), r.Offset)
+	require.Equal(t, 1200, r.Length)
+
+	// Beyond end of B's frames.
+	_, err = fdB.LocateCompressed(8192)
+	require.Error(t, err)
+}
+
+func TestSerializeDeserialize_V4_TrimmedOffsets_Error(t *testing.T) {
+	t.Parallel()
+
+	buildID := uuid.New()
+
+	// 4 frames, each 4096 uncompressed.
+	// Frame 0: U=[0,4096)     C=[0,2000)
+	// Frame 1: U=[4096,8192)  C=[2000,5000)
+	// Frame 2: U=[8192,12288) C=[5000,8500)
+	// Frame 3: U=[12288,16384) C=[8500,10300)
+	ft := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 4096, C: 2000},
+		{U: 4096, C: 3000},
+		{U: 4096, C: 3500},
+		{U: 4096, C: 1800},
+	})
+
+	metadata := &Metadata{
+		Version:     4,
+		BlockSize:   4096,
+		Size:        4096,
+		Generation:  0,
+		BuildId:     buildID,
+		BaseBuildId: buildID,
+	}
+
+	// Mapping references only frame 2 (BuildStorageOffset=8192, Length=4096).
+	// Frames 0, 1, and 3 should be trimmed away.
+	mappings := []*BuildMap{
+		{
+			Offset:             0,
+			Length:             4096,
+			BuildId:            buildID,
+			BuildStorageOffset: 8192,
+		},
+	}
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {FrameData: ft},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	fd := got.Builds[buildID].FrameData
+	require.NotNil(t, fd)
+	require.Equal(t, 1, fd.NumFrames(), "only frame 2 should survive trimming")
+
+	// The surviving frame covers U=[8192,12288). Lookup should succeed.
+	r, err := fd.LocateCompressed(8192)
+	require.NoError(t, err)
+	require.Equal(t, int64(5000), r.Offset)
+	require.Equal(t, 3500, r.Length)
+
+	// Trimmed offsets should return errors.
+	_, err = fd.LocateCompressed(0)
+	require.Error(t, err, "frame at offset 0 was trimmed, should error")
+
+	_, err = fd.LocateCompressed(4096)
+	require.Error(t, err, "frame at offset 4096 was trimmed, should error")
+
+	_, err = fd.LocateCompressed(12288)
+	require.Error(t, err, "frame at offset 12288 was trimmed, should error")
+
+	// Completely beyond original range.
+	_, err = fd.LocateCompressed(16384)
+	require.Error(t, err, "offset beyond all frames should error")
+}
+
 func TestFrameTable_LocateCompressed(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -2,7 +2,6 @@ package header
 
 import (
 	"bytes"
-	"cmp"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -45,7 +44,7 @@ func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []
 		buildIDs = append(buildIDs, id)
 	}
 	slices.SortFunc(buildIDs, func(a, b uuid.UUID) int {
-		return cmp.Compare(a.String(), b.String())
+		return bytes.Compare(a[:], b[:])
 	})
 
 	// U-space ranges per build for sparse trimming.

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -19,59 +19,74 @@ type v4SerializableBuildMap struct {
 	Length             uint64
 	BuildId            [16]byte // uuid.UUID
 	BuildStorageOffset uint64
-	CompressionType    uint32
-	NumFrames          uint32
-
-	// if CompressionType != CompressionNone and NumFrames > 0:
-	// - followed by FrameOffset (16 bytes)
-	// - followed by FrameSize × NumFrames (8 bytes each)
 }
 
-// v4SerializableBuildFileInfo is the on-disk format for a BuildFileInfo entry.
-type v4SerializableBuildFileInfo struct {
+// v4SerializableBuildInfo is the on-disk format for a build's fixed fields,
+// followed by a serialized FrameTable.
+type v4SerializableBuildInfo struct {
 	BuildId  uuid.UUID
-	Size     int64
+	FileSize int64
 	Checksum [32]byte
 }
 
-// serializeV4 writes [Metadata] [uint32 uncompressedSize] [LZ4( BuildFiles + counted mappings + FrameTables )].
-func serializeV4(metadata *Metadata, buildFiles map[uuid.UUID]BuildFileInfo, mappings []*BuildMap) ([]byte, error) {
-	// --- raw metadata prefix (not compressed) ---
+// serializeV4 writes [Metadata] [uint32 uncompressedSize] [LZ4( Builds[] + mappings[] )].
+// Frame tables are sparse-trimmed to only frames referenced by mappings.
+func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []*BuildMap) ([]byte, error) {
 	var metaBuf bytes.Buffer
 	if err := binary.Write(&metaBuf, binary.LittleEndian, metadata); err != nil {
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	// --- compressed block: build-info + mappings + frame tables ---
 	var block bytes.Buffer
 
-	// Build-info section.
-	if err := binary.Write(&block, binary.LittleEndian, uint32(len(buildFiles))); err != nil {
-		return nil, fmt.Errorf("failed to write build files count: %w", err)
-	}
-
 	// Sort by UUID for deterministic serialization.
-	buildIDs := make([]uuid.UUID, 0, len(buildFiles))
-	for id := range buildFiles {
+	buildIDs := make([]uuid.UUID, 0, len(builds))
+	for id := range builds {
 		buildIDs = append(buildIDs, id)
 	}
 	slices.SortFunc(buildIDs, func(a, b uuid.UUID) int {
 		return cmp.Compare(a.String(), b.String())
 	})
 
+	// U-space ranges per build for sparse trimming.
+	buildRanges := make(map[uuid.UUID][][2]int64, len(buildIDs))
+	for _, m := range mappings {
+		buildRanges[m.BuildId] = append(buildRanges[m.BuildId], [2]int64{
+			int64(m.BuildStorageOffset),
+			int64(m.BuildStorageOffset + m.Length),
+		})
+	}
+
+	if err := binary.Write(&block, binary.LittleEndian, uint32(len(buildIDs))); err != nil {
+		return nil, fmt.Errorf("failed to write build count: %w", err)
+	}
+
 	for _, id := range buildIDs {
-		info := buildFiles[id]
-		entry := v4SerializableBuildFileInfo{
+		bd := builds[id]
+
+		entry := v4SerializableBuildInfo{
 			BuildId:  id,
-			Size:     info.Size,
-			Checksum: info.Checksum,
+			FileSize: bd.Size,
+			Checksum: bd.Checksum,
 		}
+
 		if err := binary.Write(&block, binary.LittleEndian, &entry); err != nil {
-			return nil, fmt.Errorf("failed to write build file info: %w", err)
+			return nil, fmt.Errorf("failed to write build info: %w", err)
+		}
+
+		// Sparse-trim, then serialize.
+		ft := bd.FrameData
+		if ft != nil {
+			if ranges, ok := buildRanges[id]; ok {
+				ft = ft.TrimToRanges(ranges)
+			}
+		}
+
+		if err := ft.Serialize(&block); err != nil {
+			return nil, fmt.Errorf("failed to write build frame data: %w", err)
 		}
 	}
 
-	// Counted mappings with inline FrameTables.
 	if err := binary.Write(&block, binary.LittleEndian, uint32(len(mappings))); err != nil {
 		return nil, fmt.Errorf("failed to write mappings count: %w", err)
 	}
@@ -84,29 +99,8 @@ func serializeV4(metadata *Metadata, buildFiles map[uuid.UUID]BuildFileInfo, map
 			BuildStorageOffset: mapping.BuildStorageOffset,
 		}
 
-		var offset *storage.FrameOffset
-		var frames []storage.FrameSize
-		if mapping.FrameTable != nil {
-			v4.CompressionType = uint32(mapping.FrameTable.CompressionType())
-			v4.NumFrames = uint32(len(mapping.FrameTable.Frames))
-			if v4.CompressionType != 0 && v4.NumFrames > 0 {
-				offset = &mapping.FrameTable.Offset
-				frames = mapping.FrameTable.Frames
-			}
-		}
-
 		if err := binary.Write(&block, binary.LittleEndian, v4); err != nil {
 			return nil, fmt.Errorf("failed to write block mapping: %w", err)
-		}
-		if offset != nil {
-			if err := binary.Write(&block, binary.LittleEndian, offset); err != nil {
-				return nil, fmt.Errorf("failed to write compression frames starting offset: %w", err)
-			}
-		}
-		for _, frame := range frames {
-			if err := binary.Write(&block, binary.LittleEndian, frame); err != nil {
-				return nil, fmt.Errorf("failed to write compression frame: %w", err)
-			}
 		}
 	}
 
@@ -125,7 +119,7 @@ func serializeV4(metadata *Metadata, buildFiles map[uuid.UUID]BuildFileInfo, map
 	return result, nil
 }
 
-// deserializeV4 decompresses and reads the V4 block: build-info + counted mappings + FrameTables.
+// deserializeV4 decompresses and reads the V4 block.
 func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 	if len(blockData) < 4 {
 		return nil, fmt.Errorf("v4 header block too short for size prefix: %d bytes", len(blockData))
@@ -138,28 +132,37 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	reader := bytes.NewReader(decompressed)
 
-	// Build-info section.
 	var numBuilds uint32
 	if err := binary.Read(reader, binary.LittleEndian, &numBuilds); err != nil {
-		return nil, fmt.Errorf("failed to read build files count: %w", err)
+		return nil, fmt.Errorf("failed to read build count: %w", err)
 	}
 
-	var buildFiles map[uuid.UUID]BuildFileInfo
+	var builds map[uuid.UUID]BuildData
+
 	if numBuilds > 0 {
-		buildFiles = make(map[uuid.UUID]BuildFileInfo, numBuilds)
+		builds = make(map[uuid.UUID]BuildData, numBuilds)
+
 		for range numBuilds {
-			var entry v4SerializableBuildFileInfo
+			var entry v4SerializableBuildInfo
 			if err := binary.Read(reader, binary.LittleEndian, &entry); err != nil {
-				return nil, fmt.Errorf("failed to read build file info: %w", err)
+				return nil, fmt.Errorf("failed to read build info: %w", err)
 			}
-			buildFiles[entry.BuildId] = BuildFileInfo{
-				Size:     entry.Size,
+
+			bd := BuildData{
+				Size:     entry.FileSize,
 				Checksum: entry.Checksum,
 			}
+
+			ft, err := storage.DeserializeFrameTable(reader)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read frame table for build %s: %w", entry.BuildId, err)
+			}
+
+			bd.FrameData = ft
+			builds[entry.BuildId] = bd
 		}
 	}
 
-	// Counted mappings with inline FrameTables.
 	var numMappings uint32
 	if err := binary.Read(reader, binary.LittleEndian, &numMappings); err != nil {
 		return nil, fmt.Errorf("failed to read mappings count: %w", err)
@@ -179,25 +182,6 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 			BuildStorageOffset: v4.BuildStorageOffset,
 		}
 
-		if v4.CompressionType != 0 && v4.NumFrames > 0 {
-			m.FrameTable = storage.NewFrameTable(storage.CompressionType(v4.CompressionType))
-			numFrames := v4.NumFrames
-
-			var offset storage.FrameOffset
-			if err := binary.Read(reader, binary.LittleEndian, &offset); err != nil {
-				return nil, fmt.Errorf("failed to read compression frames starting offset: %w", err)
-			}
-			m.FrameTable.Offset = offset
-
-			for range numFrames {
-				var frame storage.FrameSize
-				if err := binary.Read(reader, binary.LittleEndian, &frame); err != nil {
-					return nil, fmt.Errorf("failed to read the expected compression frame: %w", err)
-				}
-				m.FrameTable.Frames = append(m.FrameTable.Frames, frame)
-			}
-		}
-
 		mappings = append(mappings, m)
 	}
 
@@ -205,7 +189,7 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 	if err != nil {
 		return nil, err
 	}
-	h.BuildFiles = buildFiles
+	h.Builds = builds
 
 	return h, nil
 }


### PR DESCRIPTION
**Problem**: Numerous per-mapping allocations (FrameTable subsets) fragment the heap and pressure GC at scale. Mapping count grows with snapshots; build count stays bounded by layer depth.

**Solution**: Per-build FrameTable. Allocation count scales with N(builds) < N(mappings).

**Trade-off**: 24 bytes/entry vs 8 - absolute offsets are required to store non-continuous referenced frames, and somewhat balanced by deduplication (frames shared across mappings are now stored once).


 ## Summary

  - Move `FrameTable` from per-mapping (`BuildMap.FrameTable`) to per-build (`Header.Builds[id].FrameData`), looked up by build ID at read time
  - Eliminate `SetFrames`/`Subset`/`mergeFrameTables` machinery from mapping split/merge/normalize — net deletion of ~260 lines of complex frame-subsetting logic
  - `frameEntry` uses absolute `[StartU, EndU, StartC, EndC)` offsets with binary search, replacing relative `FrameOffset` + `[]FrameSize` with linear scan
  - `TrimToRanges` for sparse serialization: only frames referenced by mappings are written to the V4 header
  - `DeserializeFrameTable` validates OOM cap, U/C-space monotonicity, and positive frame sizes