### PR TITLE
chore: simplify gcloud login to single command with --update-adc flag

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -209,7 +209,6 @@ move:
 # Login for Terraform (uses application default creds)
 .PHONY: provider-login
 provider-login:
-	gcloud --quiet auth login
+	gcloud --quiet auth login --update-adc
 	gcloud config set project "$(GCP_PROJECT_ID)"
 	gcloud --quiet auth configure-docker "$(GCP_REGION)-docker.pkg.dev"
-	gcloud --quiet auth application-default login


### PR DESCRIPTION
Replace separate 'auth login' and 'auth application-default login' commands with a single 'auth login --update-adc' that handles both.