### PR TITLE
Remount volumes on resume

### DIFF
--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -316,7 +316,7 @@ var errVolumesNotSupported = errors.New("volumes are not supported")
 
 var errNoEnvdVersion = errors.New("no envd version provided")
 
-const minEnvdVersionForVolumes = "0.5.12"
+const minEnvdVersionForVolumes = "0.5.13"
 
 func convertAPIVolumesToOrchestratorVolumes(ctx context.Context, sqlClient *sqlcdb.Client, featureFlags featureFlagsClient, teamID uuid.UUID, volumeMounts []api.SandboxVolumeMount, env *queries.EnvBuild) ([]*orchestrator.SandboxVolumeMount, error) {
 	// are any volumes configured?

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -316,7 +316,7 @@ var errVolumesNotSupported = errors.New("volumes are not supported")
 
 var errNoEnvdVersion = errors.New("no envd version provided")
 
-const minEnvdVersionForVolumes = "0.5.13"
+const minEnvdVersionForVolumes = "0.5.14"
 
 func convertAPIVolumesToOrchestratorVolumes(ctx context.Context, sqlClient *sqlcdb.Client, featureFlags featureFlagsClient, teamID uuid.UUID, volumeMounts []api.SandboxVolumeMount, env *queries.EnvBuild) ([]*orchestrator.SandboxVolumeMount, error) {
 	// are any volumes configured?

--- a/packages/envd/go.mod
+++ b/packages/envd/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.9
 	github.com/stretchr/testify v1.11.1
 	github.com/txn2/txeh v1.7.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/sys v0.42.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -75,7 +76,6 @@ require (
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/tools v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect

--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -193,7 +193,7 @@ type PostInitJSONBody struct {
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 
 	// LifecycleID Lifecycle ID of the sandbox
-	LifecycleID string `json:"lifecycleID"`
+	LifecycleID *string `json:"lifecycleID,omitempty"`
 
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    *time.Time     `json:"timestamp,omitempty"`

--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -192,6 +192,9 @@ type PostInitJSONBody struct {
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 
+	// LifecycleID Lifecycle ID of the sandbox
+	LifecycleID string `json:"lifecycleID"`
+
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    *time.Time     `json:"timestamp,omitempty"`
 	VolumeMounts *[]VolumeMount `json:"volumeMounts,omitempty"`

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -224,7 +224,9 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.VolumeMounts != nil {
-		a.setupNFS(ctx, logger, data.LifecycleID, *data.VolumeMounts)
+		if err := a.setupNFS(ctx, logger, data.LifecycleID, *data.VolumeMounts); err != nil {
+			return fmt.Errorf("failed to setup NFS volumes: %w", err)
+		}
 	}
 
 	return nil

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -253,7 +253,7 @@ var nfsOptions = strings.Join([]string{
 
 const nfsMountTimeout = 10 * time.Second
 
-func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID string, mounts []VolumeMount) (e error) {
+func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID *string, mounts []VolumeMount) (e error) {
 	// Prevent concurrent mounting attempts
 	if !a.isMountingNFS.CompareAndSwap(false, true) {
 		logger.Debug().Msg("NFS volumes already mounting")
@@ -270,16 +270,20 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID s
 
 	wg, wgCtx := errgroup.WithContext(ctx)
 
+	requestLifecycleID := derefString(lifecycleID)
+
 	for _, volume := range mounts {
 		// Check if this path is already mounted for the current lifecycle
-		if mountedLifecycle, ok := a.mountedPaths.Load(volume.Path); ok {
-			if mountedLifecycle == lifecycleID {
-				logger.Debug().Msgf("Skipping %q, already mounted for lifecycle %s", volume.Path, lifecycleID)
+		mountedLifecycle, isMounted := a.mountedPaths.Load(volume.Path)
+		mountedLifecycleID := asString(mountedLifecycle)
+		if !shouldRemountNFS(isMounted, mountedLifecycleID, requestLifecycleID) {
+			logger.Debug().Msgf("Skipping %q, already mounted for lifecycle %q", volume.Path, requestLifecycleID)
 
-				continue
-			}
+			continue
+		}
 
-			logger.Debug().Msgf("Lifecycle changed for %q: %s -> %s", volume.Path, mountedLifecycle, lifecycleID)
+		if isMounted {
+			logger.Debug().Msgf("Lifecycle changed for %q: %q -> %q", volume.Path, mountedLifecycleID, requestLifecycleID)
 		}
 
 		logger.Debug().Msgf("Setting up %s at %q", volume.NfsTarget, volume.Path)
@@ -294,7 +298,7 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID s
 				return fmt.Errorf("failed to mount NFS at %q: %w", volume.Path, err)
 			}
 
-			a.mountedPaths.Store(volume.Path, lifecycleID)
+			a.mountedPaths.Store(volume.Path, requestLifecycleID)
 
 			return nil
 		})
@@ -350,6 +354,41 @@ func (a *API) mountNFS(ctx context.Context, nfsTarget, path string) error {
 	}
 
 	return nil
+}
+
+// shouldRemountNFS determines if an NFS volume should be remounted based on lifecycle IDs.
+// Returns true if remount is needed, false if we should skip (already mounted for this lifecycle).
+//
+// Truth table (treating nil/empty as equivalent):
+//   - mounted="" + request="" → false (no remount - would cause infinite loop)
+//   - mounted="abc" + request="" → true (remount - lifecycle cleared)
+//   - mounted="" + request="abc" → true (remount - new lifecycle)
+//   - mounted="abc" + request="abc" → false (no remount - same lifecycle)
+//   - mounted="abc" + request="xyz" → true (remount - different lifecycle)
+func shouldRemountNFS(isMounted bool, mountedLifecycleID, requestLifecycleID string) bool {
+	if !isMounted {
+		return true // not mounted yet, need to mount
+	}
+
+	return mountedLifecycleID != requestLifecycleID
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+
+	return *p
+}
+
+func asString(v any) string {
+	if v == nil {
+		return ""
+	}
+
+	s, _ := v.(string)
+
+	return s
 }
 
 func (a *API) SetupHyperloop(address string) {

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -10,13 +10,12 @@ import (
 	"net/netip"
 	"os/exec"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/awnumar/memguard"
 	"github.com/rs/zerolog"
 	"github.com/txn2/txeh"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
@@ -250,106 +249,92 @@ var nfsOptions = strings.Join([]string{
 	"lookupcache=none",
 }, ",")
 
-const nfsMountTimeout = 5 * time.Second
+const nfsMountTimeout = 10 * time.Second
 
-func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID string, mounts []VolumeMount) {
+func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID string, mounts []VolumeMount) (e error) {
 	// Prevent concurrent mounting attempts
 	if !a.isMountingNFS.CompareAndSwap(false, true) {
 		logger.Debug().Msg("NFS volumes already mounting")
 
-		return
+		return e
 	}
 	defer a.isMountingNFS.Store(false)
 
-	// Check if lifecycleID changed (indicates resume to potentially different server)
-	prevLifecycleID, _ := a.mountedLifecycleID.Load().(string)
-	lifecycleChanged := prevLifecycleID != "" && prevLifecycleID != lifecycleID
-
-	if lifecycleChanged {
-		logger.Debug().Msgf("Lifecycle changed from %q to %q, will remount NFS volumes", prevLifecycleID, lifecycleID)
-	}
-
-	// Already fully mounted for this lifecycle, nothing to do
-	if a.isMountedNFS.Load() && !lifecycleChanged {
-		logger.Debug().Msg("NFS volumes already mounted for this lifecycle")
-
-		return
-	}
-
 	logger.Debug().Msg("Setting up NFS volumes")
 
-	ctx = context.WithoutCancel(ctx)
-	ctx, cancel := context.WithTimeout(ctx, nfsMountTimeout)
+	ctx = context.WithoutCancel(ctx)                         // don't allow request context cancellation to propagate
+	ctx, cancel := context.WithTimeout(ctx, nfsMountTimeout) // don't let the nfs mount run forever
 	defer cancel()
 
-	var wg sync.WaitGroup
-	var allSucceeded atomic.Bool
-	allSucceeded.Store(true)
+	wg, wgCtx := errgroup.WithContext(ctx)
 
 	for _, volume := range mounts {
-		// Skip already mounted paths unless lifecycle changed
-		if !lifecycleChanged {
-			if _, ok := a.mountedPaths.Load(volume.Path); ok {
-				logger.Debug().Msgf("Skipping already mounted %q", volume.Path)
+		// Check if this path is already mounted for the current lifecycle
+		if mountedLifecycle, ok := a.mountedPaths.Load(volume.Path); ok {
+			if mountedLifecycle == lifecycleID {
+				logger.Debug().Msgf("Skipping %q, already mounted for lifecycle %s", volume.Path, lifecycleID)
 
 				continue
 			}
+
+			logger.Debug().Msgf("Lifecycle changed for %q: %s -> %s", volume.Path, mountedLifecycle, lifecycleID)
 		}
 
 		logger.Debug().Msgf("Setting up %s at %q", volume.NfsTarget, volume.Path)
 
-		wg.Go(func() {
-			// Unmount first if lifecycle changed (stale handles from previous server)
-			if lifecycleChanged {
-				a.unmountNFS(ctx, logger, volume.Path)
+		wg.Go(func() error {
+			// Unmount if currently mounted (handles stale mounts from previous lifecycle)
+			if err := a.unmountNFS(wgCtx, logger, volume.Path); err != nil {
+				return fmt.Errorf("failed to unmount stale NFS mount at %q: %w", volume.Path, err)
 			}
 
-			if a.mountNFS(ctx, volume.NfsTarget, volume.Path) {
-				a.mountedPaths.Store(volume.Path, true)
-			} else {
-				allSucceeded.Store(false)
+			if err := a.mountNFS(wgCtx, volume.NfsTarget, volume.Path); err != nil {
+				return fmt.Errorf("failed to mount NFS at %q: %w", volume.Path, err)
 			}
+
+			a.mountedPaths.Store(volume.Path, lifecycleID)
+
+			return nil
 		})
 	}
 
-	wg.Wait()
-
-	if allSucceeded.Load() {
-		a.isMountedNFS.Store(true)
-		a.mountedLifecycleID.Store(lifecycleID)
-	}
+	return wg.Wait()
 }
 
-func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string) {
-	// Check if actually mounted before trying to unmount
+func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string) error {
+	// Check if actually mounted before trying to unmount.
+	// findmnt returns exit code 1 when path is not a mount point - that's not an error.
 	data, err := exec.CommandContext(ctx, "findmnt", "--noheadings", "--output", "SOURCE", path).CombinedOutput()
 	if err != nil {
-		// Not mounted or error checking - nothing to unmount
-		return
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			// Not mounted - nothing to unmount
+			return nil
+		}
+
+		return fmt.Errorf("failed to check if %q is mounted: %w", path, err)
 	}
 
 	source := strings.TrimSpace(string(data))
 	if source == "" {
-		return
+		return nil // already unmounted
 	}
 
 	logger.Debug().Msgf("Unmounting stale NFS mount at %q (was: %s)", path, source)
 
-	// Clear our tracking state for this path
-	a.mountedPaths.Delete(path)
-	a.isMountedNFS.Store(false)
-
 	// Force unmount since the handles are stale anyway
 	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to unmount stale NFS mount at %q: %w\n%s", path, err, string(data))
+	}
 
-	logFn := a.getLogger(err)
-	logFn.
-		Strs("command", []string{"umount", "--force", path}).
-		Str("output", string(data)).
-		Msg("Unmount NFS")
+	// Clear our tracking state for this path
+	a.mountedPaths.Delete(path)
+
+	return nil
 }
 
-func (a *API) mountNFS(ctx context.Context, nfsTarget, path string) bool {
+func (a *API) mountNFS(ctx context.Context, nfsTarget, path string) error {
 	commands := [][]string{
 		{"mkdir", "-p", path},
 		{"mount", "-v", "-t", "nfs", "-o", "fg,hard," + nfsOptions, nfsTarget, path},
@@ -357,20 +342,12 @@ func (a *API) mountNFS(ctx context.Context, nfsTarget, path string) bool {
 
 	for _, command := range commands {
 		data, err := exec.CommandContext(ctx, command[0], command[1:]...).CombinedOutput()
-
-		logger := a.getLogger(err)
-
-		logger.
-			Strs("command", command).
-			Str("output", string(data)).
-			Msg("Mount NFS")
-
 		if err != nil {
-			return false
+			return fmt.Errorf("`%s` failed: %w\n%s", strings.Join(command, " "), err, string(data))
 		}
 	}
 
-	return true
+	return nil
 }
 
 func (a *API) SetupHyperloop(address string) {

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -225,7 +225,7 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.VolumeMounts != nil {
-		a.setupNFS(ctx, logger, *data.VolumeMounts)
+		a.setupNFS(ctx, logger, data.LifecycleID, *data.VolumeMounts)
 	}
 
 	return nil
@@ -244,18 +244,15 @@ var nfsOptions = strings.Join([]string{
 	"port=2049",      // nfs proxy only supports mounting on port 2049
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
+
+	// disable caching so that pause/resume works correctly
+	"noac",
+	"lookupcache=none",
 }, ",")
 
 const nfsMountTimeout = 5 * time.Second
 
-func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, mounts []VolumeMount) {
-	// Already fully mounted, nothing to do
-	if a.isMountedNFS.Load() {
-		logger.Debug().Msg("NFS volumes already mounted")
-
-		return
-	}
-
+func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID string, mounts []VolumeMount) {
 	// Prevent concurrent mounting attempts
 	if !a.isMountingNFS.CompareAndSwap(false, true) {
 		logger.Debug().Msg("NFS volumes already mounting")
@@ -264,7 +261,22 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, mounts []Volu
 	}
 	defer a.isMountingNFS.Store(false)
 
-	logger.Debug().Msg("Mounting NFS volumes")
+	// Check if lifecycleID changed (indicates resume to potentially different server)
+	prevLifecycleID, _ := a.mountedLifecycleID.Load().(string)
+	lifecycleChanged := prevLifecycleID != "" && prevLifecycleID != lifecycleID
+
+	if lifecycleChanged {
+		logger.Debug().Msgf("Lifecycle changed from %q to %q, will remount NFS volumes", prevLifecycleID, lifecycleID)
+	}
+
+	// Already fully mounted for this lifecycle, nothing to do
+	if a.isMountedNFS.Load() && !lifecycleChanged {
+		logger.Debug().Msg("NFS volumes already mounted for this lifecycle")
+
+		return
+	}
+
+	logger.Debug().Msg("Setting up NFS volumes")
 
 	ctx = context.WithoutCancel(ctx)
 	ctx, cancel := context.WithTimeout(ctx, nfsMountTimeout)
@@ -275,16 +287,23 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, mounts []Volu
 	allSucceeded.Store(true)
 
 	for _, volume := range mounts {
-		// Skip already mounted paths
-		if _, ok := a.mountedPaths.Load(volume.Path); ok {
-			logger.Debug().Msgf("Skipping already mounted %q", volume.Path)
+		// Skip already mounted paths unless lifecycle changed
+		if !lifecycleChanged {
+			if _, ok := a.mountedPaths.Load(volume.Path); ok {
+				logger.Debug().Msgf("Skipping already mounted %q", volume.Path)
 
-			continue
+				continue
+			}
 		}
 
-		logger.Debug().Msgf("Mounting %s at %q", volume.NfsTarget, volume.Path)
+		logger.Debug().Msgf("Setting up %s at %q", volume.NfsTarget, volume.Path)
 
 		wg.Go(func() {
+			// Unmount first if lifecycle changed (stale handles from previous server)
+			if lifecycleChanged {
+				a.unmountNFS(ctx, logger, volume.Path)
+			}
+
 			if a.mountNFS(ctx, volume.NfsTarget, volume.Path) {
 				a.mountedPaths.Store(volume.Path, true)
 			} else {
@@ -297,7 +316,37 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, mounts []Volu
 
 	if allSucceeded.Load() {
 		a.isMountedNFS.Store(true)
+		a.mountedLifecycleID.Store(lifecycleID)
 	}
+}
+
+func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string) {
+	// Check if actually mounted before trying to unmount
+	data, err := exec.CommandContext(ctx, "findmnt", "--noheadings", "--output", "SOURCE", path).CombinedOutput()
+	if err != nil {
+		// Not mounted or error checking - nothing to unmount
+		return
+	}
+
+	source := strings.TrimSpace(string(data))
+	if source == "" {
+		return
+	}
+
+	logger.Debug().Msgf("Unmounting stale NFS mount at %q (was: %s)", path, source)
+
+	// Clear our tracking state for this path
+	a.mountedPaths.Delete(path)
+	a.isMountedNFS.Store(false)
+
+	// Force unmount since the handles are stale anyway
+	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
+
+	logFn := a.getLogger(err)
+	logFn.
+		Strs("command", []string{"umount", "--force", path}).
+		Str("output", string(data)).
+		Msg("Unmount NFS")
 }
 
 func (a *API) mountNFS(ctx context.Context, nfsTarget, path string) bool {

--- a/packages/envd/internal/api/init_test.go
+++ b/packages/envd/internal/api/init_test.go
@@ -585,3 +585,75 @@ func TestSetData(t *testing.T) {
 		assert.Equal(t, "value", val)
 	})
 }
+
+func TestShouldRemountNFS(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		isMounted          bool
+		mountedLifecycleID string
+		requestLifecycleID string
+		wantRemount        bool
+	}{
+		{
+			name:               "not mounted: should mount",
+			isMounted:          false,
+			mountedLifecycleID: "",
+			requestLifecycleID: "",
+			wantRemount:        true,
+		},
+		{
+			name:               "not mounted with request lifecycle: should mount",
+			isMounted:          false,
+			mountedLifecycleID: "",
+			requestLifecycleID: "abc",
+			wantRemount:        true,
+		},
+		{
+			name:               "mounted empty + request empty: no remount (would cause infinite loop)",
+			isMounted:          true,
+			mountedLifecycleID: "",
+			requestLifecycleID: "",
+			wantRemount:        false,
+		},
+		{
+			name:               "mounted with lifecycle + request empty: remount (lifecycle cleared)",
+			isMounted:          true,
+			mountedLifecycleID: "abc",
+			requestLifecycleID: "",
+			wantRemount:        true,
+		},
+		{
+			name:               "mounted empty + request with lifecycle: remount (new lifecycle)",
+			isMounted:          true,
+			mountedLifecycleID: "",
+			requestLifecycleID: "abc",
+			wantRemount:        true,
+		},
+		{
+			name:               "mounted + request same lifecycle: no remount",
+			isMounted:          true,
+			mountedLifecycleID: "abc",
+			requestLifecycleID: "abc",
+			wantRemount:        false,
+		},
+		{
+			name:               "mounted + request different lifecycle: remount",
+			isMounted:          true,
+			mountedLifecycleID: "abc",
+			requestLifecycleID: "xyz",
+			wantRemount:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldRemountNFS(tt.isMounted, tt.mountedLifecycleID, tt.requestLifecycleID)
+
+			assert.Equal(t, tt.wantRemount, got)
+		})
+	}
+}

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -39,11 +39,9 @@ type API struct {
 	lastSetTime *utils.AtomicMax
 	initLock    sync.Mutex
 
-	caCertInstaller    *host.CACertInstaller
-	isMountingNFS      atomic.Bool
-	isMountedNFS       atomic.Bool
-	mountedPaths       sync.Map     // tracks successfully mounted paths
-	mountedLifecycleID atomic.Value // tracks the lifecycleID when NFS was mounted
+	caCertInstaller *host.CACertInstaller
+	isMountingNFS   atomic.Bool
+	mountedPaths    sync.Map // map[path]lifecycleID - tracks which lifecycle each path was mounted for
 }
 
 func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.MMDSOpts, isNotFC bool) *API {
@@ -90,12 +88,4 @@ func (a *API) GetMetrics(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(metrics); err != nil {
 		a.logger.Error().Err(err).Msg("Failed to encode metrics")
 	}
-}
-
-func (a *API) getLogger(err error) *zerolog.Event {
-	if err != nil {
-		return a.logger.Error().Err(err) //nolint:zerologlint // this is only prep
-	}
-
-	return a.logger.Info() //nolint:zerologlint // this is only prep
 }

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -39,10 +39,11 @@ type API struct {
 	lastSetTime *utils.AtomicMax
 	initLock    sync.Mutex
 
-	caCertInstaller *host.CACertInstaller
-	isMountingNFS   atomic.Bool
-	isMountedNFS    atomic.Bool
-	mountedPaths    sync.Map // tracks successfully mounted paths
+	caCertInstaller    *host.CACertInstaller
+	isMountingNFS      atomic.Bool
+	isMountedNFS       atomic.Bool
+	mountedPaths       sync.Map // tracks successfully mounted paths
+	mountedLifecycleID atomic.Value // tracks the lifecycleID when NFS was mounted
 }
 
 func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.MMDSOpts, isNotFC bool) *API {

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -42,7 +42,7 @@ type API struct {
 	caCertInstaller    *host.CACertInstaller
 	isMountingNFS      atomic.Bool
 	isMountedNFS       atomic.Bool
-	mountedPaths       sync.Map // tracks successfully mounted paths
+	mountedPaths       sync.Map     // tracks successfully mounted paths
 	mountedLifecycleID atomic.Value // tracks the lifecycleID when NFS was mounted
 }
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.13"
+const Version = "0.5.14"

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -70,8 +70,6 @@ paths:
                 caBundle:
                   type: string
                   description: PEM-encoded CA certificates to install into the system trust store (may contain multiple concatenated PEM blocks)
-              required:
-                - lifecycleID
 
       responses:
         "204":

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -48,6 +48,9 @@ paths:
                 hyperloopIP:
                   type: string
                   description: IP address of the hyperloop server to connect to
+                lifecycleID:
+                  type: string
+                  description: Lifecycle ID of the sandbox
                 envVars:
                   $ref: "#/components/schemas/EnvVars"
                 accessToken:
@@ -67,6 +70,9 @@ paths:
                 caBundle:
                   type: string
                   description: PEM-encoded CA certificates to install into the system trust store (may contain multiple concatenated PEM blocks)
+              required:
+                - lifecycleID
+
       responses:
         "204":
           description: Env vars set, the time and metadata is synced with the host

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -36,6 +36,7 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 	requestCount := int64(0)
 
 	jsonBody := &envd.PostInitJSONBody{
+		LifecycleID:    s.LifecycleID,
 		EnvVars:        s.Config.Envd.Vars,
 		HyperloopIP:    s.config.NetworkConfig.OrchestratorInSandboxIPAddress,
 		AccessToken:    utils.DerefOrDefault(s.Config.Envd.AccessToken, ""),

--- a/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
+++ b/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
@@ -187,6 +187,9 @@ type PostInitJSONBody struct {
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP string `json:"hyperloopIP,omitempty"`
 
+	// LifecycleID Lifecycle ID of the sandbox
+	LifecycleID string `json:"lifecycleID"`
+
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    time.Time     `json:"timestamp,omitempty"`
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty"`

--- a/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
+++ b/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
@@ -188,7 +188,7 @@ type PostInitJSONBody struct {
 	HyperloopIP string `json:"hyperloopIP,omitempty"`
 
 	// LifecycleID Lifecycle ID of the sandbox
-	LifecycleID string `json:"lifecycleID"`
+	LifecycleID string `json:"lifecycleID,omitempty"`
 
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    time.Time     `json:"timestamp,omitempty"`

--- a/tests/integration/internal/envd/generated.go
+++ b/tests/integration/internal/envd/generated.go
@@ -196,6 +196,9 @@ type PostInitJSONBody struct {
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 
+	// LifecycleID Lifecycle ID of the sandbox
+	LifecycleID string `json:"lifecycleID"`
+
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    *time.Time     `json:"timestamp,omitempty"`
 	VolumeMounts *[]VolumeMount `json:"volumeMounts,omitempty"`

--- a/tests/integration/internal/envd/generated.go
+++ b/tests/integration/internal/envd/generated.go
@@ -197,7 +197,7 @@ type PostInitJSONBody struct {
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 
 	// LifecycleID Lifecycle ID of the sandbox
-	LifecycleID string `json:"lifecycleID"`
+	LifecycleID *string `json:"lifecycleID,omitempty"`
 
 	// Timestamp The current timestamp in RFC3339 format
 	Timestamp    *time.Time     `json:"timestamp,omitempty"`


### PR DESCRIPTION
Without the remount, NFS handles will all be stale (pointing to released mountnses) or invalid (if we resume on a different orchestrator)