### PR TITLE
test(uffd): lift cross-process test infrastructure for UFFD work

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/async_wp_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/async_wp_test.go
@@ -41,6 +41,7 @@ func TestAsyncWriteProtection(t *testing.T) {
 		operations    []operation
 		expectedDirty []int
 		expectedClean []int
+		alwaysWP      bool
 	}{
 		{
 			name:          "4k read then write same page",
@@ -229,6 +230,59 @@ func TestAsyncWriteProtection(t *testing.T) {
 			expectedDirty: []int{0, 2},
 			expectedClean: []int{1, 3},
 		},
+
+		// alwaysWP tests: handler copies with UFFDIO_COPY_MODE_WP for all faults,
+		// including writes. WP_ASYNC must automatically clear the WP bit when the
+		// original access was a write. This validates the assumption that independent
+		// prefaulting (always copy with WP) works correctly.
+		{
+			name:          "4k alwaysWP write to missing page",
+			pagesize:      header.PageSize,
+			numberOfPages: 4,
+			alwaysWP:      true,
+			operations: []operation{
+				{offset: 0, mode: operationModeWrite},
+			},
+			expectedDirty: []int{0},
+		},
+		{
+			name:          "4k alwaysWP mixed writes and reads",
+			pagesize:      header.PageSize,
+			numberOfPages: 4,
+			alwaysWP:      true,
+			operations: []operation{
+				{offset: 0 * header.PageSize, mode: operationModeWrite},
+				{offset: 1 * header.PageSize, mode: operationModeRead},
+				{offset: 2 * header.PageSize, mode: operationModeWrite},
+				{offset: 3 * header.PageSize, mode: operationModeRead},
+			},
+			expectedDirty: []int{0, 2},
+			expectedClean: []int{1, 3},
+		},
+		{
+			name:          "hugepage alwaysWP write to missing page",
+			pagesize:      header.HugepageSize,
+			numberOfPages: 4,
+			alwaysWP:      true,
+			operations: []operation{
+				{offset: 0, mode: operationModeWrite},
+			},
+			expectedDirty: []int{0},
+		},
+		{
+			name:          "hugepage alwaysWP mixed writes and reads",
+			pagesize:      header.HugepageSize,
+			numberOfPages: 4,
+			alwaysWP:      true,
+			operations: []operation{
+				{offset: 0 * header.HugepageSize, mode: operationModeWrite},
+				{offset: 1 * header.HugepageSize, mode: operationModeRead},
+				{offset: 2 * header.HugepageSize, mode: operationModeWrite},
+				{offset: 3 * header.HugepageSize, mode: operationModeRead},
+			},
+			expectedDirty: []int{0, 2},
+			expectedClean: []int{1, 3},
+		},
 	}
 
 	for _, tt := range tests {
@@ -238,19 +292,11 @@ func TestAsyncWriteProtection(t *testing.T) {
 			h, err := configureCrossProcessTest(t, testConfig{
 				pagesize:      tt.pagesize,
 				numberOfPages: tt.numberOfPages,
+				alwaysWP:      tt.alwaysWP,
 			})
 			require.NoError(t, err)
 
-			for i, op := range tt.operations {
-				switch op.mode {
-				case operationModeRead:
-					err := h.executeRead(t.Context(), op)
-					require.NoError(t, err, "step %d: read at offset %d", i, op.offset)
-				case operationModeWrite:
-					err := h.executeWrite(t.Context(), op)
-					require.NoError(t, err, "step %d: write at offset %d", i, op.offset)
-				}
-			}
+			h.executeAll(t, tt.operations)
 
 			pagemap, err := testutils.NewPagemapReader()
 			require.NoError(t, err)

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -102,10 +102,17 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 	err = register(uffdFd, memoryStart, uint64(size), UFFDIO_REGISTER_MODE_MISSING|UFFDIO_REGISTER_MODE_WP)
 	require.NoError(t, err)
 
-	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestHelperServingProcess")
+	// -test.timeout=0 disables the helper's own per-test timeout. The parent test's
+	// context (t.Context()) is the sole authority on how long the helper may run;
+	// without this the helper can be killed by `go test`'s default timeout while the
+	// parent is still doing meaningful work, producing confusing "test killed" output.
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestHelperServingProcess", "-test.timeout=0")
 	cmd.Env = append(os.Environ(), "GO_TEST_HELPER_PROCESS=1")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_MMAP_START=%d", memoryStart))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_MMAP_PAGE_SIZE=%d", tt.pagesize))
+	if tt.alwaysWP {
+		cmd.Env = append(cmd.Env, "GO_ALWAYS_WP=1")
+	}
 
 	dup, err := syscall.Dup(int(uffdFd))
 	require.NoError(t, err)
@@ -291,6 +298,10 @@ func crossProcessServe() error {
 	uffd, err := NewUserfaultfdFromFd(uffdFd, data, m, l)
 	if err != nil {
 		return fmt.Errorf("exit creating uffd: %w", err)
+	}
+
+	if os.Getenv("GO_ALWAYS_WP") == "1" {
+		uffd.defaultCopyMode = UFFDIO_COPY_MODE_WP
 	}
 
 	offsetsFile := os.NewFile(uintptr(5), "offsets")

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -102,10 +102,6 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 	err = register(uffdFd, memoryStart, uint64(size), UFFDIO_REGISTER_MODE_MISSING|UFFDIO_REGISTER_MODE_WP)
 	require.NoError(t, err)
 
-	// -test.timeout=0 disables the helper's own per-test timeout. The parent test's
-	// context (t.Context()) is the sole authority on how long the helper may run;
-	// without this the helper can be killed by `go test`'s default timeout while the
-	// parent is still doing meaningful work, producing confusing "test killed" output.
 	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=TestHelperServingProcess", "-test.timeout=0")
 	cmd.Env = append(os.Environ(), "GO_TEST_HELPER_PROCESS=1")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GO_MMAP_START=%d", memoryStart))

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"testing"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
 )
@@ -19,6 +21,8 @@ type testConfig struct {
 	numberOfPages uint64
 	// Operations to trigger on the memory area.
 	operations []operation
+	// alwaysWP makes the handler copy with UFFDIO_COPY_MODE_WP for all faults.
+	alwaysWP bool
 }
 
 type operationMode uint32
@@ -42,6 +46,29 @@ type testHandler struct {
 	// It can only be called once.
 	offsetsOnce func() ([]uint, error)
 	mutex       sync.Mutex
+}
+
+// executeAll runs the operations sequentially against the cross-process UFFD handler,
+// failing the test on the first error. It centralizes the read/write dispatch that was
+// previously duplicated across every test body.
+func (h *testHandler) executeAll(t *testing.T, operations []operation) {
+	t.Helper()
+
+	for i, op := range operations {
+		err := h.executeOperation(t.Context(), op)
+		require.NoError(t, err, "step %d: mode=%d at offset %d", i, op.mode, op.offset)
+	}
+}
+
+func (h *testHandler) executeOperation(ctx context.Context, op operation) error {
+	switch op.mode {
+	case operationModeRead:
+		return h.executeRead(ctx, op)
+	case operationModeWrite:
+		return h.executeWrite(ctx, op)
+	default:
+		return fmt.Errorf("invalid operation mode: %d", op.mode)
+	}
 }
 
 func (h *testHandler) executeRead(ctx context.Context, op operation) error {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"unsafe"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/testutils"
@@ -48,15 +50,58 @@ type testHandler struct {
 	mutex       sync.Mutex
 }
 
-// executeAll runs the operations sequentially against the cross-process UFFD handler,
-// failing the test on the first error. It centralizes the read/write dispatch that was
-// previously duplicated across every test body.
 func (h *testHandler) executeAll(t *testing.T, operations []operation) {
 	t.Helper()
 
 	for i, op := range operations {
 		err := h.executeOperation(t.Context(), op)
-		require.NoError(t, err, "step %d: mode=%d at offset %d", i, op.mode, op.offset)
+		require.NoError(t, err, "step %d: %v at offset %d", i, op.mode, op.offset)
+	}
+}
+
+type pageExpectation uint8
+
+const (
+	expectClean pageExpectation = iota // read-only: present + WP set
+	expectDirty                        // written: present + WP cleared
+)
+
+func (h *testHandler) checkDirtiness(t *testing.T, operations []operation) {
+	t.Helper()
+
+	pagemap, err := testutils.NewPagemapReader()
+	require.NoError(t, err)
+	defer pagemap.Close()
+
+	memStart := uintptr(unsafe.Pointer(&(*h.memoryArea)[0]))
+
+	// Track the final expected state per offset by replaying operations in order.
+	expected := make(map[uint]pageExpectation)
+
+	for _, op := range operations {
+		off := uint(op.offset)
+		switch op.mode {
+		case operationModeRead:
+			if _, seen := expected[off]; !seen {
+				expected[off] = expectClean
+			}
+		case operationModeWrite:
+			expected[off] = expectDirty
+		}
+	}
+
+	for off, expect := range expected {
+		entry, err := pagemap.ReadEntry(memStart + uintptr(off))
+		require.NoError(t, err, "pagemap read at offset %d", off)
+
+		switch expect {
+		case expectDirty:
+			assert.True(t, entry.IsPresent(), "written page at offset %d should be present", off)
+			assert.False(t, entry.IsWriteProtected(), "written page at offset %d should be dirty", off)
+		case expectClean:
+			assert.True(t, entry.IsPresent(), "read-only page at offset %d should be present", off)
+			assert.True(t, entry.IsWriteProtected(), "read-only page at offset %d should be clean", off)
+		}
 	}
 }
 

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
@@ -132,6 +132,8 @@ func TestMissing(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+
+			h.checkDirtiness(t, tt.operations)
 		})
 	}
 }
@@ -139,8 +141,6 @@ func TestMissing(t *testing.T) {
 func TestParallelMissing(t *testing.T) {
 	t.Parallel()
 
-	// 10_000 reads is enough to exercise parallel pagefault handling without
-	// pushing the helper child into multi-minute runtime under -race.
 	parallelOperations := 10_000
 
 	tt := testConfig{

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
@@ -124,12 +124,7 @@ func TestMissing(t *testing.T) {
 			h, err := configureCrossProcessTest(t, tt)
 			require.NoError(t, err)
 
-			for _, operation := range tt.operations {
-				if operation.mode == operationModeRead {
-					err := h.executeRead(t.Context(), operation)
-					require.NoError(t, err, "for operation %+v", operation)
-				}
-			}
+			h.executeAll(t, tt.operations)
 
 			expectedAccessedOffsets := getOperationsOffsets(tt.operations, operationModeRead|operationModeWrite)
 
@@ -144,7 +139,9 @@ func TestMissing(t *testing.T) {
 func TestParallelMissing(t *testing.T) {
 	t.Parallel()
 
-	parallelOperations := 1_000_000
+	// 10_000 reads is enough to exercise parallel pagefault handling without
+	// pushing the helper child into multi-minute runtime under -race.
+	parallelOperations := 10_000
 
 	tt := testConfig{
 		pagesize:      header.PageSize,

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
@@ -127,6 +127,8 @@ func TestMissingWrite(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.Equal(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+
+			h.checkDirtiness(t, tt.operations)
 		})
 	}
 }
@@ -134,8 +136,6 @@ func TestMissingWrite(t *testing.T) {
 func TestParallelMissingWrite(t *testing.T) {
 	t.Parallel()
 
-	// 10_000 writes is enough to exercise parallel pagefault handling without
-	// pushing the helper child into multi-minute runtime under -race.
 	parallelOperations := 10_000
 
 	tt := testConfig{

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
@@ -119,17 +119,7 @@ func TestMissingWrite(t *testing.T) {
 			h, err := configureCrossProcessTest(t, tt)
 			require.NoError(t, err)
 
-			for _, operation := range tt.operations {
-				if operation.mode == operationModeRead {
-					err := h.executeRead(t.Context(), operation)
-					require.NoError(t, err, "for operation %+v", operation)
-				}
-
-				if operation.mode == operationModeWrite {
-					err := h.executeWrite(t.Context(), operation)
-					require.NoError(t, err, "for operation %+v", operation)
-				}
-			}
+			h.executeAll(t, tt.operations)
 
 			expectedAccessedOffsets := getOperationsOffsets(tt.operations, operationModeRead|operationModeWrite)
 
@@ -144,7 +134,9 @@ func TestMissingWrite(t *testing.T) {
 func TestParallelMissingWrite(t *testing.T) {
 	t.Parallel()
 
-	parallelOperations := 1_000_000
+	// 10_000 writes is enough to exercise parallel pagefault handling without
+	// pushing the helper child into multi-minute runtime under -race.
+	parallelOperations := 10_000
 
 	tt := testConfig{
 		pagesize:      header.PageSize,

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -63,6 +63,11 @@ type Userfaultfd struct {
 
 	wg errgroup.Group
 
+	// defaultCopyMode is OR-ed into the copy mode of every UFFDIO_COPY.
+	// Production leaves this at 0; tests can set it to UFFDIO_COPY_MODE_WP to
+	// validate prefault-style flows that always copy with the WP bit asserted.
+	defaultCopyMode CULong
+
 	logger logger.Logger
 }
 
@@ -363,7 +368,7 @@ retryLoop:
 		return fmt.Errorf("failed to read from source after %d attempts: %w", attempt+1, joinedErr)
 	}
 
-	var copyMode CULong
+	copyMode := u.defaultCopyMode
 
 	// Performing copy() on UFFD clears the WP bit unless we explicitly tell
 	// it not to. We do that for faults caused by a read access. Write accesses

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -63,9 +63,7 @@ type Userfaultfd struct {
 
 	wg errgroup.Group
 
-	// defaultCopyMode is OR-ed into the copy mode of every UFFDIO_COPY.
-	// Production leaves this at 0; tests can set it to UFFDIO_COPY_MODE_WP to
-	// validate prefault-style flows that always copy with the WP bit asserted.
+	// defaultCopyMode overrides the UFFDIO_COPY mode for all faults when non-zero.
 	defaultCopyMode CULong
 
 	logger logger.Logger


### PR DESCRIPTION
## Summary

A small slice of [#1896](https://github.com/e2b-dev/infra/pull/1896) (free page reporting / UFFD REMOVE) lifted out so the remaining REMOVE-specific work can be reviewed in isolation. This PR is **tests + tiny test-only hook only**; no behavior change in production.

### Production change (intentionally minimal: ~3 lines)

- Add `Userfaultfd.defaultCopyMode CULong`, OR-ed into the copy mode of every `UFFDIO_COPY`. Production leaves it at `0`, so behavior is unchanged. Tests can set it to `UFFDIO_COPY_MODE_WP` to validate prefault-style flows where every copy carries the WP bit.

### Test infrastructure

- `helpers_test.go`: introduce `h.executeAll` / `h.executeOperation` so test bodies stop duplicating the read/write switch.
- `cross_process_helpers_test.go`:
  - Pass `-test.timeout=0` to the helper child. The parent's `t.Context()` is now the sole authority on helper lifetime, preventing confusing _"test killed"_ output when `go test`'s default timeout fires inside the child while the parent is still doing real work.
  - Wire `GO_ALWAYS_WP=1` (set when `testConfig.alwaysWP` is `true`) so the helper sets `uffd.defaultCopyMode = UFFDIO_COPY_MODE_WP`.

### Tests

- `async_wp_test.go`: refactor to `h.executeAll` and add four `alwaysWP` subtests (4k / hugepage × missing-write / mixed) that exercise the new copy-mode hook end-to-end.
- `missing_test.go` / `missing_write_test.go`: refactor to `h.executeAll` and drop the parallel-operation count from `1_000_000` → `10_000`. The old count regularly pushed the helper child into multi-minute runs under `-race`; `10_000` still meaningfully exercises parallel pagefault handling.

### Explicitly out of scope (deferred to follow-ups on top of #1896)

- `UFFD_EVENT_REMOVE` handling
- page tracker / page state machine
- deferred pagefaults + wakeup pipe
- `gated` / pause-resume test mode
- `unregister()` cleanup helper
- `UFFD_FEATURE_EVENT_REMOVE` registration
- `remove_test.go`

## Test plan

- [x] `go vet ./pkg/sandbox/uffd/...`
- [x] `go test -count=1 -run '^$' ./pkg/sandbox/uffd/...` (compile)
- [ ] CI x86 unit tests
- [ ] CI ARM64 tests
- [ ] Manually run `TestAsyncWriteProtection` (root, KVM-capable host) including new `alwaysWP` subtests