### PR TITLE
infra: switch nomad server update policy to OPPORTUNISTIC

### DIFF
--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -49,14 +49,15 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
     port = var.nomad_port
   }
 
-  # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
-  # a rolling update.
+  # Server is a stateful cluster. In non-dev environments, use OPPORTUNISTIC updates so instance template
+  # changes are only applied when instances are recreated for other reasons (e.g., auto-healing).
+  # Proactive rolling replacements of servers can cause missed client heartbeats and secret revocations:
+  # https://github.com/hashicorp/nomad/issues/9390
   update_policy {
-    type           = "OPPORTUNISTIC"
+    type           = var.environment == "dev" ? "PROACTIVE" : "OPPORTUNISTIC"
     minimal_action = "REPLACE"
 
-    // We want to keep the instance distribution even
-    instance_redistribution_type = "PROACTIVE"
+    instance_redistribution_type = var.environment == "dev" ? "PROACTIVE" : "NONE"
     max_unavailable_fixed        = 0
 
     // The number has to be a multiple of the number of zones in the region

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -58,6 +58,8 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
     minimal_action = "REPLACE"
 
     // Keep PROACTIVE redistribution to maintain even server distribution across zones for Raft quorum resilience.
+    // Note: redistributed instances will pick up the current instance template, which may apply pending template
+    // changes as a side effect of zone rebalancing. This is an acceptable trade-off for server quorum safety.
     instance_redistribution_type = "PROACTIVE"
     max_unavailable_fixed        = 0
 

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -52,7 +52,7 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
   # a rolling update.
   update_policy {
-    type           = "PROACTIVE"
+    type           = "OPPORTUNISTIC"
     minimal_action = "REPLACE"
 
     // We want to keep the instance distribution even

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -57,7 +57,8 @@ resource "google_compute_region_instance_group_manager" "server_pool" {
     type           = var.environment == "dev" ? "PROACTIVE" : "OPPORTUNISTIC"
     minimal_action = "REPLACE"
 
-    instance_redistribution_type = var.environment == "dev" ? "PROACTIVE" : "NONE"
+    // Keep PROACTIVE redistribution to maintain even server distribution across zones for Raft quorum resilience.
+    instance_redistribution_type = "PROACTIVE"
     max_unavailable_fixed        = 0
 
     // The number has to be a multiple of the number of zones in the region


### PR DESCRIPTION
## Summary
- Changes the nomad server cluster's update policy from `PROACTIVE` to `OPPORTUNISTIC`, so instance template changes no longer trigger automatic rolling replacements.
- Updates are applied only when instances are recreated for other reasons (e.g., manual restart, auto-healing), reducing the risk of unintended control plane disruptions.

## Test plan
- [ ] Run `make plan` and verify the only change is the update policy type on the server instance group manager
- [ ] Apply in staging and confirm server instances are not immediately replaced
- [ ] Verify manual instance replacement still works via GCP console or `gcloud compute instance-groups managed rolling-action start-update`