### PR TITLE
docs(self-host): document Docker Buildx prerequisite

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -22,6 +22,10 @@
 
 - [Docker](https://docs.docker.com/engine/install/)
 
+- [Docker Buildx](https://github.com/docker/buildx#installing) plugin
+  - Required by `make build-and-upload` targets. Bundled with Docker Desktop; must be installed separately if you use Docker Engine/CLI without Desktop.
+  - If `docker buildx version` errors after install, you may need to point Docker at the plugin directory — see [this note](https://github.com/replicate/cog/issues/1382#issuecomment-2409998117).
+
 - [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 
 **Accounts**

--- a/self-host.md
+++ b/self-host.md
@@ -24,7 +24,7 @@
 
 - [Docker Buildx](https://github.com/docker/buildx#installing) plugin
   - Required by `make build-and-upload` targets. Bundled with Docker Desktop; must be installed separately if you use Docker Engine/CLI without Desktop.
-  - If `docker buildx version` errors after install, you may need to point Docker at the plugin directory — see [this note](https://github.com/replicate/cog/issues/1382#issuecomment-2409998117).
+  - If `docker buildx version` errors after install, Docker can't find the plugin. Add its directory (e.g. `/opt/homebrew/lib/docker/cli-plugins` for Homebrew) to `cliPluginsExtraDirs` in `~/.docker/config.json`.
 
 - [NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 


### PR DESCRIPTION
## Summary
- Adds Docker Buildx to the `self-host.md` prerequisites, since `make build-and-upload` targets invoke `docker buildx build`/`bake`.
- Notes that buildx ships with Docker Desktop but must be installed separately for Docker Engine/CLI-only setups (common in orgs that disallow Docker Desktop), and links to the `cliPluginsExtraDirs` workaround when the plugin isn't auto-discovered.