### PR TITLE
fix(otel): drop unused high-cardinality metrics at the collector

### DIFF
--- a/iac/modules/job-otel-collector/configs/otel-collector.yaml
+++ b/iac/modules/job-otel-collector/configs/otel-collector.yaml
@@ -80,7 +80,7 @@ receivers:
           match_type: regexp
         metrics:
           system.filesystem.inodes.usage:
-            enabled: true
+            enabled: false
           system.filesystem.usage:
             enabled: true
           system.filesystem.utilization:
@@ -157,7 +157,7 @@ receivers:
       processes:
         metrics:
           system.processes.count:
-            enabled: true
+            enabled: false
           system.processes.created:
             enabled: true
 
@@ -233,6 +233,16 @@ processors:
           - "traefik.*"
           - "grpc\\..*"
           - "rpc\\.client.*"
+      # Drop metrics that no dashboard or alert references and that
+      # contribute disproportionately to the Mimir items/s budget through
+      # their samples and the exemplars attached to them.
+      exclude:
+        match_type: regexp
+        metric_names:
+          - "rpc\\.client\\.request\\.size.*"
+          - "rpc\\.client\\.response\\.size.*"
+          - "grpc\\.client\\.connections.*"
+          - "orchestrator\\.storage\\.cache\\.bytes\\.byte.*"
 
   filter/only_client_allocs:
     metrics:


### PR DESCRIPTION
Removes metrics from the otel-collector pipelines that no Grafana dashboard or alert references but that consume a disproportionate share of the Mimir tenant items/s budget. Verified zero dashboard usage via the Grafana `/api/dashboards` API.

| Metric | Series | Replacement / why safe |
|---|---:|---|
| `rpc.client.request.size.*` | 1,501 | latency covered by `rpc.client.call.duration` |
| `rpc.client.response.size.*` | 1,498 | same |
| `grpc.client.connections.*` | 3,546 | internal connection-state gauge, never queried |
| `orchestrator.storage.cache.bytes.byte.*` | 1,948 | byte-throughput metric with typo in name; ops covered by `orchestrator.storage.cache.ops.*` |
| `system.filesystem.inodes.usage` | 2,386 | filesystem fill covered by `system.filesystem.usage` / `utilization` |
| `system.processes.count` | 1,224 | process churn covered by `system.processes.created` |

**~12,000 active series removed total.**

## Honest scope note

This is the maximum achievable purely at the OTel collector level — neither the OTLP nor the prometheusremotewrite exporter in v0.146 has a way to drop exemplars, and OTTL `set(exemplars, [])` is a silent no-op (per upstream maintainers in [contrib discussion #40749](https://github.com/open-telemetry/opentelemetry-collector-contrib/discussions/40749)).

Estimated savings: ~5-10k items/s (a few percent of the ~329k/s tenant load). On its own this **does not bring us under the 100k/s rate-limit ceiling**, but it removes pure waste with no observability loss and complements either:

- #2508 (SDK env var disabling exemplars — bigger win, requires Go-service redeploys), or
- raising the Grafana Cloud tenant ingestion limit (Grafana support ticket).

Two of the three changes (`system.filesystem.inodes.usage`, `system.processes.count`) are scraper toggles in `hostmetrics`; the rest are added to the existing `filter/otlp` `exclude` block. Single-file diff.