### PR TITLE
fix(auth): surface BlockedReason in team blocked error response

### DIFF
--- a/packages/auth/pkg/auth/auth_store.go
+++ b/packages/auth/pkg/auth/auth_store.go
@@ -32,7 +32,11 @@ func validateTeamUsage(team authqueries.Team) error {
 	}
 
 	if team.IsBlocked {
-		return &TeamBlockedError{Message: "team is blocked"}
+		msg := "team is blocked"
+		if team.BlockedReason != nil && *team.BlockedReason != "" {
+			msg = fmt.Sprintf("%s: %s", msg, *team.BlockedReason)
+		}
+		return &TeamBlockedError{Message: msg}
 	}
 
 	return nil

--- a/packages/auth/pkg/auth/auth_store.go
+++ b/packages/auth/pkg/auth/auth_store.go
@@ -36,6 +36,7 @@ func validateTeamUsage(team authqueries.Team) error {
 		if team.BlockedReason != nil && *team.BlockedReason != "" {
 			msg = fmt.Sprintf("%s: %s", msg, *team.BlockedReason)
 		}
+
 		return &TeamBlockedError{Message: msg}
 	}
 

--- a/tests/integration/internal/tests/team_test.go
+++ b/tests/integration/internal/tests/team_test.go
@@ -70,5 +70,5 @@ UPDATE teams SET is_blocked = $1, blocked_reason = $2 WHERE id = $3
 
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode())
 	assert.Equal(t, http.StatusForbidden, errResp.Code)
-	assert.Equal(t, "blocked: team is blocked", errResp.Message)
+	assert.Equal(t, "blocked: team is blocked: test-reason", errResp.Message)
 }


### PR DESCRIPTION
## Summary

When a team is blocked (e.g. for exceeding spending quota), `teams.blocked_reason` is populated in the DB but the public API only returns a generic `"team is blocked"` message. Customers had no way to tell *why* their team was blocked without contacting support — the recent quota-spike incident made this pain visible.

This change appends `BlockedReason` to the existing `TeamBlockedError` message when non-empty. It flows through the existing error pipeline unchanged into the 403 response body.

Before:
```json
{ "code": 403, "message": "blocked: team is blocked" }
```

After (when `blocked_reason = "spending quota exceeded"`):
```json
{ "code": 403, "message": "blocked: team is blocked: spending quota exceeded" }
```

If `blocked_reason` is `NULL` or empty, the message is unchanged. Banned teams are unaffected (no `banned_reason` column exists).

## Test plan

- [x] Existing `TestBlockedTeam` integration test updated to assert the new message format
- [x] `go build` and `go vet` pass on `packages/auth`
- [ ] Verify integration tests pass in CI