### PR TITLE
Always associate public ip for AWS Packer build

### DIFF
--- a/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
@@ -17,8 +17,9 @@ source "amazon-ebs" "ubuntu" {
   ami_name      = "${var.prefix}orch-${formatdate("YYYY-MM-DD-hh-mm-ss", timestamp())}"
   ssh_username  = "ubuntu"
 
-  vpc_id    = var.vpc_id
-  subnet_id = var.subnet_id
+  vpc_id                      = var.vpc_id
+  subnet_id                   = var.subnet_id
+  associate_public_ip_address = true
 
   // Ubuntu Server 24.04 LTS (HVM), SSD Volume Type
   source_ami_filter {


### PR DESCRIPTION
With custom subnet that is public but without auto-assign public ip packer will fail waiting for ssh connection to be opened.