### PR TITLE
chore(clickhouse): add projection for events table

### DIFF
--- a/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
+++ b/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Add a projection ordered by (sandbox_team_id, sandbox_id, timestamp) so that
+-- queries filtering by sandbox_team_id can skip the full table scan.
+-- The base ORDER BY is (sandbox_id, timestamp) which doesn't help when only
+-- sandbox_team_id is provided.
+ALTER TABLE sandbox_events_local
+    ADD PROJECTION proj_team_id (
+        SELECT * ORDER BY sandbox_team_id, sandbox_id, timestamp
+    );
+
+ALTER TABLE sandbox_events_local
+    MATERIALIZE PROJECTION proj_team_id;
+
+-- +goose Down
+ALTER TABLE sandbox_events_local
+    DROP PROJECTION IF EXISTS proj_team_id;

--- a/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
+++ b/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
@@ -7,7 +7,7 @@
 -- (sandbox_team_id, sandbox_id, timestamp) via a CREATE + RENAME swap.
 ALTER TABLE sandbox_events_local
     ADD PROJECTION IF NOT EXISTS proj_team_id (
-        SELECT * ORDER BY sandbox_team_id, sandbox_id, timestamp
+        SELECT * ORDER BY sandbox_team_id, timestamp
     );
 
 ALTER TABLE sandbox_events_local

--- a/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
+++ b/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
@@ -1,8 +1,10 @@
 -- +goose Up
--- Add a projection ordered by (sandbox_team_id, sandbox_id, timestamp) so that
--- queries filtering by sandbox_team_id can skip the full table scan.
+-- TEMPORARY: Add a projection ordered by (sandbox_team_id, sandbox_id, timestamp)
+-- so that queries filtering by sandbox_team_id can skip the full table scan.
 -- The base ORDER BY is (sandbox_id, timestamp) which doesn't help when only
 -- sandbox_team_id is provided.
+-- This projection should be removed once we migrate the table's ORDER BY to
+-- (sandbox_team_id, sandbox_id, timestamp) via a CREATE + RENAME swap.
 ALTER TABLE sandbox_events_local
     ADD PROJECTION proj_team_id (
         SELECT * ORDER BY sandbox_team_id, sandbox_id, timestamp

--- a/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
+++ b/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
@@ -6,7 +6,7 @@
 -- This projection should be removed once we migrate the table's ORDER BY to
 -- (sandbox_team_id, sandbox_id, timestamp) via a CREATE + RENAME swap.
 ALTER TABLE sandbox_events_local
-    ADD PROJECTION proj_team_id (
+    ADD PROJECTION IF NOT EXISTS proj_team_id (
         SELECT * ORDER BY sandbox_team_id, sandbox_id, timestamp
     );
 

--- a/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
+++ b/packages/clickhouse/migrations/20260413080000_add_sandbox_events_team_projection.sql
@@ -1,10 +1,12 @@
 -- +goose Up
--- TEMPORARY: Add a projection ordered by (sandbox_team_id, sandbox_id, timestamp)
+-- TEMPORARY: Add a projection ordered by (sandbox_team_id, timestamp)
 -- so that queries filtering by sandbox_team_id can skip the full table scan.
 -- The base ORDER BY is (sandbox_id, timestamp) which doesn't help when only
 -- sandbox_team_id is provided.
 -- This projection should be removed once we migrate the table's ORDER BY to
--- (sandbox_team_id, sandbox_id, timestamp) via a CREATE + RENAME swap.
+-- (sandbox_team_id, timestamp, sandbox_id) via a CREATE + RENAME swap.
+-- Also drops the now-redundant bloom_filter index on sandbox_team_id since
+-- the projection's primary index covers that filtering.
 ALTER TABLE sandbox_events_local
     ADD PROJECTION IF NOT EXISTS proj_team_id (
         SELECT * ORDER BY sandbox_team_id, timestamp
@@ -13,6 +15,15 @@ ALTER TABLE sandbox_events_local
 ALTER TABLE sandbox_events_local
     MATERIALIZE PROJECTION proj_team_id;
 
+ALTER TABLE sandbox_events_local
+    DROP INDEX IF EXISTS idx_team_id;
+
 -- +goose Down
+ALTER TABLE sandbox_events_local
+    ADD INDEX IF NOT EXISTS idx_team_id sandbox_team_id TYPE bloom_filter(0.01) GRANULARITY 1;
+
+ALTER TABLE sandbox_events_local
+    MATERIALIZE INDEX idx_team_id;
+
 ALTER TABLE sandbox_events_local
     DROP PROJECTION IF EXISTS proj_team_id;


### PR DESCRIPTION
This should prevent full table scans on `sandbox_events`: Queries filtering by `sandbox_team_id` required scanning a lot of rows because the table is ordered by `(sandbox_id, timestamp)`. Added a projection with `(sandbox_team_id, timestamp)` ordering so these queries use an efficient index lookup.