### PR TITLE
fix(api): add FK to active builds to prevent leak

### DIFF
--- a/packages/db/migrations/20260413120000_active_template_builds_fk_envs.sql
+++ b/packages/db/migrations/20260413120000_active_template_builds_fk_envs.sql
@@ -4,6 +4,10 @@
 DELETE FROM public.active_template_builds
 WHERE template_id NOT IN (SELECT id FROM public.envs);
 
+-- Index to support the FK cascade lookup on envs row deletion.
+CREATE INDEX IF NOT EXISTS idx_active_template_builds_template_id
+    ON public.active_template_builds (template_id);
+
 -- Ensure cascade cleanup when a template is deleted.
 ALTER TABLE public.active_template_builds
     ADD CONSTRAINT fk_active_template_builds_envs
@@ -13,3 +17,5 @@ ALTER TABLE public.active_template_builds
 
 ALTER TABLE public.active_template_builds
     DROP CONSTRAINT IF EXISTS fk_active_template_builds_envs;
+
+DROP INDEX IF EXISTS public.idx_active_template_builds_template_id;

--- a/packages/db/migrations/20260413120000_active_template_builds_fk_envs.sql
+++ b/packages/db/migrations/20260413120000_active_template_builds_fk_envs.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+-- Clean up orphaned rows (templates already deleted).
+DELETE FROM public.active_template_builds
+WHERE template_id NOT IN (SELECT id FROM public.envs);
+
+-- Ensure cascade cleanup when a template is deleted.
+ALTER TABLE public.active_template_builds
+    ADD CONSTRAINT fk_active_template_builds_envs
+    FOREIGN KEY (template_id) REFERENCES public.envs(id) ON DELETE CASCADE;
+
+-- +goose Down
+
+ALTER TABLE public.active_template_builds
+    DROP CONSTRAINT IF EXISTS fk_active_template_builds_envs;


### PR DESCRIPTION
In case of template deletion during the build, the active build was leaked and never deleted. The orphaned build will occupy the build slot for 1 day.