### PR TITLE
envd/host: fix temp dir cleanup race

### DIFF
--- a/packages/envd/internal/host/cacerts_test.go
+++ b/packages/envd/internal/host/cacerts_test.go
@@ -113,7 +113,7 @@ func TestInstallCACert_SameCert(t *testing.T) {
 	waitForFile(t, extraPath) // drain the background goroutine before the hot-path call
 
 	c.install(context.Background(), certA, bundlePath, extraPath) // resume — hot path hit
-	waitForFile(t, extraPath)                                     // drain the background goroutine before the hot-path call
+	waitForFile(t, extraPath)                                     // file already written by first goroutine; guards TempDir cleanup
 
 	bundle, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)
@@ -223,9 +223,11 @@ func TestInstallCACert_ConcurrentResume(t *testing.T) {
 
 	wg.Wait()
 
-	// Acquire mu to drain any in-flight background goroutines.
-	c.mu.Lock()
-	c.mu.Unlock() //nolint:staticcheck
+	// Wait for the background goroutine spawned by the first install to finish
+	// its I/O. The mu.Lock/Unlock drain is unreliable: if the goroutine has not
+	// yet been scheduled, no one holds mu and the lock succeeds immediately —
+	// leaving the goroutine to run against the already-cleaning TempDir.
+	waitForFile(t, extraPath)
 
 	bundle, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)

--- a/packages/envd/internal/host/cacerts_test.go
+++ b/packages/envd/internal/host/cacerts_test.go
@@ -110,7 +110,10 @@ func TestInstallCACert_SameCert(t *testing.T) {
 	c := newTestInstaller(t)
 
 	c.install(context.Background(), certA, bundlePath, extraPath)
+	waitForFile(t, extraPath) // drain the background goroutine before the hot-path call
+
 	c.install(context.Background(), certA, bundlePath, extraPath) // resume — hot path hit
+	waitForFile(t, extraPath)                                     // drain the background goroutine before the hot-path call
 
 	bundle, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)


### PR DESCRIPTION
Problem:

install() appends the cert synchronously, then spawns a background
goroutine under mu to persist the cert to the extra-certs directory.
In TestInstallCACert_SameCert, if the Go scheduler runs the second
install() call before the goroutine from the first call acquires mu,
the second call sees lastCACert already set, hits the early-return
hot path, and the test returns while the goroutine is still writing
into t.TempDir(). The deferred cleanup then fails:

  TempDir RemoveAll cleanup: unlinkat /tmp/TestInstallCACert_SameCert...: directory not empty

Solution:

Add waitForFile(t, extraPath) between the two install() calls. This
matches the drain pattern used by every other test in the file and
guarantees the first goroutine has finished its I/O before the second
install() is issued or the test exits.

Testing:

Reproducer: the CI failure at
https://github.com/e2b-dev/infra/actions/runs/24497740602/job/71596563931
The fix eliminates the race by making the goroutine lifetime observable
via the filesystem, consistent with TestInstallCACert_FirstTime,
TestInstallCACert_RestartSameCert, and TestInstallCACert_RestartDifferentCert.