### PR TITLE
fix(orchestrator): add HOST_BUSYBOX_DIR to local dev env

### DIFF
--- a/packages/orchestrator/.env.local
+++ b/packages/orchestrator/.env.local
@@ -7,6 +7,7 @@ CLICKHOUSE_USERNAME=clickhouse
 DEFAULT_PERSISTENT_VOLUME_TYPE=test-volume-type
 ENVIRONMENT=local
 FIRECRACKER_VERSIONS_DIR=../fc-versions/builds
+HOST_BUSYBOX_DIR=.busybox
 HOST_ENVD_PATH=../envd/bin/envd
 HOST_KERNELS_DIR=../fc-kernels
 LOCAL_BUILD_CACHE_STORAGE_BASE_PATH=./tmp/local-build-cache


### PR DESCRIPTION
Commit bba031354939 moved busybox from compile-time go:embed to runtime disk read via `HOST_BUSYBOX_DIR`, but didn't add the variable to `.env.local`. Without it, local-dev builds fail trying to read busybox from `/fc-busybox` (the production default).

Point `HOST_BUSYBOX_DIR` at `.busybox`, the local fetch-busybox output directory.