### PR TITLE
fix(otel): drop unused rpc.client size metrics at the collector

### DIFF
--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -233,6 +233,15 @@ processors:
           - "traefik.*"
           - "grpc\\..*"
           - "rpc\\.client.*"
+      # Drop high-volume / never-queried metrics that dominate the Mimir
+      # items/s budget (samples + their exemplars). Latency is still covered
+      # by rpc.client.call.duration; payload sizes were never used in any
+      # dashboard.
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "rpc\\.client\\.request\\.size.*"
+          - "rpc\\.client\\.response\\.size.*"
 
   filter/only_client_allocs:
     metrics:


### PR DESCRIPTION
Excludes `rpc.client.request.size` and `rpc.client.response.size` from the otel-collector filter. They are not used in any dashboard; `rpc.client.call.duration` already covers latency. Together they emit ~96k observations/s and are among the highest-volume contributors to the Mimir items/s budget through their histogram samples and attached exemplars.

Alternative to #2508 (which disables exemplars at the SDK level). This PR keeps exemplars on the metrics we actually use, but removes two specific metrics entirely.