### PR TITLE
Enable verbose orchestrator logging in resume-cmd

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -965,10 +965,17 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if !verbose {
 		cmdutil.SuppressNoisyLogs()
 		l = logger.NewNopLogger()
+		sbxlogger.SetSandboxLoggerInternal(logger.NewNopLogger())
 	} else {
-		l, _ = logger.NewDevelopmentLogger()
+		var err error
+		l, err = logger.NewDevelopmentLogger()
+		if err != nil {
+			return fmt.Errorf("logger: %w", err)
+		}
+		logger.ReplaceGlobals(ctx, l)
+		sbxlogger.SetSandboxLoggerExternal(l)
+		sbxlogger.SetSandboxLoggerInternal(l)
 	}
-	sbxlogger.SetSandboxLoggerInternal(logger.NewNopLogger())
 
 	tel, err := telemetry.NewAnonymous(ctx, "resume-build")
 	if err != nil {


### PR DESCRIPTION
resume-build receives a -v flag but only logs command logging. Orchestrator logging is not enabled, as is for example build-cmd.

Enable both internal and external loggers when -v is passed, whereas configure noop logger when -v is not present.