### PR TITLE
Make possible to build image in non-default vpc

### DIFF
--- a/iac/provider-aws/nomad-cluster-disk-image/Makefile
+++ b/iac/provider-aws/nomad-cluster-disk-image/Makefile
@@ -5,7 +5,7 @@ init:
 	packer init -upgrade .
 
 build:
-	packer build -var "prefix=$(PREFIX)" -var "aws_region=$(AWS_REGION)" -var "aws_profile=$(AWS_PROFILE)" .
+	packer build -var "prefix=$(PREFIX)" -var "aws_region=$(AWS_REGION)" -var "aws_profile=$(AWS_PROFILE)" -var "vpc_id=$(PACKER_VPC_ID)" -var "subnet_id=$(PACKER_SUBNET_ID)"  .
 
 format:
 	packer fmt .

--- a/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
@@ -17,6 +17,9 @@ source "amazon-ebs" "ubuntu" {
   ami_name      = "${var.prefix}orch-${formatdate("YYYY-MM-DD-hh-mm-ss", timestamp())}"
   ssh_username  = "ubuntu"
 
+  vpc_id    = var.vpc_id
+  subnet_id = var.subnet_id
+
   // Ubuntu Server 24.04 LTS (HVM), SSD Volume Type
   source_ami_filter {
     filters = {

--- a/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
@@ -29,3 +29,13 @@ variable "base_instance_type" {
   type    = string
   default = "t3.large"
 }
+
+variable "vpc_id" {
+  type    = string
+  default = ""
+}
+
+variable "subnet_id" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Make it optional to specify `vpc_id` and `subnet_id` so the cluster image is not built in the default VPC. Requirement for envs where default VPC is disabled or cannot be used.