### PR TITLE
fix(block): fetch every chunk overlapping an unaligned Slice request

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/chunk.go
@@ -217,17 +217,20 @@ func (c *FullFetchChunker) Slice(ctx context.Context, off, length int64) ([]byte
 
 // fetchToCache ensures that the data at the given offset and length is available in the cache.
 func (c *FullFetchChunker) fetchToCache(ctx context.Context, off, length int64) error {
+	if length <= 0 {
+		return nil
+	}
+
 	var eg errgroup.Group
 
-	chunks := header.BlocksOffsets(length, storage.MemoryChunkSize)
+	// Determine which 4 MiB chunks overlap the requested range. The request can be
+	// unaligned and shorter than a chunk yet still straddle a chunk boundary, so we
+	// must iterate from the chunk containing `off` to the chunk containing the last
+	// requested byte (`off+length-1`).
+	firstChunkOff := header.BlockOffset(header.BlockIdx(off, storage.MemoryChunkSize), storage.MemoryChunkSize)
+	lastChunkOff := header.BlockOffset(header.BlockIdx(off+length-1, storage.MemoryChunkSize), storage.MemoryChunkSize)
 
-	startingChunk := header.BlockIdx(off, storage.MemoryChunkSize)
-	startingChunkOffset := header.BlockOffset(startingChunk, storage.MemoryChunkSize)
-
-	for _, chunkOff := range chunks {
-		// Ensure the closure captures the correct block offset.
-		fetchOff := startingChunkOffset + chunkOff
-
+	for fetchOff := firstChunkOff; fetchOff <= lastChunkOff; fetchOff += storage.MemoryChunkSize {
 		eg.Go(func() (err error) {
 			defer func() {
 				if r := recover(); r != nil {

--- a/packages/orchestrator/pkg/sandbox/block/chunk_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/chunk_test.go
@@ -163,3 +163,68 @@ func TestFullFetchChunker_DifferentChunksIndependent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data[off1:off1+testBlockSize], slice1)
 }
+
+// TestFullFetchChunker_SliceCrossesChunkBoundary verifies that Slice fetches
+// every 4 MiB chunk overlapping the requested range, including the case where
+// an unaligned `off` causes a request shorter than (or equal to) a chunk to
+// still straddle a chunk boundary.
+//
+// Background — the bug this regresses against:
+//
+//	The original fetchToCache derived the list of chunks to fetch from
+//	header.BlocksOffsets(length, MemoryChunkSize), i.e. "how many chunks does
+//	`length` bytes span?", offset from the chunk containing `off`. That count
+//	is correct only when `off` is chunk-aligned. For an unaligned `off`, a
+//	request that nominally fits in one chunk-worth of bytes can in fact
+//	straddle a boundary, so one (or more) additional chunk(s) need to be
+//	fetched. The bug surfaced as "failed to read from cache after ensuring
+//	data at X-Y: The requested bytes are not available on the device" because
+//	Cache.Slice would then try to read the second half of the request out of
+//	an un-fetched chunk.
+//
+// Each subtest below fails on the buggy implementation with that exact error
+// shape and passes once fetchToCache iterates over every chunk that overlaps
+// [off, off+length).
+func TestFullFetchChunker_SliceCrossesChunkBoundary(t *testing.T) {
+	t.Parallel()
+
+	const csz = int64(storage.MemoryChunkSize) // 4 MiB
+
+	// 4-chunk file so we can exercise requests that span up to 4 chunks.
+	size := int(csz * 4)
+	data := makeTestData(t, size)
+
+	cases := []struct {
+		name string
+		off  int64
+		len  int64
+	}{
+		{name: "unaligned spans 2 chunks (1B over boundary)", off: csz - 1, len: 2},
+		{name: "unaligned spans 2 chunks (real UFFD pattern, 2MiB)", off: csz - csz/4, len: csz / 2},
+		{name: "unaligned spans 2 chunks (request equals chunk size)", off: csz / 2, len: csz},
+		{name: "unaligned spans 3 chunks", off: csz - 1, len: csz + 2},
+		{name: "unaligned spans 4 chunks", off: csz / 2, len: 3 * csz},
+		{name: "unaligned ends one byte past chunk boundary", off: csz / 2, len: csz/2 + 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream := &fastUpstream{data: data, blockSize: testBlockSize}
+
+			chunker, err := NewFullFetchChunker(
+				int64(len(data)), testBlockSize,
+				upstream, t.TempDir()+"/cache",
+				newTestMetrics(t),
+			)
+			require.NoError(t, err)
+			defer chunker.Close()
+
+			slice, err := chunker.Slice(t.Context(), tc.off, tc.len)
+			require.NoError(t, err, "Slice(%d, %d)", tc.off, tc.len)
+			assert.Equal(t, data[tc.off:tc.off+tc.len], slice,
+				"Slice(%d, %d) returned wrong bytes", tc.off, tc.len)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`FullFetchChunker.fetchToCache` derived its list of chunks-to-fetch from `header.BlocksOffsets(length, MemoryChunkSize)` — i.e. *"how many chunks does `length` bytes span?"* — and then offset that count from the chunk containing `off`. That count is correct only when `off` is chunk-aligned. For an unaligned `off`, a request that nominally fits in one chunk-worth of bytes can in fact straddle a chunk boundary, so one (or more) additional chunks need to be fetched.

When this happened, `Cache.Slice`'s post-fetch lookup tried to read the second half of the request out of an un-fetched chunk and returned:

```
failed to read from cache after ensuring data at X-Y: The requested bytes are not available on the device
```

This surfaced in production UFFD logs as 2 MiB page faults at non-chunk-aligned offsets failing to serve.

## Fix

Iterate over every 4 MiB chunk that overlaps `[off, off+length)` — i.e. from the chunk containing `off` to the chunk containing `off+length-1` inclusive.

```go
firstChunkOff := header.BlockOffset(header.BlockIdx(off,            storage.MemoryChunkSize), storage.MemoryChunkSize)
lastChunkOff  := header.BlockOffset(header.BlockIdx(off+length-1,  storage.MemoryChunkSize), storage.MemoryChunkSize)
for fetchOff := firstChunkOff; fetchOff <= lastChunkOff; fetchOff += storage.MemoryChunkSize { ... }
```

Also early-returns when \`length <= 0\` (defensive; previously would fetch one chunk for a zero-length request).

## Repro

`TestFullFetchChunker_SliceCrossesChunkBoundary` covers six (off, length) shapes that straddle 1–3 chunk boundaries:

| sub-test | off | length |
| --- | --- | --- |
| 1B over boundary | csz - 1 | 2 |
| real UFFD pattern (2 MiB) | csz - csz/4 | csz/2 |
| request equals chunk size | csz/2 | csz |
| spans 3 chunks | csz - 1 | csz + 2 |
| spans 4 chunks | csz/2 | 3·csz |
| ends one byte past chunk boundary | csz/2 | csz/2 + 1 |

Each fails on \`main\` with the exact production error shape, e.g.:

\`\`\`
failed to read from cache after ensuring data at 3145728-5242880: The requested bytes are not available on the device
failed to read from cache after ensuring data at 4194303-4194305:    ... (1B over boundary)
failed to read from cache after ensuring data at 4194303-8388609:    ... (spans 3 chunks)
\`\`\`

All six pass with this change.

## Test plan

- [x] \`go test ./pkg/sandbox/block/ -run TestFullFetchChunker -count=1\` passes (locally verified).
- [x] All six new sub-tests fail on \`main\` with the production error shape (locally verified by stashing this commit and re-running the tests).
- [x] \`go vet ./pkg/sandbox/block/...\` clean.
- [x] \`go build ./...\` clean.