### PR TITLE
chore(clickhouse): tune async-insert profile

### DIFF
--- a/iac/modules/job-clickhouse/configs/config.xml
+++ b/iac/modules/job-clickhouse/configs/config.xml
@@ -8,6 +8,13 @@
     <!-- Use up 80% of available RAM to be on the safer side, default is 90% -->
     <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
 
+    <!-- Allow replicas to recover from a larger number/size of broken parts without
+         manual intervention. Defaults: 100 parts, 1 GiB (1073741824 bytes) total. -->
+    <merge_tree>
+        <max_suspicious_broken_parts>20000</max_suspicious_broken_parts>
+        <max_suspicious_broken_parts_bytes>107374182400</max_suspicious_broken_parts_bytes>
+    </merge_tree>
+
     <logger>
         <formatting>
             <type>json</type>

--- a/iac/modules/job-clickhouse/configs/config.xml
+++ b/iac/modules/job-clickhouse/configs/config.xml
@@ -8,13 +8,6 @@
     <!-- Use up 80% of available RAM to be on the safer side, default is 90% -->
     <max_server_memory_usage_to_ram_ratio>0.8</max_server_memory_usage_to_ram_ratio>
 
-    <!-- Allow replicas to recover from a larger number/size of broken parts without
-         manual intervention. Defaults: 100 parts, 1 GiB (1073741824 bytes) total. -->
-    <merge_tree>
-        <max_suspicious_broken_parts>20000</max_suspicious_broken_parts>
-        <max_suspicious_broken_parts_bytes>107374182400</max_suspicious_broken_parts_bytes>
-    </merge_tree>
-
     <logger>
         <formatting>
             <type>json</type>

--- a/iac/modules/job-clickhouse/configs/users.xml
+++ b/iac/modules/job-clickhouse/configs/users.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0"?>
 <clickhouse>
+    <profiles>
+        <default>
+            <!-- https://clickhouse.com/docs/optimize/asynchronous-inserts -->
+            <async_insert>1</async_insert>
+            <wait_for_async_insert>1</wait_for_async_insert>
+            <async_insert_busy_timeout_min_ms>400</async_insert_busy_timeout_min_ms>
+            <async_insert_busy_timeout_max_ms>4000</async_insert_busy_timeout_max_ms>
+            <async_insert_max_data_size>104857600</async_insert_max_data_size>
+
+            <!-- new: distributed forwarder behaviour -->
+            <distributed_background_insert_batch>1</distributed_background_insert_batch>
+            <distributed_background_insert_split_batch_on_failure>1</distributed_background_insert_split_batch_on_failure>
+        </default>
+    </profiles>
+
     <users>
         <${username}>
             <password>${password}</password>
@@ -10,11 +25,6 @@
                 <ip>10.0.0.0/8</ip> <!-- restrict to internal traffic -->
             </networks>
             <profile>default</profile>
-
-            <!-- https://clickhouse.com/docs/optimize/asynchronous-inserts -->
-            <async_insert>1</async_insert>
-            <wait_for_async_insert>1</wait_for_async_insert>
-
             <quota>default</quota>
             <access_management>1</access_management>
         </${username}>

--- a/iac/modules/job-clickhouse/configs/users.xml
+++ b/iac/modules/job-clickhouse/configs/users.xml
@@ -9,7 +9,7 @@
             <async_insert_busy_timeout_max_ms>4000</async_insert_busy_timeout_max_ms>
             <async_insert_max_data_size>104857600</async_insert_max_data_size>
 
-            <!-- new: distributed forwarder behaviour -->
+            <!-- distributed forwarder behaviour -->
             <distributed_background_insert_batch>1</distributed_background_insert_batch>
             <distributed_background_insert_split_batch_on_failure>1</distributed_background_insert_split_batch_on_failure>
         </default>


### PR DESCRIPTION
Users:
- Move async_insert settings from the per-user block into the default profile where they belong, and add distributed_background_insert_batch / _split_batch_on_failure to enable batching in the distributed forwarder.