### PR TITLE
refactor(terraform): remove supabase db TF_VAR fallback

### DIFF
--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -77,8 +77,6 @@ CLICKHOUSE_CLUSTER_SIZE=1
 
 # Dashboard API instance count (default: 0)
 DASHBOARD_API_COUNT=
-# Dashboard API Supabase DB connection string (default: POSTGRES_CONNECTION_STRING)
-SUPABASE_DB_CONNECTION_STRING=
 # Enable dashboard-api auth user sync background worker (default: false)
 ENABLE_AUTH_USER_SYNC_BACKGROUND_WORKER=
 # Enable dashboard-api billing/team provisioning sink (default: false)

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -78,7 +78,6 @@ tf_vars := \
 	$(call tfvar, LOKI_BOOT_DISK_TYPE) \
 	$(call tfvar, LOKI_USE_V13_SCHEMA_FROM) \
 	$(call tfvar, DASHBOARD_API_COUNT) \
-	$(call tfvar, SUPABASE_DB_CONNECTION_STRING) \
 	$(call tfvar, ENABLE_AUTH_USER_SYNC_BACKGROUND_WORKER) \
 	$(call tfvar, ENABLE_BILLING_HTTP_TEAM_PROVISION_SINK) \
 	$(call tfvar, DEFAULT_PERSISTENT_VOLUME_TYPE) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -288,7 +288,6 @@ module "nomad" {
   dashboard_api_count                          = var.dashboard_api_count
   dashboard_api_admin_token_secret_name        = module.init.dashboard_api_admin_token_secret_name
   supabase_db_connection_string_secret_version = module.init.supabase_db_connection_string_secret_version
-  supabase_db_connection_string                = var.supabase_db_connection_string
   enable_auth_user_sync_background_worker      = var.enable_auth_user_sync_background_worker
   enable_billing_http_team_provision_sink      = var.enable_billing_http_team_provision_sink
 

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -5,7 +5,7 @@ locals {
   loki_url                                = "http://loki.service.consul:${var.loki_service_port.port}"
   enable_billing_http_team_provision_sink = var.enable_billing_http_team_provision_sink
   dashboard_api_billing_server_url        = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data) : ""
-  dashboard_api_billing_server_api_token  = local.enable_billing_http_team_provision_sink ? data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data : ""
+  dashboard_api_billing_server_api_token  = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data) : ""
 }
 
 # API

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -1,12 +1,11 @@
 locals {
-  clickhouse_connection_string                = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${random_password.clickhouse_password.result}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
-  redis_url                                   = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
-  redis_cluster_url                           = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
-  loki_url                                    = "http://loki.service.consul:${var.loki_service_port.port}"
-  enable_billing_http_team_provision_sink     = var.enable_billing_http_team_provision_sink
-  dashboard_api_billing_server_url            = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data) : ""
-  dashboard_api_billing_server_api_token      = local.enable_billing_http_team_provision_sink ? data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data : ""
-  dashboard_api_supabase_db_connection_string = trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data) != "" ? trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data) : var.supabase_db_connection_string
+  clickhouse_connection_string            = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${random_password.clickhouse_password.result}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
+  redis_url                               = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
+  redis_cluster_url                       = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
+  loki_url                                = "http://loki.service.consul:${var.loki_service_port.port}"
+  enable_billing_http_team_provision_sink = var.enable_billing_http_team_provision_sink
+  dashboard_api_billing_server_url        = local.enable_billing_http_team_provision_sink ? trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data) : ""
+  dashboard_api_billing_server_api_token  = local.enable_billing_http_team_provision_sink ? data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data : ""
 }
 
 # API
@@ -164,7 +163,7 @@ module "dashboard_api" {
   postgres_connection_string              = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_connection_string               = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   auth_db_read_replica_connection_string  = trimspace(data.google_secret_manager_secret_version.postgres_read_replica_connection_string.secret_data)
-  supabase_db_connection_string           = local.dashboard_api_supabase_db_connection_string
+  supabase_db_connection_string           = trimspace(data.google_secret_manager_secret_version.supabase_db_connection_string.secret_data)
   clickhouse_connection_string            = local.clickhouse_connection_string
   supabase_jwt_secrets                    = trimspace(data.google_secret_manager_secret_version.supabase_jwt_secrets.secret_data)
   redis_url                               = local.redis_url

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -462,12 +462,6 @@ variable "supabase_db_connection_string_secret_version" {
   type = any
 }
 
-variable "supabase_db_connection_string" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 variable "enable_auth_user_sync_background_worker" {
   type    = bool
   default = false

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -184,12 +184,6 @@ variable "client_proxy_port" {
   }
 }
 
-variable "supabase_db_connection_string" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 variable "loki_cluster_size" {
   type    = number
   default = 0


### PR DESCRIPTION
## Summary
- remove the temporary `supabase_db_connection_string` Terraform input from the root and `nomad` modules
- make `dashboard-api` read the Supabase DB connection string only from the GCP Secret Manager secret again
- complete the post-migration cleanup now that the secret-backed rollout has landed on `main`

## Validation
- `terraform fmt -recursive iac/provider-gcp`
- `terraform -chdir=\"iac/provider-gcp\" validate`