### PR TITLE
refactor(dashboard-api): send creator context with team provisioning

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/team_provisioning.go
@@ -130,11 +130,11 @@ func (s *APIStore) bootstrapUser(ctx context.Context, userID uuid.UUID) (provisi
 		}
 
 		req := teamprovision.TeamBillingProvisionRequestedV1{
-			TeamID:      existingTeam.ID,
-			TeamName:    existingTeam.Name,
-			TeamEmail:   existingTeam.Email,
-			OwnerUserID: userID,
-			Reason:      teamprovision.ReasonDefaultSignupTeam,
+			TeamID:        existingTeam.ID,
+			TeamName:      existingTeam.Name,
+			TeamEmail:     existingTeam.Email,
+			CreatorUserID: userID,
+			Reason:        teamprovision.ReasonDefaultSignupTeam,
 		}
 		_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
 
@@ -176,11 +176,11 @@ func (s *APIStore) bootstrapUser(ctx context.Context, userID uuid.UUID) (provisi
 	}
 
 	req := teamprovision.TeamBillingProvisionRequestedV1{
-		TeamID:      team.ID,
-		TeamName:    team.Name,
-		TeamEmail:   team.Email,
-		OwnerUserID: userID,
-		Reason:      teamprovision.ReasonDefaultSignupTeam,
+		TeamID:        team.ID,
+		TeamName:      team.Name,
+		TeamEmail:     team.Email,
+		CreatorUserID: userID,
+		Reason:        teamprovision.ReasonDefaultSignupTeam,
 	}
 	_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
 
@@ -249,11 +249,11 @@ func (s *APIStore) createTeam(ctx context.Context, userID uuid.UUID, name string
 	}
 
 	req := teamprovision.TeamBillingProvisionRequestedV1{
-		TeamID:      team.ID,
-		TeamName:    team.Name,
-		TeamEmail:   team.Email,
-		OwnerUserID: userID,
-		Reason:      teamprovision.ReasonAdditionalTeam,
+		TeamID:        team.ID,
+		TeamName:      team.Name,
+		TeamEmail:     team.Email,
+		CreatorUserID: userID,
+		Reason:        teamprovision.ReasonAdditionalTeam,
 	}
 	if err := s.teamProvisionSink.ProvisionTeam(ctx, req); err != nil {
 		rollbackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), teamProvisionRollbackTimeout)

--- a/packages/dashboard-api/internal/teamprovision/creator_context.go
+++ b/packages/dashboard-api/internal/teamprovision/creator_context.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	authProviderGoogle = "google"
-	authProviderGitHub = "github"
+	// supabase uses "email" for password signups; everything else (google,
+	// github, apple, gitlab, ...) is treated as a social provider.
+	emailAuthProvider = "email"
 
 	signupIPMetadataKey        = "signup_ip"
 	signupUserAgentMetadataKey = "signup_user_agent"
@@ -61,7 +62,8 @@ func hasOAuthProvider(metadata map[string]any) bool {
 	}
 
 	for _, p := range rawProviders {
-		if name, ok := p.(string); ok && (name == authProviderGoogle || name == authProviderGitHub) {
+		name, ok := p.(string)
+		if ok && name != "" && name != emailAuthProvider {
 			return true
 		}
 	}

--- a/packages/dashboard-api/internal/teamprovision/creator_context.go
+++ b/packages/dashboard-api/internal/teamprovision/creator_context.go
@@ -1,0 +1,78 @@
+package teamprovision
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
+	supabasedb "github.com/e2b-dev/infra/packages/db/pkg/supabase"
+	sharedteamprovision "github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
+)
+
+const (
+	authProviderGoogle = "google"
+	authProviderGitHub = "github"
+
+	signupIPMetadataKey        = "signup_ip"
+	signupUserAgentMetadataKey = "signup_user_agent"
+	providersMetadataKey       = "providers"
+)
+
+// resolveCreatorContext reads signup IP/UA and auth provider from
+// auth.users.raw_app_meta_data, which Supabase populates for every signup flow.
+// Returns nil when the user cannot be found so callers can keep going without
+// the optional context.
+func resolveCreatorContext(ctx context.Context, supabaseDB *supabasedb.Client, userID uuid.UUID) (*sharedteamprovision.CreatorContextV1, error) {
+	authUser, err := supabaseDB.Write.GetAuthUserByID(ctx, userID)
+	if err != nil {
+		if dberrors.IsNotFoundError(err) {
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("get auth user: %w", err)
+	}
+
+	metadata := map[string]any{}
+	if len(authUser.RawAppMetaData) > 0 {
+		if err := json.Unmarshal(authUser.RawAppMetaData, &metadata); err != nil {
+			return nil, fmt.Errorf("decode raw_app_meta_data: %w", err)
+		}
+	}
+
+	authMethod := sharedteamprovision.AuthMethodPassword
+	if hasOAuthProvider(metadata) {
+		authMethod = sharedteamprovision.AuthMethodSocial
+	}
+
+	return &sharedteamprovision.CreatorContextV1{
+		IPAddress:  stringFromMetadata(metadata, signupIPMetadataKey),
+		UserAgent:  stringFromMetadata(metadata, signupUserAgentMetadataKey),
+		AuthMethod: authMethod,
+	}, nil
+}
+
+func hasOAuthProvider(metadata map[string]any) bool {
+	rawProviders, ok := metadata[providersMetadataKey].([]any)
+	if !ok {
+		return false
+	}
+
+	for _, p := range rawProviders {
+		if name, ok := p.(string); ok && (name == authProviderGoogle || name == authProviderGitHub) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func stringFromMetadata(metadata map[string]any, key string) string {
+	if value, ok := metadata[key].(string); ok {
+		return value
+	}
+
+	return ""
+}

--- a/packages/dashboard-api/internal/teamprovision/factory.go
+++ b/packages/dashboard-api/internal/teamprovision/factory.go
@@ -6,6 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
+	supabasedb "github.com/e2b-dev/infra/packages/db/pkg/supabase"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -14,7 +15,7 @@ var (
 	ErrMissingAPIToken = errors.New("billing server api token is required when billing http team provision sink is enabled")
 )
 
-func NewProvisionSink(ctx context.Context, enabled bool, baseURL, apiToken string) (TeamProvisionSink, error) {
+func NewProvisionSink(ctx context.Context, enabled bool, baseURL, apiToken string, supabaseDB *supabasedb.Client) (TeamProvisionSink, error) {
 	if !enabled {
 		logger.L().Info(ctx, "team provision sink configured",
 			zap.String("sink", "noop"),
@@ -38,5 +39,5 @@ func NewProvisionSink(ctx context.Context, enabled bool, baseURL, apiToken strin
 		zap.String("base_url", baseURL),
 	)
 
-	return NewHTTPProvisionSink(baseURL, apiToken), nil
+	return NewHTTPProvisionSink(baseURL, apiToken, supabaseDB), nil
 }

--- a/packages/dashboard-api/internal/teamprovision/http_sink.go
+++ b/packages/dashboard-api/internal/teamprovision/http_sink.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
+	supabasedb "github.com/e2b-dev/infra/packages/db/pkg/supabase"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sharedteamprovision "github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -35,10 +36,11 @@ const (
 )
 
 type HTTPProvisionSink struct {
-	baseURL  string
-	apiToken string
-	client   *retryablehttp.Client
-	timeout  time.Duration
+	baseURL    string
+	apiToken   string
+	client     *retryablehttp.Client
+	timeout    time.Duration
+	supabaseDB *supabasedb.Client
 }
 
 var _ TeamProvisionSink = (*HTTPProvisionSink)(nil)
@@ -47,12 +49,13 @@ type errorResponse struct {
 	Message string `json:"message"`
 }
 
-func NewHTTPProvisionSink(baseURL, apiToken string) *HTTPProvisionSink {
+func NewHTTPProvisionSink(baseURL, apiToken string, supabaseDB *supabasedb.Client) *HTTPProvisionSink {
 	return &HTTPProvisionSink{
-		baseURL:  strings.TrimRight(baseURL, "/"),
-		apiToken: apiToken,
-		client:   newRetryableProvisionClient(defaultProvisionAttemptTimeout),
-		timeout:  defaultProvisionTimeout,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiToken:   apiToken,
+		client:     newRetryableProvisionClient(defaultProvisionAttemptTimeout),
+		timeout:    defaultProvisionTimeout,
+		supabaseDB: supabaseDB,
 	}
 }
 
@@ -73,6 +76,18 @@ func (s *HTTPProvisionSink) ProvisionTeam(ctx context.Context, req sharedteampro
 		telemetry.ReportErrorByCode(ctx, err.StatusCode, "team provisioning failed", err, failureAttrs...)
 
 		return err
+	}
+
+	if s.supabaseDB != nil && req.CreatorContext == nil {
+		creatorContext, resolveErr := resolveCreatorContext(ctx, s.supabaseDB, req.CreatorUserID)
+		if resolveErr != nil {
+			// creator context is best-effort; keep going without it
+			logger.L().Warn(ctx, "failed to resolve creator context for team provisioning",
+				append(provisionLogFields(req, provisionSinkHTTP), zap.Error(resolveErr))...,
+			)
+		} else {
+			req.CreatorContext = creatorContext
+		}
 	}
 
 	body, err := json.Marshal(req)

--- a/packages/dashboard-api/internal/teamprovision/http_sink.go
+++ b/packages/dashboard-api/internal/teamprovision/http_sink.go
@@ -33,6 +33,8 @@ const (
 	provisionBackoffMultiplier       = 2.0
 	// Error responses only need enough body to extract a short API message without buffering large upstream payloads.
 	provisionErrorMessageReadLimit = 2 * 1024
+	// short cap so a slow auth.users lookup can't eat into the provisioning timeout.
+	creatorContextResolveTimeout = 2 * time.Second
 )
 
 type HTTPProvisionSink struct {
@@ -79,7 +81,9 @@ func (s *HTTPProvisionSink) ProvisionTeam(ctx context.Context, req sharedteampro
 	}
 
 	if s.supabaseDB != nil && req.CreatorContext == nil {
-		creatorContext, resolveErr := resolveCreatorContext(ctx, s.supabaseDB, req.CreatorUserID)
+		resolveCtx, cancel := context.WithTimeout(ctx, creatorContextResolveTimeout)
+		creatorContext, resolveErr := resolveCreatorContext(resolveCtx, s.supabaseDB, req.CreatorUserID)
+		cancel()
 		if resolveErr != nil {
 			// creator context is best-effort; keep going without it
 			logger.L().Warn(ctx, "failed to resolve creator context for team provisioning",

--- a/packages/dashboard-api/internal/teamprovision/http_sink_test.go
+++ b/packages/dashboard-api/internal/teamprovision/http_sink_test.go
@@ -24,7 +24,7 @@ func TestHTTPProvisionSink_ReturnsJSONErrorMessage(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sink := NewHTTPProvisionSink(server.URL, "token")
+	sink := NewHTTPProvisionSink(server.URL, "token", nil)
 	err := sink.ProvisionTeam(t.Context(), testProvisionRequest())
 	require.Error(t, err)
 
@@ -52,7 +52,7 @@ func TestHTTPProvisionSink_RetriesRetryableResponsesAndSucceeds(t *testing.T) {
 	}))
 	defer server.Close()
 
-	sink := NewHTTPProvisionSink(server.URL, "token")
+	sink := NewHTTPProvisionSink(server.URL, "token", nil)
 	sink.client.RetryWaitMin = time.Millisecond
 	sink.client.RetryWaitMax = time.Millisecond
 	err := sink.ProvisionTeam(t.Context(), testProvisionRequest())
@@ -74,7 +74,7 @@ func TestHTTPProvisionSink_RetriesRequestTimeoutWithinOverallBudget(t *testing.T
 	}))
 	defer server.Close()
 
-	sink := NewHTTPProvisionSink(server.URL, "token")
+	sink := NewHTTPProvisionSink(server.URL, "token", nil)
 	sink.timeout = 80 * time.Millisecond
 	sink.client.HTTPClient.Timeout = 25 * time.Millisecond
 	sink.client.RetryWaitMin = time.Millisecond
@@ -87,10 +87,10 @@ func TestHTTPProvisionSink_RetriesRequestTimeoutWithinOverallBudget(t *testing.T
 
 func testProvisionRequest() sharedteamprovision.TeamBillingProvisionRequestedV1 {
 	return sharedteamprovision.TeamBillingProvisionRequestedV1{
-		TeamID:      uuid.New(),
-		TeamName:    "Acme",
-		TeamEmail:   "acme@example.com",
-		OwnerUserID: uuid.New(),
-		Reason:      sharedteamprovision.ReasonAdditionalTeam,
+		TeamID:        uuid.New(),
+		TeamName:      "Acme",
+		TeamEmail:     "acme@example.com",
+		CreatorUserID: uuid.New(),
+		Reason:        sharedteamprovision.ReasonAdditionalTeam,
 	}
 }

--- a/packages/dashboard-api/internal/teamprovision/sink.go
+++ b/packages/dashboard-api/internal/teamprovision/sink.go
@@ -46,7 +46,7 @@ func (e *ProvisionError) Unwrap() error {
 func provisionLogFields(req sharedteamprovision.TeamBillingProvisionRequestedV1, sink string) []zap.Field {
 	return []zap.Field{
 		logger.WithTeamID(req.TeamID.String()),
-		logger.WithUserID(req.OwnerUserID.String()),
+		logger.WithUserID(req.CreatorUserID.String()),
 		zap.String("team.provision.reason", req.Reason),
 		zap.String("team.provision.sink", sink),
 	}
@@ -55,7 +55,7 @@ func provisionLogFields(req sharedteamprovision.TeamBillingProvisionRequestedV1,
 func provisionTelemetryAttrs(req sharedteamprovision.TeamBillingProvisionRequestedV1, sink string, attrs ...attribute.KeyValue) []attribute.KeyValue {
 	base := []attribute.KeyValue{
 		telemetry.WithTeamID(req.TeamID.String()),
-		telemetry.WithUserID(req.OwnerUserID.String()),
+		telemetry.WithUserID(req.CreatorUserID.String()),
 		attribute.String("team.provision.reason", req.Reason),
 		attribute.String("team.provision.sink", sink),
 	}

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -195,6 +195,7 @@ func run() int {
 		config.EnableBillingHTTPTeamProvisionSink,
 		config.BillingServerURL,
 		config.BillingServerAPIToken,
+		supabaseDB,
 	)
 	if err != nil {
 		l.Error(ctx, "initializing team provision sink", zap.Error(err))

--- a/packages/db/migrations/20000101000000_auth.sql
+++ b/packages/db/migrations/20000101000000_auth.sql
@@ -17,6 +17,7 @@ CREATE TABLE auth.users (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     email text NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),
+    raw_app_meta_data jsonb,
     PRIMARY KEY (id)
 );
 -- +goose StatementEnd

--- a/packages/db/pkg/supabase/queries/get_auth_user.sql.go
+++ b/packages/db/pkg/supabase/queries/get_auth_user.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getAuthUserByID = `-- name: GetAuthUserByID :one
-SELECT id, COALESCE(email, '') AS email, created_at
+SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
 FROM auth.users
 WHERE id = $1::uuid
 `
@@ -20,6 +20,11 @@ WHERE id = $1::uuid
 func (q *Queries) GetAuthUserByID(ctx context.Context, dollar_1 uuid.UUID) (AuthUser, error) {
 	row := q.db.QueryRow(ctx, getAuthUserByID, dollar_1)
 	var i AuthUser
-	err := row.Scan(&i.ID, &i.Email, &i.CreatedAt)
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.CreatedAt,
+		&i.RawAppMetaData,
+	)
 	return i, err
 }

--- a/packages/db/pkg/supabase/queries/models.go
+++ b/packages/db/pkg/supabase/queries/models.go
@@ -11,7 +11,8 @@ import (
 )
 
 type AuthUser struct {
-	ID        uuid.UUID
-	Email     string
-	CreatedAt *time.Time
+	ID             uuid.UUID
+	Email          string
+	CreatedAt      *time.Time
+	RawAppMetaData []byte
 }

--- a/packages/db/pkg/supabase/schema/auth_users_override.sql
+++ b/packages/db/pkg/supabase/schema/auth_users_override.sql
@@ -15,5 +15,6 @@ CREATE TABLE auth.users (
     id uuid NOT NULL DEFAULT gen_random_uuid(),
     email text NOT NULL,
     created_at timestamptz DEFAULT now(),
+    raw_app_meta_data jsonb,
     PRIMARY KEY (id)
 );

--- a/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
+++ b/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
@@ -1,4 +1,4 @@
 -- name: GetAuthUserByID :one
-SELECT id, COALESCE(email, '') AS email, created_at
+SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
 FROM auth.users
 WHERE id = $1::uuid;

--- a/packages/shared/pkg/teamprovision/request.go
+++ b/packages/shared/pkg/teamprovision/request.go
@@ -7,10 +7,22 @@ const (
 	ReasonAdditionalTeam    = "additional_team"
 )
 
+const (
+	AuthMethodPassword = "Password"
+	AuthMethodSocial   = "Social"
+)
+
+type CreatorContextV1 struct {
+	IPAddress  string `json:"ip_address,omitempty"`
+	UserAgent  string `json:"user_agent,omitempty"`
+	AuthMethod string `json:"auth_method,omitempty"`
+}
+
 type TeamBillingProvisionRequestedV1 struct {
-	TeamID      uuid.UUID `json:"team_id"`
-	TeamName    string    `json:"team_name"`
-	TeamEmail   string    `json:"team_email"`
-	OwnerUserID uuid.UUID `json:"owner_user_id"`
-	Reason      string    `json:"reason"`
+	TeamID         uuid.UUID         `json:"team_id"`
+	TeamName       string            `json:"team_name"`
+	TeamEmail      string            `json:"team_email"`
+	CreatorUserID  uuid.UUID         `json:"creator_user_id"`
+	CreatorContext *CreatorContextV1 `json:"creator_context,omitempty"`
+	Reason         string            `json:"reason"`
 }


### PR DESCRIPTION
## Motivation

Companion to [e2b-dev/belt#690](https://github.com/e2b-dev/belt/pull/690), which moves auth-user lookups out of the team provisioning receiver. The dashboard already owns the Supabase connection, so it now resolves the creator's signup metadata up front and includes it in the provisioning payload. The receiver can then drop its own `auth.users` queries.

## Summary

- Extend the shared `TeamBillingProvisionRequestedV1` payload with `creator_user_id` and an optional `creator_context` (`ip_address`, `user_agent`, `auth_method`), matching the receiver's OpenAPI schema. The deprecated `owner_user_id` is removed since the receiver already accepts the new field.
- Resolve the creator context inside `HTTPProvisionSink` (best-effort: failures are logged and the call still goes through). The noop sink stays free of any Supabase load.
- Extend `GetAuthUserByID` to return `raw_app_meta_data`, with the `auth.users` schema/test migration updated so sqlc can regenerate.
- Update telemetry/log fields to use `creator_user_id` for the user attribute.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace OwnerUserID with CreatorUserID and add optional creator context (IP, user agent, auth method) to team provisioning requests.

Main changes:
- Renamed OwnerUserID to CreatorUserID in TeamBillingProvisionRequestedV1 struct and updated all provisioning call sites
- Added CreatorContextV1 struct with IP address, user agent, and authentication method; integrated resolver that queries Supabase auth.users metadata
- Extended HTTPProvisionSink to accept supabaseDB dependency and resolve missing creator context with best-effort timeout handling

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
