### PR TITLE
Support AWS Route53 DNS provider

### DIFF
--- a/.env.aws.template
+++ b/.env.aws.template
@@ -18,3 +18,9 @@ PREFIX=e2b-
 
 # prod, staging, dev
 TERRAFORM_ENVIRONMENT=dev
+
+# DNS provider: cloudflare (default) or route53
+# DNS_PROVIDER=cloudflare
+
+# Required when DNS_PROVIDER=route53: your Route53 hosted zone ID
+# ROUTE53_ZONE_ID=

--- a/iac/provider-aws/Makefile
+++ b/iac/provider-aws/Makefile
@@ -45,7 +45,9 @@ tf_vars := AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) \
 	$(call tfvar, DB_MAX_OPEN_CONNECTIONS) \
 	$(call tfvar, DB_MIN_IDLE_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MAX_OPEN_CONNECTIONS) \
-	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS)
+	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS) \
+	$(call tfvar, DNS_PROVIDER) \
+	$(call tfvar, ROUTE53_ZONE_ID)
 
 .PHONY: provider-login
 provider-login:

--- a/iac/provider-aws/domain.tf
+++ b/iac/provider-aws/domain.tf
@@ -4,11 +4,79 @@ locals {
 
   // Take last 2 parts (1 dot)
   domain_root = local.domain_is_subdomain ? join(".", slice(local.domain_parts, length(local.domain_parts) - 2, length(local.domain_parts))) : var.domain_name
+
+  use_cloudflare = var.dns_provider == "cloudflare"
+  use_route53    = var.dns_provider == "route53"
 }
 
+// --- Cloudflare ---
+
 data "cloudflare_zone" "domain" {
-  name = local.domain_root
+  count = local.use_cloudflare ? 1 : 0
+  name  = local.domain_root
 }
+
+resource "cloudflare_record" "cert" {
+  for_each = local.use_cloudflare ? {
+    for dvo in aws_acm_certificate.wildcard.domain_validation_options : dvo.domain_name => {
+      name  = dvo.resource_record_name
+      value = dvo.resource_record_value
+      type  = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id = data.cloudflare_zone.domain[0].zone_id
+  name    = each.value.name
+  type    = each.value.type
+  value   = each.value.value
+  ttl     = 3600
+}
+
+resource "cloudflare_record" "routing" {
+  count   = local.use_cloudflare ? 1 : 0
+  zone_id = data.cloudflare_zone.domain[0].zone_id
+  name    = "*.${var.domain_name}"
+  type    = "CNAME"
+  value   = aws_lb.ingress.dns_name
+  ttl     = 3600
+  proxied = false
+}
+
+// --- Route53 ---
+
+data "aws_route53_zone" "domain" {
+  count   = local.use_route53 ? 1 : 0
+  zone_id = var.route53_zone_id
+}
+
+resource "aws_route53_record" "cert" {
+  for_each = local.use_route53 ? {
+    for dvo in aws_acm_certificate.wildcard.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  zone_id = data.aws_route53_zone.domain[0].zone_id
+  name    = each.value.name
+  type    = each.value.type
+  ttl     = 300
+
+  records = [each.value.record]
+}
+
+resource "aws_route53_record" "routing" {
+  count   = local.use_route53 ? 1 : 0
+  zone_id = data.aws_route53_zone.domain[0].zone_id
+  name    = "*.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+
+  records = [aws_lb.ingress.dns_name]
+}
+
+// --- ACM Certificate (shared) ---
 
 resource "aws_acm_certificate" "wildcard" {
   domain_name       = "*.${var.domain_name}"
@@ -21,29 +89,6 @@ resource "aws_acm_certificate" "wildcard" {
 
 resource "aws_acm_certificate_validation" "wildcard" {
   certificate_arn = aws_acm_certificate.wildcard.arn
-}
 
-resource "cloudflare_record" "cert" {
-  for_each = {
-    for dvo in aws_acm_certificate.wildcard.domain_validation_options : dvo.domain_name => {
-      name  = dvo.resource_record_name
-      value = dvo.resource_record_value
-      type  = dvo.resource_record_type
-    }
-  }
-
-  zone_id = data.cloudflare_zone.domain.zone_id
-  name    = each.value.name
-  type    = each.value.type
-  value   = each.value.value
-  ttl     = 3600
-}
-
-resource "cloudflare_record" "routing" {
-  zone_id = data.cloudflare_zone.domain.zone_id
-  name    = "*.${var.domain_name}"
-  type    = "CNAME"
-  value   = aws_lb.ingress.dns_name
-  ttl     = 3600
-  proxied = false
+  validation_record_fqdns = local.use_route53 ? [for record in aws_route53_record.cert : record.fqdn] : null
 }

--- a/iac/provider-aws/init/main.tf
+++ b/iac/provider-aws/init/main.tf
@@ -12,6 +12,7 @@ module "network" {
 
 module "cloudflare" {
   source = "../modules/cloudflare"
+  count  = var.dns_provider == "cloudflare" ? 1 : 0
 
   prefix = var.prefix
 }

--- a/iac/provider-aws/init/outputs.tf
+++ b/iac/provider-aws/init/outputs.tf
@@ -68,7 +68,7 @@ output "db_migrator_repository_name" {
 // Cloudflare
 // ---
 output "cloudflare" {
-  value = module.cloudflare.cloudflare
+  value = var.dns_provider == "cloudflare" ? module.cloudflare : []
 }
 
 // ---

--- a/iac/provider-aws/init/variables.tf
+++ b/iac/provider-aws/init/variables.tf
@@ -17,3 +17,8 @@ variable "region" {
 variable "endpoint_ingress_subnet_ids" {
   type = list(string)
 }
+
+variable "dns_provider" {
+  type    = string
+  default = "cloudflare"
+}

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -29,7 +29,9 @@ terraform {
 }
 
 provider "cloudflare" {
-  api_token = var.dns_provider == "cloudflare" ? module.init.cloudflare[0].token : "unused"
+  # When not using Cloudflare, provide a syntactically valid dummy token.
+  # No Cloudflare resources are created (all have count=0), but Terraform still validates the provider config.
+  api_token = var.dns_provider == "cloudflare" ? module.init.cloudflare[0].token : "0000000000000000000000000000000000000000"
 }
 
 provider "aws" {}

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -29,7 +29,7 @@ terraform {
 }
 
 provider "cloudflare" {
-  api_token = module.init.cloudflare.token
+  api_token = var.dns_provider == "cloudflare" ? module.init.cloudflare[0].token : "unused"
 }
 
 provider "aws" {}
@@ -58,6 +58,7 @@ module "init" {
   ]
 
   allow_force_destroy = var.allow_force_destroy
+  dns_provider        = var.dns_provider
 }
 
 locals {

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -2,6 +2,23 @@ variable "domain_name" {
   type = string
 }
 
+variable "dns_provider" {
+  type        = string
+  description = "DNS provider to use for domain management. Supported values: cloudflare, route53"
+  default     = "cloudflare"
+
+  validation {
+    condition     = contains(["cloudflare", "route53"], var.dns_provider)
+    error_message = "dns_provider must be one of: cloudflare, route53"
+  }
+}
+
+variable "route53_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID. Required when dns_provider is route53"
+  default     = ""
+}
+
 variable "allow_force_destroy" {
   default = false
 }

--- a/self-host.md
+++ b/self-host.md
@@ -26,8 +26,7 @@
 
 **Accounts**
 
-- Cloudflare account
-- Domain on Cloudflare
+- DNS provider: Cloudflare account with domain, **or** AWS Route53 hosted zone
 - PostgreSQL database (Supabase's DB only supported for now)
 
 **Optional**
@@ -121,8 +120,10 @@ Now, you should see the right quota options in `All Quotas` and be able to reque
     - `AWS_ACCOUNT_ID` - your AWS account ID
     - `AWS_REGION` - the AWS region to deploy to (must support bare metal instances for Firecracker)
     - `PREFIX` - name prefix for all resources (e.g. `e2b-`)
-    - `DOMAIN_NAME` - your domain managed by Cloudflare
+    - `DOMAIN_NAME` - your domain
     - `TERRAFORM_ENVIRONMENT` - one of `prod`, `staging`, `dev`
+    - `DNS_PROVIDER` - `cloudflare` (default) or `route53`
+    - `ROUTE53_ZONE_ID` - your Route53 hosted zone ID (required when `DNS_PROVIDER=route53`)
 2. Run `make set-env ENV={prod,staging,dev}` to start using your env
 3. Run `make provider-login` to authenticate with AWS ECR
 4. Run `make init`. This creates:
@@ -131,9 +132,9 @@ Now, you should see the right quota options in `All Quotas` and be able to reque
     - ECR repositories for container images
     - S3 buckets for templates, kernels, builds, and backups
     - Secrets in AWS Secrets Manager (with placeholder values)
-    - Cloudflare DNS records and TLS certificates
+    - DNS records and TLS certificates (via Cloudflare or Route53)
 5. Update the following secrets in [AWS Secrets Manager](https://console.aws.amazon.com/secretsmanager) with actual values:
-    - `{prefix}cloudflare` - JSON with `TOKEN` key
+    - `{prefix}cloudflare` - JSON with `TOKEN` key (**only when using Cloudflare**)
         > Get Cloudflare API Token: go to the [Cloudflare dashboard](https://dash.cloudflare.com/) -> Manage Account -> Account API Tokens -> Create Token -> Edit Zone DNS -> in "Zone Resources" select your domain and generate the token
     - `{prefix}postgres-connection-string` - your PostgreSQL connection string (**required**)
     - `{prefix}supabase-jwt-secrets` - Supabase JWT secret (optional / required for the [E2B dashboard](https://github.com/e2b-dev/dashboard))


### PR DESCRIPTION
## Summary

Adds AWS Route53 as an alternative DNS provider to Cloudflare for the AWS deployment, addressing #2305.

- Introduces `dns_provider` variable (`cloudflare` default, `route53` supported) to make DNS pluggable
- All Cloudflare resources become conditional (`count = 0` when using Route53)
- Adds Route53 equivalents: zone lookup, ACM cert validation records, wildcard CNAME routing
- Cloudflare module in `init/` is conditionally included
- No breaking changes — existing Cloudflare deployments work unchanged

### Configuration

Set in `.env` file:
```
DNS_PROVIDER=route53
ROUTE53_ZONE_ID=<your-hosted-zone-id>
```

### Files changed

- `iac/provider-aws/variables.tf` — new `dns_provider` and `route53_zone_id` variables
- `iac/provider-aws/domain.tf` — conditional Cloudflare/Route53 resources, shared ACM cert
- `iac/provider-aws/main.tf` — conditional Cloudflare provider, pass `dns_provider` to init
- `iac/provider-aws/init/` — conditional Cloudflare module
- `iac/provider-aws/Makefile` — pass new env vars
- `.env.aws.template` — document new options
- `self-host.md` — updated prerequisites and setup steps

## Test plan

- [x] Deployed full e2b stack on AWS with `DNS_PROVIDER=route53`
- [x] Route53 delegated subdomain zone resolves correctly
- [x] ACM wildcard certificate issued and validated via Route53 DNS
- [x] ALB serves HTTPS with valid cert
- [x] Nomad cluster accessible via `nomad.<domain>`
- [x] All Nomad jobs deployed successfully
- [ ] Verify existing Cloudflare deployments are unaffected (default behavior)

Closes #2305