### PR TITLE
remove(dashboard-api): auto-blocking new teams

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -259,7 +259,7 @@ func TestDeleteTeamsTeamIDMembersUserId_RechecksDefaultAfterLock(t *testing.T) {
 func createHandlerTestUser(t *testing.T, db *testutils.Database) uuid.UUID {
 	t.Helper()
 
-	createdAt := time.Now().Add(-newUserNewTeamRequireBillingMethodThreshold - time.Hour)
+	createdAt := time.Now()
 
 	return createHandlerTestUserWithCreatedAt(t, db, &createdAt)
 }
@@ -546,7 +546,7 @@ func TestBootstrapUser_ConcurrentRequestsCreateSingleDefaultTeam(t *testing.T) {
 	}
 }
 
-func TestCreateTeam_RecentUserCreatesBlockedTeam(t *testing.T) {
+func TestCreateTeam_RecentUserCreatesUnblockedTeam(t *testing.T) {
 	t.Parallel()
 
 	testDB := testutils.SetupDatabase(t)
@@ -564,34 +564,8 @@ func TestCreateTeam_RecentUserCreatesBlockedTeam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected team creation to succeed for recent user, got %v", err)
 	}
-	if !team.IsBlocked {
-		t.Fatal("expected recent user team to be blocked")
-	}
-	if team.BlockedReason == nil || *team.BlockedReason != blockedReasonMissingPayment {
-		t.Fatalf("expected blocked reason %q, got %v", blockedReasonMissingPayment, team.BlockedReason)
-	}
-}
-
-func TestCreateTeam_NullCreatedAtLeavesTeamUnblocked(t *testing.T) {
-	t.Parallel()
-
-	testDB := testutils.SetupDatabase(t)
-	ctx := t.Context()
-	userID := createHandlerTestUserWithCreatedAt(t, testDB, nil)
-
-	store := &APIStore{
-		db:                testDB.SqlcClient,
-		authDB:            testDB.AuthDB,
-		supabaseDB:        testDB.SupabaseDB,
-		teamProvisionSink: &fakeTeamProvisionSink{},
-	}
-
-	team, err := store.createTeam(ctx, userID, "Acme")
-	if err != nil {
-		t.Fatalf("expected team creation to succeed with nil created_at, got %v", err)
-	}
 	if team.IsBlocked {
-		t.Fatal("expected nil created_at team to remain unblocked")
+		t.Fatal("expected recent user team to remain unblocked")
 	}
 	if team.BlockedReason != nil {
 		t.Fatalf("expected nil blocked reason, got %v", team.BlockedReason)

--- a/packages/dashboard-api/internal/handlers/team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/team_provisioning.go
@@ -23,12 +23,10 @@ import (
 )
 
 const (
-	baseTierID                                  = "base_v1"
-	maxTeamsPerUser                             = 3
-	maxTeamsPerUserWithProTier                  = 10
-	newUserNewTeamRequireBillingMethodThreshold = 3 * 24 * time.Hour
-	blockedReasonMissingPayment                 = "missing_payment"
-	teamProvisionRollbackTimeout                = 5 * time.Second
+	baseTierID                   = "base_v1"
+	maxTeamsPerUser              = 3
+	maxTeamsPerUserWithProTier   = 10
+	teamProvisionRollbackTimeout = 5 * time.Second
 )
 
 type provisionedTeam struct {
@@ -226,14 +224,12 @@ func (s *APIStore) createTeam(ctx context.Context, userID uuid.UUID, name string
 		return provisionedTeam{}, err
 	}
 
-	isBlocked, blockedReason := teamBlockPolicy(authUser.CreatedAt, time.Now())
-
 	team, err := authTxDB.CreateTeam(ctx, authqueries.CreateTeamParams{
 		Name:          name,
 		Tier:          baseTierID,
 		Email:         authUser.Email,
-		IsBlocked:     isBlocked,
-		BlockedReason: blockedReason,
+		IsBlocked:     false,
+		BlockedReason: nil,
 	})
 	if err != nil {
 		return provisionedTeam{}, fmt.Errorf("create team: %w", err)
@@ -321,18 +317,6 @@ func validateTeamCreationAllowed(ctx context.Context, authTxDB *authqueries.Quer
 
 	return nil
 }
-
-func teamBlockPolicy(userCreatedAt *time.Time, now time.Time) (bool, *string) {
-	// Some Supabase users have a NULL created_at; unknown age should not trigger the new-user block.
-	if userCreatedAt != nil && userCreatedAt.After(now.Add(-newUserNewTeamRequireBillingMethodThreshold)) {
-		reason := blockedReasonMissingPayment
-
-		return true, &reason
-	}
-
-	return false, nil
-}
-
 func (s *APIStore) handleProvisioningError(ctx context.Context, c *gin.Context, operation string, err error) {
 	attrs := []attribute.KeyValue{
 		attribute.String("team.provision.operation", operation),

--- a/packages/dashboard-api/internal/handlers/team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/team_provisioning.go
@@ -317,6 +317,7 @@ func validateTeamCreationAllowed(ctx context.Context, authTxDB *authqueries.Quer
 
 	return nil
 }
+
 func (s *APIStore) handleProvisioningError(ctx context.Context, c *gin.Context, operation string, err error) {
 	attrs := []attribute.KeyValue{
 		attribute.String("team.provision.operation", operation),


### PR DESCRIPTION
## Summary
- remove the 3-day new-user rule from dashboard API team provisioning so additional teams are created unblocked
- delete the now-unused blocking policy constants and helper from `team_provisioning.go`
- update handler tests to assert recent users can create unblocked teams and drop the stale `NULL created_at` case

## Testing
- go test ./internal/handlers -run 'TestCreateTeam_'
- go test ./internal/handlers -run 'Test(PostTeams|CreateTeam)_'