### PR TITLE
Bake clickhouse-client and CNI plugins into cluster disk image

### DIFF
--- a/iac/nomad-cluster-disk-image/setup/install-clickhouse-client.sh
+++ b/iac/nomad-cluster-disk-image/setup/install-clickhouse-client.sh
@@ -43,18 +43,28 @@ esac
 BASE_URL="https://packages.clickhouse.com/tgz/stable"
 TARBALL="clickhouse-common-static-${VERSION}-${CH_ARCH}.tgz"
 URL="${BASE_URL}/${TARBALL}"
+CHECKSUM_URL="${URL}.sha512"
 
 echo "Installing clickhouse-client ${VERSION} (${CH_ARCH}) from ${URL}"
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+# Use a named work dir; DO NOT clobber $TMPDIR (POSIX env var used by curl/tar).
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
-curl -fsSL --retry 5 --retry-delay 5 -o "${TMPDIR}/${TARBALL}" "${URL}"
-tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+curl -fsSL --retry 5 --retry-delay 5 -o "${WORK_DIR}/${TARBALL}" "${URL}"
+curl -fsSL --retry 5 --retry-delay 5 -o "${WORK_DIR}/${TARBALL}.sha512" "${CHECKSUM_URL}"
+
+# Verify SHA-512 checksum before extracting. The .sha512 file is in standard
+# `<hash>  <filename>` format, so `sha512sum -c` works directly when run in
+# the same directory as the tarball.
+echo "Verifying SHA-512 checksum"
+(cd "${WORK_DIR}" && sha512sum -c "${TARBALL}.sha512")
+
+tar -xzf "${WORK_DIR}/${TARBALL}" -C "${WORK_DIR}"
 
 # The tarball extracts to clickhouse-common-static-<VERSION>/usr/bin/clickhouse
 # (a single multi-call binary; `clickhouse client`, `clickhouse local`, etc.).
-EXTRACTED_BIN=$(find "${TMPDIR}" -type f -name clickhouse -path '*/usr/bin/*' | head -n1)
+EXTRACTED_BIN=$(find "${WORK_DIR}" -type f -name clickhouse -path '*/usr/bin/*' | head -n1)
 if [[ -z "$EXTRACTED_BIN" ]]; then
   echo "ERROR: could not find clickhouse binary in ${TARBALL}" >&2
   exit 1

--- a/iac/nomad-cluster-disk-image/setup/install-clickhouse-client.sh
+++ b/iac/nomad-cluster-disk-image/setup/install-clickhouse-client.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Installs the ClickHouse client at a pinned version by downloading the official
+# static binary tarball from https://packages.clickhouse.com/tgz/stable/.
+# Intended to be run by Packer when building the shared Nomad cluster disk image
+# so the client is available on every node without being downloaded at boot time.
+#
+# The version should be kept in sync with the ClickHouse server version (see
+# `clickhouse_version` in iac/modules/job-clickhouse/variables.tf).
+
+set -euo pipefail
+
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unrecognized argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  echo "ERROR: --version is required" >&2
+  exit 1
+fi
+
+# Map dpkg arch -> ClickHouse tarball arch suffix.
+DPKG_ARCH=$(dpkg --print-architecture)
+case "$DPKG_ARCH" in
+  amd64) CH_ARCH="amd64" ;;
+  arm64) CH_ARCH="arm64" ;;
+  *)
+    echo "ERROR: unsupported architecture: $DPKG_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+BASE_URL="https://packages.clickhouse.com/tgz/stable"
+TARBALL="clickhouse-common-static-${VERSION}-${CH_ARCH}.tgz"
+URL="${BASE_URL}/${TARBALL}"
+
+echo "Installing clickhouse-client ${VERSION} (${CH_ARCH}) from ${URL}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL --retry 5 --retry-delay 5 -o "${TMPDIR}/${TARBALL}" "${URL}"
+tar -xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+
+# The tarball extracts to clickhouse-common-static-<VERSION>/usr/bin/clickhouse
+# (a single multi-call binary; `clickhouse client`, `clickhouse local`, etc.).
+EXTRACTED_BIN=$(find "${TMPDIR}" -type f -name clickhouse -path '*/usr/bin/*' | head -n1)
+if [[ -z "$EXTRACTED_BIN" ]]; then
+  echo "ERROR: could not find clickhouse binary in ${TARBALL}" >&2
+  exit 1
+fi
+
+INSTALL_DIR="/usr/local/bin"
+sudo install -m 0755 "$EXTRACTED_BIN" "${INSTALL_DIR}/clickhouse"
+
+# Convenience symlink so `clickhouse-client` also works (matches the apt package layout).
+sudo ln -sf "${INSTALL_DIR}/clickhouse" "${INSTALL_DIR}/clickhouse-client"
+
+# Ensure the install dir is on PATH for all shells. /usr/local/bin is on the
+# default Ubuntu PATH (via /etc/environment), but drop a profile.d snippet to
+# make this explicit and resilient to any image-level PATH changes.
+sudo tee /etc/profile.d/clickhouse.sh > /dev/null <<EOF
+# Added by install-clickhouse-client.sh
+case ":\$PATH:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *) export PATH="${INSTALL_DIR}:\$PATH" ;;
+esac
+EOF
+sudo chmod 0644 /etc/profile.d/clickhouse.sh
+
+# Verify the binary is reachable via PATH in a fresh login shell.
+if ! command -v clickhouse >/dev/null; then
+  echo "ERROR: clickhouse was not installed successfully" >&2
+  exit 1
+fi
+if ! bash -lc 'command -v clickhouse' >/dev/null; then
+  echo "ERROR: clickhouse is not on PATH for login shells" >&2
+  exit 1
+fi
+
+echo "clickhouse installed at $(command -v clickhouse):"
+clickhouse client --version

--- a/iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
+++ b/iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Installs the containernetworking/plugins (CNI) binaries into /opt/cni/bin.
+# Required by Nomad when running tasks in `bridge` network mode.
+# Safe to install on every node even if unused, the binaries just sit in /opt/cni/bin.
+#
+# Intended to be run by Packer when building the shared Nomad cluster disk
+# image so the plugins are available without being downloaded at boot time.
+
+set -euo pipefail
+
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unrecognized argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  echo "ERROR: --version is required" >&2
+  exit 1
+fi
+
+# Map uname -m to the arch suffix used by the CNI release artifacts.
+case "$(uname -m)" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *)
+    echo "ERROR: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+URL="https://github.com/containernetworking/plugins/releases/download/${VERSION}/cni-plugins-linux-${ARCH}-${VERSION}.tgz"
+
+echo "Installing CNI plugins ${VERSION} (${ARCH}) from ${URL}"
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+curl -fsSL --retry 5 --retry-delay 5 -o "${TMPDIR}/cni-plugins.tgz" "${URL}"
+
+sudo mkdir -p /opt/cni/bin
+sudo tar -C /opt/cni/bin -xzf "${TMPDIR}/cni-plugins.tgz"
+
+# Sanity check: bridge is the plugin Nomad needs for bridge-mode networking.
+if [[ ! -x /opt/cni/bin/bridge ]]; then
+  echo "ERROR: /opt/cni/bin/bridge is missing or not executable" >&2
+  exit 1
+fi
+
+echo "CNI plugins installed to /opt/cni/bin:"
+ls /opt/cni/bin

--- a/iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
+++ b/iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
@@ -38,17 +38,27 @@ case "$(uname -m)" in
     ;;
 esac
 
-URL="https://github.com/containernetworking/plugins/releases/download/${VERSION}/cni-plugins-linux-${ARCH}-${VERSION}.tgz"
+TARBALL="cni-plugins-linux-${ARCH}-${VERSION}.tgz"
+BASE_URL="https://github.com/containernetworking/plugins/releases/download/${VERSION}"
+URL="${BASE_URL}/${TARBALL}"
+CHECKSUM_URL="${URL}.sha256"
 
 echo "Installing CNI plugins ${VERSION} (${ARCH}) from ${URL}"
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+# Use a named work dir; DO NOT clobber $TMPDIR (POSIX env var used by curl/tar).
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
-curl -fsSL --retry 5 --retry-delay 5 -o "${TMPDIR}/cni-plugins.tgz" "${URL}"
+curl -fsSL --retry 5 --retry-delay 5 -o "${WORK_DIR}/${TARBALL}" "${URL}"
+curl -fsSL --retry 5 --retry-delay 5 -o "${WORK_DIR}/${TARBALL}.sha256" "${CHECKSUM_URL}"
+
+# Verify SHA-256 checksum before extracting. The .sha256 file is in standard
+# `<hash>  <filename>` format, so `sha256sum -c` works directly.
+echo "Verifying SHA-256 checksum"
+(cd "${WORK_DIR}" && sha256sum -c "${TARBALL}.sha256")
 
 sudo mkdir -p /opt/cni/bin
-sudo tar -C /opt/cni/bin -xzf "${TMPDIR}/cni-plugins.tgz"
+sudo tar -C /opt/cni/bin -xzf "${WORK_DIR}/${TARBALL}"
 
 # Sanity check: bridge is the plugin Nomad needs for bridge-mode networking.
 if [[ ! -x /opt/cni/bin/bridge ]]; then

--- a/iac/provider-aws/modules/nodepool-clickhouse/scripts/start-clickhouse.sh
+++ b/iac/provider-aws/modules/nodepool-clickhouse/scripts/start-clickhouse.sh
@@ -132,12 +132,9 @@ DNSStubListenerExtra=172.17.0.1
 EOF
 systemctl restart systemd-resolved
 
-# Install CNI plugin for networking in Nomad (bridge mode)
-ARCH_CNI=$([ "$(uname -m)" = aarch64 ] && echo arm64 || echo amd64)
-CNI_PLUGIN_VERSION=v1.6.2
-curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/$${CNI_PLUGIN_VERSION}/cni-plugins-linux-$${ARCH_CNI}-$${CNI_PLUGIN_VERSION}".tgz &&
-  sudo mkdir -p /opt/cni/bin &&
-  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
+# Note: CNI plugins (needed for Nomad bridge-mode networking) are pre-installed
+# in the cluster disk image at build time. See
+# iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
 
 # These variables are passed in via Terraform template interpolation
 /opt/consul/bin/run-consul.sh --client \
@@ -149,6 +146,3 @@ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/relea
     --dns-request-token "${CONSUL_DNS_REQUEST_TOKEN}" &
 
 /opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" &
-
-# Install clickhouse client to make it easier to interact with the ClickHouse server
-cd /usr/local/bin && curl https://clickhouse.com/ | sh && sudo ./clickhouse install &

--- a/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/main.pkr.hcl
@@ -132,6 +132,20 @@ build {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.vault_version}"
   }
 
+  # Install the ClickHouse client at the same version as the server so it's
+  # available on every node without being downloaded at boot time.
+  provisioner "shell" {
+    script          = "${local.shared_setup_dir}/install-clickhouse-client.sh"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.clickhouse_client_version}"
+  }
+
+  # Install CNI plugins (needed by Nomad bridge-mode networking on the
+  # ClickHouse nodepool). Harmless on nodes that don't use them.
+  provisioner "shell" {
+    script          = "${local.shared_setup_dir}/install-cni-plugins.sh"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.cni_plugin_version}"
+  }
+
   provisioner "shell" {
     inline = [
       "sudo mkdir -p /opt/nomad/plugins",

--- a/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
@@ -25,6 +25,17 @@ variable "vault_version" {
   default = "1.20.3"
 }
 
+# Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf
+variable "clickhouse_client_version" {
+  type    = string
+  default = "25.4.5.24"
+}
+
+variable "cni_plugin_version" {
+  type    = string
+  default = "v1.6.2"
+}
+
 variable "base_instance_type" {
   type    = string
   default = "t3.large"

--- a/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
@@ -131,6 +131,20 @@ build {
     execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.vault_version}"
   }
 
+  # Install the ClickHouse client at the same version as the server so it's
+  # available on every node without being downloaded at boot time.
+  provisioner "shell" {
+    script          = "${local.shared_setup_dir}/install-clickhouse-client.sh"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.clickhouse_client_version}"
+  }
+
+  # Install CNI plugins (needed by Nomad bridge-mode networking on the
+  # ClickHouse nodepool). Harmless on nodes that don't use them.
+  provisioner "shell" {
+    script          = "${local.shared_setup_dir}/install-cni-plugins.sh"
+    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }} --version ${var.cni_plugin_version}"
+  }
+
   provisioner "shell" {
     inline = [
       "sudo mkdir -p /opt/nomad/plugins",

--- a/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
@@ -29,3 +29,14 @@ variable "vault_version" {
   type    = string
   default = "1.20.3"
 }
+
+# Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf
+variable "clickhouse_client_version" {
+  type    = string
+  default = "25.4.5.24"
+}
+
+variable "cni_plugin_version" {
+  type    = string
+  default = "v1.6.2"
+}

--- a/iac/provider-gcp/nomad-cluster/scripts/start-clickhouse.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-clickhouse.sh
@@ -110,12 +110,9 @@ DNSStubListenerExtra=172.17.0.1
 EOF
 systemctl restart systemd-resolved
 
-# Install CNI plugin for networking in Nomad (bridge mode)
-ARCH_CNI=$([ "$(uname -m)" = aarch64 ] && echo arm64 || echo amd64)
-CNI_PLUGIN_VERSION=v1.6.2
-curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/$${CNI_PLUGIN_VERSION}/cni-plugins-linux-$${ARCH_CNI}-$${CNI_PLUGIN_VERSION}".tgz &&
-  sudo mkdir -p /opt/cni/bin &&
-  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
+# Note: CNI plugins (needed for Nomad bridge-mode networking) are pre-installed
+# in the cluster disk image at build time. See
+# iac/nomad-cluster-disk-image/setup/install-cni-plugins.sh
 
 # These variables are passed in via Terraform template interpolation
 /opt/consul/bin/run-consul.sh --client \
@@ -127,5 +124,5 @@ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/relea
 
 /opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" &
 
-# Install clickhouse client to make it easier to interact with the ClickHouse server
-cd /usr/local/bin && curl https://clickhouse.com/ | sh && sudo ./clickhouse install &
+# Note: the clickhouse client is pre-installed in the cluster disk image at build
+# time (see iac/nomad-cluster-disk-image/setup/install-clickhouse-client.sh).


### PR DESCRIPTION
Move two runtime installs out of start-clickhouse.sh into the shared Packer image build:

- clickhouse-client: installed from the official static tarball at a pinned version (default 25.4.5.24, matches clickhouse_version in job-clickhouse). Symlinked as clickhouse-client and guaranteed on PATH via /etc/profile.d/clickhouse.sh.
- CNI plugins: installed to /opt/cni/bin at a pinned version (default v1.6.2). Required by Nomad bridge-mode networking on the ClickHouse nodepool; harmless on other nodepools.

Pre-baking both removes network flakiness at boot and keeps the client version in lockstep with the server.