### PR TITLE
chore(clickhouse): add ttl only drop parts to tables

### DIFF
--- a/packages/clickhouse/migrations/20260413080000_ttl_only_drop_parts.sql
+++ b/packages/clickhouse/migrations/20260413080000_ttl_only_drop_parts.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Enable ttl_only_drop_parts on all local MergeTree tables.
+-- Since all tables use PARTITION BY toDate(timestamp), TTL boundaries align
+-- with partition boundaries. This avoids expensive part rewrites during TTL
+-- cleanup -- ClickHouse will drop entire partitions instead.
+ALTER TABLE sandbox_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE team_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE team_metrics_sum_local MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE sandbox_events_local MODIFY SETTING ttl_only_drop_parts = 1;
+ALTER TABLE sandbox_host_stats_local MODIFY SETTING ttl_only_drop_parts = 1;
+
+-- +goose Down
+ALTER TABLE sandbox_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 0;
+ALTER TABLE team_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 0;
+ALTER TABLE team_metrics_sum_local MODIFY SETTING ttl_only_drop_parts = 0;
+ALTER TABLE sandbox_events_local MODIFY SETTING ttl_only_drop_parts = 0;
+ALTER TABLE sandbox_host_stats_local MODIFY SETTING ttl_only_drop_parts = 0;

--- a/packages/clickhouse/migrations/20260417120000_ttl_only_drop_parts.sql
+++ b/packages/clickhouse/migrations/20260417120000_ttl_only_drop_parts.sql
@@ -1,8 +1,8 @@
 -- +goose Up
 -- Enable ttl_only_drop_parts on all local MergeTree tables.
 -- Since all tables use PARTITION BY toDate(timestamp), TTL boundaries align
--- with partition boundaries. This avoids expensive part rewrites during TTL
--- cleanup -- ClickHouse will drop entire partitions instead.
+-- with part boundaries. This avoids expensive part rewrites during TTL
+-- cleanup -- ClickHouse will drop entire parts instead.
 ALTER TABLE sandbox_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 1;
 ALTER TABLE team_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 1;
 ALTER TABLE team_metrics_sum_local MODIFY SETTING ttl_only_drop_parts = 1;
@@ -10,8 +10,8 @@ ALTER TABLE sandbox_events_local MODIFY SETTING ttl_only_drop_parts = 1;
 ALTER TABLE sandbox_host_stats_local MODIFY SETTING ttl_only_drop_parts = 1;
 
 -- +goose Down
-ALTER TABLE sandbox_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 0;
-ALTER TABLE team_metrics_gauge_local MODIFY SETTING ttl_only_drop_parts = 0;
-ALTER TABLE team_metrics_sum_local MODIFY SETTING ttl_only_drop_parts = 0;
-ALTER TABLE sandbox_events_local MODIFY SETTING ttl_only_drop_parts = 0;
-ALTER TABLE sandbox_host_stats_local MODIFY SETTING ttl_only_drop_parts = 0;
+ALTER TABLE sandbox_metrics_gauge_local RESET SETTING ttl_only_drop_parts;
+ALTER TABLE team_metrics_gauge_local RESET SETTING ttl_only_drop_parts;
+ALTER TABLE team_metrics_sum_local RESET SETTING ttl_only_drop_parts;
+ALTER TABLE sandbox_events_local RESET SETTING ttl_only_drop_parts;
+ALTER TABLE sandbox_host_stats_local RESET SETTING ttl_only_drop_parts;


### PR DESCRIPTION
This should decrease load on clickhouse as the data will be dropped once the whole partition is expired instead of per row