### PR TITLE
fix(api): correct VersionInfo.HasHugePages major-version check

### DIFF
--- a/packages/api/internal/sandbox/sandbox_features.go
+++ b/packages/api/internal/sandbox/sandbox_features.go
@@ -39,7 +39,7 @@ func (v *VersionInfo) Version() semver.Version {
 }
 
 func (v *VersionInfo) HasHugePages() bool {
-	if v.lastReleaseVersion.Major() >= 1 && v.lastReleaseVersion.Minor() >= 7 {
+	if v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 7) {
 		return true
 	}
 

--- a/packages/api/internal/sandbox/sandbox_features.go
+++ b/packages/api/internal/sandbox/sandbox_features.go
@@ -29,7 +29,9 @@ func NewVersionInfo(fcVersion string) (info VersionInfo, err error) {
 	}
 
 	info.lastReleaseVersion = *version
-	info.commitHash = parts[1]
+	if len(parts) > 1 {
+		info.commitHash = parts[1]
+	}
 
 	return info, nil
 }


### PR DESCRIPTION
## Summary

Extracted from #1896 to keep that PR focused.

The current `HasHugePages` check is buggy for Firecracker majors > 1:

```go
if v.lastReleaseVersion.Major() >= 1 && v.lastReleaseVersion.Minor() >= 7 {
```

For e.g. `v2.0.0`, this returns `false` because `Minor (0) < 7`, even though such a version obviously supports huge pages. Replace with the standard "≥ 1.7" semver comparison:

```go
if v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 7) {
```

No behaviour change for the only versions we currently ship (`v1.10`, `v1.12`, `v1.14`); only matters once we go past 1.x.

## Test plan
- [ ] `go test ./packages/api/internal/sandbox/...` passes locally (does pass).
- [ ] CI green.