### PR TITLE
fix(orch): uffd handle no such process

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -363,6 +363,15 @@ func (u *Userfaultfd) faultPage(
 		return nil
 	}
 
+	if errors.Is(copyErr, unix.ESRCH) {
+		// The process that triggered the fault no longer exists — FC was killed
+		// or crashed while the page fetch was in flight. This is expected during
+		// sandbox teardown; treat it as benign.
+		u.logger.Debug(ctx, "UFFD serve copy error: process no longer exists", zap.Error(copyErr))
+
+		return nil
+	}
+
 	if copyErr != nil {
 		var signalErr error
 		if onFailure != nil {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -367,6 +367,7 @@ func (u *Userfaultfd) faultPage(
 		// The faulting thread/process no longer exists — it exited or was killed
 		// while the page fetch was in flight. This is expected during sandbox
 		// teardown; treat it as benign.
+		span.SetAttributes(attribute.Bool("uffd.process_exited", true))
 		u.logger.Debug(ctx, "UFFD serve copy error: process no longer exists", zap.Error(copyErr))
 
 		return nil

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -364,9 +364,9 @@ func (u *Userfaultfd) faultPage(
 	}
 
 	if errors.Is(copyErr, unix.ESRCH) {
-		// The process that triggered the fault no longer exists — FC was killed
-		// or crashed while the page fetch was in flight. This is expected during
-		// sandbox teardown; treat it as benign.
+		// The faulting thread/process no longer exists — it exited or was killed
+		// while the page fetch was in flight. This is expected during sandbox
+		// teardown; treat it as benign.
 		u.logger.Debug(ctx, "UFFD serve copy error: process no longer exists", zap.Error(copyErr))
 
 		return nil


### PR DESCRIPTION
Don't log error on failed uffd if the process is already dead

in that case it would log
```
failed handling uffd: failed to handle uffd: failed uffdio copy: no such process
```