### PR TITLE
test(uffd): unregister UFFD range before fd close in cross-process cleanup

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/cross_process_helpers_test.go
@@ -187,6 +187,14 @@ func configureCrossProcessTest(t *testing.T, tt testConfig) (*testHandler, error
 				waitErr == nil,
 			"unexpected error: %v", waitErr,
 		)
+
+		// Tear down the UFFD registration before the early uffdFd.close()
+		// cleanup runs. Today this is a no-op (no test enables
+		// UFFD_FEATURE_EVENT_REMOVE) but a follow-up that does will
+		// otherwise see munmap block on un-acked REMOVE events queued
+		// against the still-registered range. Cleanups run LIFO, so
+		// this fires before the close registered earlier.
+		assert.NoError(t, unregister(uffdFd, memoryStart, uint64(size)))
 	})
 
 	// pageStatesOnce asks the serving process for a snapshot of its pageTracker

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd_helpers_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd_helpers_test.go
@@ -41,6 +41,21 @@ func configureApi(f Fd, pagesize uint64) error {
 	return nil
 }
 
+// unregister tears down the UFFD registration over [addr, addr+size).
+// Used in test cleanup so that any in-flight REMOVE events the kernel
+// may have queued (once UFFD_FEATURE_EVENT_REMOVE is enabled in a
+// follow-up) don't keep munmap blocked on un-acked events.
+func unregister(f Fd, addr uintptr, size uint64) error {
+	r := newUffdioRange(CULong(addr), CULong(size))
+
+	ret, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(f), UFFDIO_UNREGISTER, uintptr(unsafe.Pointer(&r)))
+	if errno != 0 {
+		return fmt.Errorf("UFFDIO_UNREGISTER ioctl failed: %w (ret=%d)", errno, ret)
+	}
+
+	return nil
+}
+
 // mode: UFFDIO_REGISTER_MODE_WP|UFFDIO_REGISTER_MODE_MISSING
 // This is already called by the FC, but only with the UFFDIO_REGISTER_MODE_MISSING
 // We need to call it with UFFDIO_REGISTER_MODE_WP when we use both missing and wp


### PR DESCRIPTION
## Summary

Split out from the `feat/free-page-reporting` branch as a small, standalone preparatory PR.

- Adds `unregister()` helper in `fd_helpers_test.go` that wraps `UFFDIO_UNREGISTER`.
- Calls it from the late \`cmd.Wait()\` cleanup in \`configureCrossProcessTest\`, before the early \`uffdFd.close()\` cleanup runs (cleanups are LIFO).

## Why now (and why it's safe to land alone)

Today this is a **no-op**: no test enables \`UFFD_FEATURE_EVENT_REMOVE\`, so the kernel never queues REMOVE events that could keep \`munmap\` blocked on un-acked events against a still-registered range.

Once the follow-up REMOVE-handling PR enables that feature, missing this cleanup would manifest as flaky hangs in test teardown rather than as an obvious failure. Landing the cleanup first means that follow-up PR doesn't silently bring along a behavioural test-cleanup change alongside the production logic.

## Diff

\`+23 / -0\` across 2 files, both \`_test.go\`.

## Test plan

- [x] \`go build ./...\`
- [x] \`golangci-lint run ./pkg/sandbox/uffd/userfaultfd/...\` — 0 issues
- [x] \`go test ./pkg/sandbox/uffd/userfaultfd/... -count=1\` — pass