### PR TITLE
fix: re-add --no-seccomp on ARM64 for UFFD snapshot restore

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/pkg/sandbox/fc/script_builder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"runtime"
 	txtTemplate "text/template"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
@@ -25,6 +26,7 @@ type startScriptArgs struct {
 	NamespaceID       string
 	FirecrackerPath   string
 	FirecrackerSocket string
+	ExtraArgs         string
 }
 
 // StartScriptResult contains the generated script and computed paths
@@ -47,7 +49,7 @@ ln -s {{ .HostRootfsPath }} {{ .DeprecatedSandboxRootfsDir }}/{{ .SandboxRootfsF
 mount -t tmpfs tmpfs {{ .SandboxDir }}/{{ .SandboxKernelDir }} -o X-mount.mkdir &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}{{ .ExtraArgs }}`
 
 const startScriptV2 = `mount --make-rprivate / &&
 mount -t tmpfs tmpfs {{ .SandboxDir }} -o X-mount.mkdir &&
@@ -57,7 +59,7 @@ ln -s {{ .HostRootfsPath }} {{ .SandboxDir }}/{{ .SandboxRootfsFile }} &&
 mkdir -p {{ .SandboxDir }}/{{ .SandboxKernelDir }} &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}{{ .ExtraArgs }}`
 
 // StartScriptBuilder handles the creation and execution of firecracker start scripts
 type StartScriptBuilder struct {
@@ -85,6 +87,17 @@ func (sb *StartScriptBuilder) buildArgs(
 	rootfsPaths RootfsPaths,
 	namespaceID string,
 ) startScriptArgs {
+	// On ARM64, disable seccomp to work around a missing syscall in Firecracker's
+	// aarch64 seccomp filter. The blocked syscall occurs during UFFD-based snapshot
+	// restore (FC exit code 148 = BadSyscall). Basic boot and file-based restore
+	// work fine; only the UFFD path triggers the violation.
+	// Tracked upstream: https://github.com/firecracker-microvm/firecracker/issues/XXXX
+	// TODO: remove once upstream adds the missing syscall to the aarch64 filter.
+	var extraArgs string
+	if runtime.GOARCH == "arm64" {
+		extraArgs = " --no-seccomp"
+	}
+
 	return startScriptArgs{
 		// General
 		SandboxDir: sb.builderConfig.SandboxDir,
@@ -103,6 +116,7 @@ func (sb *StartScriptBuilder) buildArgs(
 		NamespaceID:       namespaceID,
 		FirecrackerPath:   versions.FirecrackerPath(sb.builderConfig),
 		FirecrackerSocket: files.SandboxFirecrackerSocketPath(),
+		ExtraArgs:         extraArgs,
 	}
 }
 


### PR DESCRIPTION
## Summary

Re-adds `--no-seccomp` for Firecracker on ARM64. The aarch64 seccomp filter is missing a syscall needed during UFFD-based snapshot restore, causing FC to exit with code 148 (`BadSyscall`).

## Investigation findings

| Scenario | Seccomp | Result |
|----------|---------|--------|
| Basic boot + file-based restore | Enabled | Pass (exit 0) |
| UFFD-based restore (orchestrator) | Enabled | **Fail (exit 148)** |
| UFFD-based restore | `SECCOMP_RET_LOG` filter | Pass (build proceeds) |
| UFFD-based restore | `--no-seccomp` | Pass |

- FC exit code 148 = `FcExitCode::BadSyscall` (Firecracker's seccomp trap handler)
- The blocked syscall only triggers during UFFD-based snapshot restore, not file-based
- Switching the seccomp default action from `trap` to `log` allows the build to succeed, confirming seccomp is the blocker
- The exact blocked syscall number is TBD (strace too slow with UFFD, no perf tools for this kernel)

## Reproduction

On an ARM64 VM with KVM (e.g. Lima VZ on Apple Silicon M3+):

```bash
# Template build fails with default seccomp:
make -C packages/shared/scripts local-build-base-template
# → orchestrator log shows: "error waiting for fc process: exit status 148"

# Works with --no-seccomp or SECCOMP_RET_LOG custom filter
```

## Upstream

To be filed against `firecracker-microvm/firecracker` — aarch64 seccomp filter missing syscall for UFFD snapshot restore path.

## Test plan

- [ ] ARM64 template build succeeds with `--no-seccomp`
- [ ] x86_64 builds unaffected (no `--no-seccomp` added)