### PR TITLE
style(uffd): normalize whitespace in uffd_pagefault struct

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -12,8 +12,8 @@ package userfaultfd
 #include <sys/ioctl.h>
 
 struct uffd_pagefault {
-	__u64	flags;
-	__u64	address;
+	__u64 flags;
+	__u64 address;
 	__u32 ptid;
 };
 


### PR DESCRIPTION
Normalize inconsistent whitespace in CGo `uffd_pagefault` struct definition.