### PR TITLE
feat(orch): re-enable memory.peak per-FD reset (cgroups v2)

### DIFF
--- a/packages/clickhouse/pkg/hoststats/hoststats.go
+++ b/packages/clickhouse/pkg/hoststats/hoststats.go
@@ -25,7 +25,7 @@ type SandboxHostStat struct {
 	CgroupCPUUserUsec   uint64 `ch:"cgroup_cpu_user_usec"`      // cumulative, microseconds
 	CgroupCPUSystemUsec uint64 `ch:"cgroup_cpu_system_usec"`    // cumulative, microseconds
 	CgroupMemoryUsage   uint64 `ch:"cgroup_memory_usage_bytes"` // current, bytes
-	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // lifetime peak, bytes
+	CgroupMemoryPeak    uint64 `ch:"cgroup_memory_peak_bytes"`  // interval peak, bytes (reset after each sample)
 
 	// Pre-computed deltas between consecutive samples.
 	DeltaCgroupCPUUsageUsec  uint64 `ch:"delta_cgroup_cpu_usage_usec"`

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -42,8 +42,9 @@ type Stats struct {
 // Lifecycle: Create → GetFD → cmd.Start() → ReleaseCgroupFD → GetStats (repeatedly) → Remove
 //
 // The caller MUST call ReleaseCgroupFD() right after cmd.Start() (regardless of
-// whether Start succeeded or failed). Remove() only closes the memory.peak FD
-// and deletes the cgroup directory — it does not release the cgroup directory FD.
+// whether Start succeeded or failed). Remove() closes the memory.peak FD,
+// closes the cgroup directory FD as a safety net if ReleaseCgroupFD() was not
+// called, and deletes the cgroup directory.
 type CgroupHandle struct {
 	cgroupName     string
 	path           string

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -216,7 +216,7 @@ func (m *managerImpl) Create(ctx context.Context, cgroupName string) (*CgroupHan
 	memoryPeakFile, peakErr := os.OpenFile(memPeakPath, os.O_RDWR, 0)
 	if peakErr != nil {
 		// Not fatal — memory.peak may not exist on older kernels
-		logger.L().Debug(ctx, "failed to open memory.peak for reset (will track lifetime peak)",
+		logger.L().Warn(ctx, "failed to open memory.peak for reset",
 			zap.String("cgroup_name", cgroupName),
 			zap.String("path", memPeakPath),
 			zap.Error(peakErr))

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -312,7 +312,7 @@ func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile
 
 	// Reset per-FD peak for next interval
 	if _, err := memoryPeakFile.WriteString("0"); err != nil {
-		logger.L().Debug(ctx, "failed to reset memory.peak", zap.Error(err))
+		logger.L().Warn(ctx, "failed to reset memory.peak, interval peak semantics degraded", zap.Error(err))
 	}
 
 	return peakBytes, nil

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -33,7 +33,7 @@ type Stats struct {
 	CPUSystemUsec uint64 // microseconds
 
 	MemoryUsageBytes uint64 // bytes
-	MemoryPeakBytes  uint64 // bytes, lifetime peak
+	MemoryPeakBytes  uint64 // bytes, reset after each GetStats() call
 }
 
 // CgroupHandle represents a created cgroup for a sandbox.
@@ -42,8 +42,8 @@ type Stats struct {
 // Lifecycle: Create → GetFD → cmd.Start() → ReleaseCgroupFD → GetStats (repeatedly) → Remove
 //
 // The caller MUST call ReleaseCgroupFD() right after cmd.Start() (regardless of
-// whether Start succeeded or failed). Remove() closes the memory.peak FD and
-// deletes the cgroup directory — it does not release the cgroup directory FD.
+// whether Start succeeded or failed). Remove() only closes the memory.peak FD
+// and deletes the cgroup directory — it does not release the cgroup directory FD.
 type CgroupHandle struct {
 	cgroupName     string
 	path           string
@@ -69,8 +69,8 @@ func (h *CgroupHandle) GetFD() int {
 // Call this after cmd.Start() — the kernel has already placed the process in
 // the cgroup atomically during clone, so the directory FD is no longer needed.
 //
-// The memory.peak FD is intentionally kept open for the lifetime of stats
-// collection. It will be needed for per-FD reset when kernel 6.12+ is available.
+// The memory.peak FD is intentionally kept open because the per-FD reset
+// mechanism requires the same FD for the lifetime of stats collection.
 // That FD is closed later by Remove().
 //
 // Safe to call multiple times.
@@ -211,12 +211,12 @@ func (m *managerImpl) Create(ctx context.Context, cgroupName string) (*CgroupHan
 		return nil, fmt.Errorf("failed to open cgroup directory: %w", err)
 	}
 
-	// TODO: Change to os.O_RDWR when per-FD peak reset is re-enabled.
+	// O_RDWR FD must stay open for per-FD peak reset across GetStats() calls
 	memPeakPath := filepath.Join(cgroupPath, "memory.peak")
-	memoryPeakFile, peakErr := os.OpenFile(memPeakPath, os.O_RDONLY, 0)
+	memoryPeakFile, peakErr := os.OpenFile(memPeakPath, os.O_RDWR, 0)
 	if peakErr != nil {
 		// Not fatal — memory.peak may not exist on older kernels
-		logger.L().Debug(ctx, "failed to open memory.peak",
+		logger.L().Debug(ctx, "failed to open memory.peak for reset (will track lifetime peak)",
 			zap.String("cgroup_name", cgroupName),
 			zap.String("path", memPeakPath),
 			zap.Error(peakErr))
@@ -234,7 +234,8 @@ func (m *managerImpl) Create(ctx context.Context, cgroupName string) (*CgroupHan
 	logger.L().Debug(ctx, "created cgroup for sandbox",
 		zap.String("cgroup_name", cgroupName),
 		zap.String("path", cgroupPath),
-		zap.Int("fd", handle.GetFD()))
+		zap.Int("fd", handle.GetFD()),
+		zap.Bool("peak_reset_available", memoryPeakFile != nil))
 
 	return handle, nil
 }
@@ -276,7 +277,7 @@ func (m *managerImpl) getStatsForPath(ctx context.Context, cgroupPath string, me
 	stats.MemoryUsageBytes, _ = strconv.ParseUint(strings.TrimSpace(string(memData)), 10, 64)
 
 	if memoryPeakFile != nil {
-		peakBytes, err := m.readMemoryPeak(memoryPeakFile)
+		peakBytes, err := m.readAndResetMemoryPeak(ctx, memoryPeakFile)
 		if err != nil {
 			logger.L().Debug(ctx, "failed to read memory.peak", zap.Error(err))
 		} else {
@@ -287,12 +288,13 @@ func (m *managerImpl) getStatsForPath(ctx context.Context, cgroupPath string, me
 	return stats, nil
 }
 
-// readMemoryPeak reads the current peak memory value from the persistent FD.
-// Read requires file position 0 (seq_file), so we seek before reading.
-//
-// TODO: When per-FD peak reset is available-enabled, this function
-// should also write to the FD to reset the peak for the next interval.
-func (m *managerImpl) readMemoryPeak(memoryPeakFile *os.File) (uint64, error) {
+// readAndResetMemoryPeak reads the current peak memory value and resets it for the next interval.
+// It uses the persistent FD kept open in CgroupHandle for per-FD reset tracking.
+// The cgroups v2 kernel interface works as follows:
+//   - Read requires file position 0 (seq_file), so we seek before reading.
+//   - Write resets the per-FD peak to current memory usage. The kernel ignores
+//     both the written content and the file offset, so no seek before write is needed.
+func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile *os.File) (uint64, error) {
 	if _, err := memoryPeakFile.Seek(0, io.SeekStart); err != nil {
 		return 0, fmt.Errorf("failed to seek memory.peak for read: %w", err)
 	}
@@ -305,7 +307,10 @@ func (m *managerImpl) readMemoryPeak(memoryPeakFile *os.File) (uint64, error) {
 
 	peakBytes, _ := strconv.ParseUint(strings.TrimSpace(string(buf[:n])), 10, 64)
 
-	// TODO:The write for Per-FD peak reset introduced in kernel 6.12 belongs here.
+	// Reset per-FD peak for next interval
+	if _, err := memoryPeakFile.WriteString("0"); err != nil {
+		logger.L().Debug(ctx, "failed to reset memory.peak", zap.Error(err))
+	}
 
 	return peakBytes, nil
 }

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -305,7 +305,10 @@ func (m *managerImpl) readAndResetMemoryPeak(ctx context.Context, memoryPeakFile
 		return 0, fmt.Errorf("failed to read memory.peak: %w", err)
 	}
 
-	peakBytes, _ := strconv.ParseUint(strings.TrimSpace(string(buf[:n])), 10, 64)
+	peakBytes, parseErr := strconv.ParseUint(strings.TrimSpace(string(buf[:n])), 10, 64)
+	if parseErr != nil {
+		return 0, fmt.Errorf("failed to parse memory.peak value %q: %w", strings.TrimSpace(string(buf[:n])), parseErr)
+	}
 
 	// Reset per-FD peak for next interval
 	if _, err := memoryPeakFile.WriteString("0"); err != nil {

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -280,7 +280,7 @@ func (m *managerImpl) getStatsForPath(ctx context.Context, cgroupPath string, me
 	if memoryPeakFile != nil {
 		peakBytes, err := m.readAndResetMemoryPeak(ctx, memoryPeakFile)
 		if err != nil {
-			logger.L().Debug(ctx, "failed to read memory.peak", zap.Error(err))
+			logger.L().Warn(ctx, "failed to read memory.peak", zap.Error(err))
 		} else {
 			stats.MemoryPeakBytes = peakBytes
 		}

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager_test.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager_test.go
@@ -325,7 +325,7 @@ burst_usec 0`
 	assert.Equal(t, uint64(0), stats.MemoryPeakBytes, "MemoryPeakBytes should be 0 without peak FD")
 }
 
-func TestCgroupHandleLifetimePeak(t *testing.T) {
+func TestCgroupHandlePeakReset(t *testing.T) {
 	t.Parallel()
 
 	if os.Geteuid() != 0 {
@@ -339,14 +339,14 @@ func TestCgroupHandleLifetimePeak(t *testing.T) {
 	err = mgr.Initialize(ctx)
 	require.NoError(t, err)
 
-	testSandboxID := "test-lifetime-peak"
+	testSandboxID := "test-peak-reset"
 
 	handle, err := mgr.Create(ctx, testSandboxID)
 	require.NoError(t, err)
 	defer handle.Remove(ctx)
 	defer handle.ReleaseCgroupFD()
 
-	// Allocate memory gradually to observe lifetime peak behavior
+	// Allocate memory gradually so we can sample the peak reset behavior
 	cmd := exec.CommandContext(ctx, "bash", "-c",
 		"x=''; for i in {1..10}; do x=$x$(head -c 5M /dev/zero | tr '\\0' 'x'); sleep 0.5; done; sleep 5")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -365,33 +365,30 @@ func TestCgroupHandleLifetimePeak(t *testing.T) {
 	require.NoError(t, err)
 	peak1 := stats1.MemoryPeakBytes
 	require.Positive(t, peak1, "First peak should be non-zero")
-	assert.GreaterOrEqual(t, peak1, stats1.MemoryUsageBytes,
-		"Peak should be >= current memory")
 	t.Logf("First sample - peak: %d bytes, current: %d bytes", peak1, stats1.MemoryUsageBytes)
 
+	// Peak should represent interval peak (since last GetStats), not lifetime
 	time.Sleep(2 * time.Second)
 	stats2, err := handle.GetStats(ctx)
 	require.NoError(t, err)
 	peak2 := stats2.MemoryPeakBytes
 	require.Positive(t, peak2, "Second peak should be non-zero")
-	assert.GreaterOrEqual(t, peak2, peak1,
-		"Lifetime peak should be monotonically non-decreasing")
-	assert.GreaterOrEqual(t, peak2, stats2.MemoryUsageBytes,
-		"Peak should be >= current memory")
 	t.Logf("Second sample - peak: %d bytes, current: %d bytes", peak2, stats2.MemoryUsageBytes)
+
+	assert.GreaterOrEqual(t, peak2, stats2.MemoryUsageBytes,
+		"Peak memory should be >= current memory within the interval")
 
 	time.Sleep(2 * time.Second)
 	stats3, err := handle.GetStats(ctx)
 	require.NoError(t, err)
 	peak3 := stats3.MemoryPeakBytes
 	require.Positive(t, peak3, "Third peak should be non-zero")
-	assert.GreaterOrEqual(t, peak3, peak2,
-		"Lifetime peak should be monotonically non-decreasing")
-	assert.GreaterOrEqual(t, peak3, stats3.MemoryUsageBytes,
-		"Peak should be >= current memory")
 	t.Logf("Third sample - peak: %d bytes, current: %d bytes", peak3, stats3.MemoryUsageBytes)
 
-	t.Logf("Lifetime peak test complete - peaks: %d, %d, %d bytes",
+	assert.GreaterOrEqual(t, peak3, stats3.MemoryUsageBytes,
+		"Peak memory should be >= current memory within the interval")
+
+	t.Logf("Reset test complete - peaks tracked per interval: %d, %d, %d bytes",
 		peak1, peak2, peak3)
 
 	cmd.Process.Kill()


### PR DESCRIPTION
Now that we run on kernel 6.12+ (ubuntu24), re-enable per-FD peak reset for memory.peak. Each GetStats() call reads the interval peak and writes "0" to reset it, giving per-sample granularity instead of lifetime-only tracking.

Restores: 8cf9d74588c1 ("fix: disable memory.peak per-FD reset (requires kernel 6.12+) (#1959)")