### PR TITLE
fix(uffd): re-read page state inside worker goroutine under settleRequests.RLock

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -334,24 +334,6 @@ func (u *Userfaultfd) Serve(
 				return fmt.Errorf("failed to map: %w", err)
 			}
 
-			var source block.Slicer
-
-			switch state := u.pageTracker.get(addr); state {
-			case faulted:
-				// Skip faulting the page. This has already been faulted, either during pre-faulting
-				// or because we handled another page fault on the same address in the current
-				// iteration. It can only transition out of `faulted` via a UFFD_EVENT_REMOVE, which
-				// will mark the page as `removed`.
-				// For this to work correctly, the used pages cannot be swappable.
-				continue
-			case removed:
-				// Fault the page as empty.
-			case missing:
-				source = u.src
-			default:
-				return fmt.Errorf("unexpected pageState: %#v", state)
-			}
-
 			u.wg.Go(func() error {
 				// Test-only barrier: park the worker BEFORE it takes
 				// RLock. While parked, the parent loop is free to take
@@ -363,11 +345,38 @@ func (u *Userfaultfd) Serve(
 					hook(addr)
 				}
 
-				// The RLock must be called inside the goroutine to ensure RUnlock runs via defer,
-				// even if the errgroup is cancelled or the goroutine returns early.
-				// This check protects us against race condition between marking the request for prefetching and accessing the prefetchTracker.
+				// The RLock must be acquired inside the goroutine — and it must be acquired
+				// BEFORE we read the pageTracker / u.src state — so that the read+act+commit
+				// sequence (state lookup → faultPage → setState) is atomic with respect to
+				// any concurrent REMOVE batch (which takes settleRequests.Lock()). If the
+				// state read happened in the parent loop, a REMOVE could land between the
+				// read and the goroutine acquiring the RLock, and the goroutine would still
+				// commit `faulted` afterwards, overwriting `removed`.
+				//
+				// This also protects the read of u.src: in the future src could be swapped
+				// out under settleRequests; reading it under the RLock keeps that safe.
 				u.settleRequests.RLock()
 				defer u.settleRequests.RUnlock()
+
+				var source block.Slicer
+
+				switch state := u.pageTracker.get(addr); state {
+				case faulted:
+					// Skip faulting the page. This has already been faulted, either during pre-faulting
+					// or because we handled another page fault on the same address in the current
+					// iteration. It can only transition out of `faulted` via a UFFD_EVENT_REMOVE, which
+					// will mark the page as `removed`.
+					// For this to work correctly, the used pages cannot be swappable.
+					return nil
+				case removed:
+					// Fault the page as empty (no source). The page was MADV_DONTNEED'd; the
+					// kernel still expects an UFFDIO_COPY/ZEROPAGE ack for the original
+					// MISSING fault, otherwise the faulting thread stays blocked.
+				case missing:
+					source = u.src
+				default:
+					return fmt.Errorf("unexpected pageState: %#v", state)
+				}
 
 				var accessType block.AccessType
 


### PR DESCRIPTION
This PR is the **fix side** of a stacked pair targeting `main`. It depends
on PR #2513 (`feat/uffd-page-tracker-and-remove-events`), which lifts the
minimum production subset of UFFD code from #1896 plus the test harness
and the deterministic race tests that demonstrate this bug. **Merge this
stack as a unit**: PR #2513 first, then this PR. Otherwise PR #2513's
`TestStaleSourceRaceMissingAndRemove` fails on `main` and CI goes red.

## The bug

The `Serve()` loop on PR #2513 (and on `feat/free-page-reporting`) reads
`pageTracker` state and captures `source = u.src` in the **parent loop**,
then dispatches a worker goroutine. A `UFFD_EVENT_REMOVE` for the same
page that arrives in the window between the parent-loop state read and
the worker actually acquiring `settleRequests.RLock()` silently leaves
the worker with a stale `source = u.src` snapshot. The worker then
`UFFDIO_COPY`s `u.src` bytes into a page the kernel has just
`MADV_DONTNEED`'d, leaving `pageTracker == removed` but the kernel page
re-mapped with stale src data. Observably this also deadlocks parent
`madvise()` in the orchestrator unit test suite under tight enough
interleavings.

## The fix

Move the `pageTracker.get(addr)` lookup and the `source = u.src` capture
**inside** the worker goroutine, **after** acquiring
`settleRequests.RLock()`. Now the read+act+commit sequence
(state lookup → faultPage → setState) is atomic with respect to any
concurrent REMOVE batch (which takes `settleRequests.Lock()`). One file
changed, +30 / -21 lines.

## Verification

Run on this branch (sudo, Linux, Go 1.25.9):

- All three race tests from PR #2513 pass:
  - `TestStaleSourceRaceMissingAndRemove` (4k + hugepage) — was
    `got 0xc3` pre-fix; now zero-fills as expected.
  - `TestNoMadviseDeadlockWithInflightCopy` (4k + hugepage).
  - `TestFaultedShortCircuitOrdering` (4k + hugepage).
- Single run: `0.302s` test wallclock / `1.6s` total.
- `-count=20 -timeout=30s` soak across all three: passes in `5.5s`.
- Full `pkg/sandbox/uffd/userfaultfd/...` suite (incl. `TestRemove*`,
  `TestRemoveThenWriteGated`, `TestWriteThenRemoveGated`,
  `TestMissing*`, `TestMissingWrite*`, `TestAsyncWriteProtection`,
  `TestSerial*`, `TestParallel*`): all pass post-fix in `0.93s`.

## Related

- Test demonstration: PR #2513 (`feat/uffd-page-tracker-and-remove-events`).
  This PR is what makes its `TestStaleSourceRaceMissingAndRemove`
  assertion `got 0xc3 (sentinel) → want 0` flip green.
- Parent feature work: #1896 (`feat/free-page-reporting`). When this
  stack merges, #1896 will rebase on top and drop both lifted commits
  and the original in-tree fix.
- Originally flagged by Cursor Bugbot on PR #1896 against commit
  `c8b3d63` in the review thread.

## Stacking

- Base of this PR: `feat/uffd-page-tracker-and-remove-events` (PR #2513).
  GitHub will render this PR's diff as the single-file production fix
  on top of PR #2513's lift + harness + tests.
- After PR #2513 merges to `main`, this PR's base will auto-target
  `main`.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `sudo go test -run 'Race|Deadlock|Ordering' -count=1` — all pass.
- [x] `sudo go test -run 'Race|Deadlock|Ordering' -count=20 -timeout=30s` — soak passes (5.5s).
- [x] `sudo go test ./pkg/sandbox/uffd/userfaultfd/...` — full suite passes.