### PR TITLE
chore(lint): enable perfsprint.errorf to enforce errors.New over `fmt.Errorf`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
     - noinlineerr
     - nonamedreturns
     - nosprintfhostport
-    - perfsprint
     - prealloc
     - predeclared
     - tagliatelle
@@ -115,6 +114,22 @@ linters:
       # false failures in CI. See
       # https://github.com/golangci/golangci-lint/issues/3228
       allow-unused: true
+
+    perfsprint:
+      # Scoped to `errorf` only: enforce `errors.New` over `fmt.Errorf("static")`.
+      # Other perfsprint checks are intentionally disabled to keep this rule surgical.
+      # Can be broadened later in a follow-up.
+      error-format: true
+      errorf: true
+      err-error: false
+      integer-format: false
+      int-conversion: false
+      string-format: false
+      sprintf1: false
+      strconcat: false
+      bool-format: false
+      hex-format: false
+      concat-loop: false
 
     gocritic:
       disabled-checks:

--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -41,7 +41,6 @@ require (
 	github.com/oapi-codegen/gin-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1
-	github.com/pkg/errors v0.9.1
 	github.com/posthog/posthog-go v0.0.0-20230801140217-d607812dee69
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
@@ -292,6 +291,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/pressly/goose/v3 v3.26.0 // indirect

--- a/packages/api/internal/handlers/auth.go
+++ b/packages/api/internal/handlers/auth.go
@@ -84,7 +84,7 @@ func findTeam(teams []*types.TeamWithDefault, teamID *string) (*types.Team, erro
 		}
 	}
 
-	return nil, fmt.Errorf("default team not found")
+	return nil, errors.New("default team not found")
 }
 
 func (a *APIStore) getUserTeams(ctx context.Context, userID uuid.UUID) ([]*types.TeamWithDefault, *api.APIError) {
@@ -154,7 +154,7 @@ func (a *APIStore) resolveTemplateAndTeam(
 		return nil, nil, &api.APIError{
 			Code:      http.StatusForbidden,
 			ClientMsg: fmt.Sprintf("You don't have access to template '%s'", identifier),
-			Err:       fmt.Errorf("user does not have access to template's team"),
+			Err:       errors.New("user does not have access to template's team"),
 		}
 	}
 

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -575,7 +575,7 @@ func validateEgressRules(allowOut, denyOut []string) *api.APIError {
 		if len(allowedDomains) > 0 && !hasBlockAll {
 			return &api.APIError{
 				Code:      http.StatusBadRequest,
-				Err:       fmt.Errorf("allow out contains domains but deny out is missing 0.0.0.0/0 (ALL_TRAFFIC)"),
+				Err:       errors.New("allow out contains domains but deny out is missing 0.0.0.0/0 (ALL_TRAFFIC)"),
 				ClientMsg: ErrMsgDomainsRequireBlockAll,
 			}
 		}

--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -168,7 +169,7 @@ func (o *Orchestrator) syncClusterNode(ctx context.Context, node *nodemanager.No
 
 	cluster, clusterFound := o.clusters.GetClusterById(node.ClusterID)
 	if !clusterFound {
-		return fmt.Errorf("cluster not found")
+		return errors.New("cluster not found")
 	}
 
 	// We want to find not just node, but explicitly node with expected service instance ID

--- a/packages/api/internal/orchestrator/keep_alive.go
+++ b/packages/api/internal/orchestrator/keep_alive.go
@@ -3,7 +3,6 @@ package orchestrator
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -15,7 +14,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-var errMaxInstanceLengthExceeded = fmt.Errorf("max instance length exceeded")
+var errMaxInstanceLengthExceeded = errors.New("max instance length exceeded")
 
 func (o *Orchestrator) KeepAliveFor(ctx context.Context, teamID uuid.UUID, sandboxID string, duration time.Duration, allowShorter bool) (*sandbox.Sandbox, *api.APIError) {
 	now := time.Now()

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -2,6 +2,7 @@ package placement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel"
@@ -19,7 +20,7 @@ import (
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/api/internal/orchestrator/placement")
 
-var errSandboxCreateFailed = fmt.Errorf("failed to create a new sandbox, if the problem persists, contact us")
+var errSandboxCreateFailed = errors.New("failed to create a new sandbox, if the problem persists, contact us")
 
 // Algorithm defines the interface for sandbox placement strategies.
 // Implementations should choose an optimal node based on available resources
@@ -53,7 +54,7 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 			telemetry.ReportEvent(ctx, "Placing sandbox on the preferred node", telemetry.WithNodeID(node.ID))
 		} else {
 			if len(nodesExcluded) >= len(clusterNodes) {
-				return nil, fmt.Errorf("no nodes available")
+				return nil, errors.New("no nodes available")
 			}
 
 			node, err = algorithm.chooseNode(ctx, clusterNodes, nodesExcluded, nodemanager.SandboxResources{CPUs: sbxRequest.GetSandbox().GetVcpu(), MiBMemory: sbxRequest.GetSandbox().GetRamMb()}, buildMachineInfo, labelFilteringEnabled, requiredLabels)

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K.go
@@ -2,7 +2,7 @@ package placement
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"math"
 	"math/rand"
 	"sync"
@@ -132,7 +132,7 @@ func (b *BestOfK) chooseNode(_ context.Context, nodes []*nodemanager.Node, exclu
 	}
 
 	if bestNode == nil {
-		return nil, fmt.Errorf("no node available")
+		return nil, errors.New("no node available")
 	}
 
 	return bestNode, nil

--- a/packages/api/internal/sandbox/storage/memory/operations.go
+++ b/packages/api/internal/sandbox/storage/memory/operations.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -195,7 +196,7 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		case sandbox.AllowedTransitions[currentState][newState]:
 			return startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: opts.Action})
 		default:
-			return false, nil, fmt.Errorf("unexpected state transition")
+			return false, nil, errors.New("unexpected state transition")
 		}
 	}
 

--- a/packages/api/internal/team/limits.go
+++ b/packages/api/internal/team/limits.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -33,7 +34,7 @@ func LimitResources(limits *types.TeamLimits, cpuCount, memoryMB *int32) (int64,
 
 		if cpu != 1 && cpu%2 != 0 {
 			return 0, 0, &api.APIError{
-				Err:       fmt.Errorf("CPU count must be 1 or an even number"),
+				Err:       errors.New("CPU count must be 1 or an even number"),
 				ClientMsg: "CPU count must be 1 or an even number",
 				Code:      http.StatusBadRequest,
 			}
@@ -61,7 +62,7 @@ func LimitResources(limits *types.TeamLimits, cpuCount, memoryMB *int32) (int64,
 
 		if ramMB%2 != 0 {
 			return 0, 0, &api.APIError{
-				Err:       fmt.Errorf("user provided memory size isn't divisible by 2"),
+				Err:       errors.New("user provided memory size isn't divisible by 2"),
 				ClientMsg: "Memory must be divisible by 2",
 				Code:      http.StatusBadRequest,
 			}

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -292,9 +292,9 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 	// Validate input: exactly one source must be provided
 	switch {
 	case hasImage && hasTemplate:
-		return fmt.Errorf("cannot specify both fromImage and fromTemplate")
+		return errors.New("cannot specify both fromImage and fromTemplate")
 	case !hasImage && !hasTemplate:
-		return fmt.Errorf("must specify either fromImage or fromTemplate")
+		return errors.New("must specify either fromImage or fromTemplate")
 	case hasTemplate:
 		identifier, tag, err := id.ParseName(*fromTemplate)
 		if err != nil {

--- a/packages/api/internal/template-manager/template_manager_test.go
+++ b/packages/api/internal/template-manager/template_manager_test.go
@@ -2,10 +2,10 @@ package template_manager
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	templatemanagergrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -51,7 +51,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 				logger.L().Error(ctx, "error when setting build status to failed after waiting for too long", zap.Error(err), logger.WithBuildID(buildID.String()), logger.WithTemplateID(templateID))
 			}
 
-			return fmt.Errorf("build is in waiting state for too long, failing it")
+			return errors.New("build is in waiting state for too long, failing it")
 		}
 
 		// just wait for next sync

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -2,6 +2,7 @@ package template_manager
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"time"
 
@@ -51,7 +52,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 				logger.L().Error(ctx, "error when setting build status to failed after waiting for too long", zap.Error(err), logger.WithBuildID(buildID.String()), logger.WithTemplateID(templateID))
 			}
 
-			return errors.New("build is in waiting state for too long, failing it")
+			return stderrors.New("build is in waiting state for too long, failing it")
 		}
 
 		// just wait for next sync
@@ -59,7 +60,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 	}
 
 	if nodeID == nil {
-		return errors.New("build is not assigned to a node, but it should be")
+		return stderrors.New("build is not assigned to a node, but it should be")
 	}
 
 	checker := &PollBuildStatus{
@@ -169,7 +170,7 @@ func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 	}
 
 	if status == nil {
-		return errors.New("nil status") // this should never happen
+		return stderrors.New("nil status") // this should never happen
 	}
 
 	// debug log the status
@@ -182,7 +183,7 @@ func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 
 func (c *PollBuildStatus) dispatchBasedOnStatus(ctx context.Context, status *templatemanagergrpc.TemplateBuildStatusResponse) (bool, error) {
 	if status == nil {
-		return false, errors.New("nil status")
+		return false, stderrors.New("nil status")
 	}
 	switch status.GetStatus() {
 	case templatemanagergrpc.TemplateBuildState_Failed:
@@ -197,7 +198,7 @@ func (c *PollBuildStatus) dispatchBasedOnStatus(ctx context.Context, status *tem
 		// build completed
 		meta := status.GetMetadata()
 		if meta == nil {
-			return false, errors.New("nil metadata")
+			return false, stderrors.New("nil metadata")
 		}
 
 		err := c.client.SetFinished(ctx, c.buildID, int64(meta.GetRootfsSizeKey()), meta.GetEnvdVersionKey())

--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -2,13 +2,12 @@ package template_manager
 
 import (
 	"context"
-	stderrors "errors"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/flowchartsman/retry"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
@@ -52,7 +51,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 				logger.L().Error(ctx, "error when setting build status to failed after waiting for too long", zap.Error(err), logger.WithBuildID(buildID.String()), logger.WithTemplateID(templateID))
 			}
 
-			return stderrors.New("build is in waiting state for too long, failing it")
+			return errors.New("build is in waiting state for too long, failing it")
 		}
 
 		// just wait for next sync
@@ -60,7 +59,7 @@ func (tm *TemplateManager) BuildStatusSync(ctx context.Context, buildID uuid.UUI
 	}
 
 	if nodeID == nil {
-		return stderrors.New("build is not assigned to a node, but it should be")
+		return errors.New("build is not assigned to a node, but it should be")
 	}
 
 	checker := &PollBuildStatus{
@@ -155,14 +154,14 @@ func (e terminalError) Error() string {
 
 func newTerminalError(err error) error {
 	return terminalError{
-		err: retry.Stop(errors.WithStack(err)),
+		err: retry.Stop(err),
 	}
 }
 
 func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 	status, err := c.client.GetStatus(ctx, c.buildID, c.templateID, c.clusterID, c.nodeID)
 	if err != nil && errors.Is(err, context.DeadlineExceeded) {
-		return errors.Wrap(err, "context deadline exceeded")
+		return fmt.Errorf("context deadline exceeded: %w", err)
 	} else if err != nil { // retry only on context deadline exceeded
 		c.logger.Error(ctx, "terminal error when polling build status", zap.Error(err))
 
@@ -170,7 +169,7 @@ func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 	}
 
 	if status == nil {
-		return stderrors.New("nil status") // this should never happen
+		return errors.New("nil status") // this should never happen
 	}
 
 	// debug log the status
@@ -183,14 +182,14 @@ func (c *PollBuildStatus) setStatus(ctx context.Context) error {
 
 func (c *PollBuildStatus) dispatchBasedOnStatus(ctx context.Context, status *templatemanagergrpc.TemplateBuildStatusResponse) (bool, error) {
 	if status == nil {
-		return false, stderrors.New("nil status")
+		return false, errors.New("nil status")
 	}
 	switch status.GetStatus() {
 	case templatemanagergrpc.TemplateBuildState_Failed:
 		// build failed
 		err := c.client.SetStatus(ctx, c.buildID, types.BuildStatusGroupFailed, status.GetReason())
 		if err != nil {
-			return false, errors.Wrap(err, "error when setting build status")
+			return false, fmt.Errorf("error when setting build status: %w", err)
 		}
 
 		return true, nil
@@ -198,12 +197,12 @@ func (c *PollBuildStatus) dispatchBasedOnStatus(ctx context.Context, status *tem
 		// build completed
 		meta := status.GetMetadata()
 		if meta == nil {
-			return false, stderrors.New("nil metadata")
+			return false, errors.New("nil metadata")
 		}
 
 		err := c.client.SetFinished(ctx, c.buildID, int64(meta.GetRootfsSizeKey()), meta.GetEnvdVersionKey())
 		if err != nil {
-			return false, errors.Wrap(err, "error when finishing build")
+			return false, fmt.Errorf("error when finishing build: %w", err)
 		}
 
 		return true, nil
@@ -234,7 +233,7 @@ func (c *PollBuildStatus) checkBuildStatus(ctx context.Context) (bool, error) {
 
 	buildCompleted, err := c.dispatchBasedOnStatus(ctx, c.status)
 	if err != nil {
-		return false, errors.Wrap(err, "error when dispatching build status")
+		return false, fmt.Errorf("error when dispatching build status: %w", err)
 	}
 
 	return buildCompleted, nil

--- a/packages/api/internal/utils/sandboxes_list.go
+++ b/packages/api/internal/utils/sandboxes_list.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"slices"
@@ -65,7 +66,7 @@ func ParseCursor(cursor string) (time.Time, string, error) {
 
 	parts := strings.Split(string(decoded), "__")
 	if len(parts) != 2 {
-		return time.Time{}, "", fmt.Errorf("invalid cursor format")
+		return time.Time{}, "", errors.New("invalid cursor format")
 	}
 
 	cursorTime, err := time.Parse(time.RFC3339Nano, parts[0])
@@ -148,7 +149,7 @@ func parseFilters(query string) (map[string]string, error) {
 	for filter := range strings.SplitSeq(query, "&") {
 		parts := strings.Split(filter, "=")
 		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid key value pair in query")
+			return nil, errors.New("invalid key value pair in query")
 		}
 
 		key, err := url.QueryUnescape(parts[0])

--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -150,7 +150,7 @@ func (s *AuthService[T]) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.C
 		var zero T
 
 		return zero, &APIError{
-			Err:       fmt.Errorf("user ID has invalid type"),
+			Err:       errors.New("user ID has invalid type"),
 			ClientMsg: "Backend authentication failed",
 			Code:      http.StatusInternalServerError,
 		}

--- a/packages/clickhouse/pkg/utils/validate.go
+++ b/packages/clickhouse/pkg/utils/validate.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +19,7 @@ func ValidateRange(start time.Time, end time.Time) (time.Time, time.Time, error)
 
 	// Validate time range parameters
 	if start.After(end) {
-		return start, end, fmt.Errorf("start time cannot be after end time")
+		return start, end, errors.New("start time cannot be after end time")
 	}
 
 	return start, end, nil

--- a/packages/client-proxy/internal/proxy/paused_sandbox_resumer_grpc.go
+++ b/packages/client-proxy/internal/proxy/paused_sandbox_resumer_grpc.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,7 +24,7 @@ type grpcPausedSandboxResumer struct {
 func NewGrpcPausedSandboxResumer(address string) (PausedSandboxResumer, error) {
 	// Client-proxy uses this gRPC client to trigger ResumeSandbox when needed.
 	if strings.TrimSpace(address) == "" {
-		return nil, fmt.Errorf("api grpc address is required")
+		return nil, errors.New("api grpc address is required")
 	}
 
 	conn, err := grpc.NewClient(

--- a/packages/dashboard-api/internal/api/api_auth_test.go
+++ b/packages/dashboard-api/internal/api/api_auth_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +98,7 @@ func TestAdminBootstrapRoute_AcceptsAdminTokenOnly(t *testing.T) {
 			sharedauth.NewSupabaseTokenAuthenticator(func(_ context.Context, _ *gin.Context, _ string) (uuid.UUID, *sharedauth.APIError) {
 				supabaseCalled = true
 
-				return uuid.Nil, &sharedauth.APIError{Code: http.StatusUnauthorized, ClientMsg: "unexpected", Err: fmt.Errorf("unexpected supabase auth call")}
+				return uuid.Nil, &sharedauth.APIError{Code: http.StatusUnauthorized, ClientMsg: "unexpected", Err: errors.New("unexpected supabase auth call")}
 			}),
 		},
 		nil,

--- a/packages/dashboard-api/internal/cfg/model.go
+++ b/packages/dashboard-api/internal/cfg/model.go
@@ -1,7 +1,7 @@
 package cfg
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/caarlos0/env/v11"
 )
@@ -40,7 +40,7 @@ func Parse() (Config, error) {
 	}
 
 	if err == nil && config.RedisURL == "" && config.RedisClusterURL == "" {
-		err = fmt.Errorf("at least one of REDIS_URL or REDIS_CLUSTER_URL must be set")
+		err = errors.New("at least one of REDIS_URL or REDIS_CLUSTER_URL must be set")
 	}
 
 	return config, err

--- a/packages/dashboard-api/internal/handlers/builds_list.go
+++ b/packages/dashboard-api/internal/handlers/builds_list.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -208,7 +209,7 @@ func parseBuildsCursor(cursor *api.BuildsCursor) (time.Time, uuid.UUID, error) {
 
 	parts := strings.SplitN(*cursor, "|", 2)
 	if len(parts) != 2 {
-		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor format")
+		return time.Time{}, uuid.Nil, errors.New("invalid cursor format")
 	}
 
 	cursorTime, err := parseCursorTime(parts[0])

--- a/packages/docker-reverse-proxy/internal/cache/auth.go
+++ b/packages/docker-reverse-proxy/internal/cache/auth.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -34,7 +35,7 @@ func New() *AuthCache {
 // Get returns the auth token for the given teamID and e2bToken.
 func (c *AuthCache) Get(e2bToken string) (*AccessTokenData, error) {
 	if e2bToken == "" {
-		return nil, fmt.Errorf("e2bToken is empty")
+		return nil, errors.New("e2bToken is empty")
 	}
 
 	item := c.cache.Get(e2bToken)

--- a/packages/docker-reverse-proxy/internal/handlers/token.go
+++ b/packages/docker-reverse-proxy/internal/handlers/token.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -44,7 +45,7 @@ func (a *APIStore) GetToken(w http.ResponseWriter, r *http.Request) error {
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte("invalid access token"))
 
-		return fmt.Errorf("invalid access token")
+		return errors.New("invalid access token")
 	}
 
 	scope := r.URL.Query().Get("scope")

--- a/packages/envd/internal/api/auth.go
+++ b/packages/envd/internal/api/auth.go
@@ -41,7 +41,7 @@ func (a *API) WithAuthorization(handler http.Handler) http.Handler {
 			if !a.accessToken.Equals(authHeader) && !allowedPath {
 				a.logger.Error().Msg("Trying to access secured envd without correct access token")
 
-				err := fmt.Errorf("unauthorized access, please provide a valid access token or method signing if supported")
+				err := errors.New("unauthorized access, please provide a valid access token or method signing if supported")
 				jsonError(w, http.StatusUnauthorized, err)
 
 				return
@@ -83,14 +83,14 @@ func (a *API) validateSigning(r *http.Request, signature *string, signatureExpir
 	tokenFromHeader := r.Header.Get(accessTokenHeader)
 	if tokenFromHeader != "" {
 		if !a.accessToken.Equals(tokenFromHeader) {
-			return fmt.Errorf("access token present in header but does not match")
+			return errors.New("access token present in header but does not match")
 		}
 
 		return nil
 	}
 
 	if signature == nil {
-		return fmt.Errorf("missing signature query parameter")
+		return errors.New("missing signature query parameter")
 	}
 
 	// Empty string is used when no username is provided and the default user should be used
@@ -114,14 +114,14 @@ func (a *API) validateSigning(r *http.Request, signature *string, signatureExpir
 
 	// signature validation
 	if expectedSignature != *signature {
-		return fmt.Errorf("invalid signature")
+		return errors.New("invalid signature")
 	}
 
 	// signature expiration
 	if signatureExpiration != nil {
 		exp := int64(*signatureExpiration)
 		if exp < time.Now().Unix() {
-			return fmt.Errorf("signature is already expired")
+			return errors.New("signature is already expired")
 		}
 	}
 

--- a/packages/envd/internal/api/compose.go
+++ b/packages/envd/internal/api/compose.go
@@ -30,13 +30,13 @@ func (a *API) PostFilesCompose(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(req.SourcePaths) == 0 {
-		jsonError(w, http.StatusBadRequest, fmt.Errorf("source_paths must not be empty"))
+		jsonError(w, http.StatusBadRequest, errors.New("source_paths must not be empty"))
 
 		return
 	}
 
 	if req.Destination == "" {
-		jsonError(w, http.StatusBadRequest, fmt.Errorf("destination is required"))
+		jsonError(w, http.StatusBadRequest, errors.New("destination is required"))
 
 		return
 	}
@@ -121,7 +121,7 @@ func (a *API) PostFilesCompose(w http.ResponseWriter, r *http.Request) {
 	destFile, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
 	if err != nil {
 		if errors.Is(err, syscall.ENOSPC) {
-			jsonError(w, http.StatusInsufficientStorage, fmt.Errorf("not enough disk space available"))
+			jsonError(w, http.StatusInsufficientStorage, errors.New("not enough disk space available"))
 
 			return
 		}
@@ -163,7 +163,7 @@ func (a *API) PostFilesCompose(w http.ResponseWriter, r *http.Request) {
 			os.Remove(tmpPath)
 
 			if errors.Is(err, syscall.ENOSPC) {
-				jsonError(w, http.StatusInsufficientStorage, fmt.Errorf("not enough disk space available"))
+				jsonError(w, http.StatusInsufficientStorage, errors.New("not enough disk space available"))
 
 				return
 			}

--- a/packages/envd/internal/api/download.go
+++ b/packages/envd/internal/api/download.go
@@ -126,7 +126,7 @@ func (a *API) GetFiles(w http.ResponseWriter, r *http.Request, params GetFilesPa
 		r.Header.Get("If-Range") != ""
 	if hasRangeOrConditional {
 		if !isIdentityAcceptable(r) {
-			errMsg = fmt.Errorf("identity encoding not acceptable for Range or conditional request")
+			errMsg = errors.New("identity encoding not acceptable for Range or conditional request")
 			errorCode = http.StatusNotAcceptable
 			jsonError(w, errorCode, errMsg)
 

--- a/packages/envd/internal/api/upload.go
+++ b/packages/envd/internal/api/upload.go
@@ -22,7 +22,7 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/utils"
 )
 
-var ErrNoDiskSpace = fmt.Errorf("not enough disk space available")
+var ErrNoDiskSpace = errors.New("not enough disk space available")
 
 func processFile(r *http.Request, path string, part io.Reader, uid, gid int, logger zerolog.Logger) (int, error) {
 	logger.Debug().
@@ -324,7 +324,7 @@ func (a *API) handleMultipartUpload(r *http.Request, u *user.User, uid, gid int,
 
 func (a *API) handleRawUpload(r *http.Request, u *user.User, uid, gid int, operationID string, params PostFilesParams) (UploadSuccess, int, error) {
 	if params.Path == nil {
-		return nil, http.StatusBadRequest, fmt.Errorf("path query parameter is required for raw body upload")
+		return nil, http.StatusBadRequest, errors.New("path query parameter is required for raw body upload")
 	}
 
 	filePath, err := permissions.ExpandAndResolve(*params.Path, u, a.defaults.Workdir)

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,7 +82,7 @@ func getMMDSToken(ctx context.Context, client *http.Client) (string, error) {
 	token := string(body)
 
 	if len(token) == 0 {
-		return "", fmt.Errorf("mmds token is an empty string")
+		return "", errors.New("mmds token is an empty string")
 	}
 
 	return token, nil

--- a/packages/envd/internal/permissions/authenticate.go
+++ b/packages/envd/internal/permissions/authenticate.go
@@ -2,7 +2,7 @@ package permissions
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"os/user"
 
 	"connectrpc.com/authn"
@@ -32,7 +32,7 @@ func GetAuthUser(ctx context.Context, defaultUser string) (*user.User, error) {
 	if !ok {
 		username, err := execcontext.ResolveDefaultUsername(nil, defaultUser)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeUnauthenticated, fmt.Errorf("no user specified"))
+			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("no user specified"))
 		}
 
 		u, err := GetUser(username)

--- a/packages/envd/internal/services/filesystem/watch.go
+++ b/packages/envd/internal/services/filesystem/watch.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -90,13 +91,13 @@ func (s Service) watchHandler(ctx context.Context, req *connect.Request[rpc.Watc
 			return ctx.Err()
 		case chErr, ok := <-w.Errors:
 			if !ok {
-				return connect.NewError(connect.CodeInternal, fmt.Errorf("watcher error channel closed"))
+				return connect.NewError(connect.CodeInternal, errors.New("watcher error channel closed"))
 			}
 
 			return connect.NewError(connect.CodeInternal, fmt.Errorf("watcher error: %w", chErr))
 		case e, ok := <-w.Events:
 			if !ok {
-				return connect.NewError(connect.CodeInternal, fmt.Errorf("watcher event channel closed"))
+				return connect.NewError(connect.CodeInternal, errors.New("watcher event channel closed"))
 			}
 
 			// One event can have multiple operations.

--- a/packages/envd/internal/services/filesystem/watch_sync.go
+++ b/packages/envd/internal/services/filesystem/watch_sync.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -57,7 +58,7 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 				return
 			case chErr, ok := <-w.Errors:
 				if !ok {
-					fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("watcher error channel closed"))
+					fw.Error = connect.NewError(connect.CodeInternal, errors.New("watcher error channel closed"))
 
 					return
 				}
@@ -67,7 +68,7 @@ func CreateFileWatcher(ctx context.Context, watchPath string, recursive bool, op
 				return
 			case e, ok := <-w.Events:
 				if !ok {
-					fw.Error = connect.NewError(connect.CodeInternal, fmt.Errorf("watcher event channel closed"))
+					fw.Error = connect.NewError(connect.CodeInternal, errors.New("watcher event channel closed"))
 
 					return
 				}

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -347,7 +347,7 @@ func getProcType(req *rpc.StartRequest) cgroups.ProcessType {
 
 func (p *Handler) SendSignal(signal syscall.Signal) error {
 	if p.cmd.Process == nil {
-		return fmt.Errorf("process not started")
+		return errors.New("process not started")
 	}
 
 	if signal == syscall.SIGKILL || signal == syscall.SIGTERM {
@@ -359,7 +359,7 @@ func (p *Handler) SendSignal(signal syscall.Signal) error {
 
 func (p *Handler) ResizeTty(size *pty.Winsize) error {
 	if p.tty == nil {
-		return fmt.Errorf("tty not assigned to process")
+		return errors.New("tty not assigned to process")
 	}
 
 	return pty.Setsize(p.tty, size)
@@ -367,14 +367,14 @@ func (p *Handler) ResizeTty(size *pty.Winsize) error {
 
 func (p *Handler) WriteStdin(data []byte) error {
 	if p.tty != nil {
-		return fmt.Errorf("tty assigned to process — input should be written to the pty, not the stdin")
+		return errors.New("tty assigned to process — input should be written to the pty, not the stdin")
 	}
 
 	p.stdinMu.Lock()
 	defer p.stdinMu.Unlock()
 
 	if p.stdin == nil {
-		return fmt.Errorf("stdin not enabled or closed")
+		return errors.New("stdin not enabled or closed")
 	}
 
 	_, err := p.stdin.Write(data)
@@ -389,7 +389,7 @@ func (p *Handler) WriteStdin(data []byte) error {
 // Only works for non-PTY processes.
 func (p *Handler) CloseStdin() error {
 	if p.tty != nil {
-		return fmt.Errorf("cannot close stdin for PTY process — send Ctrl+D (0x04) instead")
+		return errors.New("cannot close stdin for PTY process — send Ctrl+D (0x04) instead")
 	}
 
 	p.stdinMu.Lock()
@@ -409,7 +409,7 @@ func (p *Handler) CloseStdin() error {
 
 func (p *Handler) WriteTty(data []byte) error {
 	if p.tty == nil {
-		return fmt.Errorf("tty not assigned to process — input should be written to the stdin, not the tty")
+		return errors.New("tty not assigned to process — input should be written to the stdin, not the tty")
 	}
 
 	_, err := p.tty.Write(data)

--- a/packages/local-dev/seed-local-database.go
+++ b/packages/local-dev/seed-local-database.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 
-	"github.com/e2b-dev/infra/packages/db/pkg/auth"
-	"github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	authdb "github.com/e2b-dev/infra/packages/db/pkg/auth"
+	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/keys"
 )
 
@@ -189,12 +189,12 @@ func createTokenHash(prefix, accessToken string) (string, keys.MaskedIdentifier,
 	tokenWithoutPrefix := strings.TrimPrefix(accessToken, prefix)
 	accessTokenBytes, err := hex.DecodeString(tokenWithoutPrefix)
 	if err != nil {
-		return "", keys.MaskedIdentifier{}, fmt.Errorf("failed to hex decode string")
+		return "", keys.MaskedIdentifier{}, errors.New("failed to hex decode string")
 	}
 	accessTokenHash := hasher.Hash(accessTokenBytes)
 	accessTokenMask, err := keys.MaskKey(prefix, tokenWithoutPrefix)
 	if err != nil {
-		return "", keys.MaskedIdentifier{}, fmt.Errorf("failed to mask key")
+		return "", keys.MaskedIdentifier{}, errors.New("failed to mask key")
 	}
 
 	return accessTokenHash, accessTokenMask, nil

--- a/packages/nomad-nodepool-apm/plugin/plugin.go
+++ b/packages/nomad-nodepool-apm/plugin/plugin.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -111,7 +112,7 @@ func (p *NodePoolPlugin) Query(query string, _ sdk.TimeRange) (sdk.TimestampedMe
 	nodePool := query
 
 	if nodePool == "" {
-		return nil, fmt.Errorf("node pool name is required as query parameter")
+		return nil, errors.New("node pool name is required as query parameter")
 	}
 
 	p.logger.Debug("querying node count for node pool", "node_pool", nodePool)

--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -109,7 +109,7 @@ func (o *osFileBlob) Exists(_ context.Context) (bool, error) {
 }
 
 func (o *osFileBlob) Put(_ context.Context, _ []byte) error {
-	return fmt.Errorf("not implemented")
+	return errors.New("not implemented")
 }
 
 func NewHeaderFromPath(ctx context.Context, from, headerPath string) (*header.Header, error) {

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -115,7 +115,7 @@ func setupEnv(ctx context.Context, storagePath, sandboxDir, kernel, fc string, l
 
 	if localMode {
 		if os.Geteuid() != 0 {
-			return fmt.Errorf("local mode requires root")
+			return errors.New("local mode requires root")
 		}
 
 		dataDir := storagePath

--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -237,7 +238,7 @@ type templateInfo struct {
 func resolveTemplateID(input string) (string, error) {
 	apiKey := os.Getenv("E2B_API_KEY")
 	if apiKey == "" {
-		return "", fmt.Errorf("E2B_API_KEY environment variable required for -template flag")
+		return "", errors.New("E2B_API_KEY environment variable required for -template flag")
 	}
 
 	// Determine API URL

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -1041,7 +1042,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 		return fmt.Errorf("storage provider: %w", err)
 	}
 	if persistence == nil {
-		return fmt.Errorf("storage provider is nil")
+		return errors.New("storage provider is nil")
 	}
 
 	if verbose {

--- a/packages/orchestrator/cmd/simulate-gcs-traffic/files.go
+++ b/packages/orchestrator/cmd/simulate-gcs-traffic/files.go
@@ -82,7 +82,7 @@ func newFiles(paths []fileInfo, chunkSize int64, allowRepeatReads bool) *files {
 
 func (f *files) nextRead() (string, int64, error) {
 	if len(f.paths) == 0 {
-		return "", 0, fmt.Errorf("no files found")
+		return "", 0, errors.New("no files found")
 	}
 
 	idx := f.rand.Intn(len(f.paths))

--- a/packages/orchestrator/cmd/simulate-nfs-traffic/files.go
+++ b/packages/orchestrator/cmd/simulate-nfs-traffic/files.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"math/rand"
@@ -61,7 +62,7 @@ type files struct {
 
 func (f *files) selectFile() (string, error) {
 	if len(f.paths) == 0 {
-		return "", fmt.Errorf("no files found")
+		return "", errors.New("no files found")
 	}
 
 	idx := f.rand.Intn(len(f.paths))

--- a/packages/orchestrator/go.mod
+++ b/packages/orchestrator/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/ngrok/firewall_toolkit v0.0.18
 	github.com/oapi-codegen/gin-middleware v1.0.2
 	github.com/oapi-codegen/runtime v1.4.0
-	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/shirou/gopsutil/v4 v4.25.9
 	github.com/soheilhy/cmux v0.1.5
@@ -270,6 +269,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect

--- a/packages/orchestrator/pkg/chrooted/fs.go
+++ b/packages/orchestrator/pkg/chrooted/fs.go
@@ -1,7 +1,7 @@
 package chrooted
 
 import (
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -180,7 +180,7 @@ func (fs *Chrooted) Readlink(link string) (target string, err error) {
 }
 
 func (fs *Chrooted) Chroot(_ string) (*Chrooted, error) {
-	return nil, fmt.Errorf("chroot not supported")
+	return nil, errors.New("chroot not supported")
 }
 
 func (fs *Chrooted) Root() string {

--- a/packages/orchestrator/pkg/chrooted/mountns.go
+++ b/packages/orchestrator/pkg/chrooted/mountns.go
@@ -2,6 +2,7 @@ package chrooted
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"runtime"
@@ -47,7 +48,7 @@ type mountNS struct {
 	doneCh chan struct{}
 }
 
-var ErrNamespaceClosed = fmt.Errorf("namespace is closed")
+var ErrNamespaceClosed = errors.New("namespace is closed")
 
 func (ns *mountNS) errorIfClosed() error {
 	ns.mu.Lock()

--- a/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
+++ b/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -78,7 +79,7 @@ func (h *APIStore) Logs(c *gin.Context) {
 // validatePayloadSandboxID checks if the payload contains correct instanceID to prevent slow requests to contaminating the logs of other sandboxes.
 func (h *APIStore) validatePayloadSandboxID(payload map[string]any, sbxID string) error {
 	if payload["instanceID"] == nil {
-		return fmt.Errorf("missing sandboxID in logs payload")
+		return errors.New("missing sandboxID in logs payload")
 	}
 
 	payloadSandboxID, ok := payload["instanceID"].(string)

--- a/packages/orchestrator/pkg/nfsproxy/recovery/main.go
+++ b/packages/orchestrator/pkg/nfsproxy/recovery/main.go
@@ -2,6 +2,7 @@ package recovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 
@@ -81,7 +82,7 @@ func tryRecovery(ctx context.Context, name string) {
 	}
 }
 
-var ErrPanic = fmt.Errorf("panic")
+var ErrPanic = errors.New("panic")
 
 func deferErrRecovery(ctx context.Context, name string, perr *error) {
 	if r := recover(); r != nil { //nolint:revive // always called via defer

--- a/packages/orchestrator/pkg/sandbox/block/empty.go
+++ b/packages/orchestrator/pkg/sandbox/block/empty.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -68,5 +69,5 @@ func (e *Empty) Header() *header.Header {
 }
 
 func (e *Empty) UpdateSize() error {
-	return fmt.Errorf("update size not supported for empty block")
+	return errors.New("update size not supported for empty block")
 }

--- a/packages/orchestrator/pkg/sandbox/block/overlay.go
+++ b/packages/orchestrator/pkg/sandbox/block/overlay.go
@@ -52,7 +52,7 @@ func (o *Overlay) ReadAt(ctx context.Context, p []byte, off int64) (int, error) 
 
 func (o *Overlay) EjectCache() (*Cache, error) {
 	if !o.cacheEjected.CompareAndSwap(false, true) {
-		return nil, fmt.Errorf("cache already ejected")
+		return nil, errors.New("cache already ejected")
 	}
 
 	return o.cache, nil
@@ -63,7 +63,7 @@ func (o *Overlay) EjectCache() (*Cache, error) {
 //
 // When we are implementing this we might want to just enforce the length to be the same as the block size.
 func (o *Overlay) Slice(_ context.Context, _, _ int64) ([]byte, error) {
-	return nil, fmt.Errorf("not implemented")
+	return nil, errors.New("not implemented")
 }
 
 func (o *Overlay) WriteAt(p []byte, off int64) (int, error) {

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	mathrand "math/rand/v2"
@@ -134,7 +135,7 @@ func (r *errorAfterNReader) Read(p []byte) (int, error) {
 	}
 
 	if r.pos >= r.failAfter {
-		return 0, fmt.Errorf("simulated upstream error")
+		return 0, errors.New("simulated upstream error")
 	}
 
 	end := min(r.pos+r.blockSize, len(r.data))

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -2,6 +2,7 @@ package cgroup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -90,7 +91,7 @@ func (h *CgroupHandle) ReleaseCgroupFD() error {
 // Returns error if the handle is nil (unexpected) or stats cannot be read.
 func (h *CgroupHandle) GetStats(ctx context.Context) (*Stats, error) {
 	if h == nil {
-		return nil, fmt.Errorf("cgroup handle is nil")
+		return nil, errors.New("cgroup handle is nil")
 	}
 
 	if h.noop {

--- a/packages/orchestrator/pkg/sandbox/fc/process.go
+++ b/packages/orchestrator/pkg/sandbox/fc/process.go
@@ -249,7 +249,7 @@ func (p *Process) configure(
 	}
 
 	startCtx, cancelStart := context.WithCancelCause(ctx)
-	defer cancelStart(fmt.Errorf("fc finished starting"))
+	defer cancelStart(errors.New("fc finished starting"))
 
 	go func() {
 		defer stderrWriter.Close()
@@ -606,7 +606,7 @@ func (p *Process) Resume(
 
 func (p *Process) Pid() (int, error) {
 	if p.cmd.Process == nil {
-		return 0, fmt.Errorf("fc process not started")
+		return 0, errors.New("fc process not started")
 	}
 
 	return p.cmd.Process.Pid, nil
@@ -626,7 +626,7 @@ func getProcessStatus(pid int) ([]string, error) {
 
 func (p *Process) Stop(ctx context.Context) error {
 	if p.cmd.Process == nil {
-		return fmt.Errorf("fc process not started")
+		return errors.New("fc process not started")
 	}
 
 	// Always remove the metrics FIFO, even if the process already exited,

--- a/packages/orchestrator/pkg/sandbox/health.go
+++ b/packages/orchestrator/pkg/sandbox/health.go
@@ -25,7 +25,7 @@ func (c *Checks) getHealth(ctx context.Context, timeout time.Duration) (bool, er
 	response, err := sandboxHttpClient.Do(request)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return false, fmt.Errorf("health check timed out")
+			return false, errors.New("health check timed out")
 		}
 
 		return false, err

--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -101,7 +102,7 @@ func (m *Map) GetByHostPort(hostPort string) (*Sandbox, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("sandbox not found")
+	return nil, errors.New("sandbox not found")
 }
 
 func (m *Map) Insert(ctx context.Context, sbx *Sandbox) {

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -195,14 +195,14 @@ func (d *Dispatch) Handle(ctx context.Context) error {
 			request.Length = binary.BigEndian.Uint32(header[24:28])
 
 			if request.Magic != NBDRequestMagic {
-				return fmt.Errorf("received invalid MAGIC")
+				return errors.New("received invalid MAGIC")
 			}
 
 			switch request.Type {
 			case NBDCmdDisconnect:
 				return nil // All done
 			case NBDCmdFlush:
-				return fmt.Errorf("not supported: Flush")
+				return errors.New("not supported: Flush")
 			case NBDCmdRead:
 				rp += 28
 				err := d.cmdRead(ctx, request.Handle, request.From, request.Length)

--- a/packages/orchestrator/pkg/sandbox/network/host.go
+++ b/packages/orchestrator/pkg/sandbox/network/host.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/vishvananda/netlink"
@@ -50,5 +51,5 @@ func getDefaultGateway(ctx context.Context) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("cannot find default gateway")
+	return "", errors.New("cannot find default gateway")
 }

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -119,7 +120,7 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 	}
 
 	if slot == nil {
-		return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
+		return nil, errors.New("failed to acquire IP slot: no empty slots found")
 	}
 
 	return slot, nil

--- a/packages/orchestrator/pkg/sandbox/network/storage_local.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_local.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,10 +65,10 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 	for {
 		select {
 		case <-acquireTimeoutCtx.Done():
-			return nil, fmt.Errorf("failed to acquire IP slot: timeout")
+			return nil, errors.New("failed to acquire IP slot: timeout")
 		default:
 			if len(s.acquiredNs) > s.slotsSize {
-				return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
+				return nil, errors.New("failed to acquire IP slot: no empty slots found")
 			}
 
 			slotIdx++

--- a/packages/orchestrator/pkg/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_memory.go
@@ -2,7 +2,7 @@ package network
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"strconv"
 	"sync"
 )
@@ -40,7 +40,7 @@ func (s *StorageMemory) Acquire(_ context.Context) (*Slot, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("failed to acquire IP slot: no empty slots found")
+	return nil, errors.New("failed to acquire IP slot: no empty slots found")
 }
 
 func (s *StorageMemory) Release(ips *Slot) error {

--- a/packages/orchestrator/pkg/sandbox/rootfs/direct.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/direct.go
@@ -76,7 +76,7 @@ func (o *DirectProvider) ExportDiff(
 	defer childSpan.End()
 
 	if !o.closed.CompareAndSwap(false, true) {
-		return nil, fmt.Errorf("direct provider close is already in progress")
+		return nil, errors.New("direct provider close is already in progress")
 	}
 
 	defer func() {
@@ -97,7 +97,7 @@ func (o *DirectProvider) ExportDiff(
 	select {
 	case <-o.finishedOperations:
 	case <-ctx.Done():
-		return nil, fmt.Errorf("timeout waiting for overlay device to be released")
+		return nil, errors.New("timeout waiting for overlay device to be released")
 	}
 	telemetry.ReportEvent(ctx, "sandbox stopped")
 

--- a/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
@@ -99,7 +99,7 @@ func (o *NBDProvider) ExportDiff(
 			logger.L().Warn(ctx, "error closing cache", zap.Error(closeErr))
 		}
 
-		return nil, fmt.Errorf("timeout waiting for overlay device to be released")
+		return nil, errors.New("timeout waiting for overlay device to be released")
 	}
 	telemetry.ReportEvent(ctx, "sandbox stopped")
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -861,7 +861,7 @@ func (f *Factory) ResumeSandbox(
 	})
 
 	uffdStartCtx, cancelUffdStartCtx := context.WithCancelCause(ctx)
-	defer cancelUffdStartCtx(fmt.Errorf("uffd finished starting"))
+	defer cancelUffdStartCtx(errors.New("uffd finished starting"))
 	go func() {
 		uffdWaitErr := fcUffd.Exit().Wait()
 
@@ -1338,7 +1338,7 @@ func (s *Sandbox) WaitForExit(ctx context.Context) error {
 
 	select {
 	case <-time.After(timeout):
-		return fmt.Errorf("waiting for exit took too long")
+		return errors.New("waiting for exit took too long")
 	case <-ctx.Done():
 		return nil
 	case <-s.exit.Done():
@@ -1378,7 +1378,7 @@ func (s *Sandbox) WaitForEnvd(
 		select {
 		// Ensure the syncing takes at most timeout seconds.
 		case <-time.After(timeout):
-			cancel(fmt.Errorf("syncing took too long"))
+			cancel(errors.New("syncing took too long"))
 		case <-ctx.Done():
 			return
 		case <-s.process.Exit.Done():

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
@@ -2,6 +2,7 @@ package peerclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync/atomic"
@@ -105,7 +106,7 @@ func openPeerBlobStream(
 	}
 
 	if !checkPeerAvailability(msg.GetAvailability(), uploaded) {
-		return nil, fmt.Errorf("peer not available for blob stream")
+		return nil, errors.New("peer not available for blob stream")
 	}
 
 	first := msg.GetData()

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
@@ -150,7 +150,7 @@ func openPeerSeekableStream(
 	}
 
 	if !checkPeerAvailability(msg.GetAvailability(), uploaded) {
-		return nil, fmt.Errorf("peer not available for seekable stream")
+		return nil, errors.New("peer not available for seekable stream")
 	}
 
 	first := msg.GetData()

--- a/packages/orchestrator/pkg/sandbox/template/peerserver/resolve.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerserver/resolve.go
@@ -2,6 +2,7 @@ package peerserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
@@ -10,7 +11,7 @@ import (
 )
 
 // ErrUnknownFile is returned when the requested file name is not recognised.
-var ErrUnknownFile = fmt.Errorf("unknown file")
+var ErrUnknownFile = errors.New("unknown file")
 
 // ResolveSeekable maps (buildID, fileName) to a SeekableSource.
 // Supported file names: memfile, rootfs.ext4.

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -57,7 +57,7 @@ const (
 
 func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequest) (_ *orchestrator.SandboxCreateResponse, createErr error) {
 	// set max request timeout for this request
-	ctx, cancel := context.WithTimeoutCause(ctx, requestTimeout, fmt.Errorf("request timed out"))
+	ctx, cancel := context.WithTimeoutCause(ctx, requestTimeout, errors.New("request timed out"))
 	defer cancel()
 
 	// set up tracing
@@ -410,7 +410,7 @@ func (s *Server) List(ctx context.Context, _ *emptypb.Empty) (*orchestrator.Sand
 }
 
 func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteRequest) (*emptypb.Empty, error) {
-	ctx, cancel := context.WithTimeoutCause(ctxConn, requestTimeout, fmt.Errorf("request timed out"))
+	ctx, cancel := context.WithTimeoutCause(ctxConn, requestTimeout, errors.New("request timed out"))
 	defer cancel()
 
 	ctx, childSpan := tracer.Start(ctx, "sandbox-delete")

--- a/packages/orchestrator/pkg/service/machineinfo/main.go
+++ b/packages/orchestrator/pkg/service/machineinfo/main.go
@@ -1,6 +1,7 @@
 package machineinfo
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 
@@ -53,5 +54,5 @@ func Detect() (MachineInfo, error) {
 		}, nil
 	}
 
-	return MachineInfo{}, fmt.Errorf("unable to detect CPU platform from any source")
+	return MachineInfo{}, errors.New("unable to detect CPU platform from any source")
 }

--- a/packages/orchestrator/pkg/tcpfirewall/utils.go
+++ b/packages/orchestrator/pkg/tcpfirewall/utils.go
@@ -1,7 +1,7 @@
 package tcpfirewall
 
 import (
-	"fmt"
+	"errors"
 	"net"
 	"syscall"
 	"unsafe"
@@ -12,7 +12,7 @@ import (
 func getOriginalDst(conn net.Conn) (net.IP, int, error) {
 	tcpConn, ok := conn.(*net.TCPConn)
 	if !ok {
-		return nil, 0, fmt.Errorf("not a TCP connection")
+		return nil, 0, errors.New("not a TCP connection")
 	}
 
 	rawConn, err := tcpConn.SyscallConn()

--- a/packages/orchestrator/pkg/template/build/commands/run.go
+++ b/packages/orchestrator/pkg/template/build/commands/run.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
@@ -30,7 +31,7 @@ func (r *Run) Execute(
 	args := step.GetArgs()
 	// args: [command optional_user]
 	if len(args) < 1 {
-		return metadata.Context{}, fmt.Errorf("RUN requires command argument")
+		return metadata.Context{}, errors.New("RUN requires command argument")
 	}
 
 	originalMetadata := cmdMetadata

--- a/packages/orchestrator/pkg/template/build/commands/user.go
+++ b/packages/orchestrator/pkg/template/build/commands/user.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.uber.org/zap/zapcore"
@@ -30,7 +31,7 @@ func (u *User) Execute(
 	args := step.GetArgs()
 	// args: [username, optional_add_to_sudo]
 	if len(args) < 1 {
-		return metadata.Context{}, fmt.Errorf("USER requires a username argument")
+		return metadata.Context{}, errors.New("USER requires a username argument")
 	}
 
 	userArg := args[0]

--- a/packages/orchestrator/pkg/template/build/commands/workdir.go
+++ b/packages/orchestrator/pkg/template/build/commands/workdir.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ func (w *Workdir) Execute(
 	args := step.GetArgs()
 	// args: [path]
 	if len(args) < 1 {
-		return metadata.Context{}, fmt.Errorf("WORKDIR requires a path argument")
+		return metadata.Context{}, errors.New("WORKDIR requires a path argument")
 	}
 
 	workDir := defaultRelativeToAbsoluteWorkdir

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,7 +36,7 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 	defer tuneSpan.End()
 
 	if blockSize < inodesRatio {
-		return fmt.Errorf("block size must be greater than inodes ratio")
+		return errors.New("block size must be greater than inodes ratio")
 	}
 
 	cmd := exec.CommandContext(ctx,
@@ -359,7 +360,7 @@ func parseFreeBlocks(debugfsOutput string) (int64, error) {
 	re := regexp.MustCompile(`Free blocks:\s+(\d+)`)
 	matches := re.FindStringSubmatch(debugfsOutput)
 	if len(matches) < 2 {
-		return 0, fmt.Errorf("could not find free blocks in debugfs output")
+		return 0, errors.New("could not find free blocks in debugfs output")
 	}
 	freeBlocks, err := strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {
@@ -374,7 +375,7 @@ func parseReservedBlocks(debugfsOutput string) (int64, error) {
 	re := regexp.MustCompile(`Reserved block count:\s+(\d+)`)
 	matches := re.FindStringSubmatch(debugfsOutput)
 	if len(matches) < 2 {
-		return 0, fmt.Errorf("could not find reserved blocks in debugfs output")
+		return 0, errors.New("could not find reserved blocks in debugfs output")
 	}
 	reservedBlocks, err := strconv.ParseInt(matches[1], 10, 64)
 	if err != nil {

--- a/packages/orchestrator/pkg/template/build/core/oci/auth/aws.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/auth/aws.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -50,7 +51,7 @@ func (p *AWSAuthProvider) GetAuthOption(ctx context.Context) (remote.Option, err
 	}
 
 	if len(token.AuthorizationData) == 0 {
-		return nil, fmt.Errorf("no ECR authorization data returned")
+		return nil, errors.New("no ECR authorization data returned")
 	}
 
 	// Decode the authorization token
@@ -63,7 +64,7 @@ func (p *AWSAuthProvider) GetAuthOption(ctx context.Context) (remote.Option, err
 	// Parse the token (format is username:password)
 	parts := strings.SplitN(string(decodedToken), ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid ECR token format")
+		return nil, errors.New("invalid ECR token format")
 	}
 
 	return remote.WithAuth(&authn.Basic{

--- a/packages/orchestrator/pkg/template/build/phases/base/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/builder.go
@@ -322,7 +322,7 @@ func (bb *BaseBuilder) Layer(
 		tm, err := bb.index.Cached(ctx, bb.Config.FromTemplate.GetBuildID())
 		if err != nil {
 			if errors.Is(err, storage.ErrObjectNotExist) {
-				return phases.LayerResult{}, phases.NewPhaseBuildError(bb.Metadata(), fmt.Errorf("error getting base template, you may need to rebuild it first"))
+				return phases.LayerResult{}, phases.NewPhaseBuildError(bb.Metadata(), errors.New("error getting base template, you may need to rebuild it first"))
 			}
 
 			return phases.LayerResult{}, fmt.Errorf("error getting base template: %w", err)

--- a/packages/orchestrator/pkg/template/build/phases/phase.go
+++ b/packages/orchestrator/pkg/template/build/phases/phase.go
@@ -138,7 +138,7 @@ func validateLayer(
 	layer LayerResult,
 ) (err error) {
 	if layer.Hash == "" {
-		err = errors.Join(err, fmt.Errorf("layer hash is empty"))
+		err = errors.Join(err, errors.New("layer hash is empty"))
 	}
 
 	return errors.Join(err, validateMetadata(layer.Metadata))
@@ -157,13 +157,13 @@ func validateTemplate(
 	metadata metadata.TemplateMetadata,
 ) (err error) {
 	if metadata.BuildID == "" {
-		err = errors.Join(err, fmt.Errorf("template build ID is empty"))
+		err = errors.Join(err, errors.New("template build ID is empty"))
 	}
 	if metadata.KernelVersion == "" {
-		err = errors.Join(err, fmt.Errorf("template kernel version is empty"))
+		err = errors.Join(err, errors.New("template kernel version is empty"))
 	}
 	if metadata.FirecrackerVersion == "" {
-		err = errors.Join(err, fmt.Errorf("template firecracker version is empty"))
+		err = errors.Join(err, errors.New("template firecracker version is empty"))
 	}
 
 	return err
@@ -173,10 +173,10 @@ func validateContext(
 	context metadata.Context,
 ) (err error) {
 	if context.User == "" {
-		err = errors.Join(err, fmt.Errorf("context user is empty"))
+		err = errors.Join(err, errors.New("context user is empty"))
 	}
 	if context.WorkDir != nil && *context.WorkDir == "" {
-		err = errors.Join(err, fmt.Errorf("context working dir is empty"))
+		err = errors.Join(err, errors.New("context working dir is empty"))
 	}
 
 	return err

--- a/packages/orchestrator/pkg/template/server/template_status.go
+++ b/packages/orchestrator/pkg/template/server/template_status.go
@@ -2,10 +2,9 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
-
-	"github.com/pkg/errors"
 
 	template_manager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 )
@@ -23,7 +22,7 @@ func (s *ServerStore) TemplateBuildStatus(ctx context.Context, in *template_mana
 
 	buildInfo, err := s.buildCache.Get(in.GetBuildID())
 	if err != nil {
-		return nil, errors.Wrap(err, "error while getting build info, maybe already expired")
+		return nil, fmt.Errorf("error while getting build info, maybe already expired: %w", err)
 	}
 
 	limit := maxLogEntriesPerRequest

--- a/packages/shared/pkg/artifacts-registry/registry_aws.go
+++ b/packages/shared/pkg/artifacts-registry/registry_aws.go
@@ -111,7 +111,7 @@ func (g *AWSArtifactsRegistry) getAuthToken(ctx context.Context) (*authn.Basic, 
 	}
 
 	if len(res.AuthorizationData) == 0 {
-		return nil, fmt.Errorf("no aws ecr auth token found")
+		return nil, errors.New("no aws ecr auth token found")
 	}
 
 	authData := res.AuthorizationData[0]
@@ -123,7 +123,7 @@ func (g *AWSArtifactsRegistry) getAuthToken(ctx context.Context) (*authn.Basic, 
 	// split into username and password
 	parts := strings.SplitN(string(decodedToken), ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid aws ecr auth token")
+		return nil, errors.New("invalid aws ecr auth token")
 	}
 
 	username := parts[0]

--- a/packages/shared/pkg/cache/redis_test.go
+++ b/packages/shared/pkg/cache/redis_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -338,7 +339,7 @@ func TestRedisCache_RedisRefresh_ErrorKeepsStaleValue(t *testing.T) {
 	result, err := rc.GetOrSet(t.Context(), key, func(_ context.Context, _ string) (testValue, error) {
 		callCount.Add(1)
 
-		return testValue{}, fmt.Errorf("database unavailable")
+		return testValue{}, errors.New("database unavailable")
 	})
 
 	require.NoError(t, err)

--- a/packages/shared/pkg/dockerhub/repository_aws.go
+++ b/packages/shared/pkg/dockerhub/repository_aws.go
@@ -3,6 +3,7 @@ package dockerhub
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -64,7 +65,7 @@ func (g *AWSRemoteRepository) getAuthToken(ctx context.Context) (authn.Authentic
 	}
 
 	if len(res.AuthorizationData) == 0 {
-		return nil, fmt.Errorf("no aws ecr auth token found")
+		return nil, errors.New("no aws ecr auth token found")
 	}
 
 	authData := res.AuthorizationData[0]
@@ -76,7 +77,7 @@ func (g *AWSRemoteRepository) getAuthToken(ctx context.Context) (authn.Authentic
 	// split into username and password
 	parts := strings.SplitN(string(decodedToken), ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid aws ecr auth token")
+		return nil, errors.New("invalid aws ecr auth token")
 	}
 
 	username := parts[0]

--- a/packages/shared/pkg/factories/redis.go
+++ b/packages/shared/pkg/factories/redis.go
@@ -97,7 +97,7 @@ func NewRedisClient(ctx context.Context, config RedisConfig) (redis.UniversalCli
 			if !certPool.AppendCertsFromPEM(cert) {
 				logger.L().Error(ctx, "Failed to parse Redis cluster TLS CA certificate")
 
-				return nil, fmt.Errorf("failed to parse Redis cluster TLS CA certificate")
+				return nil, errors.New("failed to parse Redis cluster TLS CA certificate")
 			}
 
 			// Remove the port if present

--- a/packages/shared/pkg/keys/key.go
+++ b/packages/shared/pkg/keys/key.go
@@ -3,6 +3,7 @@ package keys
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -98,13 +99,13 @@ func MaskToken(prefix, token string) string {
 
 func VerifyKey(prefix string, key string) (string, error) {
 	if !strings.HasPrefix(key, prefix) {
-		return "", fmt.Errorf("invalid key prefix")
+		return "", errors.New("invalid key prefix")
 	}
 
 	keyValue := key[len(prefix):]
 	keyBytes, err := hex.DecodeString(keyValue)
 	if err != nil {
-		return "", fmt.Errorf("invalid key")
+		return "", errors.New("invalid key")
 	}
 
 	return hasher.Hash(keyBytes), nil

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -55,7 +56,7 @@ func NewLogger(loggerConfig LoggerConfig) (Logger, error) {
 	}
 
 	if encoding != "console" && loggerConfig.EncoderConfig == nil {
-		return nil, fmt.Errorf("encoder config has to be provided when encoding is not console")
+		return nil, errors.New("encoder config has to be provided when encoding is not console")
 	}
 
 	var encoderConfig zapcore.EncoderConfig

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -662,7 +662,7 @@ func TestProxyReuseConnectionsWhenBackendChangesFails(t *testing.T) {
 
 		backendKey, ok := backendMapping[backendAddr]
 		if !ok {
-			return nil, fmt.Errorf("backend not found")
+			return nil, errors.New("backend not found")
 		}
 
 		return &pool.Destination{
@@ -735,7 +735,7 @@ func TestProxyDoesNotReuseConnectionsWhenBackendChanges(t *testing.T) {
 
 		backendKey, ok := backendMapping[backendAddr]
 		if !ok {
-			return nil, fmt.Errorf("backend not found")
+			return nil, errors.New("backend not found")
 		}
 
 		return &pool.Destination{

--- a/packages/shared/pkg/storage/gcs_retry_test.go
+++ b/packages/shared/pkg/storage/gcs_retry_test.go
@@ -2,7 +2,7 @@ package storage
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -24,7 +24,7 @@ func transientErr() error {
 
 // permanentErr returns an error that storage.ShouldRetry does NOT retry.
 func permanentErr() error {
-	return fmt.Errorf("permanent: object not found")
+	return errors.New("permanent: object not found")
 }
 
 func TestRetryWithBackoff_SuccessOnFirstAttempt(t *testing.T) {

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -2,6 +2,7 @@ package header
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -20,7 +21,7 @@ type Header struct {
 
 func NewHeader(metadata *Metadata, mapping []BuildMap) (*Header, error) {
 	if metadata.BlockSize == 0 {
-		return nil, fmt.Errorf("block size cannot be zero")
+		return nil, errors.New("block size cannot be zero")
 	}
 
 	if len(mapping) == 0 {

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -63,7 +64,7 @@ func (s *fsStorage) GetDetails() string {
 
 func (s *fsStorage) UploadSignedURL(_ context.Context, path string, ttl time.Duration) (string, error) {
 	if s.uploadURL == "" || s.hmacKey == nil {
-		return "", fmt.Errorf("file system storage does not support signed URLs (no local upload endpoint configured)")
+		return "", errors.New("file system storage does not support signed URLs (no local upload endpoint configured)")
 	}
 
 	expires := time.Now().Add(ttl).Unix()

--- a/packages/shared/pkg/utils/error_once_test.go
+++ b/packages/shared/pkg/utils/error_once_test.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"fmt"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ func TestErrorOnce(t *testing.T) {
 	errorOnce := NewErrorOnce()
 
 	// Test setting error
-	expectedErr := fmt.Errorf("test error")
+	expectedErr := errors.New("test error")
 	err := errorOnce.SetError(expectedErr)
 	require.NoError(t, err)
 
@@ -23,7 +23,7 @@ func TestErrorOnce(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 
 	// Trying to set again should return ErrAlreadySet
-	err = errorOnce.SetError(fmt.Errorf("another error"))
+	err = errorOnce.SetError(errors.New("another error"))
 	require.ErrorIs(t, err, ErrAlreadySet)
 
 	// Wait should still return the original error
@@ -45,7 +45,7 @@ func TestErrorOnceSetSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Trying to set error after success should return ErrAlreadySet
-	err = errorOnce.SetError(fmt.Errorf("test error"))
+	err = errorOnce.SetError(errors.New("test error"))
 	require.ErrorIs(t, err, ErrAlreadySet)
 
 	// Wait should still return nil

--- a/packages/shared/pkg/utils/set_once.go
+++ b/packages/shared/pkg/utils/set_once.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 )
 
@@ -52,7 +52,7 @@ func (s *SetOnce[T]) SetResult(value T, err error) error {
 	return s.SetValue(value)
 }
 
-var ErrAlreadySet = fmt.Errorf("value already set")
+var ErrAlreadySet = errors.New("value already set")
 
 // SetResult internal method for setting the result only once.
 func (s *SetOnce[T]) setResult(r result[T]) error {

--- a/packages/shared/pkg/utils/set_once_test.go
+++ b/packages/shared/pkg/utils/set_once_test.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -27,7 +27,7 @@ func TestSetOnce(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, value)
 
-	setOnce.SetError(fmt.Errorf("error"))
+	setOnce.SetError(errors.New("error"))
 
 	value, err = setOnce.Wait()
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestSetOnce(t *testing.T) {
 func TestSetOnceSetError(t *testing.T) {
 	t.Parallel()
 	setOnce := NewSetOnce[int]()
-	expectedErr := fmt.Errorf("error")
+	expectedErr := errors.New("error")
 
 	err := setOnce.SetError(expectedErr)
 	require.NoError(t, err)


### PR DESCRIPTION
Enables the perfsprint linter scoped to its errorf check so that fmt.Errorf("static message") is flagged and auto-fixed to errors.New("static message"). Other perfsprint sub-checks remain disabled to keep the rule surgical.

Autofix applied via golangci-lint run --fix across all go.work modules, followed by goimports to add missing "errors" imports and drop unused "fmt" imports. CI's make lint already runs --fix, so future regressions are auto-corrected.

Superset of  e2b-dev/infra#2454