### PR TITLE
chore: add .envrc for mise tool activation via direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+if command -v mise &>/dev/null; then
+  use_mise() {
+    direnv_load mise direnv exec
+  }
+  use mise
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .env*
 !.env.aws.template
 !.env.gcp.template
+!/.envrc
 .last_used_env
 .tfplan.*
 *.tfvars


### PR DESCRIPTION
Eval mise env in .envrc so all tools declared in .tool-versions (Go, Terraform, etc.) are automatically available when entering the repo directory and removed when leaving.

Add !.envrc exception to .gitignore so it is not caught by the existing .env* ignore rule.