### PR TITLE
chore: set Nomad server heartbeat_grace to 1m

### DIFF
--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -180,6 +180,7 @@ function generate_nomad_config {
 server {
   enabled = true
   bootstrap_expect = $num_servers
+  heartbeat_grace = "1m"
 }
 
 EOF

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -191,6 +191,7 @@ function generate_nomad_config {
 server {
   enabled = true
   bootstrap_expect = $num_servers
+  heartbeat_grace = "1m"
 }
 
 EOF


### PR DESCRIPTION
Increase the period for the client nodes before they're marked as dead