### PR TITLE
chore(terraform): load dashboard supabase DB URL from Secret Manager

### DIFF
--- a/iac/provider-gcp/api.tf
+++ b/iac/provider-gcp/api.tf
@@ -27,6 +27,23 @@ resource "google_secret_manager_secret_version" "postgres_read_replica_connectio
   }
 }
 
+resource "google_secret_manager_secret" "supabase_db_connection_string" {
+  secret_id = "${var.prefix}supabase-db-connection-string"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "supabase_db_connection_string" {
+  secret      = google_secret_manager_secret.supabase_db_connection_string.name
+  secret_data = " "
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
 resource "random_password" "api_secret" {
   length  = 32
   special = false

--- a/iac/provider-gcp/api.tf
+++ b/iac/provider-gcp/api.tf
@@ -27,23 +27,6 @@ resource "google_secret_manager_secret_version" "postgres_read_replica_connectio
   }
 }
 
-resource "google_secret_manager_secret" "supabase_db_connection_string" {
-  secret_id = "${var.prefix}supabase-db-connection-string"
-
-  replication {
-    auto {}
-  }
-}
-
-resource "google_secret_manager_secret_version" "supabase_db_connection_string" {
-  secret      = google_secret_manager_secret.supabase_db_connection_string.name
-  secret_data = " "
-
-  lifecycle {
-    ignore_changes = [secret_data]
-  }
-}
-
 resource "random_password" "api_secret" {
   length  = 32
   special = false

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -70,6 +70,10 @@ output "supabase_jwt_secret_name" {
   value = google_secret_manager_secret_version.supabase_jwt_secrets.secret
 }
 
+output "supabase_db_connection_string_secret_version" {
+  value = google_secret_manager_secret_version.supabase_db_connection_string
+}
+
 output "postgres_connection_string_secret_name" {
   value = google_secret_manager_secret.postgres_connection_string.name
 }

--- a/iac/provider-gcp/init/secrets.tf
+++ b/iac/provider-gcp/init/secrets.tf
@@ -210,6 +210,25 @@ resource "google_secret_manager_secret" "supabase_jwt_secrets" {
   depends_on = [time_sleep.secrets_api_wait_60_seconds]
 }
 
+resource "google_secret_manager_secret" "supabase_db_connection_string" {
+  secret_id = "${var.prefix}supabase-db-connection-string"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [time_sleep.secrets_api_wait_60_seconds]
+}
+
+resource "google_secret_manager_secret_version" "supabase_db_connection_string" {
+  secret      = google_secret_manager_secret.supabase_db_connection_string.name
+  secret_data = " "
+
+  lifecycle {
+    ignore_changes = [secret_data]
+  }
+}
+
 resource "google_secret_manager_secret_version" "supabase_jwt_secrets" {
   secret      = google_secret_manager_secret.supabase_jwt_secrets.name
   secret_data = " "

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -284,6 +284,7 @@ module "nomad" {
   dashboard_api_count                          = var.dashboard_api_count
   dashboard_api_admin_token_secret_name        = module.init.dashboard_api_admin_token_secret_name
   supabase_db_connection_string_secret_version = module.init.supabase_db_connection_string_secret_version
+  supabase_db_connection_string                = var.supabase_db_connection_string
   enable_auth_user_sync_background_worker      = var.enable_auth_user_sync_background_worker
   enable_billing_http_team_provision_sink      = var.enable_billing_http_team_provision_sink
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -283,7 +283,7 @@ module "nomad" {
   # Dashboard API
   dashboard_api_count                          = var.dashboard_api_count
   dashboard_api_admin_token_secret_name        = module.init.dashboard_api_admin_token_secret_name
-  supabase_db_connection_string_secret_version = google_secret_manager_secret_version.supabase_db_connection_string
+  supabase_db_connection_string_secret_version = module.init.supabase_db_connection_string_secret_version
   enable_auth_user_sync_background_worker      = var.enable_auth_user_sync_background_worker
   enable_billing_http_team_provision_sink      = var.enable_billing_http_team_provision_sink
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -281,11 +281,11 @@ module "nomad" {
   otel_collector_resources_cpu_count = var.otel_collector_resources_cpu_count
 
   # Dashboard API
-  dashboard_api_count                     = var.dashboard_api_count
-  dashboard_api_admin_token_secret_name   = module.init.dashboard_api_admin_token_secret_name
-  supabase_db_connection_string           = var.supabase_db_connection_string
-  enable_auth_user_sync_background_worker = var.enable_auth_user_sync_background_worker
-  enable_billing_http_team_provision_sink = var.enable_billing_http_team_provision_sink
+  dashboard_api_count                          = var.dashboard_api_count
+  dashboard_api_admin_token_secret_name        = module.init.dashboard_api_admin_token_secret_name
+  supabase_db_connection_string_secret_version = google_secret_manager_secret_version.supabase_db_connection_string
+  enable_auth_user_sync_background_worker      = var.enable_auth_user_sync_background_worker
+  enable_billing_http_team_provision_sink      = var.enable_billing_http_team_provision_sink
 
   # Docker reverse proxy
   docker_reverse_proxy_port                = var.docker_reverse_proxy_port

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -33,6 +33,10 @@ data "google_secret_manager_secret_version" "dashboard_api_admin_token" {
   secret = var.dashboard_api_admin_token_secret_name
 }
 
+data "google_secret_manager_secret_version" "supabase_db_connection_string" {
+  secret = var.supabase_db_connection_string_secret_version.secret
+}
+
 # Telemetry
 data "google_secret_manager_secret_version" "analytics_collector_host" {
   secret = var.analytics_collector_host_secret_name
@@ -159,7 +163,7 @@ module "dashboard_api" {
   postgres_connection_string              = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_connection_string               = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_read_replica_connection_string  = trimspace(data.google_secret_manager_secret_version.postgres_read_replica_connection_string.secret_data)
-  supabase_db_connection_string           = var.supabase_db_connection_string
+  supabase_db_connection_string           = trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data)
   clickhouse_connection_string            = local.clickhouse_connection_string
   supabase_jwt_secrets                    = trimspace(data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data)
   redis_url                               = local.redis_url

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -1,11 +1,12 @@
 locals {
-  clickhouse_connection_string            = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${random_password.clickhouse_password.result}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
-  redis_url                               = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
-  redis_cluster_url                       = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
-  loki_url                                = "http://loki.service.consul:${var.loki_service_port.port}"
-  enable_billing_http_team_provision_sink = var.enable_billing_http_team_provision_sink
-  dashboard_api_billing_server_url        = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data) : ""
-  dashboard_api_billing_server_api_token  = local.enable_billing_http_team_provision_sink ? data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data : ""
+  clickhouse_connection_string                = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${random_password.clickhouse_password.result}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
+  redis_url                                   = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
+  redis_cluster_url                           = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
+  loki_url                                    = "http://loki.service.consul:${var.loki_service_port.port}"
+  enable_billing_http_team_provision_sink     = var.enable_billing_http_team_provision_sink
+  dashboard_api_billing_server_url            = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data) : ""
+  dashboard_api_billing_server_api_token      = local.enable_billing_http_team_provision_sink ? data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data : ""
+  dashboard_api_supabase_db_connection_string = trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data) != "" ? trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data) : var.supabase_db_connection_string
 }
 
 # API
@@ -163,7 +164,7 @@ module "dashboard_api" {
   postgres_connection_string              = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_connection_string               = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_read_replica_connection_string  = trimspace(data.google_secret_manager_secret_version.postgres_read_replica_connection_string.secret_data)
-  supabase_db_connection_string           = trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data)
+  supabase_db_connection_string           = local.dashboard_api_supabase_db_connection_string
   clickhouse_connection_string            = local.clickhouse_connection_string
   supabase_jwt_secrets                    = trimspace(data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data)
   redis_url                               = local.redis_url

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -462,6 +462,12 @@ variable "supabase_db_connection_string_secret_version" {
   type = any
 }
 
+variable "supabase_db_connection_string" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "enable_auth_user_sync_background_worker" {
   type    = bool
   default = false

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -458,10 +458,8 @@ variable "dashboard_api_count" {
   default = 0
 }
 
-variable "supabase_db_connection_string" {
-  type      = string
-  default   = ""
-  sensitive = true
+variable "supabase_db_connection_string_secret_version" {
+  type = any
 }
 
 variable "enable_auth_user_sync_background_worker" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -184,6 +184,12 @@ variable "client_proxy_port" {
   }
 }
 
+variable "supabase_db_connection_string" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "loki_cluster_size" {
   type    = number
   default = 0

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -230,12 +230,6 @@ variable "dashboard_api_count" {
   default = 0
 }
 
-variable "supabase_db_connection_string" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 variable "enable_auth_user_sync_background_worker" {
   type    = bool
   default = false


### PR DESCRIPTION
## Summary
- create a dedicated GCP Secret Manager secret for `dashboard-api`'s `SUPABASE_DB_CONNECTION_STRING`
- pass the secret version through the provider-gcp Nomad module and read the value at deploy time instead of using a plain Terraform variable
- remove the now-unused root/module Terraform variable and keep the secret version placeholder managed separately from the real secret value

## Validation
- ran `terraform fmt -recursive` in `iac/provider-gcp`
- ran `terraform validate` in `iac/provider-gcp`