### PR TITLE
feat(api): make Nomad node pool configurable

### DIFF
--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -141,6 +141,7 @@ module "api" {
   auth_db_min_idle_connections   = var.auth_db_min_idle_connections
 
   job_env_vars = {
+    NOMAD_NODE_POOL               = var.orchestrator_node_pool
     VOLUME_TOKEN_ISSUER           = var.domain_name
     VOLUME_TOKEN_SIGNING_KEY      = "HMAC:${base64encode(random_password.volume_token_key.result)}"
     VOLUME_TOKEN_SIGNING_KEY_NAME = "e2b-volume-token-key"

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -111,6 +111,7 @@ module "api" {
   default_persistent_volume_type          = var.default_persistent_volume_type
 
   job_env_vars = {
+    NOMAD_NODE_POOL               = var.orchestrator_node_pool
     VOLUME_TOKEN_ISSUER           = var.volume_token_issuer
     VOLUME_TOKEN_SIGNING_KEY      = var.volume_token_signing_key
     VOLUME_TOKEN_SIGNING_KEY_NAME = var.volume_token_signing_key_name

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -34,8 +34,9 @@ type Config struct {
 	LokiURL      string `env:"LOKI_URL,required"`
 	LokiUser     string `env:"LOKI_USER"`
 
-	NomadAddress string `env:"NOMAD_ADDRESS" envDefault:"http://localhost:4646"`
-	NomadToken   string `env:"NOMAD_TOKEN"`
+	NomadAddress  string `env:"NOMAD_ADDRESS"   envDefault:"http://localhost:4646"`
+	NomadToken    string `env:"NOMAD_TOKEN"`
+	NomadNodePool string `env:"NOMAD_NODE_POOL" envDefault:"default"`
 
 	PostgresConnectionString string `env:"POSTGRES_CONNECTION_STRING,required,notEmpty"`
 	DBMaxOpenConnections     int32  `env:"DB_MAX_OPEN_CONNECTIONS"                      envDefault:"40"`

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -100,8 +100,7 @@ func (o *Orchestrator) listNomadNodes(ctx context.Context) ([]nodemanager.NomadS
 	defer listSpan.End()
 
 	options := &nomadapi.QueryOptions{
-		// TODO: Use variable for node pool name ("default")
-		Filter: "Status == \"ready\" and NodePool == \"default\"",
+		Filter: fmt.Sprintf("Status == \"ready\" and NodePool == \"%s\"", o.nomadNodePool),
 	}
 	nomadNodes, _, err := o.nomadClient.Nodes().List(options.WithContext(ctx))
 	if err != nil {

--- a/packages/api/internal/orchestrator/client_test.go
+++ b/packages/api/internal/orchestrator/client_test.go
@@ -40,9 +40,10 @@ func newTestOrchestrator(t *testing.T, nomad *nomadapi.Client) *Orchestrator {
 	logger.ReplaceGlobals(ctx, logger.NewNopLogger())
 
 	return &Orchestrator{
-		nodes:       smap.New[*nodemanager.Node](),
-		nomadClient: nomad,
-		tel:         telemetry.NewNoopClient(),
+		nodes:         smap.New[*nodemanager.Node](),
+		nomadClient:   nomad,
+		nomadNodePool: "default",
+		tel:           telemetry.NewNoopClient(),
 	}
 }
 

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -48,6 +48,7 @@ type SnapshotCacheInvalidator interface {
 type Orchestrator struct {
 	httpClient                    *http.Client
 	nomadClient                   *nomadapi.Client
+	nomadNodePool                 string
 	sandboxStore                  *sandbox.Store
 	nodes                         *smap.Map[*nodemanager.Node]
 	placementAlgorithm            *placement.BestOfK
@@ -142,6 +143,7 @@ func New(
 		analytics:            analyticsInstance,
 		posthogClient:        posthogClient,
 		nomadClient:          nomadClient,
+		nomadNodePool:        config.NomadNodePool,
 		nodes:                smap.New[*nodemanager.Node](),
 		placementAlgorithm:   bestOfKAlgorithm,
 		featureFlagsClient:   featureFlags,


### PR DESCRIPTION
## Summary

The Nomad node pool name is currently hardcoded as `"default"` in the API's orchestrator client . This PR makes it configurable via the `NOMAD_NODE_POOL` environment variable, enabling deployments that use custom Nomad node pools.

## Changes

- Add `NomadNodePool` config field (`NOMAD_NODE_POOL` env var, defaults to `"default"`)
- Replace hardcoded `"default"` pool filter in `listNomadNodes` with the configurable value
- Pass `NOMAD_NODE_POOL` from Terraform (`var.orchestrator_node_pool`) to the API job in both GCP and AWS providers
- Update tests to include the new field

