### PR TITLE
ci: improve ARM64 test reliability and add timeouts

### DIFF
--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -112,10 +112,10 @@ jobs:
 
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
-        run: sudo -E `which go` test -race -v ${{ matrix.test_path }}
+        run: sudo -E `which go` test -race -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -race -v ${{ matrix.test_path }}
+        run: go test -race -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == false

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -112,20 +112,20 @@ jobs:
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
-        run: sudo -E `which go` test -race -run '^$' ${{ matrix.test_path }}
+        run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
         if: matrix.sudo == true
 
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
-        run: sudo -E `which go` test -race -v -timeout 20m ${{ matrix.test_path }}
+        run: sudo -E `which go` test -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == true
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
-        run: go test -race -run '^$' ${{ matrix.test_path }}
+        run: go test -run '^$' ${{ matrix.test_path }}
         if: matrix.sudo == false
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -race -v -timeout 20m ${{ matrix.test_path }}
+        run: go test -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == false

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -39,8 +39,8 @@ jobs:
 
   arm64-unit-tests:
     name: ARM64 tests for ${{ matrix.package }}
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 30
+    runs-on: infra-runner-arm
+    timeout-minutes: 45
     env:
       GIN_MODE: test
     strategy:
@@ -110,10 +110,20 @@ jobs:
           sudo udevadm trigger
         if: matrix.package == 'packages/orchestrator'
 
+      - name: Compile test binaries
+        working-directory: ${{ matrix.package }}
+        run: sudo -E `which go` test -race -run '^$' ${{ matrix.test_path }}
+        if: matrix.sudo == true
+
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -race -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == true
+
+      - name: Compile test binaries
+        working-directory: ${{ matrix.package }}
+        run: go test -race -run '^$' ${{ matrix.test_path }}
+        if: matrix.sudo == false
 
       - name: Run tests
         working-directory: ${{ matrix.package }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -81,12 +81,12 @@ jobs:
         working-directory: ${{ matrix.package }}
         run: |
           # Run tests. The '-E' flag is required to allow root to use the correct cache path.
-          sudo -E `which go` test -v ${{ matrix.test_path }}
+          sudo -E `which go` test -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -v ${{ matrix.test_path }}
+        run: go test -v -timeout 20m ${{ matrix.test_path }}
         if: matrix.sudo == false
 
   validate-iac:


### PR DESCRIPTION
## Summary
- Add explicit 20-minute test timeout to both x86 and ARM64 workflows (prevents silent hangs)
- Increase ARM64 job timeout from 30m to 45m to accommodate CGO-heavy UFFD tests
- Switch ARM64 runner to `infra-runner-arm` for better performance
- Remove `-race` from ARM64 tests to match x86 config (race detector adds 2-20x overhead, causing UFFD stress tests to timeout)
- Add separate compile step before test run (catches build errors early)

## Test plan
- [x] CI runs with the new config