### PR TITLE
chore: revert default Firecracker version to v1.12

### DIFF
--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -242,7 +242,7 @@ const (
 	DefaultFirecackerV1_10Version = "v1.10.1_30cbb07"
 	DefaultFirecackerV1_12Version = "v1.12.1_210cbac"
 	DefaultFirecackerV1_14Version = "v1.14.1_458ca91"
-	DefaultFirecrackerVersion     = DefaultFirecackerV1_14Version
+	DefaultFirecrackerVersion     = DefaultFirecackerV1_12Version
 )
 
 var FirecrackerVersionMap = map[string]string{


### PR DESCRIPTION
## Summary

- Switch `featureflags.DefaultFirecrackerVersion` back to `DefaultFirecackerV1_12Version` (`v1.12.1_210cbac`).
- The v1.14 default landed in #2415 but we don't want to roll it out yet; v1.14 stays available via the `firecracker-versions` flag and per-build overrides.

## Test plan

- [ ] Confirm new builds pick `v1.12.1_210cbac` when no explicit `--firecracker` / `DEFAULT_FIRECRACKER_VERSION` is set.
- [ ] Existing v1.14 builds continue to resolve via `FirecrackerVersionMap` / feature flag overrides.