### PR TITLE
add H2C ingress backend for BYOC

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -37,7 +37,7 @@ resource "google_compute_health_check" "ingress" {
 resource "google_compute_backend_service" "ingress" {
   name = "${var.prefix}ingress"
 
-  protocol  = "HTTP"
+  protocol  = "H2C"
   port_name = var.ingress_port.name
 
   session_affinity = null

--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -37,6 +37,27 @@ resource "google_compute_health_check" "ingress" {
 resource "google_compute_backend_service" "ingress" {
   name = "${var.prefix}ingress"
 
+  protocol  = "HTTP"
+  port_name = var.ingress_port.name
+
+  session_affinity = null
+  health_checks    = [google_compute_health_check.ingress.id]
+
+  timeout_sec = var.ingress_timeout_seconds
+
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+  locality_lb_policy    = "ROUND_ROBIN"
+
+  security_policy = google_compute_security_policy.ingress.id
+
+  backend {
+    group = var.api_instance_group
+  }
+}
+
+resource "google_compute_backend_service" "http2_ingress" {
+  name = "${var.prefix}http2-ingress"
+
   protocol  = "H2C"
   port_name = var.ingress_port.name
 

--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -55,8 +55,8 @@ resource "google_compute_backend_service" "ingress" {
   }
 }
 
-resource "google_compute_backend_service" "http2_ingress" {
-  name = "${var.prefix}http2-ingress"
+resource "google_compute_backend_service" "h2c_ingress" {
+  name = "${var.prefix}h2c-ingress"
 
   protocol  = "H2C"
   port_name = var.ingress_port.name


### PR DESCRIPTION
adds a H2C ingress backend in addition to existing HTTP one to use for future infra for BYOC; it's not used currently but that's fine