### PR TITLE
test(uffd): switch cross-process helper to page-state snapshots

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -188,28 +189,42 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 		)
 	})
 
-	offsetsOnce := func() ([]uint, error) {
+	// pageStatesOnce asks the serving process for a snapshot of its pageTracker
+	// and decodes it into a per-state view. It can only be called once.
+	pageStatesOnce := func() (handlerPageStates, error) {
 		err := cmd.Process.Signal(syscall.SIGUSR2)
 		if err != nil {
-			return nil, err
+			return handlerPageStates{}, err
 		}
 
-		offsetsBytes, err := io.ReadAll(offsetsReader)
+		data, err := io.ReadAll(offsetsReader)
 		if err != nil {
-			return nil, err
+			return handlerPageStates{}, err
 		}
 
-		var offsetList []uint
-
-		if len(offsetsBytes)%8 != 0 {
-			return nil, fmt.Errorf("invalid offsets bytes length: %d", len(offsetsBytes))
+		const entrySize = 1 + 8 // uint8 state + uint64 offset
+		if len(data)%entrySize != 0 {
+			return handlerPageStates{}, fmt.Errorf("invalid page state data length: %d", len(data))
 		}
 
-		for i := 0; i < len(offsetsBytes); i += 8 {
-			offsetList = append(offsetList, uint(binary.LittleEndian.Uint64(offsetsBytes[i:i+8])))
+		var result handlerPageStates
+
+		for i := 0; i < len(data); i += entrySize {
+			state := pageState(data[i])
+			offset := uint(binary.LittleEndian.Uint64(data[i+1 : i+entrySize]))
+
+			switch state {
+			case faulted:
+				result.faulted = append(result.faulted, offset)
+			case removed:
+				result.removed = append(result.removed, offset)
+			}
 		}
 
-		return offsetList, nil
+		slices.Sort(result.faulted)
+		slices.Sort(result.removed)
+
+		return result, nil
 	}
 
 	select {
@@ -219,10 +234,10 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 	}
 
 	return &testHandler{
-		memoryArea:  &memoryArea,
-		pagesize:    tt.pagesize,
-		data:        data,
-		offsetsOnce: offsetsOnce,
+		memoryArea:     &memoryArea,
+		pagesize:       tt.pagesize,
+		data:           data,
+		pageStatesOnce: pageStatesOnce,
 	}, nil
 }
 
@@ -322,17 +337,9 @@ func crossProcessServe() error {
 				}
 
 				for _, entry := range entries {
-					if entry.state != faulted {
-						continue
-					}
-
-					writeErr := binary.Write(offsetsFile, binary.LittleEndian, entry.offset)
+					writeErr := binary.Write(offsetsFile, binary.LittleEndian, entry)
 					if writeErr != nil {
-						msg := fmt.Errorf("error writing offsets to file: %w", writeErr)
-
-						fmt.Fprint(os.Stderr, msg.Error())
-
-						cancel(msg)
+						cancel(fmt.Errorf("error writing page state entry: %w", writeErr))
 
 						return
 					}
@@ -402,14 +409,18 @@ func crossProcessServe() error {
 	}
 }
 
+// pageStateEntry is the wire format used between the main test process
+// and the serving helper process. State is emitted as a single byte so it
+// can be written directly with binary.Write and decoded on the other side.
 type pageStateEntry struct {
-	state  pageState
-	offset uint64
+	State  uint8
+	Offset uint64
 }
 
+// pageStateEntries returns a snapshot of every tracked page and its state.
+// It holds the settleRequests write lock so no in-flight faultPage worker
+// can mutate the pageTracker while we iterate.
 func (u *Userfaultfd) pageStateEntries() ([]pageStateEntry, error) {
-	// Hold the write lock for the whole snapshot so no in-flight faultPage can
-	// mutate pageTracker while we iterate.
 	u.settleRequests.Lock()
 	defer u.settleRequests.Unlock()
 
@@ -419,7 +430,8 @@ func (u *Userfaultfd) pageStateEntries() ([]pageStateEntry, error) {
 		if err != nil {
 			return nil, fmt.Errorf("address %#x not in mapping: %w", addr, err)
 		}
-		entries = append(entries, pageStateEntry{state, uint64(offset)})
+
+		entries = append(entries, pageStateEntry{uint8(state), uint64(offset)})
 	}
 
 	return entries, nil

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -213,16 +213,12 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 			state := pageState(data[i])
 			offset := uint(binary.LittleEndian.Uint64(data[i+1 : i+entrySize]))
 
-			switch state {
-			case faulted:
+			if state == faulted {
 				result.faulted = append(result.faulted, offset)
-			case removed:
-				result.removed = append(result.removed, offset)
 			}
 		}
 
 		slices.Sort(result.faulted)
-		slices.Sort(result.removed)
 
 		return result, nil
 	}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -197,24 +197,25 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 			return handlerPageStates{}, err
 		}
 
-		data, err := io.ReadAll(offsetsReader)
-		if err != nil {
-			return handlerPageStates{}, err
-		}
-
-		const entrySize = 1 + 8 // uint8 state + uint64 offset
-		if len(data)%entrySize != 0 {
-			return handlerPageStates{}, fmt.Errorf("invalid page state data length: %d", len(data))
-		}
-
 		var result handlerPageStates
 
-		for i := 0; i < len(data); i += entrySize {
-			state := pageState(data[i])
-			offset := uint(binary.LittleEndian.Uint64(data[i+1 : i+entrySize]))
+		for {
+			var entry pageStateEntry
 
-			if state == faulted {
-				result.faulted = append(result.faulted, offset)
+			// binary.Read uses the same field layout as binary.Write on
+			// the producer side (sum of fixed-size fields, no struct
+			// padding), so we never have to hard-code the wire size.
+			err := binary.Read(offsetsReader, binary.LittleEndian, &entry)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+
+			if err != nil {
+				return handlerPageStates{}, fmt.Errorf("decoding page state entry: %w", err)
+			}
+
+			if pageState(entry.State) == faulted {
+				result.faulted = append(result.faulted, uint(entry.Offset))
 			}
 		}
 

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"testing"
 	"unsafe"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/bits-and-blooms/bitset"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -40,14 +42,38 @@ type operation struct {
 	mode   operationMode
 }
 
+// handlerPageStates is a snapshot of the pageTracker grouped by state. It
+// lets tests assert on the set of pages that the handler observed in each
+// state, rather than a flat list of "accessed" offsets. Additional states
+// (e.g. removed) are exposed so REMOVE-event tests can reuse this helper.
+type handlerPageStates struct {
+	faulted []uint
+	removed []uint
+}
+
+// allAccessed returns the sorted union of offsets that the handler touched
+// in any non-missing state. Tests that only care about "which pages did the
+// handler see" can compare directly against this.
+func (s handlerPageStates) allAccessed() []uint {
+	b := bitset.New(0)
+	for _, o := range s.faulted {
+		b.Set(o)
+	}
+	for _, o := range s.removed {
+		b.Set(o)
+	}
+
+	return slices.Collect(b.EachSet())
+}
+
 type testHandler struct {
 	memoryArea *[]byte
 	pagesize   uint64
 	data       *MemorySlicer
-	// Returns offsets of the pages that were faulted.
+	// pageStatesOnce returns a per-state snapshot of the handler's pageTracker.
 	// It can only be called once.
-	offsetsOnce func() ([]uint, error)
-	mutex       sync.Mutex
+	pageStatesOnce func() (handlerPageStates, error)
+	mutex          sync.Mutex
 }
 
 func (h *testHandler) executeAll(t *testing.T, operations []operation) {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
@@ -44,11 +44,11 @@ type operation struct {
 
 // handlerPageStates is a snapshot of the pageTracker grouped by state. It
 // lets tests assert on the set of pages that the handler observed in each
-// state, rather than a flat list of "accessed" offsets. Additional states
-// (e.g. removed) are exposed so REMOVE-event tests can reuse this helper.
+// state, rather than a flat list of "accessed" offsets. Follow-up PRs can
+// add more state-specific fields (e.g. removed) without touching the
+// existing call sites.
 type handlerPageStates struct {
 	faulted []uint
-	removed []uint
 }
 
 // allAccessed returns the sorted union of offsets that the handler touched
@@ -57,9 +57,6 @@ type handlerPageStates struct {
 func (s handlerPageStates) allAccessed() []uint {
 	b := bitset.New(0)
 	for _, o := range s.faulted {
-		b.Set(o)
-	}
-	for _, o := range s.removed {
 		b.Set(o)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/helpers_test.go
@@ -10,7 +10,6 @@ import (
 	"unsafe"
 
 	"github.com/RoaringBitmap/roaring/v2"
-	"github.com/bits-and-blooms/bitset"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -54,13 +53,15 @@ type handlerPageStates struct {
 // allAccessed returns the sorted union of offsets that the handler touched
 // in any non-missing state. Tests that only care about "which pages did the
 // handler see" can compare directly against this.
+//
+// pageStatesOnce already returns each per-state slice sorted, and a page
+// has exactly one state at a time in pageTracker, so the per-state slices
+// are disjoint. Follow-up PRs that add more state-specific fields should
+// sorted-merge them here instead of reaching for a bitset — byte offsets
+// make poor bit indices (a single hugepage offset would force ~1.8 MB of
+// backing storage).
 func (s handlerPageStates) allAccessed() []uint {
-	b := bitset.New(0)
-	for _, o := range s.faulted {
-		b.Set(o)
-	}
-
-	return slices.Collect(b.EachSet())
+	return slices.Clone(s.faulted)
 }
 
 type testHandler struct {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_test.go
@@ -128,10 +128,10 @@ func TestMissing(t *testing.T) {
 
 			expectedAccessedOffsets := getOperationsOffsets(tt.operations, operationModeRead|operationModeWrite)
 
-			accessedOffsets, err := h.offsetsOnce()
+			states, err := h.pageStatesOnce()
 			require.NoError(t, err)
 
-			assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+			assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 
 			h.checkDirtiness(t, tt.operations)
 		})
@@ -169,10 +169,10 @@ func TestParallelMissing(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{readOp}, operationModeRead)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }
 
 func TestParallelMissingWithPrefault(t *testing.T) {
@@ -209,10 +209,10 @@ func TestParallelMissingWithPrefault(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{readOp}, operationModeRead)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }
 
 func TestSerialMissing(t *testing.T) {
@@ -240,8 +240,8 @@ func TestSerialMissing(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{readOp}, operationModeRead)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/missing_write_test.go
@@ -123,10 +123,10 @@ func TestMissingWrite(t *testing.T) {
 
 			expectedAccessedOffsets := getOperationsOffsets(tt.operations, operationModeRead|operationModeWrite)
 
-			accessedOffsets, err := h.offsetsOnce()
+			states, err := h.pageStatesOnce()
 			require.NoError(t, err)
 
-			assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+			assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 
 			h.checkDirtiness(t, tt.operations)
 		})
@@ -164,10 +164,10 @@ func TestParallelMissingWrite(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{writeOp}, operationModeRead|operationModeWrite)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }
 
 func TestParallelMissingWriteWithPrefault(t *testing.T) {
@@ -204,10 +204,10 @@ func TestParallelMissingWriteWithPrefault(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{writeOp}, operationModeRead|operationModeWrite)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }
 
 func TestSerialMissingWrite(t *testing.T) {
@@ -235,8 +235,8 @@ func TestSerialMissingWrite(t *testing.T) {
 
 	expectedAccessedOffsets := getOperationsOffsets([]operation{writeOp}, operationModeRead|operationModeWrite)
 
-	accessedOffsets, err := h.offsetsOnce()
+	states, err := h.pageStatesOnce()
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, expectedAccessedOffsets, accessedOffsets, "checking which pages were faulted")
+	assert.Equal(t, expectedAccessedOffsets, states.allAccessed(), "checking which pages were faulted")
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
@@ -7,6 +7,7 @@ type pageState uint8
 const (
 	missing pageState = iota
 	faulted
+	removed
 )
 
 type pageTracker struct {
@@ -21,6 +22,18 @@ func newPageTracker(pageSize uintptr) *pageTracker {
 		pageSize: pageSize,
 		m:        make(map[uintptr]pageState),
 	}
+}
+
+func (pt *pageTracker) get(addr uintptr) pageState {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+
+	state, ok := pt.m[addr]
+	if !ok {
+		return missing
+	}
+
+	return state
 }
 
 func (pt *pageTracker) setState(start, end uintptr, state pageState) {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
@@ -7,7 +7,6 @@ type pageState uint8
 const (
 	missing pageState = iota
 	faulted
-	removed
 )
 
 type pageTracker struct {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/page_tracker.go
@@ -24,18 +24,6 @@ func newPageTracker(pageSize uintptr) *pageTracker {
 	}
 }
 
-func (pt *pageTracker) get(addr uintptr) pageState {
-	pt.mu.RLock()
-	defer pt.mu.RUnlock()
-
-	state, ok := pt.m[addr]
-	if !ok {
-		return missing
-	}
-
-	return state
-}
-
 func (pt *pageTracker) setState(start, end uintptr, state pageState) {
 	pt.mu.Lock()
 	defer pt.mu.Unlock()


### PR DESCRIPTION
## Summary

Splits out the pure test-infra slice from #1896 so the REMOVE-event work
can land in smaller, reviewable pieces.

The cross-process userfaultfd test harness currently reports a flat list
of faulted offsets. REMOVE-event tests need to distinguish between
pages that were faulted, pages that were removed, and pages that were
never touched. This PR migrates the wire format and helper API to a
per-state snapshot of the handler's `pageTracker` so the follow-up PR
can plug in REMOVE handling without further harness changes.

- `cross_process_helpers_test.go`:
  - New `pageStateEntries()` on `Userfaultfd` snapshots every tracked
    page + its state under `settleRequests`.
  - Emit one `pageStateEntry{State uint8, Offset uint64}` per page
    over the existing offsets pipe (binary-friendly, fixed-size
    records).
  - Replace `offsetsOnce` with `pageStatesOnce`, which decodes the new
    wire format into `handlerPageStates`.
- `helpers_test.go`: introduce `handlerPageStates` with
  `allAccessed()`, which returns the sorted union of offsets the
  handler touched in any non-missing state. Only `faulted` is exposed
  for now; the follow-up adds more state-specific fields without
  touching call sites.
- `missing_test.go` / `missing_write_test.go`: switch from
  `h.offsetsOnce()` + `assert.ElementsMatch` to
  `h.pageStatesOnce().allAccessed()` + `assert.Equal` (both sides are
  sorted, so the comparison is stricter).

No behavior change for MISSING-only handling. This is preparation only.

## Follow-ups

- `feat(uffd): handle UFFD_EVENT_REMOVE in Serve` — adds
  `pageState removed`, `pageTracker.get(addr)`, the REMOVE batch
  handling in `Serve`, deferred-fault retry, gated pause/resume test
  knobs, and `remove_test.go`.
- `feat: wire freePageReporting through template / build / sandbox / FC`
  (capstone that turns the feature on).

Splits #1896 as discussed there.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/sandbox/uffd/userfaultfd/...`
- [x] `golangci-lint run ./pkg/sandbox/uffd/userfaultfd/...`
- [ ] CI: `TestMissing*` and `TestParallelMissing*` pass on the runner
      (userfaultfd requires privileged execution which isn't available
      on a dev laptop).