### PR TITLE
feat(api): add VersionInfo.HasFreePageReporting

### DIFF
--- a/packages/api/internal/sandbox/sandbox_features.go
+++ b/packages/api/internal/sandbox/sandbox_features.go
@@ -45,3 +45,11 @@ func (v *VersionInfo) HasHugePages() bool {
 
 	return false
 }
+
+func (v *VersionInfo) HasFreePageReporting() bool {
+	if v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 14) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

Extracted from #1896 to shrink that PR.

Adds a `HasFreePageReporting()` helper on `sandbox.VersionInfo` — a feature-check for Firecracker's free-page-reporting (balloon) feature, which landed upstream in v1.14. Mirrors the existing `HasHugePages()` helper.

```go
func (v *VersionInfo) HasFreePageReporting() bool {
    if v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 14) {
        return true
    }

    return false
}
```

The helper is currently unused on `main` — the only caller lives on #1896 (`feat/free-page-reporting`). Landing it here first lets the feature PR focus on the UFFD / balloon wiring.

## Notes
- Depends on nothing. Independent of #2436 (the `HasHugePages` major-version fix), but uses the correct `Major() > 1 || …` form from the start.
- Pairs with #2436 — once both land, `feat/free-page-reporting` stops carrying this file and future main-merges become conflict-free on it.

## Test plan
- [x] `go test ./packages/api/internal/sandbox/...` green locally.
- [ ] CI green.