### PR TITLE
fix(api): clarify template lookup errors

### DIFF
--- a/packages/api/internal/cache/templates/alias_cache.go
+++ b/packages/api/internal/cache/templates/alias_cache.go
@@ -90,10 +90,7 @@ func (c *AliasCache) Resolve(ctx context.Context, identifier string, namespaceFa
 
 	// If not found, try NULL namespace (promoted templates)
 	if errors.Is(err, ErrTemplateNotFound) {
-		info, err = c.lookup(ctx, nil, alias)
-		if err == nil {
-			return info, nil
-		}
+		return c.lookup(ctx, nil, alias)
 	}
 
 	return nil, err
@@ -113,7 +110,7 @@ func (c *AliasCache) lookup(ctx context.Context, namespace *string, alias string
 	}
 
 	if info.NotFound {
-		return nil, ErrTemplateNotFound
+		return nil, templateNotFoundError{Identifier: key}
 	}
 
 	resolved := *info

--- a/packages/api/internal/cache/templates/alias_cache_test.go
+++ b/packages/api/internal/cache/templates/alias_cache_test.go
@@ -192,6 +192,32 @@ func TestAliasCacheResolve_NotFound(t *testing.T) {
 	info, err := cache.Resolve(ctx, "non-existent", teamSlug)
 	require.ErrorIs(t, err, ErrTemplateNotFound)
 	require.Nil(t, info)
+
+	var notFoundErr templateNotFoundError
+	require.ErrorAs(t, err, &notFoundErr)
+	assert.Equal(t, "non-existent", notFoundErr.Identifier)
+}
+
+func TestAliasCacheResolve_ExplicitNamespaceNotFoundUsesRequestedIdentifier(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	teamSlug := testutils.GetTeamSlug(t, ctx, db, teamID)
+	identifier := teamSlug + "/missing"
+
+	cache := NewAliasCache(db.SqlcClient, redis)
+	defer cache.Close(ctx)
+
+	info, err := cache.Resolve(ctx, identifier, teamSlug)
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+	require.Nil(t, info)
+
+	var notFoundErr templateNotFoundError
+	require.ErrorAs(t, err, &notFoundErr)
+	assert.Equal(t, identifier, notFoundErr.Identifier)
 }
 
 // TestAliasCacheLookupByID tests direct template ID lookup

--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -159,8 +159,7 @@ func (c *TemplateCache) fetchTemplateWithBuild(templateID string, tag *string) f
 		if err != nil {
 			if dberrors.IsNotFoundError(err) {
 				return nil, templateTagNotFoundError{
-					Identifier: templateID,
-					Tag:        sharedUtils.DerefOrDefault(tag, id.DefaultTag),
+					Tag: sharedUtils.DerefOrDefault(tag, id.DefaultTag),
 				}
 			}
 

--- a/packages/api/internal/cache/templates/cache.go
+++ b/packages/api/internal/cache/templates/cache.go
@@ -158,7 +158,10 @@ func (c *TemplateCache) fetchTemplateWithBuild(templateID string, tag *string) f
 		})
 		if err != nil {
 			if dberrors.IsNotFoundError(err) {
-				return nil, ErrTemplateNotFound
+				return nil, templateTagNotFoundError{
+					Identifier: templateID,
+					Tag:        sharedUtils.DerefOrDefault(tag, id.DefaultTag),
+				}
 			}
 
 			return nil, fmt.Errorf("fetching template with build: %w", err)

--- a/packages/api/internal/cache/templates/cache_test.go
+++ b/packages/api/internal/cache/templates/cache_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
@@ -83,6 +84,52 @@ func TestTemplateCache_InvalidateAllTagsDeletesRedisEntries(t *testing.T) {
 	exists, err := redisClient.Exists(ctx, redisKey).Result()
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), exists, "Redis entry should be deleted after InvalidateAllTags")
+}
+
+func TestTemplateCache_Get_ClassifiesMissingDefaultTag(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "ready")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "dev")
+
+	tc := NewTemplateCache(db.SqlcClient, redis)
+	defer tc.Close(ctx)
+
+	_, _, err := tc.Get(ctx, templateID, nil, teamID, consts.LocalClusterID)
+
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+
+	var tagErr templateTagNotFoundError
+	require.ErrorAs(t, err, &tagErr)
+	assert.Equal(t, id.DefaultTag, tagErr.Tag)
+}
+
+func TestTemplateCache_Get_ExistingTagWithoutReadyBuildIsTagNotFound(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "building")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "default")
+
+	tc := NewTemplateCache(db.SqlcClient, redis)
+	defer tc.Close(ctx)
+
+	_, _, err := tc.Get(ctx, templateID, nil, teamID, consts.LocalClusterID)
+
+	require.ErrorIs(t, err, ErrTemplateNotFound)
+
+	var tagErr templateTagNotFoundError
+	require.ErrorAs(t, err, &tagErr)
+	assert.Equal(t, id.DefaultTag, tagErr.Tag)
 }
 
 // TestTemplateCache_InvalidateAllTagsAlsoInvalidatesMetadata tests that

--- a/packages/api/internal/cache/templates/errors.go
+++ b/packages/api/internal/cache/templates/errors.go
@@ -27,12 +27,11 @@ func (e templateNotFoundError) Unwrap() error {
 }
 
 type templateTagNotFoundError struct {
-	Identifier string
-	Tag        string
+	Tag string
 }
 
 func (e templateTagNotFoundError) Error() string {
-	return fmt.Sprintf("%s: %s:%s", ErrTemplateNotFound, e.Identifier, e.Tag)
+	return fmt.Sprintf("%s: tag %s", ErrTemplateNotFound, e.Tag)
 }
 
 func (e templateTagNotFoundError) Unwrap() error {
@@ -54,7 +53,7 @@ func ToAPIError(err error, identifier string) *api.APIError {
 	case errors.As(err, &tagErr):
 		return &api.APIError{
 			Code:      http.StatusNotFound,
-			ClientMsg: fmt.Sprintf("tag '%s' does not exist for template '%s'", tagErr.Tag, tagErr.Identifier),
+			ClientMsg: fmt.Sprintf("tag '%s' does not exist for template '%s'", tagErr.Tag, identifier),
 			Err:       err,
 		}
 	case errors.Is(err, ErrTemplateNotFound):

--- a/packages/api/internal/cache/templates/errors.go
+++ b/packages/api/internal/cache/templates/errors.go
@@ -14,43 +14,77 @@ var (
 	ErrClusterMismatch  = errors.New("template not available in cluster")
 )
 
-type TemplateRef struct {
-	Subject    string
+type templateNotFoundError struct {
 	Identifier string
-	TemplateID string
-	Tag        *string
+}
+
+func (e templateNotFoundError) Error() string {
+	return fmt.Sprintf("%s: %s", ErrTemplateNotFound, e.Identifier)
+}
+
+func (e templateNotFoundError) Unwrap() error {
+	return ErrTemplateNotFound
+}
+
+type templateTagNotFoundError struct {
+	Identifier string
+	Tag        string
+}
+
+func (e templateTagNotFoundError) Error() string {
+	return fmt.Sprintf("%s: %s:%s", ErrTemplateNotFound, e.Identifier, e.Tag)
+}
+
+func (e templateTagNotFoundError) Unwrap() error {
+	return ErrTemplateNotFound
+}
+
+type TemplateRef struct {
+	Identifier string
 	Visible    bool
 }
 
 func ErrorToAPIError(err error, fallbackIdentifier string) *api.APIError {
-	return ToAPIError(err, "template", fallbackIdentifier)
+	return ToAPIError(err, fallbackIdentifier)
 }
 
-func ToAPIError(err error, subject, identifier string) *api.APIError {
+func ToAPIError(err error, identifier string) *api.APIError {
+	var tagErr templateTagNotFoundError
 	switch {
-	case errors.Is(err, ErrTemplateNotFound):
+	case errors.As(err, &tagErr):
 		return &api.APIError{
 			Code:      http.StatusNotFound,
-			ClientMsg: fmt.Sprintf("%s not found", formatTemplateRef(subject, identifier, "")),
+			ClientMsg: fmt.Sprintf("tag '%s' does not exist for template '%s'", tagErr.Tag, tagErr.Identifier),
+			Err:       err,
+		}
+	case errors.Is(err, ErrTemplateNotFound):
+		var notFoundErr templateNotFoundError
+		if errors.As(err, &notFoundErr) {
+			identifier = notFoundErr.Identifier
+		}
+
+		return &api.APIError{
+			Code:      http.StatusNotFound,
+			ClientMsg: fmt.Sprintf("template '%s' not found", identifier),
 			Err:       err,
 		}
 	case errors.Is(err, ErrAccessDenied):
 		return &api.APIError{
 			Code:      http.StatusForbidden,
-			ClientMsg: fmt.Sprintf("you don't have access to %s", formatTemplateRef(subject, identifier, "")),
+			ClientMsg: fmt.Sprintf("you don't have access to template '%s'", identifier),
 			Err:       err,
 		}
 	case errors.Is(err, ErrClusterMismatch):
 		return &api.APIError{
 			Code:      http.StatusBadRequest,
-			ClientMsg: fmt.Sprintf("%s is not available in the requested cluster", formatTemplateRef(subject, identifier, "")),
+			ClientMsg: fmt.Sprintf("template '%s' is not available in the requested cluster", identifier),
 			Err:       err,
 		}
 	}
 
 	return &api.APIError{
 		Code:      http.StatusInternalServerError,
-		ClientMsg: fmt.Sprintf("error resolving %s", formatTemplateRef(subject, identifier, "")),
+		ClientMsg: fmt.Sprintf("error resolving template '%s'", identifier),
 		Err:       err,
 	}
 }
@@ -59,36 +93,21 @@ func (r TemplateRef) APIError(err error) *api.APIError {
 	if !r.Visible && (errors.Is(err, ErrAccessDenied) || errors.Is(err, ErrTemplateNotFound)) {
 		return &api.APIError{
 			Code:      http.StatusNotFound,
-			ClientMsg: fmt.Sprintf("%s not found", formatTemplateRef(r.Subject, r.Identifier, "")),
+			ClientMsg: fmt.Sprintf("template '%s' not found", r.Identifier),
 			Err:       err,
 		}
 	}
 
-	if !errors.Is(err, ErrTemplateNotFound) {
-		return ToAPIError(err, r.Subject, r.Identifier)
+	var tagErr templateTagNotFoundError
+	if !errors.As(err, &tagErr) {
+		return ToAPIError(err, r.Identifier)
 	}
 
-	label := formatTemplateRef(r.Subject, r.Identifier, r.TemplateID)
-	clientMsg := fmt.Sprintf("%s has no ready build", label)
-	if r.Tag != nil {
-		clientMsg = fmt.Sprintf("%s with tag '%s' not found", label, *r.Tag)
-	}
+	clientMsg := fmt.Sprintf("tag '%s' does not exist for template '%s'", tagErr.Tag, r.Identifier)
 
 	return &api.APIError{
 		Code:      http.StatusNotFound,
 		ClientMsg: clientMsg,
 		Err:       err,
 	}
-}
-
-func formatTemplateRef(subject, identifier, templateID string) string {
-	if subject == "" {
-		subject = "template"
-	}
-
-	if templateID == "" || templateID == identifier {
-		return fmt.Sprintf("%s '%s'", subject, identifier)
-	}
-
-	return fmt.Sprintf("%s '%s' (%s)", subject, identifier, templateID)
 }

--- a/packages/api/internal/cache/templates/errors_test.go
+++ b/packages/api/internal/cache/templates/errors_test.go
@@ -8,45 +8,61 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTemplateRef_APIError_MissingBuildWithTag(t *testing.T) {
+func TestTemplateRef_APIError_MissingBuildWithTagReturnsMissingTag(t *testing.T) {
 	t.Parallel()
 
 	tag := "v2"
 	apiErr := TemplateRef{
-		Subject:    "template",
 		Identifier: "mytemplate",
-		TemplateID: "tmpl-abc",
-		Tag:        &tag,
 		Visible:    true,
-	}.APIError(ErrTemplateNotFound)
+	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: tag})
 
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Equal(t, "template 'mytemplate' (tmpl-abc) with tag 'v2' not found", apiErr.ClientMsg)
+	assert.Equal(t, "tag 'v2' does not exist for template 'mytemplate'", apiErr.ClientMsg)
 }
 
-func TestTemplateRef_APIError_MissingBuildWithoutTag(t *testing.T) {
+func TestTemplateRef_APIError_MissingTag(t *testing.T) {
+	t.Parallel()
+
+	tag := "v2"
+	apiErr := TemplateRef{
+		Identifier: "mytemplate",
+		Visible:    true,
+	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: tag})
+
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Equal(t, "tag 'v2' does not exist for template 'mytemplate'", apiErr.ClientMsg)
+}
+
+func TestTemplateRef_APIError_MissingDefaultTag(t *testing.T) {
 	t.Parallel()
 
 	apiErr := TemplateRef{
-		Subject:    "template",
 		Identifier: "mytemplate",
-		TemplateID: "tmpl-abc",
 		Visible:    true,
-	}.APIError(ErrTemplateNotFound)
+	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
 
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Equal(t, "template 'mytemplate' (tmpl-abc) has no ready build", apiErr.ClientMsg)
+	assert.Equal(t, "tag 'default' does not exist for template 'mytemplate'", apiErr.ClientMsg)
+}
+
+func TestTemplateRef_APIError_MissingBuildWithoutTagReturnsMissingDefaultTag(t *testing.T) {
+	t.Parallel()
+
+	apiErr := TemplateRef{
+		Identifier: "mytemplate",
+		Visible:    true,
+	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
+
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Equal(t, "tag 'default' does not exist for template 'mytemplate'", apiErr.ClientMsg)
 }
 
 func TestTemplateRef_APIError_HiddenTemplate(t *testing.T) {
 	t.Parallel()
 
-	tag := "v2"
 	apiErr := TemplateRef{
-		Subject:    "template",
 		Identifier: "mytemplate",
-		TemplateID: "tmpl-abc",
-		Tag:        &tag,
 		Visible:    false,
 	}.APIError(ErrTemplateNotFound)
 
@@ -57,12 +73,8 @@ func TestTemplateRef_APIError_HiddenTemplate(t *testing.T) {
 func TestTemplateRef_APIError_HiddenAccessDenied(t *testing.T) {
 	t.Parallel()
 
-	tag := "v2"
 	apiErr := TemplateRef{
-		Subject:    "template",
 		Identifier: "mytemplate",
-		TemplateID: "tmpl-abc",
-		Tag:        &tag,
 		Visible:    false,
 	}.APIError(ErrAccessDenied)
 
@@ -79,23 +91,48 @@ func TestErrorToAPIError_TemplateNotFound(t *testing.T) {
 	assert.Equal(t, "template 'mytemplate' not found", apiErr.ClientMsg)
 }
 
-func TestErrorToAPIError_FormatTemplateRef_IdentifierEqualsTemplateID(t *testing.T) {
+func TestErrorToAPIError_UsesIdentifierFromNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := ErrorToAPIError(templateNotFoundError{Identifier: "myteam/desktop"}, "desktop")
+
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Equal(t, "template 'myteam/desktop' not found", apiErr.ClientMsg)
+}
+
+func TestToAPIError_UsesIdentifierFromNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	apiErr := ToAPIError(templateNotFoundError{Identifier: "myteam/desktop"}, "desktop")
+
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Equal(t, "template 'myteam/desktop' not found", apiErr.ClientMsg)
+}
+
+func TestToAPIError_TemplateTagNotFound(t *testing.T) {
+	t.Parallel()
+
+	apiErr := ToAPIError(templateTagNotFoundError{Identifier: "myteam/desktop", Tag: "dev"}, "desktop")
+
+	assert.Equal(t, http.StatusNotFound, apiErr.Code)
+	assert.Equal(t, "tag 'dev' does not exist for template 'myteam/desktop'", apiErr.ClientMsg)
+}
+
+func TestTemplateRef_APIError_IdentifierEqualsTemplateID(t *testing.T) {
 	t.Parallel()
 
 	apiErr := TemplateRef{
-		Subject:    "template",
 		Identifier: "tmpl-abc",
-		TemplateID: "tmpl-abc",
 		Visible:    true,
-	}.APIError(ErrTemplateNotFound)
+	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
 
-	assert.Equal(t, "template 'tmpl-abc' has no ready build", apiErr.ClientMsg)
+	assert.Equal(t, "tag 'default' does not exist for template 'tmpl-abc'", apiErr.ClientMsg)
 }
 
 func TestErrorToAPIError_AccessDenied(t *testing.T) {
 	t.Parallel()
 
-	apiErr := ToAPIError(ErrAccessDenied, "template", "mytemplate")
+	apiErr := ToAPIError(ErrAccessDenied, "mytemplate")
 
 	assert.Equal(t, http.StatusForbidden, apiErr.Code)
 	assert.Equal(t, "you don't have access to template 'mytemplate'", apiErr.ClientMsg)
@@ -104,26 +141,10 @@ func TestErrorToAPIError_AccessDenied(t *testing.T) {
 func TestErrorToAPIError_ClusterMismatch(t *testing.T) {
 	t.Parallel()
 
-	apiErr := ToAPIError(ErrClusterMismatch, "template", "mytemplate")
+	apiErr := ToAPIError(ErrClusterMismatch, "mytemplate")
 
 	assert.Equal(t, http.StatusBadRequest, apiErr.Code)
 	assert.Equal(t, "template 'mytemplate' is not available in the requested cluster", apiErr.ClientMsg)
-}
-
-func TestTemplateRef_APIError_BaseTemplateUsesSubject(t *testing.T) {
-	t.Parallel()
-
-	tag := "v2"
-	apiErr := TemplateRef{
-		Subject:    "base template",
-		Identifier: "mytemplate",
-		TemplateID: "tmpl-abc",
-		Tag:        &tag,
-		Visible:    true,
-	}.APIError(ErrTemplateNotFound)
-
-	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Equal(t, "base template 'mytemplate' (tmpl-abc) with tag 'v2' not found", apiErr.ClientMsg)
 }
 
 func TestErrorToAPIError_Unknown(t *testing.T) {

--- a/packages/api/internal/cache/templates/errors_test.go
+++ b/packages/api/internal/cache/templates/errors_test.go
@@ -8,51 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestTemplateRef_APIError_MissingBuildWithTagReturnsMissingTag(t *testing.T) {
+func TestTemplateRef_APIError_TagNotFound(t *testing.T) {
 	t.Parallel()
 
 	tag := "v2"
 	apiErr := TemplateRef{
 		Identifier: "mytemplate",
 		Visible:    true,
-	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: tag})
+	}.APIError(templateTagNotFoundError{Tag: tag})
 
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)
 	assert.Equal(t, "tag 'v2' does not exist for template 'mytemplate'", apiErr.ClientMsg)
 }
 
-func TestTemplateRef_APIError_MissingTag(t *testing.T) {
-	t.Parallel()
-
-	tag := "v2"
-	apiErr := TemplateRef{
-		Identifier: "mytemplate",
-		Visible:    true,
-	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: tag})
-
-	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Equal(t, "tag 'v2' does not exist for template 'mytemplate'", apiErr.ClientMsg)
-}
-
-func TestTemplateRef_APIError_MissingDefaultTag(t *testing.T) {
+func TestTemplateRef_APIError_DefaultTagNotFound(t *testing.T) {
 	t.Parallel()
 
 	apiErr := TemplateRef{
 		Identifier: "mytemplate",
 		Visible:    true,
-	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
-
-	assert.Equal(t, http.StatusNotFound, apiErr.Code)
-	assert.Equal(t, "tag 'default' does not exist for template 'mytemplate'", apiErr.ClientMsg)
-}
-
-func TestTemplateRef_APIError_MissingBuildWithoutTagReturnsMissingDefaultTag(t *testing.T) {
-	t.Parallel()
-
-	apiErr := TemplateRef{
-		Identifier: "mytemplate",
-		Visible:    true,
-	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
+	}.APIError(templateTagNotFoundError{Tag: "default"})
 
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)
 	assert.Equal(t, "tag 'default' does not exist for template 'mytemplate'", apiErr.ClientMsg)
@@ -112,7 +87,7 @@ func TestToAPIError_UsesIdentifierFromNotFoundError(t *testing.T) {
 func TestToAPIError_TemplateTagNotFound(t *testing.T) {
 	t.Parallel()
 
-	apiErr := ToAPIError(templateTagNotFoundError{Identifier: "myteam/desktop", Tag: "dev"}, "desktop")
+	apiErr := ToAPIError(templateTagNotFoundError{Tag: "dev"}, "myteam/desktop")
 
 	assert.Equal(t, http.StatusNotFound, apiErr.Code)
 	assert.Equal(t, "tag 'dev' does not exist for template 'myteam/desktop'", apiErr.ClientMsg)
@@ -124,7 +99,7 @@ func TestTemplateRef_APIError_IdentifierEqualsTemplateID(t *testing.T) {
 	apiErr := TemplateRef{
 		Identifier: "tmpl-abc",
 		Visible:    true,
-	}.APIError(templateTagNotFoundError{Identifier: "tmpl-abc", Tag: "default"})
+	}.APIError(templateTagNotFoundError{Tag: "default"})
 
 	assert.Equal(t, "tag 'default' does not exist for template 'tmpl-abc'", apiErr.ClientMsg)
 }

--- a/packages/api/internal/handlers/sandbox_create.go
+++ b/packages/api/internal/handlers/sandbox_create.go
@@ -98,10 +98,7 @@ func (a *APIStore) PostSandboxes(c *gin.Context) {
 		}
 
 		ref := templatecache.TemplateRef{
-			Subject:    "template",
 			Identifier: aliasInfo.MatchedIdentifier,
-			TemplateID: aliasInfo.TemplateID,
-			Tag:        tag,
 			Visible:    visible,
 		}
 

--- a/packages/api/internal/handlers/sandbox_create_test.go
+++ b/packages/api/internal/handlers/sandbox_create_test.go
@@ -518,6 +518,56 @@ func TestPostSandboxes_MissingTagDisclosure(t *testing.T) {
 		t.Parallel()
 		assertMissingTagDisclosure(t, false, "private-missing-tag")
 	})
+
+	t.Run("public template without default tag names default", func(t *testing.T) {
+		t.Parallel()
+		assertMissingDefaultTagDisclosure(t)
+	})
+}
+
+func TestPostSandboxes_MissingBareAliasUsesPromotedFallbackKey(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	requesterTeamID := testutils.CreateTestTeam(t, db)
+	requesterTeamSlug := testutils.GetTeamSlug(t, ctx, db, requesterTeamID)
+
+	store := &APIStore{
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+	defer func() {
+		require.NoError(t, store.templateCache.Close(ctx))
+	}()
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+
+	body, err := json.Marshal(api.PostSandboxesJSONRequestBody{TemplateID: "desktop"})
+	require.NoError(t, err)
+
+	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
+	ginCtx.Request.Header.Set("Content-Type", "application/json")
+	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+		Team: &authqueries.Team{
+			ID:   requesterTeamID,
+			Slug: requesterTeamSlug,
+		},
+		Limits: &authtypes.TeamLimits{MaxLengthHours: 24},
+	})
+
+	//nolint:contextcheck // PostSandboxes reads ctx from ginCtx.Request.Context().
+	store.PostSandboxes(ginCtx)
+
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var apiErr api.Error
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &apiErr))
+
+	assert.Equal(t, int32(http.StatusNotFound), apiErr.Code)
+	assert.Equal(t, "template 'desktop' not found", apiErr.Message)
 }
 
 // Valid tag exists on a private template owned by another team. A non-owner
@@ -634,13 +684,68 @@ func assertMissingTagDisclosure(t *testing.T, public bool, alias string) {
 
 	var wantMessage string
 	if public {
-		wantMessage = fmt.Sprintf("template '%s' (%s) with tag 'v2' not found", id.WithNamespace(ownerTeamSlug, alias), templateID)
+		wantMessage = fmt.Sprintf("tag 'v2' does not exist for template '%s'", id.WithNamespace(ownerTeamSlug, alias))
 	} else {
 		wantMessage = fmt.Sprintf("template '%s' not found", id.WithNamespace(ownerTeamSlug, alias))
 	}
 
 	assert.Equal(t, int32(http.StatusNotFound), apiErr.Code)
 	assert.Equal(t, wantMessage, apiErr.Message)
+}
+
+func assertMissingDefaultTagDisclosure(t *testing.T) {
+	t.Helper()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	ownerTeamID := testutils.CreateTestTeam(t, db)
+	ownerTeamSlug := testutils.GetTeamSlug(t, ctx, db, ownerTeamID)
+	requesterTeamID := testutils.CreateTestTeam(t, db)
+	requesterTeamSlug := testutils.GetTeamSlug(t, ctx, db, requesterTeamID)
+
+	store := &APIStore{
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+	defer func() {
+		require.NoError(t, store.templateCache.Close(ctx))
+	}()
+
+	alias := "public-missing-default-tag"
+	templateID := createTestTemplate(ctx, t, db, ownerTeamID)
+	createTestTemplateAliasWithName(ctx, t, db, templateID, alias, &ownerTeamSlug)
+
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "ready")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "dev")
+
+	templateRef := id.WithNamespace(ownerTeamSlug, alias)
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+
+	body, err := json.Marshal(api.PostSandboxesJSONRequestBody{TemplateID: templateRef})
+	require.NoError(t, err)
+
+	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
+	ginCtx.Request.Header.Set("Content-Type", "application/json")
+	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+		Team: &authqueries.Team{
+			ID:   requesterTeamID,
+			Slug: requesterTeamSlug,
+		},
+		Limits: &authtypes.TeamLimits{MaxLengthHours: 24},
+	})
+
+	//nolint:contextcheck // PostSandboxes reads ctx from ginCtx.Request.Context().
+	store.PostSandboxes(ginCtx)
+
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+
+	var apiErr api.Error
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &apiErr))
+
+	assert.Equal(t, int32(http.StatusNotFound), apiErr.Code)
+	assert.Equal(t, fmt.Sprintf("tag 'default' does not exist for template '%s'", templateRef), apiErr.Message)
 }
 
 func setTemplatePublic(ctx context.Context, t *testing.T, db *testutils.Database, templateID string, public bool) {

--- a/packages/api/internal/template-manager/create_template.go
+++ b/packages/api/internal/template-manager/create_template.go
@@ -310,7 +310,7 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 		// Step 1: Resolve alias to template ID (using cache with fallback for promoted templates)
 		aliasInfo, metadata, err := tm.templateCache.ResolveAliasWithMetadata(ctx, identifier, teamSlug)
 		if err != nil {
-			apiErr := templatecache.ToAPIError(err, "base template", identifier)
+			apiErr := templatecache.ErrorToAPIError(err, identifier)
 
 			return &FromTemplateError{
 				err:     err,
@@ -319,10 +319,7 @@ func setTemplateSource(ctx context.Context, tm *TemplateManager, teamID uuid.UUI
 		}
 
 		ref := templatecache.TemplateRef{
-			Subject:    "base template",
 			Identifier: aliasInfo.MatchedIdentifier,
-			TemplateID: aliasInfo.TemplateID,
-			Tag:        tag,
 			Visible:    aliasInfo.TeamID == teamID || metadata.Public,
 		}
 

--- a/packages/api/internal/template-manager/create_template_test.go
+++ b/packages/api/internal/template-manager/create_template_test.go
@@ -57,17 +57,16 @@ func TestSetTemplateSource_FromTemplateMissingBuildReturnsNotFound(t *testing.T)
 		name          string
 		requesterTeam string
 		public        bool
-		wantMessage   func(ownerSlug, alias, templateID string) string
+		wantMessage   func(ownerSlug, alias string) string
 	}{
 		{
 			name:          "owner gets tag-specific not found",
 			requesterTeam: "owner",
 			public:        false,
-			wantMessage: func(ownerSlug, alias, templateID string) string {
+			wantMessage: func(ownerSlug, alias string) string {
 				return fmt.Sprintf(
-					"base template '%s' (%s) with tag 'v2' not found",
+					"tag 'v2' does not exist for template '%s'",
 					id.WithNamespace(ownerSlug, alias),
-					templateID,
 				)
 			},
 		},
@@ -75,11 +74,10 @@ func TestSetTemplateSource_FromTemplateMissingBuildReturnsNotFound(t *testing.T)
 			name:          "foreign team gets tag-specific not found for public template",
 			requesterTeam: "foreign",
 			public:        true,
-			wantMessage: func(ownerSlug, alias, templateID string) string {
+			wantMessage: func(ownerSlug, alias string) string {
 				return fmt.Sprintf(
-					"base template '%s' (%s) with tag 'v2' not found",
+					"tag 'v2' does not exist for template '%s'",
 					id.WithNamespace(ownerSlug, alias),
-					templateID,
 				)
 			},
 		},
@@ -87,8 +85,8 @@ func TestSetTemplateSource_FromTemplateMissingBuildReturnsNotFound(t *testing.T)
 			name:          "foreign team gets generic not found for private template",
 			requesterTeam: "foreign",
 			public:        false,
-			wantMessage: func(ownerSlug, alias, _ string) string {
-				return fmt.Sprintf("base template '%s' not found", id.WithNamespace(ownerSlug, alias))
+			wantMessage: func(ownerSlug, alias string) string {
+				return fmt.Sprintf("template '%s' not found", id.WithNamespace(ownerSlug, alias))
 			},
 		},
 	}
@@ -137,7 +135,7 @@ func TestSetTemplateSource_FromTemplateMissingBuildReturnsNotFound(t *testing.T)
 			var fromTemplateErr *FromTemplateError
 			require.ErrorAs(t, err, &fromTemplateErr)
 
-			assert.Equal(t, tt.wantMessage(ownerTeamSlug, "base-template-missing", templateID), err.Error())
+			assert.Equal(t, tt.wantMessage(ownerTeamSlug, "base-template-missing"), err.Error())
 			assert.Nil(t, template.GetFromTemplate())
 		})
 	}


### PR DESCRIPTION
When a user asks for a template that cannot be resolved, the API should return the name it actually tried instead of a vague or internal-looking message. This matters most for default-tag lookups: if a template only has `dev`, asking for the implicit `default` tag should tell the user that `default` is missing, not that the template has no ready build.

This also removes the template ID from these client-facing errors. The alias or requested name is the useful part for users.