### PR TITLE
chore(orch): add nbd read duration

### DIFF
--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -23,6 +23,10 @@ var (
 		metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
 		metric.WithUnit("ms"),
 	))
+	nbdReadsInFlight = utils.Must(meter.Int64UpDownCounter("orchestrator.nbd.dispatch.reads_in_flight",
+		metric.WithDescription("Number of NBD read requests currently waiting for a response. A sustained high value indicates reads stuck in kernel I/O."),
+		metric.WithUnit("{read}"),
+	))
 	nbdReadSuccess = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", true)))
 	nbdReadFailure = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", false)))
 )
@@ -260,6 +264,8 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		errchan := make(chan error, 1)
 		data := make([]byte, length)
 
+		nbdReadsInFlight.Add(ctx, 1)
+
 		go func() {
 			start := time.Now()
 			_, err := d.prov.ReadAt(ctx, data, int64(from))
@@ -273,13 +279,17 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		}()
 
 		// Wait until either the ReadAt completed, or our context is cancelled...
+		var readErr error
 		select {
 		case <-ctx.Done():
+			readErr = ctx.Err()
+		case readErr = <-errchan:
+		}
+
+		nbdReadsInFlight.Add(ctx, -1)
+
+		if readErr != nil {
 			return d.writeResponse(1, handle, []byte{})
-		case err := <-errchan:
-			if err != nil {
-				return d.writeResponse(1, handle, []byte{})
-			}
 		}
 
 		// read was successful

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -19,11 +19,11 @@ import (
 )
 
 var (
-	nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
+	nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read.duration",
 		metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
 		metric.WithUnit("ms"),
 	))
-	nbdReadsInFlight = utils.Must(meter.Int64UpDownCounter("orchestrator.nbd.dispatch.reads_in_flight",
+	nbdReadConncurent = utils.Must(meter.Int64UpDownCounter("orchestrator.nbd.dispatch.read.concurrent",
 		metric.WithDescription("Number of NBD read requests currently waiting for a response. A sustained high value indicates reads stuck in kernel I/O."),
 		metric.WithUnit("{read}"),
 	))
@@ -265,7 +265,7 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		errchan := make(chan error, 1)
 		data := make([]byte, length)
 
-		nbdReadsInFlight.Add(ctx, 1)
+		nbdReadConncurent.Add(ctx, 1)
 
 		go func() {
 			start := time.Now()
@@ -292,7 +292,7 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		case readErr = <-errchan:
 		}
 
-		nbdReadsInFlight.Add(ctx, -1)
+		nbdReadConncurent.Add(ctx, -1)
 
 		if readErr != nil {
 			return d.writeResponse(1, handle, []byte{})

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
@@ -17,10 +18,14 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
-var nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
-	metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
-	metric.WithUnit("ms"),
-))
+var (
+	nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
+		metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
+		metric.WithUnit("ms"),
+	))
+	nbdReadSuccess = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", true)))
+	nbdReadFailure = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", false)))
+)
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
 
@@ -258,7 +263,12 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		go func() {
 			start := time.Now()
 			_, err := d.prov.ReadAt(ctx, data, int64(from))
-			nbdReadDuration.Record(ctx, time.Since(start).Milliseconds())
+			attrs := nbdReadSuccess
+			if err != nil {
+				attrs = nbdReadFailure
+			}
+
+			nbdReadDuration.Record(ctx, time.Since(start).Milliseconds(), attrs)
 			errchan <- err
 		}()
 

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -17,12 +17,10 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
-var (
-	nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
-		metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
-		metric.WithUnit("ms"),
-	))
-)
+var nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
+	metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
+	metric.WithUnit("ms"),
+))
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
 

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -27,8 +27,9 @@ var (
 		metric.WithDescription("Number of NBD read requests currently waiting for a response. A sustained high value indicates reads stuck in kernel I/O."),
 		metric.WithUnit("{read}"),
 	))
-	nbdReadSuccess = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", true)))
-	nbdReadFailure = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("success", false)))
+	nbdReadSuccess   = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "success")))
+	nbdReadFailure   = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "failure")))
+	nbdReadCancelled = metric.WithAttributeSet(attribute.NewSet(attribute.String("result", "cancelled")))
 )
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
@@ -269,9 +270,14 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		go func() {
 			start := time.Now()
 			_, err := d.prov.ReadAt(ctx, data, int64(from))
+
 			attrs := nbdReadSuccess
 			if err != nil {
-				attrs = nbdReadFailure
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					attrs = nbdReadCancelled
+				} else {
+					attrs = nbdReadFailure
+				}
 			}
 
 			nbdReadDuration.Record(ctx, time.Since(start).Milliseconds(), attrs)

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -7,11 +7,21 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"time"
 
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+var (
+	nbdReadDuration = utils.Must(meter.Int64Histogram("orchestrator.nbd.dispatch.read_duration",
+		metric.WithDescription("Duration of NBD dispatch handler ReadAt calls to the backend."),
+		metric.WithUnit("ms"),
+	))
 )
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
@@ -248,7 +258,9 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 		data := make([]byte, length)
 
 		go func() {
+			start := time.Now()
 			_, err := d.prov.ReadAt(ctx, data, int64(from))
+			nbdReadDuration.Record(ctx, time.Since(start).Milliseconds())
 			errchan <- err
 		}()
 


### PR DESCRIPTION
Add a metric to
- measure the time to read from nbd independently on the backend
- measure concurrent reads