### PR TITLE
fix(iac): use state-migrate for admin token resource moves

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -116,6 +116,12 @@ init:
 .PHONY: state-migrate
 state-migrate:
 	@ printf "Running Terraform state migrations for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
+	@ $(tf_vars) $(TF) state mv 'random_password.api_admin_secret' 'module.init.random_password.api_admin_secret' || true
+	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret.api_admin_token' 'module.init.google_secret_manager_secret.api_admin_token' || true
+	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret_version.api_admin_token_value' 'module.init.google_secret_manager_secret_version.api_admin_token_value' || true
+	@ $(tf_vars) $(TF) state mv 'random_password.dashboard_api_admin_secret' 'module.init.random_password.dashboard_api_admin_secret' || true
+	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret.dashboard_api_admin_token' 'module.init.google_secret_manager_secret.dashboard_api_admin_token' || true
+	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret_version.dashboard_api_admin_token_value' 'module.init.google_secret_manager_secret_version.dashboard_api_admin_token_value' || true
 
 .PHONY: apply-init
 apply-init:

--- a/iac/provider-gcp/moved.tf
+++ b/iac/provider-gcp/moved.tf
@@ -34,32 +34,3 @@ moved {
   to   = module.init.google_secret_manager_secret_version.supabase_jwt_secrets
 }
 
-moved {
-  from = random_password.api_admin_secret
-  to   = module.init.random_password.api_admin_secret
-}
-
-moved {
-  from = google_secret_manager_secret.api_admin_token
-  to   = module.init.google_secret_manager_secret.api_admin_token
-}
-
-moved {
-  from = google_secret_manager_secret_version.api_admin_token_value
-  to   = module.init.google_secret_manager_secret_version.api_admin_token_value
-}
-
-moved {
-  from = random_password.dashboard_api_admin_secret
-  to   = module.init.random_password.dashboard_api_admin_secret
-}
-
-moved {
-  from = google_secret_manager_secret.dashboard_api_admin_token
-  to   = module.init.google_secret_manager_secret.dashboard_api_admin_token
-}
-
-moved {
-  from = google_secret_manager_secret_version.dashboard_api_admin_token_value
-  to   = module.init.google_secret_manager_secret_version.dashboard_api_admin_token_value
-}


### PR DESCRIPTION
## Summary

- Fixes `make apply-init` failing because `moved` blocks for admin token resources conflict with `-target=module.init`
- Replaces the 6 `moved` blocks with `terraform state mv` commands in `state-migrate`, which already runs before `apply-init` in CI
- Follows the same pattern used previously for nomad job state migrations (cleaned up in #2277)