### PR TITLE
feat(resume-build): add -no-default-route flag to skip in-namespace default route

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -56,6 +56,7 @@ func main() {
 	iterations := flag.Int("iterations", 0, "run N iterations (0 = interactive)")
 	coldStart := flag.Bool("cold", false, "clear cache between iterations (cold start each time)")
 	noPrefetch := flag.Bool("no-prefetch", false, "disable memory prefetching")
+	noDefaultRoute := flag.Bool("no-default-route", false, "skip adding the in-namespace default route (default via VethIP)")
 	verbose := flag.Bool("v", false, "verbose logging")
 
 	// Command execution (no pause)
@@ -155,7 +156,7 @@ func main() {
 		iterations: *iterations,
 	}
 
-	err := run(ctx, *fromBuild, *iterations, *coldStart, *noPrefetch, *verbose, pauseOpts, runOpts)
+	err := run(ctx, *fromBuild, *iterations, *coldStart, *noPrefetch, *noDefaultRoute, *verbose, pauseOpts, runOpts)
 	cancel()
 
 	if err != nil {
@@ -955,7 +956,7 @@ func (r *runner) benchmark(ctx context.Context, n int) error {
 	return lastErr
 }
 
-func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefetch, verbose bool, pauseOpts pauseOptions, runOpts runOptions) error {
+func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefetch, noDefaultRoute, verbose bool, pauseOpts pauseOptions, runOpts runOptions) error {
 	// Silence other loggers unless verbose mode
 	var l logger.Logger
 	if !verbose {
@@ -987,6 +988,8 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if err != nil {
 		return fmt.Errorf("config: %w", err)
 	}
+
+	config.NetworkConfig.SkipDefaultRoute = noDefaultRoute
 
 	if verbose {
 		fmt.Println("🔧 Creating feature flags client...")

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -157,12 +157,14 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 	}
 
 	// Add NS default route
-	err = netlink.RouteAdd(&netlink.Route{
-		Scope: netlink.SCOPE_UNIVERSE,
-		Gw:    s.VethIP(),
-	})
-	if err != nil {
-		return fmt.Errorf("error adding default NS route: %w", err)
+	if !s.config.SkipDefaultRoute {
+		err = netlink.RouteAdd(&netlink.Route{
+			Scope: netlink.SCOPE_UNIVERSE,
+			Gw:    s.VethIP(),
+		})
+		if err != nil {
+			return fmt.Errorf("error adding default NS route: %w", err)
+		}
 	}
 
 	tables, err := iptables.New()

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -67,6 +67,10 @@ type Config struct {
 	SandboxTCPFirewallHTTPPort  uint16 `env:"SANDBOX_TCP_FIREWALL_HTTP_PORT"  envDefault:"5016"`
 	SandboxTCPFirewallTLSPort   uint16 `env:"SANDBOX_TCP_FIREWALL_TLS_PORT"   envDefault:"5017"`
 	SandboxTCPFirewallOtherPort uint16 `env:"SANDBOX_TCP_FIREWALL_OTHER_PORT" envDefault:"5018"`
+
+	// SkipDefaultRoute, when true, makes Slot.CreateNetwork skip installing the
+	// in-namespace default route (`default via <VethIP>`).
+	SkipDefaultRoute bool
 }
 
 func ParseConfig() (Config, error) {


### PR DESCRIPTION
Allows experimenting with sandbox resume behavior when the guest has no default egress route. Controlled solely via CLI; the new network.Config.SkipDefaultRoute field is not exposed via env to avoid affecting production.