### PR TITLE
fix(api): skip kill after waiting for pause to complete

### DIFF
--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gogo/status"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
@@ -181,8 +183,11 @@ func (o *Orchestrator) killSandboxOnNode(ctx context.Context, node *nodemanager.
 
 	client, ctx := node.GetSandboxDeleteCtx(ctx, sbx.SandboxID, sbx.ExecutionID)
 	_, err := client.Sandbox.Delete(ctx, req)
-	if err != nil {
-		return fmt.Errorf("failed to delete sandbox '%s': %w", sbx.SandboxID, err)
+	st, ok := status.FromError(err)
+	if ok && st.Code() == codes.NotFound {
+		logger.L().Info(ctx, "Sandbox not found during kill", logger.WithSandboxID(sbx.SandboxID), logger.WithNodeID(node.ID))
+	} else if err != nil {
+		return fmt.Errorf("failed to delete sandbox: %w", err)
 	}
 
 	node.OptimisticRemove(ctx, nodemanager.SandboxResources{


### PR DESCRIPTION
When a kill request arrives while a sandbox is being paused, the code waits for the pause transition to finish and fails as the sandbox isn't present anymore. If the sandbox isn't present, the code now continues as if the sandbox was removed from the node by this call