### PR TITLE
fix(otel): drop exemplars at collector to fit Mimir items/s budget

### DIFF
--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -300,6 +300,20 @@ processors:
         statements:
           - replace_pattern(attributes["device"], "^nvme.*$$", "nvme")
 
+  # Strip exemplars before export. Exemplars (trace-id annotations on histogram
+  # buckets) count 1:1 against Mimir's items/s tenant limit. With trace-based
+  # exemplar filtering on by default in the SDKs and ~12k histogram series across
+  # rpc.server.call.duration / rpc.client.call.duration, they were ~90% of the
+  # data we shipped (peak ~420k exemplars/s vs 100k/s tenant limit), causing
+  # rate_limited / exemplar_too_old / aggregator-sample-too-old discards across
+  # all signal types. We are not querying exemplars in Grafana today.
+  transform/drop_exemplars:
+    error_mode: ignore
+    metric_statements:
+      - context: datapoint
+        statements:
+          - set(exemplars, [])
+
   metricstransform/aggregate_disks:
     transforms:
       - include: "system.disk.*"
@@ -469,6 +483,7 @@ service:
         - otlp
       processors:
         - filter/otlp
+        - transform/drop_exemplars
         - resourcedetection
         - transform/set-name
         - batch
@@ -479,6 +494,7 @@ service:
         - prometheus
       processors:
         - filter/only_client_allocs
+        - transform/drop_exemplars
         - resourcedetection
         - transform/set-name
         - batch
@@ -489,6 +505,7 @@ service:
         - otlp
       processors:
         - filter/rpc_duration_only
+        - transform/drop_exemplars
         - resource/remove_instance
         - resourcedetection
         - transform/set-name
@@ -499,6 +516,7 @@ service:
       receivers:
         - hostmetrics
       processors:
+        - transform/drop_exemplars
         - resourcedetection
         - transform/set-name
         - metricstransform/single_cpu


### PR DESCRIPTION
## Summary

Foxtrot's Grafana Cloud Mimir tenant is being rate-limited (100k items/s, 300k burst) — samples, metadata, and exemplars are all being dropped, breaking API dashboards. Querying `grafanacloud_instance_*_per_second` directly shows that **exemplars alone account for ~90% of what we ship**:

| Signal | Accepted | Discarded (rate_limited) | Discarded (other) | **Total sent** |
|---|---:|---:|---:|---:|
| samples   |  7,840/s | 16,271/s | 23/s aggregator-too-old | **24,134/s** |
| **exemplars** | 38,651/s | **103,326/s** | **156,341/s** too_old | **298,318/s** |
| metadata  |  2,708/s |  4,357/s | — | **7,065/s** |
| **total** | **49,199/s** | **123,954/s** | **156,364/s** | **🔥 329,517/s** |

24h peak exemplars hit ~420k/s alone. We are not querying exemplars in any dashboard today.

This PR adds a `transform/drop_exemplars` processor that calls `set(exemplars, [])` on every metric data point and wires it into the four Grafana-Cloud-bound metrics pipelines (`metrics`, `metrics/prometheus`, `metrics/rpc_only`, `metrics/host`). The clickhouse-bound `metrics/external` pipeline is intentionally not touched.

### Why exemplars exploded

- OTel Go SDK defaults `OTEL_METRICS_EXEMPLAR_FILTER=trace_based`, so every metric data point inside a sampled span gets a trace-id exemplar attached.
- Tracing is currently unsampled (~42k spans/s peak).
- Histograms `rpc.server.call.duration` (8,820 series) and `rpc.client.call.duration` (3,304 series) each carry ~16 buckets, so each scrape can emit thousands of exemplars.

### Projected impact (after rollout)

```
samples sent     :  24,134/s   (unchanged)
exemplars sent   :       0/s   (stripped)
metadata sent    :   7,065/s   (unchanged)
total            :  31,199/s   ->  31% of the 100k items/s limit
```

Eliminates:
- samples \`rate_limited\` (16k/s -> 0)
- samples \`aggregator-sample-too-old\` on \`orchestrator_sandbox_envd_init_calls_total\` (queue stops backing up)
- exemplars \`rate_limited\` (103k/s -> 0)
- exemplars \`exemplar_too_old\` (156k/s -> 0)
- exemplars \`aggregator-exemplar-too-old\` (126/s -> 0)
- metadata \`rate_limited\` (4k/s -> 0)

Does **not** fix:
- samples \`new-value-for-timestamp\` (~0.3/s) — separate root cause (duplicate writers, likely orphaned regional API VMs from a reverted deploy still publishing alongside the MIG).

### Tradeoff

We lose the "click metric -> jump to trace" navigation in Grafana for histograms. Trace browsing in Tempo is unaffected. If we want to reintroduce exemplars later for a specific high-value metric, the processor's OTTL filter can be scoped to exclude that metric name — but right now the cheapest correct change is to drop them all.

### Minimal-change rationale

- 18 lines added, 0 removed.
- Pure config; no app/SDK changes, no Nomad-job changes, no exporter changes.
- \`error_mode: ignore\` so the processor is a no-op for metric types without exemplars.
- Placed early in each pipeline (right after the filter) so downstream processors and the batcher do less work.

## Test plan

- [ ] CI: terraform plan + nomad job validate on the otel-collector module
- [ ] Roll out to one node-pool first (e.g. \`api\`), confirm in \`grafanacloud_instance_exemplars_per_second{id="1952274"}\` that exemplar volume drops
- [ ] Confirm \`grafanacloud_instance_samples_discarded_per_second{id="1952274", reason="rate_limited"}\` drops to ~0
- [ ] Confirm Grafana dashboards continue to render histograms (\`rpc_*_duration_seconds_bucket\`, \`traefik_*_bucket\`, etc.) — only the exemplar dots disappear
- [ ] Roll out to remaining pools