### PR TITLE
chore(dashboard-api): reduce shared Supabase pool size

### DIFF
--- a/packages/dashboard-api/internal/backgroundworker/config.go
+++ b/packages/dashboard-api/internal/backgroundworker/config.go
@@ -4,7 +4,7 @@ const (
 	authCustomSchema             = "auth_custom"
 	authUserProjectionQueue      = "auth_user_projection"
 	authUserProjectionKind       = "auth_user_projection"
-	authUserProjectionMaxWorkers = 10
+	authUserProjectionMaxWorkers = 1
 
 	workerMeterName          = "github.com/e2b-dev/infra/packages/dashboard-api/internal/backgroundworker"
 	jobResultError           = "error"

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -147,7 +147,7 @@ func run() int {
 	supabaseDB, err := supabasedb.NewClient(
 		ctx,
 		config.SupabaseDBConnectionString,
-		pool.WithMaxConnections(2),
+		pool.WithMaxConnections(3),
 	)
 	if err != nil {
 		l.Error(ctx, "Initializing supabase database client", zap.Error(err))

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -147,7 +147,7 @@ func run() int {
 	supabaseDB, err := supabasedb.NewClient(
 		ctx,
 		config.SupabaseDBConnectionString,
-		pool.WithMaxConnections(4),
+		pool.WithMaxConnections(2),
 	)
 	if err != nil {
 		l.Error(ctx, "Initializing supabase database client", zap.Error(err))


### PR DESCRIPTION
## Summary
- lower the shared `dashboard-api` Supabase pool size from 4 to 3
- reduce production Supabase connections used by auth user sync without adding a separate worker-specific client
- keep the change minimal and verify `go test ./packages/dashboard-api/... -run '^$'`