### PR TITLE
feat(resume-build): add optional telemetry/tracing support

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -1049,7 +1049,10 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if verbose {
 		fmt.Println("🔧 Creating block metrics...")
 	}
-	blockMetrics, _ := blockmetrics.NewMetrics(tel.MeterProvider)
+	blockMetrics, err := blockmetrics.NewMetrics(tel.MeterProvider)
+	if err != nil {
+		return fmt.Errorf("block metrics: %w", err)
+	}
 
 	if verbose {
 		fmt.Println("🔧 Creating template cache...")

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -18,7 +18,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
-	"go.opentelemetry.io/otel/metric/noop"
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/clickhouse/pkg/hoststats"
@@ -44,6 +43,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
@@ -965,6 +965,14 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	}
 	sbxlogger.SetSandboxLoggerInternal(logger.NewNopLogger())
 
+	// Initialize telemetry (traces, metrics) if OTEL_COLLECTOR_GRPC_ENDPOINT is set.
+	// When unset, telemetry.New() returns a noop client with zero overhead.
+	tel, err := telemetry.New(ctx, "resume-build", "resume-build", "", "dev", uuid.NewString())
+	if err != nil {
+		return fmt.Errorf("telemetry: %w", err)
+	}
+	defer tel.Shutdown(context.WithoutCancel(ctx))
+
 	if os.Getenv("NODE_IP") == "" {
 		os.Setenv("NODE_IP", "127.0.0.1")
 	}
@@ -991,7 +999,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if verbose {
 		fmt.Println("🔧 Starting TCP firewall...")
 	}
-	tcpFw := tcpfirewall.New(l, config.NetworkConfig, sandboxes, noop.NewMeterProvider(), flags)
+	tcpFw := tcpfirewall.New(l, config.NetworkConfig, sandboxes, tel.MeterProvider, flags)
 	go tcpFw.Start(ctx)
 	defer tcpFw.Close(context.WithoutCancel(ctx))
 
@@ -1037,7 +1045,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if verbose {
 		fmt.Println("🔧 Creating block metrics...")
 	}
-	blockMetrics, _ := blockmetrics.NewMetrics(&noop.MeterProvider{})
+	blockMetrics, _ := blockmetrics.NewMetrics(tel.MeterProvider)
 
 	if verbose {
 		fmt.Println("🔧 Creating template cache...")

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -965,7 +965,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	}
 	sbxlogger.SetSandboxLoggerInternal(logger.NewNopLogger())
 
-	tel, err := telemetry.New(ctx, "resume-build", "resume-build", "", "dev", uuid.NewString())
+	tel, err := telemetry.NewAnonymous(ctx, "resume-build")
 	if err != nil {
 		return fmt.Errorf("telemetry: %w", err)
 	}

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -965,8 +965,6 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	}
 	sbxlogger.SetSandboxLoggerInternal(logger.NewNopLogger())
 
-	// Initialize telemetry (traces, metrics) if OTEL_COLLECTOR_GRPC_ENDPOINT is set.
-	// When unset, telemetry.New() returns a noop client with zero overhead.
 	tel, err := telemetry.New(ctx, "resume-build", "resume-build", "", "dev", uuid.NewString())
 	if err != nil {
 		return fmt.Errorf("telemetry: %w", err)

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -971,7 +971,11 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if err != nil {
 		return fmt.Errorf("telemetry: %w", err)
 	}
-	defer tel.Shutdown(context.WithoutCancel(ctx))
+	defer func() {
+		if err := tel.Shutdown(context.WithoutCancel(ctx)); err != nil {
+			log.Printf("error shutting down telemetry: %v", err)
+		}
+	}()
 
 	if os.Getenv("NODE_IP") == "" {
 		os.Setenv("NODE_IP", "127.0.0.1")

--- a/packages/shared/pkg/telemetry/main.go
+++ b/packages/shared/pkg/telemetry/main.go
@@ -29,6 +29,9 @@ type Client struct {
 	LogsProvider    LogProvider
 }
 
+// New creates a telemetry client that exports traces, metrics, and logs via gRPC.
+// Telemetry is enabled when the OTEL_COLLECTOR_GRPC_ENDPOINT environment variable is set
+// (e.g. "localhost:4317"). When unset, a noop client is returned with zero overhead.
 func New(ctx context.Context, nodeID, serviceName, serviceCommit, serviceVersion, serviceInstanceID string, additional ...attribute.KeyValue) (*Client, error) {
 	if otelCollectorGRPCEndpoint == "" {
 		return NewNoopClient(), nil

--- a/packages/shared/pkg/telemetry/main.go
+++ b/packages/shared/pkg/telemetry/main.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -92,6 +94,20 @@ func New(ctx context.Context, nodeID, serviceName, serviceCommit, serviceVersion
 		TracePropagator: propagator,
 		LogsProvider:    logProvider,
 	}, nil
+}
+
+// NewAnonymous creates a telemetry client for tools and CLI commands that don't
+// have build-time injected metadata (commitSHA, version, nodeID).
+// serviceName is the primary identifier used for filtering traces and metrics
+// in observability tools (e.g. Grafana). The remaining resource attributes
+// are filled with sensible defaults (hostname, "unknown" commit, "dev" version).
+func NewAnonymous(ctx context.Context, serviceName string) (*Client, error) {
+	nodeID, _ := os.Hostname()
+	if nodeID == "" {
+		nodeID = "unknown"
+	}
+
+	return New(ctx, nodeID, serviceName, "unknown", "dev", uuid.NewString())
 }
 
 func (t *Client) Shutdown(ctx context.Context) error {


### PR DESCRIPTION
Wire telemetry.New() into resume-build so traces and metrics are exported when `OTEL_COLLECTOR_GRPC_ENDPOINT` is set. When unset, behavior is unchanged (noop client, zero overhead).

---

This is useful for sandbox debugging.