### PR TITLE
feat(orch): add cloud provider awareness to provisioning script

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -84,6 +84,7 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         DOMAIN_NAME                  = "${domain_name}"
         SHARED_CHUNK_CACHE_PATH      = "${shared_chunk_cache_path}"
         ORCHESTRATOR_SERVICES        = "${orchestrator_services}"
+        PROVIDER                     = "${provider}"
 
 %{ if build_cache_bucket_name != "" }
         BUILD_CACHE_BUCKET_NAME      = "${build_cache_bucket_name}"

--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -33,6 +33,8 @@ type BuilderConfig struct {
 
 	DefaultCacheDir string `env:"DEFAULT_CACHE_DIR,expand" envDefault:"${ORCHESTRATOR_BASE_PATH}/build"`
 
+	Provider string `env:"PROVIDER" envDefault:"gcp"`
+
 	StorageConfig storage.Config
 	NetworkConfig network.Config
 }

--- a/packages/orchestrator/pkg/template/build/phases/base/files.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/files.go
@@ -45,6 +45,7 @@ func constructLayerFilesFromOCI(
 	provisionScript, err := getProvisionScript(ctx, ProvisionScriptParams{
 		BusyBox:    rootfs.SandboxBusyBoxPath,
 		ResultPath: provisionScriptResultPath,
+		Provider:   buildContext.BuilderConfig.Provider,
 	})
 	if err != nil {
 		return nil, nil, containerregistry.Config{}, fmt.Errorf("error getting provision script: %w", err)

--- a/packages/orchestrator/pkg/template/build/phases/base/provision.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.go
@@ -50,6 +50,7 @@ const (
 type ProvisionScriptParams struct {
 	BusyBox    string
 	ResultPath string
+	Provider   string
 }
 
 func getProvisionScript(

--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -6,6 +6,10 @@ RESULT_PATH="{{ .ResultPath }}"
 
 echo "Starting provisioning script"
 
+{{ if eq .Provider "gcp" }}
+# GCP Specific logic
+{{ end }}
+
 echo "Making configuration immutable"
 $BUSYBOX chattr +i /etc/resolv.conf
 


### PR DESCRIPTION
Add a PROVIDER environment variable to BuilderConfig and thread it
through to the provision.sh template as a new .Provider parameter. This
allows the provisioning script to execute provider-specific logic during
template builds.

Changes:
- cfg/model.go: Add Provider field to BuilderConfig, read from
  PROVIDER env var (defaults to "gcp").
- provision.go: Add Provider field to ProvisionScriptParams struct.
- files.go: Populate Provider from BuilderConfig.Provider when
  constructing ProvisionScriptParams in constructLayerFilesFromOCI.
- provision.sh: Add a Go template conditional block that executes
  when Provider equals "gcp".