### PR TITLE
feat(api): add native MPP (Machine Payments Protocol) support

### DIFF
--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/orcaman/concurrent-map/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/posthog/posthog-go v0.0.0-20230801140217-d607812dee69
+	github.com/tempoxyz/mpp-go v0.1.0
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.65.0

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -73,6 +73,16 @@ type Config struct {
 	SandboxStorageBackend string `env:"SANDBOX_STORAGE_BACKEND" envDefault:"memory"`
 
 	DomainName string `env:"DOMAIN_NAME" envDefault:""`
+
+	// MPP (Machine Payments Protocol) configuration for 402 payment support.
+	// When enabled, agents can pay for sandbox usage via the HTTP 402 flow
+	// instead of using API keys.
+	MPPEnabled   bool   `env:"MPP_ENABLED"    envDefault:"false"`
+	MPPSecretKey string `env:"MPP_SECRET_KEY"`
+	MPPRealm     string `env:"MPP_REALM"`
+	MPPCurrency  string `env:"MPP_CURRENCY"`
+	MPPRecipient string `env:"MPP_RECIPIENT"`
+	MPPTeamID    string `env:"MPP_TEAM_ID"` // Team ID to map MPP-authenticated requests to
 }
 
 type JWTSigningKey any

--- a/packages/api/internal/handlers/mpp_method.go
+++ b/packages/api/internal/handlers/mpp_method.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tempoxyz/mpp-go/mpp"
+	mppserver "github.com/tempoxyz/mpp-go/server"
+)
+
+// TempoMethod implements mppserver.Method for the Tempo payment method.
+type TempoMethod struct {
+	currency  string
+	recipient string
+}
+
+// NewTempoMethod creates a TempoMethod with the given currency and recipient.
+func NewTempoMethod(currency, recipient string) mppserver.Method {
+	return &TempoMethod{
+		currency:  currency,
+		recipient: recipient,
+	}
+}
+
+func (m *TempoMethod) Name() string {
+	return "tempo"
+}
+
+func (m *TempoMethod) Intents() map[string]mppserver.Intent {
+	return map[string]mppserver.Intent{
+		"charge": &TempoChargeIntent{
+			currency:  m.currency,
+			recipient: m.recipient,
+		},
+	}
+}
+
+// TempoChargeIntent implements mppserver.Intent for the charge intent.
+type TempoChargeIntent struct {
+	currency  string
+	recipient string
+}
+
+func (i *TempoChargeIntent) Name() string {
+	return "charge"
+}
+
+func (i *TempoChargeIntent) Verify(ctx context.Context, credential *mpp.Credential, request map[string]any) (*mpp.Receipt, error) {
+	// Verify that the credential contains a valid transaction signature.
+	// For now, accept any credential that passes HMAC challenge verification
+	// (handled by the mpp-go server library). Full on-chain verification
+	// can be added by checking the transaction on the Tempo RPC.
+	if credential == nil {
+		return nil, fmt.Errorf("missing credential")
+	}
+
+	txHash := ""
+	if credential.Payload != nil {
+		if sig, ok := credential.Payload["signature"].(string); ok {
+			txHash = sig
+		}
+	}
+
+	return mpp.Success(txHash, mpp.WithReceiptMethod("tempo")), nil
+}

--- a/packages/api/internal/handlers/payment_auth.go
+++ b/packages/api/internal/handlers/payment_auth.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
+)
+
+// PaymentAuthenticator implements auth.Authenticator for the PaymentAuth
+// security scheme. It allows requests with Authorization: Payment credentials
+// to pass through the OpenAPI validation layer. The actual payment verification
+// is handled by the MPP middleware.
+type PaymentAuthenticator struct {
+	enabled bool
+	teamID  string
+	getTeam func(ctx context.Context, teamID uuid.UUID) (*types.Team, error)
+}
+
+// NewPaymentAuthenticator creates a PaymentAuthenticator.
+// When a valid Payment credential is present, it maps the request to the
+// pre-configured MPP team so downstream handlers have a team context.
+func NewPaymentAuthenticator(
+	enabled bool,
+	teamID string,
+	getTeam func(ctx context.Context, teamID uuid.UUID) (*types.Team, error),
+) auth.Authenticator {
+	return &PaymentAuthenticator{
+		enabled: enabled,
+		teamID:  teamID,
+		getTeam: getTeam,
+	}
+}
+
+func (a *PaymentAuthenticator) SecuritySchemeName() string {
+	return "PaymentAuth"
+}
+
+func (a *PaymentAuthenticator) Authenticate(ctx context.Context, ginCtx *gin.Context, input *openapi3filter.AuthenticationInput) error {
+	if !a.enabled {
+		return fmt.Errorf("payment auth is not enabled")
+	}
+
+	header := input.RequestValidationInput.Request.Header.Get("Authorization")
+	if header == "" || !strings.HasPrefix(strings.ToLower(strings.TrimSpace(header)), "payment ") {
+		ginCtx.Status(http.StatusPaymentRequired)
+		return &auth.AuthorizationHeaderMissingError{}
+	}
+
+	teamUUID, err := uuid.Parse(a.teamID)
+	if err != nil {
+		ginCtx.Status(http.StatusInternalServerError)
+		return fmt.Errorf("invalid MPP team ID configuration: %w", err)
+	}
+
+	team, err := a.getTeam(ctx, teamUUID)
+	if err != nil {
+		ginCtx.Status(http.StatusInternalServerError)
+		return fmt.Errorf("failed to get MPP team: %w", err)
+	}
+
+	auth.SetTeamInfo(ginCtx, team)
+
+	return nil
+}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -327,3 +327,14 @@ func (a *APIStore) GetTeamFromSupabaseToken(ctx context.Context, ginCtx *gin.Con
 
 	return a.authService.ValidateSupabaseTeam(ctx, ginCtx, teamID)
 }
+
+// GetTeamByID looks up a team directly by its UUID. Used by the MPP
+// payment authenticator to map paid requests to the configured team.
+func (a *APIStore) GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error) {
+	result, err := a.authDB.Read.GetTeamWithTierByTeamID(ctx, teamID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get team by ID: %w", err)
+	}
+
+	return types.NewTeam(&result.Team, &result.TeamLimit), nil
+}

--- a/packages/api/internal/middleware/mpp.go
+++ b/packages/api/internal/middleware/mpp.go
@@ -1,0 +1,136 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tempoxyz/mpp-go/mpp"
+	mppserver "github.com/tempoxyz/mpp-go/server"
+)
+
+// MPPConfig holds configuration for the MPP payment middleware.
+type MPPConfig struct {
+	Enabled   bool
+	SecretKey string
+	Realm     string
+	Currency  string
+	Recipient string
+}
+
+// MPPMiddleware returns a Gin middleware that handles the MPP 402 payment flow.
+//
+// When MPP is enabled and a request arrives without standard E2B auth (API key
+// or bearer token), the middleware checks for an Authorization: Payment header.
+// If absent, it issues a 402 challenge. If present and valid, it verifies the
+// payment credential and lets the request through with a Payment-Receipt header.
+func MPPMiddleware(cfg MPPConfig, method mppserver.Method) gin.HandlerFunc {
+	handler := mppserver.New(method, cfg.Realm, cfg.SecretKey)
+
+	return func(c *gin.Context) {
+		if !cfg.Enabled {
+			c.Next()
+			return
+		}
+
+		// Skip if the request already has standard E2B auth.
+		if c.GetHeader("X-API-Key") != "" || hasBearer(c.GetHeader("Authorization")) {
+			c.Next()
+			return
+		}
+
+		authHeader := c.GetHeader("Authorization")
+
+		// Only intercept if there's a Payment credential or no auth at all.
+		if authHeader != "" && !hasPaymentScheme(authHeader) {
+			c.Next()
+			return
+		}
+
+		amount := chargeAmount(c.Request.Method, c.FullPath())
+		if amount == "" {
+			c.Next()
+			return
+		}
+
+		// Free endpoints — let through without payment.
+		if amount == "0" {
+			c.Next()
+			return
+		}
+
+		result, err := handler.Charge(c.Request.Context(), mppserver.ChargeParams{
+			Authorization: authHeader,
+			Amount:        amount,
+			Currency:      cfg.Currency,
+			Recipient:     cfg.Recipient,
+		})
+		if err != nil {
+			writeMPPError(c, err)
+			c.Abort()
+			return
+		}
+
+		if result.IsChallenge() {
+			c.Header("WWW-Authenticate", result.Challenge.ToWWWAuthenticate(cfg.Realm))
+			c.Header("Content-Type", "application/problem+json")
+			c.Header("Cache-Control", "no-store")
+			c.Writer.WriteHeader(http.StatusPaymentRequired)
+			pe := mpp.ErrPaymentRequired(cfg.Realm, "")
+			json.NewEncoder(c.Writer).Encode(pe.ProblemDetails(result.Challenge.ID))
+			c.Abort()
+			return
+		}
+
+		// Payment verified.
+		c.Header("Payment-Receipt", result.Receipt.ToPaymentReceipt())
+		if result.Credential != nil && result.Credential.Source != "" {
+			c.Set("mpp_payer", result.Credential.Source)
+		}
+
+		c.Next()
+	}
+}
+
+func hasBearer(header string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(header)), "bearer ")
+}
+
+func hasPaymentScheme(header string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(header)), "payment ")
+}
+
+// chargeAmount returns the charge amount in base units for a given endpoint.
+// Returns empty string for non-billable endpoints, "0" for free endpoints.
+func chargeAmount(method, path string) string {
+	switch {
+	case method == "POST" && path == "/sandboxes":
+		return "1000000" // 1 USDC
+	case method == "POST" && strings.HasSuffix(path, "/connect"):
+		return "500000" // 0.5 USDC
+	case method == "POST" && strings.HasSuffix(path, "/timeout"):
+		return "100000" // 0.1 USDC
+	case method == "POST" && strings.HasSuffix(path, "/refreshes"):
+		return "100000" // 0.1 USDC
+	case method == "DELETE" && strings.Contains(path, "/sandboxes/"):
+		return "0" // free
+	default:
+		return ""
+	}
+}
+
+func writeMPPError(c *gin.Context, err error) {
+	c.Header("Content-Type", "application/problem+json")
+	c.Header("Cache-Control", "no-store")
+
+	if pe, ok := err.(*mpp.PaymentError); ok {
+		c.Writer.WriteHeader(pe.Status)
+		json.NewEncoder(c.Writer).Encode(pe.ProblemDetails(""))
+		return
+	}
+
+	c.Writer.WriteHeader(http.StatusPaymentRequired)
+	problem := mpp.ErrVerificationFailed(err.Error())
+	json.NewEncoder(c.Writer).Encode(problem.ProblemDetails(""))
+}

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -148,6 +148,8 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 		// API Key header
 		"Authorization",
 		"X-API-Key",
+		// MPP headers
+		"Accept-Payment",
 		// Supabase headers
 		auth.HeaderSupabaseToken,
 		auth.HeaderSupabaseTeam,
@@ -167,14 +169,22 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 	r.Use(cors.New(corsConfig))
 
 	// Create a team API Key auth validator
+	authenticators := []auth.Authenticator{
+		auth.NewApiKeyAuthenticator(apiStore.GetTeamFromAPIKey),
+		auth.NewAccessTokenAuthenticator(apiStore.GetUserFromAccessToken),
+		auth.NewSupabaseTokenAuthenticator(apiStore.GetUserIDFromSupabaseToken),
+		auth.NewSupabaseTeamAuthenticator(apiStore.GetTeamFromSupabaseToken),
+		auth.NewAdminTokenAuthenticator(config.AdminToken),
+	}
+
+	if config.MPPEnabled {
+		authenticators = append(authenticators,
+			handlers.NewPaymentAuthenticator(config.MPPEnabled, config.MPPTeamID, apiStore.GetTeamByID),
+		)
+	}
+
 	AuthenticationFunc := auth.CreateAuthenticationFunc(
-		[]auth.Authenticator{
-			auth.NewApiKeyAuthenticator(apiStore.GetTeamFromAPIKey),
-			auth.NewAccessTokenAuthenticator(apiStore.GetUserFromAccessToken),
-			auth.NewSupabaseTokenAuthenticator(apiStore.GetUserIDFromSupabaseToken),
-			auth.NewSupabaseTeamAuthenticator(apiStore.GetTeamFromSupabaseToken),
-			auth.NewAdminTokenAuthenticator(config.AdminToken),
-		},
+		authenticators,
 		metricsMiddleware.SetProcessingStartTime,
 	)
 
@@ -199,6 +209,18 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 	)
 
 	r.Use(customMiddleware.InitLaunchDarklyContext)
+
+	// MPP (Machine Payments Protocol) middleware for 402 payment support.
+	if config.MPPEnabled {
+		tempoMethod := handlers.NewTempoMethod(config.MPPCurrency, config.MPPRecipient)
+		r.Use(customMiddleware.MPPMiddleware(customMiddleware.MPPConfig{
+			Enabled:   true,
+			SecretKey: config.MPPSecretKey,
+			Realm:     config.MPPRealm,
+			Currency:  config.MPPCurrency,
+			Recipient: config.MPPRecipient,
+		}, tempoMethod))
+	}
 
 	// Per-team rate limiting (after auth + LD context, before handlers).
 	// Only applied to connect and resume endpoints. Gated by feature flag.

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -31,6 +31,10 @@ components:
       type: apiKey
       in: header
       name: X-Admin-Token
+    PaymentAuth:
+      type: http
+      scheme: payment
+      description: Machine Payments Protocol (MPP) - pay per request via HTTP 402
 
   parameters:
     templateID:
@@ -1961,6 +1965,7 @@ paths:
       tags: [sandboxes]
       security:
         - ApiKeyAuth: []
+        - PaymentAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
       requestBody:
@@ -2186,6 +2191,7 @@ paths:
       tags: [sandboxes]
       security:
         - ApiKeyAuth: []
+        - PaymentAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
       parameters:
@@ -2305,6 +2311,7 @@ paths:
       tags: [sandboxes]
       security:
         - ApiKeyAuth: []
+        - PaymentAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
       parameters:
@@ -2342,6 +2349,7 @@ paths:
       description: Set the timeout for the sandbox. The sandbox will expire x seconds from the time of the request. Calling this method multiple times overwrites the TTL, each time using the current timestamp as the starting point to measure the timeout duration.
       security:
         - ApiKeyAuth: []
+        - PaymentAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
       tags: [sandboxes]
@@ -2414,6 +2422,7 @@ paths:
       description: Refresh the sandbox extending its time to live
       security:
         - ApiKeyAuth: []
+        - PaymentAuth: []
         - Supabase1TokenAuth: []
           Supabase2TeamAuth: []
       tags: [sandboxes]


### PR DESCRIPTION
## Summary

Add native HTTP 402 payment support via the [Machine Payments Protocol](https://mpp.dev) so AI agents can pay for E2B sandbox usage with crypto (Tempo USDC) instead of API keys.

## Motivation

MPP enables **no-signup, pay-per-use** access to E2B sandboxes. An AI agent with a Tempo wallet can create and manage sandboxes by paying per request — no API key, no account, no billing setup. This is especially useful for autonomous agents that need compute on demand.

## Changes

### OpenAPI spec (`spec/openapi.yml`)
- Add `PaymentAuth` security scheme (`http/payment`)
- Add `PaymentAuth` as an alternative auth option on sandbox endpoints: create, kill, connect, timeout, refreshes

### Config (`packages/api/internal/cfg/model.go`)
- Add `MPP_ENABLED`, `MPP_SECRET_KEY`, `MPP_REALM`, `MPP_CURRENCY`, `MPP_RECIPIENT`, `MPP_TEAM_ID` env vars

### Auth (`packages/api/internal/handlers/payment_auth.go`)
- `PaymentAuthenticator` implements `auth.Authenticator` for the `PaymentAuth` security scheme
- Maps MPP-authenticated requests to a pre-configured team via `MPP_TEAM_ID`

### Middleware (`packages/api/internal/middleware/mpp.go`)
- Gin middleware handling the full 402 challenge/credential flow
- Issues `WWW-Authenticate: Payment` challenges when no auth is present
- Verifies payment credentials and sets `Payment-Receipt` header
- Skips requests that already have API key or bearer auth

### Payment method (`packages/api/internal/handlers/mpp_method.go`)
- `TempoMethod` / `TempoChargeIntent` implementing `mpp-go/server.Method` interface
- Placeholder verification (HMAC challenge binding verified by mpp-go; full on-chain verification can be added later)

### Wiring (`packages/api/main.go`)
- Add `PaymentAuthenticator` to authenticator chain when `MPP_ENABLED=true`
- Add MPP middleware after LaunchDarkly context, before rate limiting
- Add `Accept-Payment` to CORS allowed headers

### Store (`packages/api/internal/handlers/store.go`)
- Add `GetTeamByID` using existing `GetTeamWithTierByTeamID` query

### Dependency
- Add `github.com/tempoxyz/mpp-go` to `go.mod`

## Protocol flow

```
Agent                                    E2B API
  │                                        │
  │  POST /sandboxes (no auth)             │
  ├───────────────────────────────────────>│
  │                                        │
  │  402 + WWW-Authenticate: Payment ...   │
  │<───────────────────────────────────────┤
  │                                        │
  │  POST /sandboxes                       │
  │  Authorization: Payment <credential>   │
  ├───────────────────────────────────────>│
  │                                        │
  │  201 Created                           │
  │  Payment-Receipt: <receipt>            │
  │<───────────────────────────────────────┤
```

## Testing

This is gated behind `MPP_ENABLED=false` (default), so existing behavior is unchanged. When enabled, requires `MPP_SECRET_KEY`, `MPP_REALM`, `MPP_CURRENCY`, `MPP_RECIPIENT`, and `MPP_TEAM_ID`.

Prompted by: georgios