### PR TITLE
fix: use command substitution for GOMAXPROCS instead of literal string

### DIFF
--- a/iac/provider-gcp/modules/nodepool-api/scripts/start-api.sh
+++ b/iac/provider-gcp/modules/nodepool-api/scripts/start-api.sh
@@ -17,7 +17,7 @@ set -x
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 ulimit -n 1048576
-export GOMAXPROCS='nproc'
+export GOMAXPROCS=$(nproc)
 
 sudo tee -a /etc/sysctl.conf <<EOF
 # Increase the maximum number of socket connections

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -112,7 +112,7 @@ mkdir -p /mnt/snapshot-cache
 mount -t tmpfs -o size=65G tmpfs /mnt/snapshot-cache
 
 ulimit -n 1048576
-export GOMAXPROCS='nproc'
+export GOMAXPROCS=$(nproc)
 
 tee -a /etc/sysctl.conf <<EOF
 # Increase the maximum number of socket connections

--- a/iac/provider-gcp/nomad-cluster/scripts/start-server.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-server.sh
@@ -10,7 +10,7 @@ set -e
 exec > >(tee /var/log/user-data.log | logger -t user-data -s 2>/dev/console) 2>&1
 
 ulimit -n 65536
-export GOMAXPROCS='nproc'
+export GOMAXPROCS=$(nproc)
 
 gsutil cp "gs://${SCRIPTS_BUCKET}/run-consul-${RUN_CONSUL_FILE_HASH}.sh" /opt/consul/bin/run-consul.sh
 gsutil cp "gs://${SCRIPTS_BUCKET}/run-nomad-${RUN_NOMAD_FILE_HASH}.sh" /opt/nomad/bin/run-nomad.sh


### PR DESCRIPTION
`GOMAXPROCS='nproc'` sets the literal string "nproc" rather than the CPU count. Use `$(nproc)` to correctly capture the output of the command.