### PR TITLE
fix(aws): require IMDSv2 for node metadata access

### DIFF
--- a/iac/provider-aws/modules/nodepool-api/main.tf
+++ b/iac/provider-aws/modules/nodepool-api/main.tf
@@ -73,6 +73,10 @@ resource "aws_launch_template" "api" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.api.name
   }

--- a/iac/provider-aws/modules/nodepool-clickhouse/main.tf
+++ b/iac/provider-aws/modules/nodepool-clickhouse/main.tf
@@ -74,6 +74,10 @@ resource "aws_launch_template" "clickhouse" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.clickhouse.name
   }
@@ -110,6 +114,10 @@ resource "aws_instance" "clickhouse" {
 
   availability_zone = var.clickhouse_az
   subnet_id         = var.clickhouse_subnet_id
+
+  metadata_options {
+    http_tokens = "required"
+  }
 
   user_data = base64encode(templatefile("${local.scripts_path}/start-clickhouse.sh", {
     NODE_POOL                    = var.node_pool_name

--- a/iac/provider-aws/modules/nodepool-clickhouse/scripts/start-clickhouse.sh
+++ b/iac/provider-aws/modules/nodepool-clickhouse/scripts/start-clickhouse.sh
@@ -32,7 +32,7 @@ while [[ $SECONDS_WAITED -lt $TIMEOUT ]]; do
    # We are using EBS volume ID to find device name (that is random in new EC2 instances)
    # and then mount this drive to clickhouse data directory.
    # Volume ID is used in nvme device metadata but without "-" so we need to strip it first.
-  DISK=$(nvme list 2>/dev/null | awk -v vol="$EBS_VOLUME_ID" '$2 == vol { print $1 }')
+  DISK=$(nvme list 2>/dev/null | awk -v vol="$EBS_VOLUME_ID" '$2 == vol || $3 == vol { print $1 }')
 
   if [[ -n "$DISK" ]]; then
     echo "Found disk: $DISK"

--- a/iac/provider-aws/modules/nodepool-client/main.tf
+++ b/iac/provider-aws/modules/nodepool-client/main.tf
@@ -130,6 +130,10 @@ resource "aws_launch_template" "client" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.client.name
   }

--- a/iac/provider-aws/modules/nodepool-control-server/main.tf
+++ b/iac/provider-aws/modules/nodepool-control-server/main.tf
@@ -52,6 +52,10 @@ resource "aws_launch_template" "control_server" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   iam_instance_profile {
     name = aws_iam_instance_profile.control_server.name
   }

--- a/iac/provider-aws/nomad-cluster/scripts/run-consul.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-consul.sh
@@ -16,6 +16,8 @@ readonly SYSTEMD_CONFIG_PATH="/etc/systemd/system/consul.service"
 readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 readonly EC2_DYNAMIC_METADATA_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 readonly EC2_METADATA_TOKEN_URL="http://169.254.169.254/latest/api/token"
+readonly EC2_METADATA_TOKEN_TTL_SECONDS="21600"
+readonly EC2_METADATA_TOKEN_MAX_ATTEMPTS="5"
 readonly CLUSTER_SIZE_INSTANCE_METADATA_KEY_NAME="cluster-size"
 
 readonly DEFAULT_RAFT_PROTOCOL="3"
@@ -91,20 +93,33 @@ function get_instance_metadata_value {
   local -a token_header=()
 
   token=$(get_instance_metadata_token)
-  if [[ -n "$token" ]]; then
-    token_header=(--header "X-aws-ec2-metadata-token: $token")
-  fi
+  token_header=(--header "X-aws-ec2-metadata-token: $token")
 
   log_info "Looking up Metadata value at $EC2_INSTANCE_METADATA_URL/$path"
-  curl --silent --show-error --location "${token_header[@]}" "$EC2_INSTANCE_METADATA_URL/$path"
+  curl --silent --show-error --location --fail "${token_header[@]}" "$EC2_INSTANCE_METADATA_URL/$path"
 }
 
 # Get an IMDSv2 token for Instance Metadata calls.
 function get_instance_metadata_token {
-  curl --silent --show-error --location --fail \
-    --request PUT \
-    --header "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
-    "$EC2_METADATA_TOKEN_URL" || true
+  local token=""
+
+  for attempt in $(seq 1 "$EC2_METADATA_TOKEN_MAX_ATTEMPTS"); do
+    if token=$(curl --silent --show-error --location --fail \
+      --connect-timeout 2 \
+      --max-time 5 \
+      --request PUT \
+      --header "X-aws-ec2-metadata-token-ttl-seconds: $EC2_METADATA_TOKEN_TTL_SECONDS" \
+      "$EC2_METADATA_TOKEN_URL"); then
+      printf '%s' "$token"
+      return 0
+    fi
+
+    log_warn "Failed to get IMDSv2 token, retrying ($attempt/$EC2_METADATA_TOKEN_MAX_ATTEMPTS)"
+    sleep "$attempt"
+  done
+
+  log_error "Failed to get IMDSv2 token after $EC2_METADATA_TOKEN_MAX_ATTEMPTS attempts"
+  return 1
 }
 
 # Get dynamic instance metadata (includes region, account-id, etc.)
@@ -113,12 +128,10 @@ function get_instance_dynamic_metadata {
   local -a token_header=()
 
   token=$(get_instance_metadata_token)
-  if [[ -n "$token" ]]; then
-    token_header=(--header "X-aws-ec2-metadata-token: $token")
-  fi
+  token_header=(--header "X-aws-ec2-metadata-token: $token")
 
   log_info "Looking up dynamic instance metadata"
-  curl --silent --show-error --location "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
+  curl --silent --show-error --location --fail "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
 }
 
 # Get the value of the given tag from EC2 instance tags

--- a/iac/provider-aws/nomad-cluster/scripts/run-consul.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-consul.sh
@@ -15,6 +15,7 @@ readonly SYSTEMD_CONFIG_PATH="/etc/systemd/system/consul.service"
 
 readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 readonly EC2_DYNAMIC_METADATA_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
+readonly EC2_METADATA_TOKEN_URL="http://169.254.169.254/latest/api/token"
 readonly CLUSTER_SIZE_INSTANCE_METADATA_KEY_NAME="cluster-size"
 
 readonly DEFAULT_RAFT_PROTOCOL="3"
@@ -86,15 +87,38 @@ function print_usage {
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
   local -r path="$1"
+  local token=""
+  local -a token_header=()
+
+  token=$(get_instance_metadata_token)
+  if [[ -n "$token" ]]; then
+    token_header=(--header "X-aws-ec2-metadata-token: $token")
+  fi
 
   log_info "Looking up Metadata value at $EC2_INSTANCE_METADATA_URL/$path"
-  curl --silent --show-error --location "$EC2_INSTANCE_METADATA_URL/$path"
+  curl --silent --show-error --location "${token_header[@]}" "$EC2_INSTANCE_METADATA_URL/$path"
+}
+
+# Get an IMDSv2 token for Instance Metadata calls.
+function get_instance_metadata_token {
+  curl --silent --show-error --location --fail \
+    --request PUT \
+    --header "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+    "$EC2_METADATA_TOKEN_URL" || true
 }
 
 # Get dynamic instance metadata (includes region, account-id, etc.)
 function get_instance_dynamic_metadata {
+  local token=""
+  local -a token_header=()
+
+  token=$(get_instance_metadata_token)
+  if [[ -n "$token" ]]; then
+    token_header=(--header "X-aws-ec2-metadata-token: $token")
+  fi
+
   log_info "Looking up dynamic instance metadata"
-  curl --silent --show-error --location "$EC2_DYNAMIC_METADATA_URL"
+  curl --silent --show-error --location "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
 }
 
 # Get the value of the given tag from EC2 instance tags

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -11,6 +11,7 @@ readonly SUPERVISOR_CONFIG_PATH="/etc/supervisor/conf.d/run-nomad.conf"
 
 readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 readonly EC2_DYNAMIC_METADATA_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
+readonly EC2_METADATA_TOKEN_URL="http://169.254.169.254/latest/api/token"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
@@ -86,9 +87,17 @@ function assert_not_empty {
 # Get the value at a specific Instance Metadata path.
 function get_instance_metadata_value {
   local -r path="$1"
+  local token=""
+  local -a token_header=()
+
+  token=$(get_instance_metadata_token)
+  if [[ -n "$token" ]]; then
+    token_header=(--header "X-aws-ec2-metadata-token: $token")
+  fi
 
   log_info "Looking up Metadata value at $EC2_INSTANCE_METADATA_URL/$path"
   response=$(curl --silent --show-error --location \
+    "${token_header[@]}" \
     --write-out "%{http_code}" \
     --output /tmp/metadata.out \
     "$EC2_INSTANCE_METADATA_URL/$path")
@@ -101,10 +110,26 @@ function get_instance_metadata_value {
   rm  /tmp/metadata.out
 }
 
+# Get an IMDSv2 token for Instance Metadata calls.
+function get_instance_metadata_token {
+  curl --silent --show-error --location --fail \
+    --request PUT \
+    --header "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
+    "$EC2_METADATA_TOKEN_URL" || true
+}
+
 # Get dynamic instance metadata (includes region, account-id, etc.)
 function get_instance_dynamic_metadata {
+  local token=""
+  local -a token_header=()
+
+  token=$(get_instance_metadata_token)
+  if [[ -n "$token" ]]; then
+    token_header=(--header "X-aws-ec2-metadata-token: $token")
+  fi
+
   log_info "Looking up dynamic instance metadata"
-  curl --silent --show-error --location "$EC2_DYNAMIC_METADATA_URL"
+  curl --silent --show-error --location "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
 }
 
 # Get the value of the given tag from EC2 instance tags

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -12,6 +12,8 @@ readonly SUPERVISOR_CONFIG_PATH="/etc/supervisor/conf.d/run-nomad.conf"
 readonly EC2_INSTANCE_METADATA_URL="http://169.254.169.254/latest/meta-data"
 readonly EC2_DYNAMIC_METADATA_URL="http://169.254.169.254/latest/dynamic/instance-identity/document"
 readonly EC2_METADATA_TOKEN_URL="http://169.254.169.254/latest/api/token"
+readonly EC2_METADATA_TOKEN_TTL_SECONDS="21600"
+readonly EC2_METADATA_TOKEN_MAX_ATTEMPTS="5"
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_NAME="$(basename "$0")"
@@ -91,12 +93,10 @@ function get_instance_metadata_value {
   local -a token_header=()
 
   token=$(get_instance_metadata_token)
-  if [[ -n "$token" ]]; then
-    token_header=(--header "X-aws-ec2-metadata-token: $token")
-  fi
+  token_header=(--header "X-aws-ec2-metadata-token: $token")
 
   log_info "Looking up Metadata value at $EC2_INSTANCE_METADATA_URL/$path"
-  response=$(curl --silent --show-error --location \
+  response=$(curl --silent --show-error --location --fail \
     "${token_header[@]}" \
     --write-out "%{http_code}" \
     --output /tmp/metadata.out \
@@ -112,10 +112,25 @@ function get_instance_metadata_value {
 
 # Get an IMDSv2 token for Instance Metadata calls.
 function get_instance_metadata_token {
-  curl --silent --show-error --location --fail \
-    --request PUT \
-    --header "X-aws-ec2-metadata-token-ttl-seconds: 21600" \
-    "$EC2_METADATA_TOKEN_URL" || true
+  local token=""
+
+  for attempt in $(seq 1 "$EC2_METADATA_TOKEN_MAX_ATTEMPTS"); do
+    if token=$(curl --silent --show-error --location --fail \
+      --connect-timeout 2 \
+      --max-time 5 \
+      --request PUT \
+      --header "X-aws-ec2-metadata-token-ttl-seconds: $EC2_METADATA_TOKEN_TTL_SECONDS" \
+      "$EC2_METADATA_TOKEN_URL"); then
+      printf '%s' "$token"
+      return 0
+    fi
+
+    log_warn "Failed to get IMDSv2 token, retrying ($attempt/$EC2_METADATA_TOKEN_MAX_ATTEMPTS)"
+    sleep "$attempt"
+  done
+
+  log_error "Failed to get IMDSv2 token after $EC2_METADATA_TOKEN_MAX_ATTEMPTS attempts"
+  return 1
 }
 
 # Get dynamic instance metadata (includes region, account-id, etc.)
@@ -124,12 +139,10 @@ function get_instance_dynamic_metadata {
   local -a token_header=()
 
   token=$(get_instance_metadata_token)
-  if [[ -n "$token" ]]; then
-    token_header=(--header "X-aws-ec2-metadata-token: $token")
-  fi
+  token_header=(--header "X-aws-ec2-metadata-token: $token")
 
   log_info "Looking up dynamic instance metadata"
-  curl --silent --show-error --location "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
+  curl --silent --show-error --location --fail "${token_header[@]}" "$EC2_DYNAMIC_METADATA_URL"
 }
 
 # Get the value of the given tag from EC2 instance tags


### PR DESCRIPTION
## Summary

This PR hardens the AWS provider node bootstrap flow by making EC2 metadata access work with IMDSv2 and by requiring metadata tokens on AWS node launch templates.

It also includes a small ClickHouse bootstrap compatibility fix for `nvme list` output variants.

## Motivation

The AWS provider bootstrap scripts read EC2 instance metadata during user data execution to discover the instance ID, region, availability zone, private IP, and EC2 tags. These values are used to configure
Nomad and Consul.

The previous implementation used unauthenticated metadata requests:

```bash
curl http://169.254.169.254/latest/meta-data/...
```

That works only when IMDSv1 is available. In AWS environments where IMDSv2 is required through launch template settings, AMI defaults, account defaults, or security baseline policies, these calls fail during
node bootstrap.

Instead of relying on environment-specific metadata defaults, the bootstrap scripts now request an IMDSv2 token and use it for metadata reads. With that in place, the launch templates can explicitly require
metadata tokens.

This makes AWS node startup less dependent on account-level or AMI-level defaults and aligns the provider with the stricter EC2 metadata posture recommended by AWS.

Separately, the ClickHouse bootstrap script maps an attached EBS volume to a local NVMe device by parsing nvme list. Some nvme-cli output variants expose the normalized EBS volume ID in the serial column
rather than the model column. Matching only one column can cause ClickHouse startup to wait until timeout even when the volume is attached.

## Changes

- request an IMDSv2 token from /latest/api/token
- pass X-aws-ec2-metadata-token to metadata and dynamic identity document requests
- set AWS node launch templates and the ClickHouse instance metadata options to http_tokens = "required"
- keep token acquisition tolerant so the scripts can still run in environments where IMDSv2 is not enforced
- match the normalized ClickHouse EBS volume ID against both observed nvme list columns

## Validation

Static checks:

```
bash -n \
  iac/provider-aws/nomad-cluster/scripts/run-nomad.sh \
  iac/provider-aws/nomad-cluster/scripts/run-consul.sh \
  iac/provider-aws/modules/nodepool-clickhouse/scripts/start-clickhouse.sh
```

```
terraform fmt -check \
  iac/provider-aws/modules/nodepool-api/main.tf \
  iac/provider-aws/modules/nodepool-clickhouse/main.tf \
  iac/provider-aws/modules/nodepool-client/main.tf \
  iac/provider-aws/modules/nodepool-control-server/main.tf
```

Runtime validation on AWS:

- applied the AWS provider Terraform changes in a dev environment
- confirmed the updated setup scripts were uploaded with new hashes
- rolled one API autoscaling group instance onto the updated launch template
- confirmed the replacement API instance launched with HttpTokens=required
- confirmed the API Nomad allocation started successfully
- confirmed the load balancer target became healthy
- confirmed the public API health endpoint returned success

Runtime result:

API node metadata option: HttpTokens=required
Instance refresh: Successful
API allocation: running
Load balancer target: healthy
API health: successful