### PR TITLE
fix(orch): cancel gRPC stream contexts in peerclient to prevent goroutine leak

### DIFF
--- a/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
@@ -22,17 +22,23 @@ type peerBlob struct {
 func (b *peerBlob) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
 	return withPeerFallback(ctx, &b.peerHandle, "peer-blob-write-to", attrOpWriteTo,
 		func(ctx context.Context) (peerAttempt[int64], error) {
-			recv, err := openPeerBlobStream(ctx, b.client, &orchestrator.GetBuildBlobRequest{
+			streamCtx, cancel := context.WithCancel(ctx)
+
+			recv, err := openPeerBlobStream(streamCtx, b.client, &orchestrator.GetBuildBlobRequest{
 				BuildId:  b.buildID,
 				FileName: b.fileName,
 			}, b.uploaded)
 			if err != nil {
+				cancel()
 				logger.L().Warn(ctx, "failed to open peer blob stream", logger.WithBuildID(b.buildID), zap.String("file_name", b.fileName), zap.Error(err))
 
 				return peerAttempt[int64]{}, nil
 			}
 
-			n, err := io.Copy(dst, newPeerStreamReader(recv, func() {}))
+			reader := newPeerStreamReader(recv, cancel)
+			defer reader.Close()
+
+			n, err := io.Copy(dst, reader)
 			if err != nil {
 				return peerAttempt[int64]{value: n, bytes: n, hit: true},
 					fmt.Errorf("failed to stream file %q from peer: %w", b.fileName, err)

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
@@ -87,6 +87,7 @@ func (b *peerBlob) Put(ctx context.Context, data []byte) error {
 
 // openPeerBlobStream opens a GetBuildBlob stream, checks peer availability,
 // and returns a recv function that yields data chunks starting with the first message's data.
+// The passed context HAS to be canceled by the caller when done with the stream to avoid leaks.
 func openPeerBlobStream(
 	ctx context.Context,
 	client orchestrator.ChunkServiceClient,

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
@@ -132,6 +132,7 @@ func (s *peerSeekable) StoreFile(ctx context.Context, path string) error {
 
 // openPeerSeekableStream opens a ReadAtBuildSeekable stream, checks peer availability,
 // and returns a recv function that yields data chunks starting with the first message's data.
+// The passed context HAS to be canceled by the caller when done with the stream to avoid leaks.
 func openPeerSeekableStream(
 	ctx context.Context,
 	client orchestrator.ChunkServiceClient,

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
@@ -48,7 +48,10 @@ func (s *peerSeekable) Size(ctx context.Context) (int64, error) {
 func (s *peerSeekable) ReadAt(ctx context.Context, buf []byte, off int64) (int, error) {
 	return withPeerFallback(ctx, &s.peerHandle, "read-at peer-seekable", attrOpReadAt,
 		func(ctx context.Context) (peerAttempt[int], error) {
-			recv, err := openPeerSeekableStream(ctx, s.client, &orchestrator.ReadAtBuildSeekableRequest{
+			streamCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			recv, err := openPeerSeekableStream(streamCtx, s.client, &orchestrator.ReadAtBuildSeekableRequest{
 				BuildId:  s.buildID,
 				FileName: s.fileName,
 				Offset:   off,


### PR DESCRIPTION
## Problem

Goroutine leak in `peerclient`: gRPC server-streaming RPCs (`GetBuildBlob`, `ReadAtBuildSeekable`) opened without cancelling the stream context on completion. Each leaked stream leaves a goroutine in `grpc.newClientStreamWithParams.func4` waiting indefinitely. Production pprof shows ~127 leaked goroutines/min, causing GC pressure that eventually makes the orchestrator unresponsive.

## Fix

Cancel the stream context on all exit paths — matching the pattern `OpenRangeReader` already uses correctly:
- `blob.go WriteTo`: `context.WithCancel` + `defer reader.Close()`
- `seekable.go ReadAt`: `context.WithCancel` + `defer cancel()`

## Introduced in

`9bdd4a4f9` — feat(orchestrator): implement direct peer-to-peer chunk transfer (#2032)