### PR TITLE
fix(orch): prevent send-on-closed-channel panic in network pool

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -79,6 +79,9 @@ type Pool struct {
 	done     chan struct{}
 	doneOnce sync.Once
 
+	closeMu sync.RWMutex
+	closed  bool
+
 	newSlots    chan *Slot
 	reusedSlots chan *Slot
 
@@ -187,15 +190,22 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 	select {
 	case <-ctx.Done():
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return errors.Join(ctx.Err(), fmt.Errorf("cleanup slot '%d' on cancelled context: %w", slot.Idx, cerr))
+		}
+
 		return ctx.Err()
 	case <-p.done:
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closed pool: %w", slot.Idx, cerr))
+		}
+
 		return ErrClosed
 	default:
 	}
 
 	err := slot.ResetInternet(ctx)
 	if err != nil {
-		// Cleanup the slot if resetting internet fails
 		if cerr := p.cleanup(ctx, slot); cerr != nil {
 			return fmt.Errorf("reset internet: %w; cleanup: %w", err, cerr)
 		}
@@ -203,22 +213,54 @@ func (p *Pool) Return(ctx context.Context, slot *Slot) error {
 		return fmt.Errorf("error resetting slot internet access: %w", err)
 	}
 
+	// RLock only guards the closed flag and the reusedSlots send. It is
+	// released before cleanup() so Close()'s Lock() is never pinned by a
+	// slow RemoveNetwork syscall (iptables, netlink) running in a
+	// concurrent Return.
+	p.closeMu.RLock()
+
+	if p.closed {
+		p.closeMu.RUnlock()
+
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closed pool: %w", slot.Idx, cerr))
+		}
+
+		return ErrClosed
+	}
+
 	select {
 	case <-ctx.Done():
+		p.closeMu.RUnlock()
+
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return errors.Join(ctx.Err(), fmt.Errorf("cleanup slot '%d' on cancelled context: %w", slot.Idx, cerr))
+		}
+
 		return ctx.Err()
 	case <-p.done:
+		p.closeMu.RUnlock()
+
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closing pool: %w", slot.Idx, cerr))
+		}
+
 		return ErrClosed
 	case p.reusedSlots <- slot:
 		returnedSlotCounter.Add(ctx, 1)
 		reusableSlotsAvailableCounter.Add(ctx, 1)
-	default:
-		err := p.cleanup(ctx, slot)
-		if err != nil {
-			return fmt.Errorf("failed to return slot '%d': %w", slot.Idx, err)
-		}
-	}
+		p.closeMu.RUnlock()
 
-	return nil
+		return nil
+	default:
+		p.closeMu.RUnlock()
+
+		if cerr := p.cleanup(ctx, slot); cerr != nil {
+			return fmt.Errorf("failed to return slot '%d': %w", slot.Idx, cerr)
+		}
+
+		return nil
+	}
 }
 
 func (p *Pool) cleanup(ctx context.Context, slot *Slot) error {
@@ -246,21 +288,33 @@ func (p *Pool) Close(ctx context.Context) error {
 		close(p.done)
 	})
 
+	p.closeMu.Lock()
+	p.closed = true
+	p.closeMu.Unlock()
+
 	var errs []error
 
 	for slot := range p.newSlots {
+		newSlotsAvailableCounter.Add(ctx, -1)
+
 		err := p.cleanup(ctx, slot)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
 		}
 	}
 
-	close(p.reusedSlots)
+drain:
+	for {
+		select {
+		case slot := <-p.reusedSlots:
+			reusableSlotsAvailableCounter.Add(ctx, -1)
 
-	for slot := range p.reusedSlots {
-		err := p.cleanup(ctx, slot)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
+			err := p.cleanup(ctx, slot)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to cleanup slot '%d': %w", slot.Idx, err))
+			}
+		default:
+			break drain
 		}
 	}
 

--- a/packages/orchestrator/pkg/sandbox/network/pool_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool_test.go
@@ -1,0 +1,122 @@
+package network
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStorage struct {
+	released  atomic.Int64
+	releaseFn func(*Slot) error
+}
+
+func (f *fakeStorage) Acquire(_ context.Context) (*Slot, error) {
+	return nil, context.Canceled
+}
+
+func (f *fakeStorage) Release(s *Slot) error {
+	f.released.Add(1)
+	if f.releaseFn != nil {
+		return f.releaseFn(s)
+	}
+
+	return nil
+}
+
+// testSlotIdxOffset keeps test slot indices outside the range any real
+// pool would allocate (vrtSlotsSize == 32766) so cleanup()'s namespace
+// teardown can't collide with namespaces another test binary is actively
+// using — e.g. the smoketest package creating ns-2, ns-3, …
+const testSlotIdxOffset = 1 << 30
+
+func newTestSlot(idx int) *Slot {
+	return &Slot{Idx: idx + testSlotIdxOffset, egressProxy: NoopEgressProxy{}}
+}
+
+// TestReturn_NoPanicDuringClose races Return against Close to guard
+// against regressions of the send-on-closed-channel panic.
+func TestReturn_NoPanicDuringClose(t *testing.T) {
+	t.Parallel()
+
+	const runs = 20
+	const workers = 32
+	const iters = 50
+
+	for run := range runs {
+		storage := &fakeStorage{}
+		pool := NewPool(2, workers*iters, storage, Config{})
+		close(pool.newSlots)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for w := range workers {
+			wg.Go(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("Return panicked (run=%d worker=%d): %v", run, w, r)
+					}
+				}()
+
+				<-start
+
+				for i := range iters {
+					_ = pool.Return(t.Context(), newTestSlot(w*iters+i+1))
+				}
+			})
+		}
+
+		close(start)
+		_ = pool.Close(t.Context())
+
+		wg.Wait()
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	pool := NewPool(2, 4, &fakeStorage{}, Config{})
+	close(pool.newSlots)
+
+	require.NoError(t, pool.Close(t.Context()))
+	require.NoError(t, pool.Close(t.Context()))
+}
+
+func TestReturn_AfterCloseCleansUpLocally(t *testing.T) {
+	t.Parallel()
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, 4, storage, Config{})
+	close(pool.newSlots)
+
+	require.NoError(t, pool.Close(t.Context()))
+
+	before := storage.released.Load()
+	err := pool.Return(t.Context(), newTestSlot(1))
+	after := storage.released.Load()
+
+	assert.Equal(t, int64(1), after-before, "Return after Close must invoke Storage.Release via cleanup")
+	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestReturn_AfterClose_CleanupFailure_PreservesErrClosed(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+	storage := &fakeStorage{releaseFn: func(_ *Slot) error { return boom }}
+	pool := NewPool(2, 4, storage, Config{})
+	close(pool.newSlots)
+
+	require.NoError(t, pool.Close(t.Context()))
+
+	err := pool.Return(t.Context(), newTestSlot(1))
+	require.ErrorIs(t, err, ErrClosed)
+	require.ErrorIs(t, err, boom)
+}


### PR DESCRIPTION
Return's send on p.reusedSlots could race with Close's close of the same channel. A send on a closed channel is always "ready" in selectgo and panics when selected, so the sibling <-p.done case did not prevent the panic. 
