### PR TITLE
perf(sandbox): reduce memory dirtying from journald and envd logging

### DIFF
--- a/packages/envd/internal/logs/logger.go
+++ b/packages/envd/internal/logs/logger.go
@@ -18,18 +18,21 @@ func NewLogger(ctx context.Context, isNotFC bool, mmdsChan <-chan *host.MMDSOpts
 
 	exporters := []io.Writer{}
 
+	var level zerolog.Level
 	if isNotFC {
 		exporters = append(exporters, os.Stdout)
 	} else {
-		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan), os.Stdout)
+		// HTTP exporter only — stdout goes to journald which dirties guest memory pages.
+		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan))
 	}
+	level = zerolog.DebugLevel
 
 	l := zerolog.
 		New(io.MultiWriter(exporters...)).
 		With().
 		Timestamp().
 		Logger().
-		Level(zerolog.DebugLevel)
+		Level(level)
 
 	return &l
 }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.14"
+const Version = "0.5.15"

--- a/packages/orchestrator/cmd/resume-build/measure-memory-dirtying.sh
+++ b/packages/orchestrator/cmd/resume-build/measure-memory-dirtying.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Measure memory/rootfs diff sizes across pause-resume cycles.
+#
+# This script builds a base template, then runs a series of pause-resume
+# cycles to measure how many pages get dirtied during each cycle —
+# both idle and under normal envd operations (file writes, process starts).
+#
+# Usage:
+#   sudo ./measure-memory-dirtying.sh [storage-path]
+#
+# Requires: root, KVM, Docker, NBD, hugepages
+set -euo pipefail
+
+STORAGE="${1:-.local-build}"
+CREATE_BUILD="go run ./packages/orchestrator/cmd/create-build"
+RESUME_BUILD="go run ./packages/orchestrator/cmd/resume-build"
+
+BASE_ID="measure-base-$(date +%s)"
+echo "=== Step 1: Build base template ==="
+$CREATE_BUILD \
+  -to-build "$BASE_ID" \
+  -storage "$STORAGE" \
+  -hugepages \
+  -v
+
+echo ""
+echo "=== Step 2: Immediate pause (baseline — no activity) ==="
+LAYER_IDLE="$BASE_ID-idle"
+$RESUME_BUILD \
+  -from-build "$BASE_ID" \
+  -to-build "$LAYER_IDLE" \
+  -storage "$STORAGE" \
+  -pause
+
+echo ""
+echo "=== Step 3: Resume + sleep 2s + pause (idle drift) ==="
+LAYER_SLEEP="$LAYER_IDLE-sleep2"
+$RESUME_BUILD \
+  -from-build "$LAYER_IDLE" \
+  -to-build "$LAYER_SLEEP" \
+  -storage "$STORAGE" \
+  -cmd-pause "sleep 2"
+
+echo ""
+echo "=== Step 4: Resume + sleep 5s + pause (longer idle drift) ==="
+LAYER_SLEEP5="$LAYER_SLEEP-sleep5"
+$RESUME_BUILD \
+  -from-build "$LAYER_SLEEP" \
+  -to-build "$LAYER_SLEEP5" \
+  -storage "$STORAGE" \
+  -cmd-pause "sleep 5"
+
+echo ""
+echo "=== Step 5: Resume + write files via envd + pause ==="
+LAYER_WRITE="$LAYER_SLEEP5-write"
+$RESUME_BUILD \
+  -from-build "$LAYER_SLEEP5" \
+  -to-build "$LAYER_WRITE" \
+  -storage "$STORAGE" \
+  -cmd-pause "dd if=/dev/urandom of=/tmp/testfile bs=1K count=64 2>/dev/null && echo written"
+
+echo ""
+echo "=== Step 6: Resume + start process via envd + pause ==="
+LAYER_PROC="$LAYER_WRITE-proc"
+$RESUME_BUILD \
+  -from-build "$LAYER_WRITE" \
+  -to-build "$LAYER_PROC" \
+  -storage "$STORAGE" \
+  -cmd-pause "python3 -c 'print(sum(range(10000)))' || echo 'python not available, using echo'; echo done"
+
+echo ""
+echo "=== Step 7: Multi-iteration pause benchmark (10x immediate pause) ==="
+$RESUME_BUILD \
+  -from-build "$LAYER_IDLE" \
+  -storage "$STORAGE" \
+  -pause \
+  -iterations 10
+
+echo ""
+echo "=== Done ==="
+echo "Compare the '📦 Artifacts' memfile/rootfs diff sizes above."
+echo "Smaller diffs = fewer dirty pages = faster snapshot restore."

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
@@ -1,0 +1,9 @@
+{{- /*gotype:github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs.templateModel*/ -}}
+{{ .WriteFile "etc/systemd/journald.conf.d/e2b.conf" 0o644 }}
+
+[Journal]
+Storage=none
+MaxLevelConsole=warning
+MaxLevelKMsg=warning
+MaxLevelWall=emerg
+ForwardToSyslog=no

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -88,7 +88,7 @@ func TestAdditionalOCILayers(t *testing.T) {
 
 		keysIter := maps.Keys(actualFiles)
 		keys := slices.Collect(keysIter)
-		assert.Len(t, keys, 13)
+		assert.Len(t, keys, 14)
 		assert.Equal(t, "e2b.local", actualFiles["etc/hostname"])
 		assert.Equal(t, "nameserver 8.8.8.8", actualFiles["etc/resolv.conf"])
 
@@ -101,5 +101,9 @@ func TestAdditionalOCILayers(t *testing.T) {
 WatchdogSec=0`)
 		assert.Equal(t, disabledContent, actualFiles["etc/systemd/system/systemd-journald.service.d/override.conf"])
 		assert.Equal(t, disabledContent, actualFiles["etc/systemd/system/systemd-networkd.service.d/override.conf"])
+
+		journaldConf := strings.TrimSpace(actualFiles["etc/systemd/journald.conf.d/e2b.conf"])
+		assert.Contains(t, journaldConf, "Storage=none")
+		assert.Contains(t, journaldConf, "MaxLevelConsole=warning")
 	})
 }


### PR DESCRIPTION
## Summary
- Add journald `Storage=none` drop-in inside guest VMs to prevent journal writes from dirtying memory pages during pause-resume cycles
- Remove stdout writer from envd in FC mode — debug logs still ship via HTTP exporter to the orchestrator, but never touch journald/disk inside the VM
- Add `measure-memory-dirtying.sh` benchmark script for measuring diff sizes across pause-resume cycles

## Motivation
During frequent pause-resume cycles, journald and envd stdout were constantly writing to memory, dirtying pages that then had to be captured in every snapshot diff layer. This increased layer sizes and slowed snapshot restore.

## Changes
- **`journald.conf.tpl`** (new): `Storage=none`, `MaxLevelConsole=warning`, `MaxLevelKMsg=warning` — system errors still reach the kernel console, but nothing is stored in journal files
- **`logger.go`**: In FC mode, envd writes only to the HTTP exporter (debug level preserved). In non-FC mode, stdout + debug unchanged
- **`envd version`**: Bumped to 0.5.15
- **`rootfs_test.go`**: Updated file count and added assertions for journald conf
- **`measure-memory-dirtying.sh`**: Benchmark script that chains build → pause-resume cycles and prints memfile/rootfs diff sizes

## Test plan
- [ ] Unit test passes (`TestAdditionalOCILayers`)
- [ ] Run benchmark on staging machine with GCS access to measure before/after diff sizes
- [ ] Verify envd debug logs still arrive at orchestrator via HTTP exporter