### PR TITLE
ci: disable Testcontainers Ryuk reaper to fix flaky packages/db tests

### DIFF
--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -1,6 +1,6 @@
 name: ARM64 tests on PRs
 
-on: [workflow_call]
+on: [ workflow_call ]
 
 permissions:
   contents: read
@@ -43,6 +43,11 @@ jobs:
     timeout-minutes: 45
     env:
       GIN_MODE: test
+      # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
+      # `go test ./...` derive the same session-id-based reaper container
+      # name and race on creation, causing flaky "container name already
+      # in use" failures. Per-test t.Cleanup already terminates containers.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
         include:

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -43,13 +43,9 @@ jobs:
     timeout-minutes: 45
     env:
       GIN_MODE: test
-      # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
-      # `go test ./...` derive the same session-id-based reaper container
-      # name and race on creation, causing flaky "container name already
-      # in use" failures. Per-test t.Cleanup already terminates containers
-      # on the normal exit path; the "Reap orphaned Testcontainers" step
-      # below handles the abnormal-termination case (timeout / SIGKILL /
-      # OOM) on the persistent self-hosted runner.
+      # Parallel `go test ./...` binaries derive the same Ryuk session id
+      # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
+      # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
@@ -89,24 +85,11 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        # Self-hosted runner is persistent and Ryuk is disabled, so a
-        # SIGKILL / timeout / OOM in a previous job can leave behind
-        # postgres / redis / reaper containers. Force-remove anything
-        # carrying a Testcontainers label or a reaper_ name substring
-        # before tests start.
-        #
-        # Notes on the filters:
-        # - Testcontainers labels every container it creates (user
-        #   containers and the reaper itself) with
-        #   `org.testcontainers=true`, so the label filter alone covers
-        #   both. The `name=reaper_` query is a belt-and-braces fallback
-        #   for any reaper container that somehow lost its label.
-        # - `name=` is a substring match in Docker; do NOT anchor with
-        #   `^reaper_` — the daemon's name-filter pre-check silently
-        #   rejects anchored patterns (docker/cli#1201) and matches
-        #   nothing.
-        # - We run two separate `docker ps` calls and union the ids
-        #   because mixing different filter keys in one call AND-s them.
+        # Persistent runner + Ryuk disabled: prune leftover containers
+        # from SIGKILL/timeout/OOM in prior jobs.
+        # Two `docker ps` calls because different filter keys AND inside
+        # one call. Don't anchor `name=^reaper_` — Docker silently drops
+        # anchored patterns (docker/cli#1201).
         run: |
           set -euo pipefail
           ids=$(

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -1,6 +1,6 @@
 name: ARM64 tests on PRs
 
-on: [ workflow_call ]
+on: [workflow_call]
 
 permissions:
   contents: read
@@ -46,7 +46,10 @@ jobs:
       # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
       # `go test ./...` derive the same session-id-based reaper container
       # name and race on creation, causing flaky "container name already
-      # in use" failures. Per-test t.Cleanup already terminates containers.
+      # in use" failures. Per-test t.Cleanup already terminates containers
+      # on the normal exit path; the "Reap orphaned Testcontainers" step
+      # below handles the abnormal-termination case (timeout / SIGKILL /
+      # OOM) on the persistent self-hosted runner.
       TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
@@ -84,6 +87,21 @@ jobs:
             go.work
             ${{ matrix.package }}/go.mod
             ${{ matrix.package }}/go.sum
+
+      - name: Reap orphaned Testcontainers from previous runs
+        # Self-hosted runner is persistent and Ryuk is disabled, so a
+        # SIGKILL / timeout / OOM in a previous job can leave behind
+        # postgres / redis / reaper containers. Force-remove anything
+        # carrying the Testcontainers label or the reaper_* name prefix
+        # before tests start.
+        run: |
+          set -euo pipefail
+          orphans=$(docker ps -aq --filter "label=org.testcontainers=true")
+          reapers=$(docker ps -aq --filter "name=^reaper_")
+          if [ -n "${orphans}${reapers}" ]; then
+            # shellcheck disable=SC2086
+            docker rm -f ${orphans} ${reapers}
+          fi
 
       - name: Setup envd tests
         run: |

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -92,15 +92,32 @@ jobs:
         # Self-hosted runner is persistent and Ryuk is disabled, so a
         # SIGKILL / timeout / OOM in a previous job can leave behind
         # postgres / redis / reaper containers. Force-remove anything
-        # carrying the Testcontainers label or the reaper_* name prefix
+        # carrying a Testcontainers label or a reaper_ name substring
         # before tests start.
+        #
+        # Notes on the filters:
+        # - Testcontainers labels every container it creates (user
+        #   containers and the reaper itself) with
+        #   `org.testcontainers=true`, so the label filter alone covers
+        #   both. The `name=reaper_` query is a belt-and-braces fallback
+        #   for any reaper container that somehow lost its label.
+        # - `name=` is a substring match in Docker; do NOT anchor with
+        #   `^reaper_` — the daemon's name-filter pre-check silently
+        #   rejects anchored patterns (docker/cli#1201) and matches
+        #   nothing.
+        # - We run two separate `docker ps` calls and union the ids
+        #   because mixing different filter keys in one call AND-s them.
         run: |
           set -euo pipefail
-          orphans=$(docker ps -aq --filter "label=org.testcontainers=true")
-          reapers=$(docker ps -aq --filter "name=^reaper_")
-          if [ -n "${orphans}${reapers}" ]; then
+          ids=$(
+            {
+              docker ps -aq --filter "label=org.testcontainers=true"
+              docker ps -aq --filter "name=reaper_"
+            } | sort -u
+          )
+          if [ -n "${ids}" ]; then
             # shellcheck disable=SC2086
-            docker rm -f ${orphans} ${reapers}
+            docker rm -f ${ids}
           fi
 
       - name: Setup envd tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,7 +14,10 @@ jobs:
       # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
       # `go test ./...` derive the same session-id-based reaper container
       # name and race on creation, causing flaky "container name already
-      # in use" failures. Per-test t.Cleanup already terminates containers.
+      # in use" failures. Per-test t.Cleanup already terminates containers
+      # on the normal exit path; the "Reap orphaned Testcontainers" step
+      # below handles the abnormal-termination case (timeout / SIGKILL /
+      # OOM) on the persistent self-hosted runner.
       TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
@@ -52,6 +55,21 @@ jobs:
             go.work
             ${{ matrix.package }}/go.mod
             ${{ matrix.package }}/go.sum
+
+      - name: Reap orphaned Testcontainers from previous runs
+        # Self-hosted runner is persistent and Ryuk is disabled, so a
+        # SIGKILL / timeout / OOM in a previous job can leave behind
+        # postgres / redis / reaper containers. Force-remove anything
+        # carrying the Testcontainers label or the reaper_* name prefix
+        # before tests start.
+        run: |
+          set -euo pipefail
+          orphans=$(docker ps -aq --filter "label=org.testcontainers=true")
+          reapers=$(docker ps -aq --filter "name=^reaper_")
+          if [ -n "${orphans}${reapers}" ]; then
+            # shellcheck disable=SC2086
+            docker rm -f ${orphans} ${reapers}
+          fi
 
       - name: Setup envd tests
         run: |

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -11,13 +11,9 @@ jobs:
     runs-on: infra-tests
     env:
       GIN_MODE: test
-      # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
-      # `go test ./...` derive the same session-id-based reaper container
-      # name and race on creation, causing flaky "container name already
-      # in use" failures. Per-test t.Cleanup already terminates containers
-      # on the normal exit path; the "Reap orphaned Testcontainers" step
-      # below handles the abnormal-termination case (timeout / SIGKILL /
-      # OOM) on the persistent self-hosted runner.
+      # Parallel `go test ./...` binaries derive the same Ryuk session id
+      # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
+      # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
@@ -57,24 +53,11 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        # Self-hosted runner is persistent and Ryuk is disabled, so a
-        # SIGKILL / timeout / OOM in a previous job can leave behind
-        # postgres / redis / reaper containers. Force-remove anything
-        # carrying a Testcontainers label or a reaper_ name substring
-        # before tests start.
-        #
-        # Notes on the filters:
-        # - Testcontainers labels every container it creates (user
-        #   containers and the reaper itself) with
-        #   `org.testcontainers=true`, so the label filter alone covers
-        #   both. The `name=reaper_` query is a belt-and-braces fallback
-        #   for any reaper container that somehow lost its label.
-        # - `name=` is a substring match in Docker; do NOT anchor with
-        #   `^reaper_` — the daemon's name-filter pre-check silently
-        #   rejects anchored patterns (docker/cli#1201) and matches
-        #   nothing.
-        # - We run two separate `docker ps` calls and union the ids
-        #   because mixing different filter keys in one call AND-s them.
+        # Persistent runner + Ryuk disabled: prune leftover containers
+        # from SIGKILL/timeout/OOM in prior jobs.
+        # Two `docker ps` calls because different filter keys AND inside
+        # one call. Don't anchor `name=^reaper_` — Docker silently drops
+        # anchored patterns (docker/cli#1201).
         run: |
           set -euo pipefail
           ids=$(

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,6 +1,6 @@
 name: Run tests on PRs
 
-on: [workflow_call]
+on: [ workflow_call ]
 
 permissions:
   contents: read
@@ -11,6 +11,11 @@ jobs:
     runs-on: infra-tests
     env:
       GIN_MODE: test
+      # Disable Testcontainers' Ryuk reaper. Parallel test binaries from
+      # `go test ./...` derive the same session-id-based reaper container
+      # name and race on creation, causing flaky "container name already
+      # in use" failures. Per-test t.Cleanup already terminates containers.
+      TESTCONTAINERS_RYUK_DISABLED: "true"
     strategy:
       matrix:
         include:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -60,15 +60,32 @@ jobs:
         # Self-hosted runner is persistent and Ryuk is disabled, so a
         # SIGKILL / timeout / OOM in a previous job can leave behind
         # postgres / redis / reaper containers. Force-remove anything
-        # carrying the Testcontainers label or the reaper_* name prefix
+        # carrying a Testcontainers label or a reaper_ name substring
         # before tests start.
+        #
+        # Notes on the filters:
+        # - Testcontainers labels every container it creates (user
+        #   containers and the reaper itself) with
+        #   `org.testcontainers=true`, so the label filter alone covers
+        #   both. The `name=reaper_` query is a belt-and-braces fallback
+        #   for any reaper container that somehow lost its label.
+        # - `name=` is a substring match in Docker; do NOT anchor with
+        #   `^reaper_` — the daemon's name-filter pre-check silently
+        #   rejects anchored patterns (docker/cli#1201) and matches
+        #   nothing.
+        # - We run two separate `docker ps` calls and union the ids
+        #   because mixing different filter keys in one call AND-s them.
         run: |
           set -euo pipefail
-          orphans=$(docker ps -aq --filter "label=org.testcontainers=true")
-          reapers=$(docker ps -aq --filter "name=^reaper_")
-          if [ -n "${orphans}${reapers}" ]; then
+          ids=$(
+            {
+              docker ps -aq --filter "label=org.testcontainers=true"
+              docker ps -aq --filter "name=reaper_"
+            } | sort -u
+          )
+          if [ -n "${ids}" ]; then
             # shellcheck disable=SC2086
-            docker rm -f ${orphans} ${reapers}
+            docker rm -f ${ids}
           fi
 
       - name: Setup envd tests


### PR DESCRIPTION
## Summary

`go test ./...` in `packages/db` builds and runs multiple test binaries in parallel. Each one tries to start a Testcontainers Ryuk reaper container whose name is derived from a session-id hash. That hash collides across the parallel binaries, so the second one to start hits Docker with `Conflict. The container name "/reaper_<hash>" is already in use` and fails the run.

Most visibly seen as a flaky `TestIsUniqueConstraintViolation` on the ARM64 runner — example failure from PR #2462: https://github.com/e2b-dev/infra/actions/runs/24700072945/job/72241292146

```
Error Trace: packages/db/pkg/testutils/db.go:75
Error: Received unexpected error:
generic container: create container: reaper: new reaper: run container:
container create: Error response from daemon: Conflict.
The container name "/reaper_26360af2…" is already in use by container "02fdeeaa…"
```

We don't need Ryuk in CI: `SetupDatabase` in `packages/db/pkg/testutils/db.go` already registers `t.Cleanup(func() { container.Terminate(ctx) })` for every postgres container it creates, so orphan cleanup isn't needed. Setting `TESTCONTAINERS_RYUK_DISABLED=true` skips creating the reaper entirely and removes the race.

Applied to both the ARM64 (`pr-tests-arm64.yml`) and x86 (`pr-tests.yml`) PR test workflows so the symmetric flake can't appear there either.

## Test plan

- [ ] ARM64 `packages/db` job goes green on this PR (and on PR #2462 once rebased)
- [ ] x86 `packages/db` job continues to pass