### PR TITLE
fix(db): make seed-db script idempotent by cleaning up FK dependencies

### DIFF
--- a/packages/db/scripts/seed/postgres/seed-db.go
+++ b/packages/db/scripts/seed/postgres/seed-db.go
@@ -77,8 +77,46 @@ func main() {
 	}
 	defer authDb.Close()
 
-	// Open .e2b/config.json
-	// Delete existing user and recreate (simpler for seeding)
+	// Clean up existing data for idempotent re-seeding.
+	// Delete child rows that have ON DELETE NO ACTION constraints
+	// before deleting the team and user.
+	err = authDb.TestsRawSQL(ctx, `
+DELETE FROM envs WHERE team_id IN (SELECT id FROM teams WHERE email = $1)
+`, email)
+	if err != nil {
+		panic(err)
+	}
+
+	err = authDb.TestsRawSQL(ctx, `
+DELETE FROM snapshots WHERE team_id IN (SELECT id FROM teams WHERE email = $1)
+`, email)
+	if err != nil {
+		panic(err)
+	}
+
+	err = authDb.TestsRawSQL(ctx, `
+DELETE FROM volumes WHERE team_id IN (SELECT id FROM teams WHERE email = $1)
+`, email)
+	if err != nil {
+		panic(err)
+	}
+
+	err = authDb.TestsRawSQL(ctx, `
+DELETE FROM addons WHERE added_by IN (SELECT id FROM auth.users WHERE email = $1)
+`, email)
+	if err != nil {
+		panic(err)
+	}
+
+	// Now safe to delete team (team_api_keys, users_teams cascade automatically)
+	err = authDb.TestsRawSQL(ctx, `
+DELETE FROM teams WHERE email = $1
+`, email)
+	if err != nil {
+		panic(err)
+	}
+
+	// Now safe to delete user (access_tokens cascade automatically)
 	err = authDb.TestsRawSQL(ctx, `
 DELETE FROM auth.users WHERE email = $1
 `, email)
@@ -87,6 +125,10 @@ DELETE FROM auth.users WHERE email = $1
 	}
 
 	// Create the user
+	// NOTE: Inserting into auth.users fires the sync_inserts_to_public_users trigger,
+	// which inserts into public.users, which fires the post_user_signup trigger,
+	// which auto-creates a default team + users_teams row. We delete that
+	// trigger-created team below so we can create our own with a known ID/name.
 	userID := uuid.New()
 	err = authDb.TestsRawSQL(ctx, `
 INSERT INTO auth.users (id, email)
@@ -96,7 +138,8 @@ VALUES ($1, $2)
 		panic(err)
 	}
 
-	// Delete team
+	// Remove the team auto-created by the post_user_signup trigger so we can
+	// create our own seed team with a deterministic ID and custom name/slug.
 	err = authDb.TestsRawSQL(ctx, `
 DELETE FROM teams WHERE email = $1
 `, email)


### PR DESCRIPTION
The seed script failed on repeated runs with a foreign key violation:
  "envs_teams_envs" on table "envs" (SQLSTATE 23503)

This happened because DELETE FROM teams was attempted while rows in envs, snapshots, and volumes still referenced the team via ON DELETE NO ACTION constraints. Similarly, deleting auth.users could be blocked by addons.added_by (also ON DELETE NO ACTION).

Fix the deletion order to explicitly remove blocking child rows before deleting the parent team and user:
  1. DELETE envs for the team
  2. DELETE snapshots for the team
  3. DELETE volumes for the team
  4. DELETE addons for the user
  5. DELETE teams (team_api_keys, users_teams cascade automatically)
  6. DELETE auth.users (access_tokens cascade automatically)
  7. Re-create user, team, and associated credentials

Tables with ON DELETE CASCADE/SET NULL (team_api_keys, users_teams, access_tokens, env_aliases, env_builds, etc.) are cleaned up automatically and do not need explicit deletes.