### PR TITLE
chore(terraform): move admin token generation to init

### DIFF
--- a/iac/provider-gcp/api.tf
+++ b/iac/provider-gcp/api.tf
@@ -46,42 +46,6 @@ resource "google_secret_manager_secret_version" "api_secret_value" {
   secret_data = random_password.api_secret.result
 }
 
-resource "random_password" "api_admin_secret" {
-  length  = 32
-  special = true
-}
-
-
-resource "google_secret_manager_secret" "api_admin_token" {
-  secret_id = "${var.prefix}api-admin-token"
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "api_admin_token_value" {
-  secret      = google_secret_manager_secret.api_admin_token.id
-  secret_data = random_password.api_admin_secret.result
-}
-
-resource "random_password" "dashboard_api_admin_secret" {
-  length  = 32
-  special = false
-}
-
-resource "google_secret_manager_secret" "dashboard_api_admin_token" {
-  secret_id = "${var.prefix}dashboard-api-admin-token"
-
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "dashboard_api_admin_token_value" {
-  secret      = google_secret_manager_secret.dashboard_api_admin_token.id
-  secret_data = random_password.dashboard_api_admin_secret.result
-}
-
 resource "random_password" "sandbox_access_token_hash_seed" {
   length  = 32
   special = false

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -14,6 +14,14 @@ output "nomad_acl_token_secret" {
   value = google_secret_manager_secret_version.nomad_acl_token.secret_data
 }
 
+output "api_admin_token_secret_name" {
+  value = google_secret_manager_secret_version.api_admin_token_value.secret
+}
+
+output "dashboard_api_admin_token_secret_name" {
+  value = google_secret_manager_secret_version.dashboard_api_admin_token_value.secret
+}
+
 output "grafana_api_key_secret_name" {
   value = google_secret_manager_secret.grafana_api_key.name
 }

--- a/iac/provider-gcp/init/secrets.tf
+++ b/iac/provider-gcp/init/secrets.tf
@@ -43,6 +43,46 @@ resource "google_secret_manager_secret_version" "nomad_acl_token" {
   secret_data = random_uuid.nomad_acl_token.result
 }
 
+resource "random_password" "api_admin_secret" {
+  length  = 32
+  special = true
+}
+
+resource "google_secret_manager_secret" "api_admin_token" {
+  secret_id = "${var.prefix}api-admin-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [time_sleep.secrets_api_wait_60_seconds]
+}
+
+resource "google_secret_manager_secret_version" "api_admin_token_value" {
+  secret      = google_secret_manager_secret.api_admin_token.id
+  secret_data = random_password.api_admin_secret.result
+}
+
+resource "random_password" "dashboard_api_admin_secret" {
+  length  = 32
+  special = false
+}
+
+resource "google_secret_manager_secret" "dashboard_api_admin_token" {
+  secret_id = "${var.prefix}dashboard-api-admin-token"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [time_sleep.secrets_api_wait_60_seconds]
+}
+
+resource "google_secret_manager_secret_version" "dashboard_api_admin_token_value" {
+  secret      = google_secret_manager_secret.dashboard_api_admin_token.id
+  secret_data = random_password.dashboard_api_admin_secret.result
+}
+
 
 
 # grafana api key

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -246,7 +246,7 @@ module "nomad" {
   posthog_api_key_secret_name                            = module.init.posthog_api_key_secret_name
   analytics_collector_host_secret_name                   = module.init.analytics_collector_host_secret_name
   analytics_collector_api_token_secret_name              = module.init.analytics_collector_api_token_secret_name
-  api_admin_token                                        = random_password.api_admin_secret.result
+  api_admin_token_secret_name                            = module.init.api_admin_token_secret_name
   redis_cluster_url_secret_version                       = module.init.redis_cluster_url_secret_version
   redis_tls_ca_base64_secret_version                     = module.init.redis_tls_ca_base64_secret_version
   sandbox_access_token_hash_seed                         = random_password.sandbox_access_token_hash_seed.result
@@ -282,7 +282,7 @@ module "nomad" {
 
   # Dashboard API
   dashboard_api_count                     = var.dashboard_api_count
-  dashboard_api_admin_token               = random_password.dashboard_api_admin_secret.result
+  dashboard_api_admin_token_secret_name   = module.init.dashboard_api_admin_token_secret_name
   supabase_db_connection_string           = var.supabase_db_connection_string
   enable_auth_user_sync_background_worker = var.enable_auth_user_sync_background_worker
   enable_billing_http_team_provision_sink = var.enable_billing_http_team_provision_sink

--- a/iac/provider-gcp/moved.tf
+++ b/iac/provider-gcp/moved.tf
@@ -33,3 +33,33 @@ moved {
   from = google_secret_manager_secret_version.supabase_jwt_secrets
   to   = module.init.google_secret_manager_secret_version.supabase_jwt_secrets
 }
+
+moved {
+  from = random_password.api_admin_secret
+  to   = module.init.random_password.api_admin_secret
+}
+
+moved {
+  from = google_secret_manager_secret.api_admin_token
+  to   = module.init.google_secret_manager_secret.api_admin_token
+}
+
+moved {
+  from = google_secret_manager_secret_version.api_admin_token_value
+  to   = module.init.google_secret_manager_secret_version.api_admin_token_value
+}
+
+moved {
+  from = random_password.dashboard_api_admin_secret
+  to   = module.init.random_password.dashboard_api_admin_secret
+}
+
+moved {
+  from = google_secret_manager_secret.dashboard_api_admin_token
+  to   = module.init.google_secret_manager_secret.dashboard_api_admin_token
+}
+
+moved {
+  from = google_secret_manager_secret_version.dashboard_api_admin_token_value
+  to   = module.init.google_secret_manager_secret_version.dashboard_api_admin_token_value
+}

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -119,7 +119,7 @@ module "api" {
   analytics_collector_host                = trimspace(data.google_secret_manager_secret_version.analytics_collector_host.secret_data)
   analytics_collector_api_token           = trimspace(data.google_secret_manager_secret_version.analytics_collector_api_token.secret_data)
   nomad_acl_token                         = var.nomad_acl_token_secret
-  admin_token                             = data.google_secret_manager_secret_version.api_admin_token.secret_data
+  admin_token                             = trimspace(data.google_secret_manager_secret_version.api_admin_token.secret_data)
   redis_url                               = local.redis_url
   redis_cluster_url                       = local.redis_cluster_url
   redis_tls_ca_base64                     = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
@@ -155,7 +155,7 @@ module "dashboard_api" {
 
   image = data.google_artifact_registry_docker_image.dashboard_api_image[0].self_link
 
-  admin_token                             = data.google_secret_manager_secret_version.dashboard_api_admin_token.secret_data
+  admin_token                             = trimspace(data.google_secret_manager_secret_version.dashboard_api_admin_token.secret_data)
   postgres_connection_string              = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_connection_string               = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_read_replica_connection_string  = trimspace(data.google_secret_manager_secret_version.postgres_read_replica_connection_string.secret_data)

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -25,6 +25,14 @@ data "google_secret_manager_secret_version" "posthog_api_key" {
   secret = var.posthog_api_key_secret_name
 }
 
+data "google_secret_manager_secret_version" "api_admin_token" {
+  secret = var.api_admin_token_secret_name
+}
+
+data "google_secret_manager_secret_version" "dashboard_api_admin_token" {
+  secret = var.dashboard_api_admin_token_secret_name
+}
+
 # Telemetry
 data "google_secret_manager_secret_version" "analytics_collector_host" {
   secret = var.analytics_collector_host_secret_name
@@ -111,7 +119,7 @@ module "api" {
   analytics_collector_host                = trimspace(data.google_secret_manager_secret_version.analytics_collector_host.secret_data)
   analytics_collector_api_token           = trimspace(data.google_secret_manager_secret_version.analytics_collector_api_token.secret_data)
   nomad_acl_token                         = var.nomad_acl_token_secret
-  admin_token                             = var.api_admin_token
+  admin_token                             = data.google_secret_manager_secret_version.api_admin_token.secret_data
   redis_url                               = local.redis_url
   redis_cluster_url                       = local.redis_cluster_url
   redis_tls_ca_base64                     = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
@@ -147,7 +155,7 @@ module "dashboard_api" {
 
   image = data.google_artifact_registry_docker_image.dashboard_api_image[0].self_link
 
-  admin_token                             = var.dashboard_api_admin_token
+  admin_token                             = data.google_secret_manager_secret_version.dashboard_api_admin_token.secret_data
   postgres_connection_string              = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_connection_string               = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_read_replica_connection_string  = trimspace(data.google_secret_manager_secret_version.postgres_read_replica_connection_string.secret_data)

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -94,11 +94,11 @@ variable "api_secret" {
   type = string
 }
 
-variable "api_admin_token" {
+variable "api_admin_token_secret_name" {
   type = string
 }
 
-variable "dashboard_api_admin_token" {
+variable "dashboard_api_admin_token_secret_name" {
   type = string
 }
 


### PR DESCRIPTION
## Summary
- move both API and dashboard API admin token generation into `iac/provider-gcp/init/secrets.tf`
- expose the Secret Manager secret names from `init` and have the Nomad module read those values when rendering the API jobs
- add Terraform `moved` blocks so existing environments keep their current admin token resources without forced recreation

## Validation
- `terraform -chdir=\"iac/provider-gcp\" validate`