### PR TITLE
docs: add Go doc comments for exported functions (golint/godoc)

### DIFF
--- a/packages/api/internal/handlers/auth.go
+++ b/packages/api/internal/handlers/auth.go
@@ -16,6 +16,10 @@ import (
 	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 )
 
+// GetTeam retrieves the effective team for the current request context.
+// It first checks for team information injected by authentication middleware
+// and falls back to resolving teams by user ID if available. If a teamID is
+// provided it validates access to that team. Returns an APIError on failure.
 func (a *APIStore) GetTeam(
 	ctx context.Context,
 	c *gin.Context,

--- a/packages/docker-reverse-proxy/internal/cache/auth.go
+++ b/packages/docker-reverse-proxy/internal/cache/auth.go
@@ -20,10 +20,20 @@ type AccessTokenData struct {
 	TemplateID  string
 }
 
+// AccessTokenData holds authentication details associated with a generated
+// temporary e2b token: the underlying Docker registry token and the
+// template identifier this token is valid for.
 type AuthCache struct {
 	cache *ttlcache.Cache[string, *AccessTokenData]
 }
 
+// AuthCache provides a TTL-backed in-memory cache for mapping generated
+// e2b tokens to `AccessTokenData`. It is intended to be short-lived and
+// is used during reverse-proxy authentication flows.
+
+// New returns a new initialized AuthCache instance.
+// The cache is started in a separate goroutine and will store temporary
+// access tokens for template/docker authentication lookup.
 func New() *AuthCache {
 	cache := ttlcache.New(ttlcache.WithTTL[string, *AccessTokenData](authInfoExpiration))
 

--- a/packages/docker-reverse-proxy/internal/cache/auth.go
+++ b/packages/docker-reverse-proxy/internal/cache/auth.go
@@ -15,21 +15,20 @@ const (
 	authInfoExpiration = time.Hour * 2
 )
 
+// AccessTokenData holds authentication details associated with a generated
+// temporary e2b token: the underlying Docker registry token and the
+// template identifier this token is valid for.
 type AccessTokenData struct {
 	DockerToken string
 	TemplateID  string
 }
 
-// AccessTokenData holds authentication details associated with a generated
-// temporary e2b token: the underlying Docker registry token and the
-// template identifier this token is valid for.
-type AuthCache struct {
-	cache *ttlcache.Cache[string, *AccessTokenData]
-}
-
 // AuthCache provides a TTL-backed in-memory cache for mapping generated
 // e2b tokens to `AccessTokenData`. It is intended to be short-lived and
 // is used during reverse-proxy authentication flows.
+type AuthCache struct {
+	cache *ttlcache.Cache[string, *AccessTokenData]
+}
 
 // New returns a new initialized AuthCache instance.
 // The cache is started in a separate goroutine and will store temporary

--- a/packages/envd/internal/api/auth.go
+++ b/packages/envd/internal/api/auth.go
@@ -15,7 +15,12 @@ import (
 )
 
 const (
-	SigningReadOperation  = "read"
+	// SigningReadOperation is the operation name used when generating
+	// signatures for read operations.
+	SigningReadOperation = "read"
+
+	// SigningWriteOperation is the operation name used when generating
+	// signatures for write operations.
 	SigningWriteOperation = "write"
 
 	accessTokenHeader = "X-Access-Token"
@@ -23,6 +28,9 @@ const (
 
 // paths that are always allowed without general authentication
 // POST/init is secured via MMDS hash validation instead
+// authExcludedPaths lists request methods+paths that are allowed without
+// general access token authentication (for example health checks and
+// endpoints that support signing instead of a token).
 var authExcludedPaths = []string{
 	"GET/health",
 	"GET/files",
@@ -30,6 +38,10 @@ var authExcludedPaths = []string{
 	"POST/init",
 }
 
+// WithAuthorization is middleware that enforces access token authentication
+// for requests handled by the returned handler. If the API's access token
+// is not set the middleware is a no-op. Requests that match
+// authExcludedPaths or present a valid access token are allowed.
 func (a *API) WithAuthorization(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if a.accessToken.IsSet() {


### PR DESCRIPTION
- Motivation: 
   Ensure exported Go symbols follow godoc/golint conventions so generated docs are complete and linters stop flagging missing comments.
- Scope: 
   Add doc comments for exported functions, types and constants in auth.go files (e.g., GetTeam, AccessTokenData, AuthCache, signing constants); fix misplaced comments and run gofmt.
- Impact: 
   Documentation/formatting only — no runtime behavior changes. Improves generated API docs and reduces linter noise.