### PR TITLE
fix(orchestrator): prefer running sandbox on host IP lookups

### DIFF
--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -88,17 +88,31 @@ func (m *Map) Get(sandboxID string) (*Sandbox, bool) {
 }
 
 // GetByHostPort looks up a sandbox by its host IP address parsed from hostPort.
-// It matches any sandbox in the map (starting, running, or stopping).
+// It prefers a running sandbox and only falls back to a non-running one when
+// no running sandbox matches.
 func (m *Map) GetByHostPort(hostPort string) (*Sandbox, error) {
 	reqIP, _, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing remote address %s: %w", hostPort, err)
 	}
 
+	var fallback *Sandbox
 	for _, sbx := range m.sandboxes.Items() {
-		if sbx.Slot.HostIPString() == reqIP {
+		if sbx.Slot.HostIPString() != reqIP {
+			continue
+		}
+
+		if sbx.IsRunning() {
 			return sbx, nil
 		}
+
+		if fallback == nil {
+			fallback = sbx
+		}
+	}
+
+	if fallback != nil {
+		return fallback, nil
 	}
 
 	return nil, fmt.Errorf("sandbox with address %s not found", hostPort)

--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -106,7 +106,10 @@ func (m *Map) GetByHostPort(hostPort string) (*Sandbox, error) {
 			return sbx, nil
 		}
 
-		if fallback == nil {
+		// Prefer a starting sandbox over a stopping one so that when an IP
+		// slot is freed by a stopping sandbox and immediately reused by a
+		// new starting sandbox, we route to the new sandbox.
+		if fallback == nil || SandboxStatus(sbx.status.Load()) == StatusStarting {
 			fallback = sbx
 		}
 	}

--- a/packages/orchestrator/pkg/sandbox/map_test.go
+++ b/packages/orchestrator/pkg/sandbox/map_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
 )
 
@@ -27,13 +29,32 @@ func TestGetByHostPortPrefersRunningSandbox(t *testing.T) {
 	m.sandboxes.Insert("running", running)
 
 	sbx, err := m.GetByHostPort("10.11.0.2:2049")
-	if err != nil {
-		t.Fatalf("GetByHostPort returned error: %v", err)
-	}
+	require.NoError(t, err)
+	require.Same(t, running, sbx)
+}
 
-	if sbx != running {
-		t.Fatalf("expected running sandbox, got %#v", sbx)
+func TestGetByHostPortPrefersStartingOverStopping(t *testing.T) {
+	m := NewSandboxesMap()
+
+	stopping := &Sandbox{
+		Resources: &Resources{
+			Slot: &network.Slot{HostIP: net.ParseIP("10.11.0.2")},
+		},
 	}
+	stopping.status.Store(int32(StatusStopping))
+	m.sandboxes.Insert("stopping", stopping)
+
+	starting := &Sandbox{
+		Resources: &Resources{
+			Slot: &network.Slot{HostIP: net.ParseIP("10.11.0.2")},
+		},
+	}
+	starting.status.Store(int32(StatusStarting))
+	m.sandboxes.Insert("starting", starting)
+
+	sbx, err := m.GetByHostPort("10.11.0.2:2049")
+	require.NoError(t, err)
+	require.Same(t, starting, sbx)
 }
 
 func TestGetByHostPortFallsBackToStoppingSandbox(t *testing.T) {
@@ -48,11 +69,6 @@ func TestGetByHostPortFallsBackToStoppingSandbox(t *testing.T) {
 	m.sandboxes.Insert("stopping", stopping)
 
 	sbx, err := m.GetByHostPort("10.11.0.3:2049")
-	if err != nil {
-		t.Fatalf("GetByHostPort returned error: %v", err)
-	}
-
-	if sbx != stopping {
-		t.Fatalf("expected stopping sandbox, got %#v", sbx)
-	}
+	require.NoError(t, err)
+	require.Same(t, stopping, sbx)
 }

--- a/packages/orchestrator/pkg/sandbox/map_test.go
+++ b/packages/orchestrator/pkg/sandbox/map_test.go
@@ -1,0 +1,58 @@
+package sandbox
+
+import (
+	"net"
+	"testing"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
+)
+
+func TestGetByHostPortPrefersRunningSandbox(t *testing.T) {
+	m := NewSandboxesMap()
+
+	stopping := &Sandbox{
+		Resources: &Resources{
+			Slot: &network.Slot{HostIP: net.ParseIP("10.11.0.2")},
+		},
+	}
+	stopping.status.Store(int32(StatusStopping))
+	m.sandboxes.Insert("stopping", stopping)
+
+	running := &Sandbox{
+		Resources: &Resources{
+			Slot: &network.Slot{HostIP: net.ParseIP("10.11.0.2")},
+		},
+	}
+	running.status.Store(int32(StatusRunning))
+	m.sandboxes.Insert("running", running)
+
+	sbx, err := m.GetByHostPort("10.11.0.2:2049")
+	if err != nil {
+		t.Fatalf("GetByHostPort returned error: %v", err)
+	}
+
+	if sbx != running {
+		t.Fatalf("expected running sandbox, got %#v", sbx)
+	}
+}
+
+func TestGetByHostPortFallsBackToStoppingSandbox(t *testing.T) {
+	m := NewSandboxesMap()
+
+	stopping := &Sandbox{
+		Resources: &Resources{
+			Slot: &network.Slot{HostIP: net.ParseIP("10.11.0.3")},
+		},
+	}
+	stopping.status.Store(int32(StatusStopping))
+	m.sandboxes.Insert("stopping", stopping)
+
+	sbx, err := m.GetByHostPort("10.11.0.3:2049")
+	if err != nil {
+		t.Fatalf("GetByHostPort returned error: %v", err)
+	}
+
+	if sbx != stopping {
+		t.Fatalf("expected stopping sandbox, got %#v", sbx)
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/map_test.go
+++ b/packages/orchestrator/pkg/sandbox/map_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestGetByHostPortPrefersRunningSandbox(t *testing.T) {
+	t.Parallel()
+
 	m := NewSandboxesMap()
 
 	stopping := &Sandbox{
@@ -34,6 +36,8 @@ func TestGetByHostPortPrefersRunningSandbox(t *testing.T) {
 }
 
 func TestGetByHostPortPrefersStartingOverStopping(t *testing.T) {
+	t.Parallel()
+
 	m := NewSandboxesMap()
 
 	stopping := &Sandbox{
@@ -58,6 +62,8 @@ func TestGetByHostPortPrefersStartingOverStopping(t *testing.T) {
 }
 
 func TestGetByHostPortFallsBackToStoppingSandbox(t *testing.T) {
+	t.Parallel()
+
 	m := NewSandboxesMap()
 
 	stopping := &Sandbox{


### PR DESCRIPTION
Fixes GetByHostPort to handle IP slot reuse during sandbox lifecycle transitions. When a stopping sandbox frees an IP slot that is immediately claimed by a new starting sandbox, both temporarily coexist in the map with the same IP. Previously, GetByHostPort returned the first match (which could be the stale stopping sandbox). Now it applies a priority:

1. Running → return immediately
2. Starting preferred over Stopping as fallback
3. Stopping only if nothing better exists