### PR TITLE
refactor(orch): make base provision.sh idempotent

### DIFF
--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -10,13 +10,31 @@ echo "Starting provisioning script"
 # GCP Specific logic
 {{ end }}
 
-echo "Making configuration immutable"
-$BUSYBOX chattr +i /etc/resolv.conf
-
 # Helper function to check if a package is installed
 is_package_installed() {
     dpkg-query -W -f='${Status}' "$1" 2>/dev/null | grep -q "install ok installed"
 }
+
+# Helper: idempotently append a line to a file only if the exact line isn't present.
+# Usage: append_line_if_missing <line> <file>
+append_line_if_missing() {
+    line=$1
+    file=$2
+    grep -qxF "$line" "$file" 2>/dev/null || echo "$line" >>"$file"
+}
+
+# Helper: check whether a file has the immutable (`i`) attribute set.
+# Returns 0 if immutable, non-zero otherwise.
+# Usage: is_immutable <file>
+is_immutable() {
+    $BUSYBOX lsattr "$1" 2>/dev/null | cut -c5 | grep -q i
+}
+
+echo "Making configuration immutable"
+# Idempotent: only set immutable bit if not already set
+if ! is_immutable /etc/resolv.conf; then
+    $BUSYBOX chattr +i /etc/resolv.conf
+fi
 
 # Install required packages if not already installed
 PACKAGES="systemd systemd-sysv openssh-server sudo chrony socat curl ca-certificates fuse3 iptables git nfs-common"
@@ -39,13 +57,19 @@ else
 fi
 
 echo "Setting up shell"
+# These two are idempotent (`>` truncates)
 echo "export SHELL='/bin/bash'" >/etc/profile.d/shell.sh
 echo "export PS1='\w \$ '" >/etc/profile.d/prompt.sh
-echo "export PS1='\w \$ '" >>"/etc/profile"
-echo "export PS1='\w \$ '" >>"/root/.bashrc"
+
+# Idempotent: only append PS1 if the exact line isn't present yet
+PS1_LINE="export PS1='\w \$ '"
+append_line_if_missing "$PS1_LINE" /etc/profile
+append_line_if_missing "$PS1_LINE" /root/.bashrc
 
 echo "Use .bashrc and .profile"
-echo "if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; if [ -f ~/.profile ]; then source ~/.profile; fi" >>/etc/profile
+# Idempotent: only append the source snippet if not already present
+SOURCE_LINE='if [ -f ~/.bashrc ]; then source ~/.bashrc; fi; if [ -f ~/.profile ]; then source ~/.profile; fi'
+append_line_if_missing "$SOURCE_LINE" /etc/profile
 
 echo "Remove root password"
 passwd -d root
@@ -61,14 +85,15 @@ echo "include /etc/chrony/chrony.conf" >/etc/chrony.conf
 
 echo "Setting up SSH"
 mkdir -p /etc/ssh
-cat <<EOF >>/etc/ssh/sshd_config
-PermitRootLogin yes
-PermitEmptyPasswords yes
-PasswordAuthentication yes
-EOF
+touch /etc/ssh/sshd_config
+# Idempotent: only append each directive if not already present
+for ssh_line in "PermitRootLogin yes" "PermitEmptyPasswords yes" "PasswordAuthentication yes"; do
+    append_line_if_missing "$ssh_line" /etc/ssh/sshd_config
+done
 
 echo "Increasing inotify watch limit"
-echo 'fs.inotify.max_user_watches=65536' | tee -a /etc/sysctl.conf
+# Idempotent: only append if not already present
+append_line_if_missing 'fs.inotify.max_user_watches=65536' /etc/sysctl.conf
 
 echo "Don't wait for ttyS0 (serial console kernel logs)"
 # This is required when the Firecracker kernel args has specified console=ttyS0
@@ -89,13 +114,16 @@ echo "Linking systemd to init"
 ln -sf /lib/systemd/systemd /usr/sbin/init
 
 echo "Unlocking immutable configuration"
-$BUSYBOX chattr -i /etc/resolv.conf
+# Idempotent: only unset immutable bit if currently set
+if is_immutable /etc/resolv.conf; then
+    $BUSYBOX chattr -i /etc/resolv.conf
+fi
 
 echo "Finished provisioning script"
 
-# Delete itself
-rm -rf /etc/init.d/rcS
-rm -rf /usr/local/bin/provision.sh
+# Delete itself (idempotent with -f: no error if already removed)
+rm -f /etc/init.d/rcS
+rm -f /usr/local/bin/provision.sh
 
 # Report successful provisioning
 printf "0" > "$RESULT_PATH"


### PR DESCRIPTION
Make the base template provisioning script safe to re-run without producing duplicated configuration lines or failing on already-applied state changes. This enables the same script to be executed multiple times against the same rootfs (e.g. when re-running the base phase of template builds) without drift or errors.

Non-idempotent behaviors addressed:

- chattr +i / -i on /etc/resolv.conf would fail (under set -eu) when the immutable bit was already in the target state. Both calls are now guarded by a new is_immutable helper that inspects lsattr output.

- PS1 exports were blindly appended to /etc/profile and /root/.bashrc with >>, producing duplicate lines on every run. They are now appended only when the exact line is not already present.

- The "source ~/.bashrc / ~/.profile" snippet appended to /etc/profile had the same duplication problem and is now guarded the same way.

- The sshd_config heredoc appended PermitRootLogin, PermitEmptyPasswords, and PasswordAuthentication directives on every invocation, producing repeated entries. The directives are now appended individually via a loop, each guarded against duplication. A touch ensures the file exists before grep on first run.

- fs.inotify.max_user_watches=65536 written to /etc/sysctl.conf via tee -a would duplicate on re-runs. Replaced with a guarded append.

- rm -rf on the self-deletion paths switched to rm -f; semantics are unchanged but intent is clearer for single-file removal.

Introduced three POSIX-sh helpers (compatible with the #!/bin/sh shebang and BusyBox sh / dash):

- is_package_installed <pkg> (pre-existing, relocated up)
- append_line_if_missing <line> <file>
- is_immutable <file>

Helpers are defined at the top of the script, before the first use site, so the immutable-bit check can leverage is_immutable.

Already-idempotent operations left unchanged: package install loop (skips when installed), passwd -d root, chrony config writes (use > truncate), systemctl mask invocations, rm -rf /etc/machine-id, ln -sf for the systemd init symlink, and the final RESULT_PATH write.

Verified with sh -n syntax check.