### PR TITLE
chore(orchestrator): unify OTEL env variable name in benchmarks

### DIFF
--- a/packages/orchestrator/benchmarks/benchmark_test.go
+++ b/packages/orchestrator/benchmarks/benchmark_test.go
@@ -80,7 +80,7 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 		return utils.Must(filepath.Abs(s))
 	}
 
-	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	endpoint := os.Getenv("OTEL_COLLECTOR_GRPC_ENDPOINT")
 	if endpoint != "" {
 		spanExporter, err := telemetry.NewSpanExporter(b.Context(),
 			otlptracegrpc.WithEndpoint(endpoint),

--- a/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
+++ b/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
@@ -166,7 +166,7 @@ func BenchmarkConcurrentResume(b *testing.B) {
 	}
 
 	// optional OTEL tracing
-	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+	endpoint := os.Getenv("OTEL_COLLECTOR_GRPC_ENDPOINT")
 	if endpoint != "" {
 		spanExporter, err := telemetry.NewSpanExporter(b.Context(),
 			otlptracegrpc.WithEndpoint(endpoint),


### PR DESCRIPTION
The concurrent benchmark was based on the original benchmark test, which used `OTEL_EXPORTER_OTLP_ENDPOINT`. The rest of the codebase consistently uses `OTEL_COLLECTOR_GRPC_ENDPOINT`. Unify the benchmarks to match.