### PR TITLE
feat(api): forward structured errorCode on APIError responses

### DIFF
--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -52,7 +52,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 	template, apiErr := a.buildTemplate(ctx, userID, team, templateID, body)
 	if apiErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
-		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		a.sendAPIStoreAPIError(c, apiErr)
 
 		return
 	}
@@ -131,7 +131,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 	template, apiErr := a.buildTemplate(ctx, userID, team, templateID, body)
 	if apiErr != nil {
 		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
-		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		a.sendAPIStoreAPIError(c, apiErr)
 
 		return
 	}

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -250,7 +250,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		mcp,
 	)
 	if createErr != nil {
-		a.sendAPIStoreError(c, createErr.Code, createErr.ClientMsg)
+		a.sendAPIStoreAPIError(c, createErr)
 
 		return
 	}

--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -163,7 +163,7 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 		nil, // mcp
 	)
 	if createErr != nil {
-		a.sendAPIStoreError(c, createErr.Code, createErr.ClientMsg)
+		a.sendAPIStoreAPIError(c, createErr)
 
 		return
 	}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -290,6 +290,14 @@ func (a *APIStore) sendAPIStoreError(c *gin.Context, code int, message string) {
 	apierrors.SendAPIStoreError(c, code, message)
 }
 
+// sendAPIStoreAPIError sends an APIError, forwarding its structured
+// ErrorCode to the wire when set. Prefer this over sendAPIStoreError when
+// the APIError is available, so SDKs can programmatically distinguish
+// failure modes (e.g. concurrency_limit_exceeded) from generic 4xx/5xx.
+func (a *APIStore) sendAPIStoreAPIError(c *gin.Context, err *apierrors.APIError) {
+	apierrors.SendAPIStoreErrorWithCode(c, err.Code, err.ErrorCode, err.ClientMsg)
+}
+
 func (a *APIStore) GetHealth(c *gin.Context) {
 	if a.Healthy.Load() {
 		c.String(http.StatusOK, "Health check successful")

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -132,7 +132,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 
 	template, apiError := template.RegisterBuild(ctx, a.templateCache, a.sqlcDB, buildReq)
 	if apiError != nil {
-		a.sendAPIStoreError(c, apiError.Code, apiError.ClientMsg)
+		a.sendAPIStoreAPIError(c, apiError)
 		telemetry.ReportCriticalError(ctx, "build template register failed", apiError.Err)
 
 		return nil

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -20,6 +20,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/builds"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
@@ -120,7 +121,8 @@ func (o *Orchestrator) CreateSandbox(
 		switch {
 		case errors.As(err, &limitErr):
 			return sandbox.Sandbox{}, &api.APIError{
-				Code: http.StatusTooManyRequests,
+				Code:      http.StatusTooManyRequests,
+				ErrorCode: apierrors.ErrCodeConcurrencyLimitExceeded,
 				ClientMsg: fmt.Sprintf(
 					"you have reached the maximum number of concurrent E2B sandboxes (%d). If you need more, "+
 						"please visit 'https://e2b.dev/docs/billing'", totalConcurrentInstances),

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -17,6 +17,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	dbtypes "github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -86,7 +87,8 @@ func RegisterBuild(
 		telemetry.ReportError(ctx, "team has reached max concurrent template builds", nil, telemetry.WithTeamID(data.Team.ID.String()), attribute.Int64("total.concurrent_template_builds", totalConcurrentTemplateBuilds))
 
 		return nil, &api.APIError{
-			Code: http.StatusTooManyRequests,
+			Code:      http.StatusTooManyRequests,
+			ErrorCode: apierrors.ErrCodeConcurrencyLimitExceeded,
 			ClientMsg: fmt.Sprintf(
 				"you have reached the maximum number of concurrent template builds (%d). Please wait for existing builds to complete or contact support if you need more concurrent builds.",
 				totalConcurrentTemplateBuilds),

--- a/packages/shared/pkg/apierrors/apierrors.go
+++ b/packages/shared/pkg/apierrors/apierrors.go
@@ -8,22 +8,52 @@ import (
 
 var _ error = (*APIError)(nil)
 
-// APIError represents a structured error with an HTTP status code and client-facing message.
+// Stable, machine-readable error codes. SDKs switch on these; humans read
+// the accompanying `message`. Keep the set small and deliberate — this is
+// wire protocol.
+const (
+	// ErrCodeConcurrencyLimitExceeded: a hard concurrency quota (e.g. the
+	// maximum number of live sandboxes or in-flight template builds) was
+	// reached. Releasing an existing resource is what unblocks further
+	// requests — waiting alone does not.
+	ErrCodeConcurrencyLimitExceeded = "concurrency_limit_exceeded"
+)
+
+// APIError represents a structured error with an HTTP status code and
+// client-facing message.
+//
+// ErrorCode is optional; when set, it's emitted alongside message so SDKs
+// can programmatically distinguish failure modes from the generic
+// `{code, message}` body.
 type APIError struct {
 	Err       error
 	ClientMsg string
 	Code      int
+	ErrorCode string
 }
 
 func (e *APIError) Error() string {
 	return e.Err.Error()
 }
 
-// SendAPIStoreError sends a JSON error response and records the error on the gin context.
+// SendAPIStoreError sends a JSON error response and records the error on
+// the gin context.
 func SendAPIStoreError(c *gin.Context, code int, message string) {
+	SendAPIStoreErrorWithCode(c, code, "", message)
+}
+
+// SendAPIStoreErrorWithCode is SendAPIStoreError with an explicit structured
+// error code. An empty errorCode is omitted from the response body to keep
+// backward compatibility with the pre-existing `{code, message}` shape.
+func SendAPIStoreErrorWithCode(c *gin.Context, code int, errorCode, message string) {
 	c.Error(errors.New(message))
-	c.JSON(code, gin.H{
+
+	body := gin.H{
 		"code":    int32(code),
 		"message": message,
-	})
+	}
+	if errorCode != "" {
+		body["errorCode"] = errorCode
+	}
+	c.JSON(code, body)
 }


### PR DESCRIPTION
APIError gains an optional ErrorCode field emitted alongside message so SDKs can programmatically distinguish failure modes from the generic {code, message} body. Adds SendAPIStoreErrorWithCode helper and a sendAPIStoreAPIError dispatch method on APIStore.

The only code currently defined is concurrency_limit_exceeded, set on the 429 returned by the per-team concurrent-sandbox and concurrent- template-build quotas (in create_instance.go and register_build.go). Handler call-sites that surface those errors are migrated to forward the ErrorCode to the wire.