### PR TITLE
chore(orch): simplify errors to make them group-able

### DIFF
--- a/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
+++ b/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
@@ -119,8 +119,11 @@ func (h *NFSHandler) Mount(
 ) (nfs.MountStatus, billy.Filesystem, []nfs.AuthFlavor) {
 	fs, err := h.getChroot(ctx, conn.RemoteAddr(), request)
 	if err != nil {
+		sourceIP, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+
 		logger.L().Warn(ctx, "failed to get path",
 			zap.String("request", string(request.Dirpath)),
+			logger.WithSandboxIP(sourceIP),
 			zap.Error(err))
 
 		return nfs.MountStatusErrAcces, mountFailedFS{}, nil

--- a/packages/orchestrator/pkg/sandbox/health.go
+++ b/packages/orchestrator/pkg/sandbox/health.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,7 +24,7 @@ func (c *Checks) getHealth(ctx context.Context, timeout time.Duration) (bool, er
 
 	response, err := sandboxHttpClient.Do(request)
 	if err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			return false, fmt.Errorf("health check timed out")
 		}
 

--- a/packages/orchestrator/pkg/sandbox/health.go
+++ b/packages/orchestrator/pkg/sandbox/health.go
@@ -23,6 +23,10 @@ func (c *Checks) getHealth(ctx context.Context, timeout time.Duration) (bool, er
 
 	response, err := sandboxHttpClient.Do(request)
 	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return false, fmt.Errorf("health check timed out")
+		}
+
 		return false, err
 	}
 	defer func() {

--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -101,7 +101,7 @@ func (m *Map) GetByHostPort(hostPort string) (*Sandbox, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("sandbox with address %s not found", hostPort)
+	return nil, fmt.Errorf("sandbox not found")
 }
 
 func (m *Map) Insert(ctx context.Context, sbx *Sandbox) {


### PR DESCRIPTION
This makes errors easier to classify as they won't contain random strings