### PR TITLE
Add AWS/GCP load balancer trace ID to api root trace

### DIFF
--- a/packages/shared/pkg/logger/fields.go
+++ b/packages/shared/pkg/logger/fields.go
@@ -47,6 +47,10 @@ func WithClusterID(clusterID uuid.UUID) zap.Field {
 	return zap.String("cluster.id", clusterID.String())
 }
 
+func WithEdgeTraceID(traceID string) zap.Field {
+	return zap.String("edge.trace.id", traceID)
+}
+
 func WithServiceInstanceID(instanceID string) zap.Field {
 	return zap.String("service.instance.id", instanceID)
 }

--- a/packages/shared/pkg/middleware/otel/tracing/middleware.go
+++ b/packages/shared/pkg/middleware/otel/tracing/middleware.go
@@ -87,22 +87,26 @@ func Middleware(tracerProvider oteltrace.TracerProvider, service string) gin.Han
 		if c.Request.Header.Get("traceparent") != "" {
 			c.Request.Header.Del("traceparent")
 		}
-		if edgeTraceID, ok := telemetry.ParseEdgeTraceID(
-			c.Request.Header.Get(telemetry.GCPTraceContextHeader),
-			c.Request.Header.Get(telemetry.AWSTraceContextHeader),
-		); ok {
-			ctx = logger.ContextWithEdgeTraceID(ctx, edgeTraceID)
-		}
 		opts := []oteltrace.SpanStartOption{
 			oteltrace.WithAttributes(semconv.NetAttributesFromHTTPRequest("tcp", c.Request)...),
 			oteltrace.WithAttributes(semconv.EndUserAttributesFromHTTPRequest(c.Request)...),
 			oteltrace.WithAttributes(semconv.HTTPServerAttributesFromHTTPRequest(service, c.FullPath(), c.Request)...),
 			oteltrace.WithSpanKind(oteltrace.SpanKindServer),
 		}
+
+		if edgeTraceID, ok := telemetry.ParseEdgeTraceID(
+			c.Request.Header.Get(telemetry.GCPTraceContextHeader),
+			c.Request.Header.Get(telemetry.AWSTraceContextHeader),
+		); ok {
+			ctx = logger.ContextWithEdgeTraceID(ctx, edgeTraceID)
+			opts = append(opts, oteltrace.WithAttributes(telemetry.WithEdgeTraceID(edgeTraceID)))
+		}
+
 		spanName := c.FullPath()
 		if spanName == "" {
 			spanName = fmt.Sprintf("HTTP %s route not found", c.Request.Method)
 		}
+
 		ctx, span := tracer.Start(ctx, spanName, opts...)
 		defer span.End()
 

--- a/packages/shared/pkg/telemetry/fields.go
+++ b/packages/shared/pkg/telemetry/fields.go
@@ -36,6 +36,10 @@ func WithClusterID(clusterID uuid.UUID) attribute.KeyValue {
 	return zapFieldToOTELAttribute(logger.WithClusterID(clusterID))
 }
 
+func WithEdgeTraceID(traceID string) attribute.KeyValue {
+	return zapFieldToOTELAttribute(logger.WithEdgeTraceID(traceID))
+}
+
 func WithUserID(userID string) attribute.KeyValue {
 	return zapFieldToOTELAttribute(logger.WithUserID(userID))
 }


### PR DESCRIPTION
This allows easier search between GCP/AWS load balancer logs and internal API traces as you can directly search for a concrete trace ID coming from a load balancer.