### PR TITLE
perf(orch): pool NBD dispatch buffer

### DIFF
--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -34,6 +34,14 @@ var (
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
 
+var dispatchBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, dispatchBufferSize)
+
+		return &b
+	},
+}
+
 type Provider interface {
 	storage.SeekableReader
 	io.WriterAt
@@ -141,7 +149,9 @@ func (d *Dispatch) writeResponse(respError uint32, respHandle uint64, chunk []by
  *
  */
 func (d *Dispatch) Handle(ctx context.Context) error {
-	buffer := make([]byte, dispatchBufferSize)
+	poolBuf := dispatchBufPool.Get().(*[]byte)
+	defer dispatchBufPool.Put(poolBuf)
+	buffer := *poolBuf
 	wp := 0
 
 	request := Request{}


### PR DESCRIPTION
## Summary
- Pool the 4 MiB dispatch buffer in `nbd.Dispatch.Handle` via `sync.Pool`
- Each NBD connection allocates this buffer for reading request packets; pooling it across connection lifecycles avoids repeated 4 MiB allocations

## Test plan
- [x] Existing NBD tests pass
- [x] Full orchestrator build passes