### PR TITLE
fix(envd): make systemd retry envd.service indefinitely

### DIFF
--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.14"
+const Version = "0.5.15"

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -4,6 +4,8 @@
 [Unit]
 Description=Env Daemon Service
 After=multi-user.target
+# Disable rate limiting; retry forever
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -95,6 +95,9 @@ func TestAdditionalOCILayers(t *testing.T) {
 		// verify that memory function works
 		assert.Contains(t, actualFiles["etc/systemd/system/envd.service"], `"GOMEMLIMIT=50MiB"`)
 
+		// verify that systemd is configured to retry envd forever
+		assert.Contains(t, actualFiles["etc/systemd/system/envd.service"], "StartLimitIntervalSec=0")
+
 		// ensure that both files have identical content
 		disabledContent := strings.TrimSpace(`
 [Service]


### PR DESCRIPTION
envd.service inherits systemd's default `StartLimit` of 5 restarts per 10s. If envd hits a rapid crash loop -- e.g. a transient disk issue causing `SIGBUS` -- the burst is exhausted and the unit can wedge in `ActiveState=failed`. That state persists across pause+resume, so a restored sandbox may come up without envd and stay unreachable via the orchestrator until the service is manually restarted.

Set `StartLimitIntervalSec=0` so transient faults self-heal once the underlying condition clears, including across pause/resume.