### PR TITLE
chore(redis): use max conn time instead of idle time, decrease idle connections

### DIFF
--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -94,7 +94,8 @@ type Config struct {
 	RedisClusterURL            string            `env:"REDIS_CLUSTER_URL"`
 	RedisTLSCABase64           string            `env:"REDIS_TLS_CA_BASE64"`
 	RedisURL                   string            `env:"REDIS_URL"`
-	RedisPoolSize              int               `env:"REDIS_POOL_SIZE"               envDefault:"10"`
+	RedisPoolSize              int               `env:"REDIS_POOL_SIZE"               envDefault:"5"`
+	RedisMinIdleConns          int               `env:"REDIS_MIN_IDLE_CONNS"          envDefault:"2"`
 	NBDPoolSize                int               `env:"NBD_POOL_SIZE"                 envDefault:"64"`
 	Services                   []string          `env:"ORCHESTRATOR_SERVICES"         envDefault:"orchestrator"`
 	PersistentVolumeMounts     map[string]string `env:"PERSISTENT_VOLUME_MOUNTS"`

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -382,6 +382,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 		RedisClusterURL:  config.RedisClusterURL,
 		RedisTLSCABase64: config.RedisTLSCABase64,
 		PoolSize:         config.RedisPoolSize,
+		MinIdleConns:     config.RedisMinIdleConns,
 	})
 	if err != nil && !errors.Is(err, sharedFactories.ErrRedisDisabled) {
 		logger.L().Fatal(ctx, "Could not connect to Redis", zap.Error(err))

--- a/packages/shared/pkg/factories/redis.go
+++ b/packages/shared/pkg/factories/redis.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/extra/redisotel/v9"
 	"github.com/redis/go-redis/v9"
@@ -25,15 +26,45 @@ type RedisConfig struct {
 	// PoolSize overrides the default connection pool size.
 	// When non-positive, defaults to 40.
 	PoolSize int
+	// MinIdleConns overrides the minimum number of idle connections maintained in the pool
+	// (per cluster node for cluster clients).
+	// When non-positive, defaults to min(defaultMinIdleConns, PoolSize).
+	MinIdleConns int
 }
 
 const (
 	defaultPoolSize     = 40
 	defaultMinIdleConns = 10
+
+	// connMaxLifetime controls the maximum age of a connection before it is recycled.
+	// Combined with connMaxLifetimeJitter, this spreads connection recycling evenly over time
+	// instead of expiring in bursts (which happens with idle-time-based eviction under LIFO reuse).
+	connMaxLifetime = 30 * time.Minute
+	// connMaxLifetimeJitter adds random offset in [-jitter, +jitter] to each connection's lifetime,
+	// so connections expire between 20-40 minutes instead of all at exactly 30 minutes.
+	connMaxLifetimeJitter = 10 * time.Minute
 )
+
+// resolvePoolSize computes the effective pool size and minimum idle connections
+// from the given config, applying defaults and floors.
+func resolvePoolSize(config RedisConfig) (poolSize, minIdleConns int) {
+	poolSize = defaultPoolSize
+	if config.PoolSize > 0 {
+		poolSize = config.PoolSize
+	}
+
+	minIdleConns = min(defaultMinIdleConns, poolSize)
+	if config.MinIdleConns > 0 {
+		minIdleConns = min(config.MinIdleConns, poolSize)
+	}
+
+	return poolSize, minIdleConns
+}
 
 func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalClient, error) {
 	var redisClient redis.UniversalClient
+
+	poolSize, minIdleConns := resolvePoolSize(config)
 
 	switch {
 	case config.RedisClusterURL != "":
@@ -42,17 +73,16 @@ func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalCli
 		// https://cloud.google.com/memorystore/docs/cluster/cluster-node-specification#cluster_endpoints
 		// https://cloud.google.com/memorystore/docs/cluster/client-library-code-samples#go-redis
 
-		poolSize := defaultPoolSize
-		minIdleConns := defaultMinIdleConns
-		if config.PoolSize > 0 {
-			poolSize = max(defaultMinIdleConns, config.PoolSize)
-			minIdleConns = max(defaultMinIdleConns, config.PoolSize/4)
-		}
-
 		clusterOpts := &redis.ClusterOptions{
 			Addrs:        []string{config.RedisClusterURL},
 			PoolSize:     poolSize,
 			MinIdleConns: minIdleConns,
+			// Disable idle-time eviction; use lifetime-based recycling with jitter instead.
+			// Under the default LIFO reuse, ConnMaxIdleTime causes thundering-herd bursts because
+			// the cold (bottom-of-stack) connections all idle-expire simultaneously.
+			ConnMaxIdleTime:       -1,
+			ConnMaxLifetime:       connMaxLifetime,
+			ConnMaxLifetimeJitter: connMaxLifetimeJitter,
 		}
 
 		if config.RedisTLSCABase64 != "" {
@@ -83,16 +113,13 @@ func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalCli
 
 		redisClient = redis.NewClusterClient(clusterOpts)
 	case config.RedisURL != "":
-		poolSize := defaultPoolSize
-		minIdleConns := defaultMinIdleConns
-		if config.PoolSize > 0 {
-			poolSize = max(defaultMinIdleConns, config.PoolSize)
-			minIdleConns = max(defaultMinIdleConns, config.PoolSize/4)
-		}
 		opts := &redis.Options{
-			Addr:         config.RedisURL,
-			PoolSize:     poolSize,
-			MinIdleConns: minIdleConns,
+			Addr:                  config.RedisURL,
+			PoolSize:              poolSize,
+			MinIdleConns:          minIdleConns,
+			ConnMaxIdleTime:       -1,
+			ConnMaxLifetime:       connMaxLifetime,
+			ConnMaxLifetimeJitter: connMaxLifetimeJitter,
 		}
 
 		redisClient = redis.NewClient(opts)


### PR DESCRIPTION
The go-redis pool uses LIFO reuse, which means a small number of connections stay hot while the rest sit cold at the bottom of the stack. With the default `ConnMaxIdleTime=30min`, all cold connections idle-expire simultaneously, causing bursts of TLS handshakes and brief pool waits — visible as spikes on the Redis dashboard despite low utilization.

- Replace idle-time eviction with lifetime-based recycling (`ConnMaxLifetime=30min`) plus jitter (`±10min`), spreading connection renewal evenly over a 20-40min window
- Add `MinIdleConns` to `RedisConfig` so services can tune idle connections independently of pool size
- Reduce orchestrator pool from 50 to 25 connections per instance (10→5 per cluster node) and idle minimum from 50 to 10 (10→2 per node)