### PR TITLE
Use `memfd` to track sandbox memory

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -67,12 +67,17 @@ func main() {
 	memory := flag.Int("memory", 1024, "memory MB")
 	disk := flag.Int("disk", 1024, "disk MB")
 	hugePages := flag.Bool("hugepages", true, "use 2MB huge pages for memory (false = 4KB pages)")
+	useMemfd := flag.Bool("use-memfd", false, "enable memfd-backed guest memory (passes use_memfd on snapshot load)")
 	startCmd := flag.String("start-cmd", "", "start command")
 	setupCmd := flag.String("setup-cmd", "", "setup command to run during build (e.g., install deps)")
 	readyCmd := flag.String("ready-cmd", "", "ready check command")
 	timeout := flag.Int("timeout", 5, "build timeout in minutes")
 	verbose := flag.Bool("v", false, "verbose output")
 	flag.Parse()
+
+	if *useMemfd {
+		featureflags.OverrideBoolFlag(featureflags.UseMemFdFlag, true)
+	}
 
 	if *toBuild == "" {
 		log.Fatal("-to-build required")

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -58,6 +58,7 @@ func main() {
 	coldStart := flag.Bool("cold", false, "clear cache between iterations (cold start each time)")
 	noPrefetch := flag.Bool("no-prefetch", false, "disable memory prefetching")
 	noEgress := flag.Bool("no-egress", false, "block all guest internet egress")
+	useMemfd := flag.Bool("use-memfd", false, "enable memfd-backed guest memory (passes use_memfd on snapshot load)")
 	verbose := flag.Bool("v", false, "verbose logging")
 
 	// Command execution (no pause)
@@ -93,6 +94,10 @@ func main() {
 			"compact_memory": 1000,
 			"fstrim":         500,
 		}))
+	}
+
+	if *useMemfd {
+		featureflags.OverrideBoolFlag(featureflags.UseMemFdFlag, true)
 	}
 
 	if *fromBuild == "" {

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -408,7 +408,7 @@ func (c *Cache) WriteZeroesAt(off, length int64) (int, error) {
 
 // FileSize returns the size of the cache on disk.
 // The size might differ from the dirty size, as it may not be fully on disk.
-func (c *Cache) FileSize() (int64, error) {
+func (c *Cache) FileSize(_ context.Context) (int64, error) {
 	var stat syscall.Stat_t
 	err := syscall.Stat(c.filePath, &stat)
 	if err != nil {
@@ -471,8 +471,8 @@ func (c *Cache) BlockSize() int64 {
 	return c.blockSize
 }
 
-func (c *Cache) Path() string {
-	return c.filePath
+func (c *Cache) Path(_ context.Context) (string, error) {
+	return c.filePath, nil
 }
 
 func NewCacheFromProcessMemory(

--- a/packages/orchestrator/pkg/sandbox/block/device.go
+++ b/packages/orchestrator/pkg/sandbox/block/device.go
@@ -46,3 +46,16 @@ type Device interface {
 	io.WriterAt
 	WriteZeroesAt(off, length int64) (int, error)
 }
+
+// DiffSource is what the diff/upload layer reads from. *Cache satisfies it
+// directly; *MemfdCache wraps *Cache, waits for the background copy to complete
+// and then delegates to *Cache.
+type DiffSource interface {
+	io.Closer
+	ReadAt(b []byte, off int64) (int, error)
+	Slice(off, length int64) ([]byte, error)
+	Size() (int64, error)
+	FileSize(ctx context.Context) (int64, error)
+	BlockSize() int64
+	Path(ctx context.Context) (string, error)
+}

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -73,16 +73,26 @@ func NewCacheFromMemfd(
 	if err != nil {
 		return nil, errors.Join(err, memfd.Close())
 	}
+	if err := copyFromMemfd(ctx, cache, memfd, dirty, blockSize); err != nil {
+		return nil, errors.Join(err, memfd.Close(), cache.Close())
+	}
+	if err := memfd.Close(); err != nil {
+		return nil, errors.Join(fmt.Errorf("close memfd: %w", err), cache.Close())
+	}
 
+	return cache, nil
+}
+
+func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) error {
 	var cacheOff int64
 	for r := range BitsetRanges(dirty, blockSize) {
 		if err := ctx.Err(); err != nil {
-			return nil, errors.Join(err, memfd.Close(), cache.Close())
+			return err
 		}
 
 		src, err := memfd.Slice(r.Start, r.Size)
 		if err != nil {
-			return nil, errors.Join(fmt.Errorf("memfd slice [%d,%d): %w", r.Start, r.Start+r.Size, err), memfd.Close(), cache.Close())
+			return fmt.Errorf("memfd slice [%d,%d): %w", r.Start, r.Start+r.Size, err)
 		}
 
 		copy((*cache.mmap)[cacheOff:cacheOff+r.Size], src)
@@ -90,9 +100,120 @@ func NewCacheFromMemfd(
 		cacheOff += r.Size
 	}
 
-	if err := memfd.Close(); err != nil {
-		return nil, errors.Join(fmt.Errorf("close memfd: %w", err), cache.Close())
+	return nil
+}
+
+// MemfdCache wraps a Cache populated from a memfd on a background
+// goroutine. Reads block on the copy via Wait. Once it finishes, runCopy
+// closes the memfd (releasing the hugetlb pages — potentially tens of GB)
+// and reads delegate to the embedded Cache.
+type MemfdCache struct {
+	cache *Cache
+
+	cancel context.CancelFunc
+	done   chan struct{} // closed by runCopy; happens-before for err
+	err    error
+}
+
+// NewCacheFromMemfdAsync starts the memfd→cache copy on a goroutine so
+// Pause can return as soon as the snapshot file + diff metadata are
+// written. The returned wrapper takes ownership of memfd; runCopy closes
+// it when the copy completes (or is cancelled via Close).
+func NewCacheFromMemfdAsync(
+	ctx context.Context,
+	blockSize int64,
+	filePath string,
+	memfd *Memfd,
+	dirty *roaring.Bitmap,
+) (*MemfdCache, error) {
+	cache, err := NewCache(int64(dirty.GetCardinality())*blockSize, blockSize, filePath, false)
+	if err != nil {
+		return nil, errors.Join(err, memfd.Close())
+	}
+	if dirty.IsEmpty() {
+		if closeErr := memfd.Close(); closeErr != nil {
+			return nil, errors.Join(fmt.Errorf("close memfd: %w", closeErr), cache.Close())
+		}
+
+		return &MemfdCache{cache: cache}, nil
 	}
 
-	return cache, nil
+	// Detach from the request context so the copy outlives Pause.
+	copyCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	m := &MemfdCache{
+		cache:  cache,
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	go m.runCopy(copyCtx, memfd, dirty, blockSize)
+
+	return m, nil
 }
+
+func (m *MemfdCache) runCopy(ctx context.Context, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) {
+	err := copyFromMemfd(ctx, m.cache, memfd, dirty, blockSize)
+	if closeErr := memfd.Close(); closeErr != nil {
+		err = errors.Join(err, fmt.Errorf("close memfd: %w", closeErr))
+	}
+	m.err = err
+	close(m.done)
+}
+
+// Wait blocks until the background copy completes (or ctx is cancelled).
+func (m *MemfdCache) Wait(ctx context.Context) error {
+	if m.done == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.done:
+	}
+
+	return m.err
+}
+
+func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
+	if err := m.Wait(context.Background()); err != nil {
+		return 0, err
+	}
+
+	return m.cache.ReadAt(b, off)
+}
+
+func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
+	if err := m.Wait(context.Background()); err != nil {
+		return nil, err
+	}
+
+	return m.cache.Slice(off, length)
+}
+
+func (m *MemfdCache) Close() error {
+	if m.cancel != nil {
+		m.cancel()
+		<-m.done
+	}
+
+	return m.cache.Close()
+}
+
+func (m *MemfdCache) Path(ctx context.Context) (string, error) {
+	if err := m.Wait(ctx); err != nil {
+		return "", err
+	}
+
+	return m.cache.filePath, nil
+}
+
+func (m *MemfdCache) FileSize(ctx context.Context) (int64, error) {
+	if err := m.Wait(ctx); err != nil {
+		return 0, err
+	}
+
+	return m.cache.FileSize(ctx)
+}
+
+func (m *MemfdCache) BlockSize() int64     { return m.cache.BlockSize() }
+func (m *MemfdCache) Size() (int64, error) { return m.cache.Size() }

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sys/unix"
 )
 
@@ -69,6 +71,13 @@ func NewCacheFromMemfd(
 	memfd *Memfd,
 	dirty *roaring.Bitmap,
 ) (*Cache, error) {
+	ctx, span := tracer.Start(ctx, "export-memory-from-memfd",
+		trace.WithAttributes(
+			attribute.Bool("async", false),
+		),
+	)
+	defer span.End()
+
 	cache, err := NewCache(int64(dirty.GetCardinality())*blockSize, blockSize, filePath, false)
 	if err != nil {
 		return nil, errors.Join(err, memfd.Close())
@@ -126,6 +135,13 @@ func NewCacheFromMemfdAsync(
 	memfd *Memfd,
 	dirty *roaring.Bitmap,
 ) (*MemfdCache, error) {
+	ctx, span := tracer.Start(ctx, "export-memory-from-memfd",
+		trace.WithAttributes(
+			attribute.Bool("async", true),
+		),
+	)
+	defer span.End()
+
 	cache, err := NewCache(int64(dirty.GetCardinality())*blockSize, blockSize, filePath, false)
 	if err != nil {
 		return nil, errors.Join(err, memfd.Close())

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+package block
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	"golang.org/x/sys/unix"
+)
+
+// Memfd wraps a memfd received from Firecracker. NewFromFd takes ownership of
+// the fd and mmaps it; Close releases both.
+type Memfd struct {
+	fd   int
+	mmap []byte
+}
+
+func NewFromFd(fd int) (*Memfd, error) {
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		_ = unix.Close(fd)
+
+		return nil, fmt.Errorf("fstat memfd: %w", err)
+	}
+	b, err := unix.Mmap(fd, 0, int(st.Size), unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		_ = unix.Close(fd)
+
+		return nil, fmt.Errorf("mmap memfd: %w", err)
+	}
+
+	return &Memfd{fd: fd, mmap: b}, nil
+}
+
+// Slice returns a zero-copy view of [offset, offset+size). Valid until Close.
+func (m *Memfd) Slice(offset, size int64) ([]byte, error) {
+	if offset < 0 || offset+size > int64(len(m.mmap)) {
+		return nil, fmt.Errorf("range [%d, %d) out of bounds (size %d)", offset, offset+size, len(m.mmap))
+	}
+
+	return m.mmap[offset : offset+size], nil
+}
+
+// Close releases the mmap and the fd. Single-use: every Memfd has exactly
+// one owner (NewCacheFromMemfd consumes it during construction; the UFFD
+// handshake transfers ownership via atomic Swap), so we don't guard against
+// double-close.
+func (m *Memfd) Close() error {
+	var err error
+	if e := unix.Munmap(m.mmap); e != nil {
+		err = fmt.Errorf("munmap memfd: %w", e)
+	}
+	if e := unix.Close(m.fd); e != nil {
+		err = errors.Join(err, fmt.Errorf("close memfd: %w", e))
+	}
+
+	return err
+}
+
+// NewCacheFromMemfd builds a Cache populated from a memfd. The memfd is
+// consumed and closed during construction.
+func NewCacheFromMemfd(
+	ctx context.Context,
+	blockSize int64,
+	filePath string,
+	memfd *Memfd,
+	dirty *roaring.Bitmap,
+) (*Cache, error) {
+	cache, err := NewCache(int64(dirty.GetCardinality())*blockSize, blockSize, filePath, false)
+	if err != nil {
+		return nil, errors.Join(err, memfd.Close())
+	}
+
+	var cacheOff int64
+	for r := range BitsetRanges(dirty, blockSize) {
+		if err := ctx.Err(); err != nil {
+			return nil, errors.Join(err, memfd.Close(), cache.Close())
+		}
+
+		src, err := memfd.Slice(r.Start, r.Size)
+		if err != nil {
+			return nil, errors.Join(fmt.Errorf("memfd slice [%d,%d): %w", r.Start, r.Start+r.Size, err), memfd.Close(), cache.Close())
+		}
+
+		copy((*cache.mmap)[cacheOff:cacheOff+r.Size], src)
+		cache.setIsCached(cacheOff, r.Size)
+		cacheOff += r.Size
+	}
+
+	if err := memfd.Close(); err != nil {
+		return nil, errors.Join(fmt.Errorf("close memfd: %w", err), cache.Close())
+	}
+
+	return cache, nil
+}

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -3,7 +3,9 @@
 package block
 
 import (
+	"context"
 	"crypto/rand"
+	"os"
 	"testing"
 
 	"github.com/RoaringBitmap/roaring/v2"
@@ -75,4 +77,30 @@ func TestNewCacheFromMemfd_NonZeroRangeStart(t *testing.T) {
 	_, err = cache.ReadAt(got, 0)
 	require.NoError(t, err)
 	require.Equal(t, expected[pageSize*3:pageSize*5], got)
+}
+
+// Async: the copy detaches from the request context (cancelling the parent
+// ctx doesn't abort it). After Wait the file on disk has the full payload.
+func TestNewCacheFromMemfdAsync_DetachesAndFlushes(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	numPages := uint32(16)
+	memfd, expected := newTestMemfd(t, pageSize*int64(numPages))
+
+	dirty := roaring.New()
+	dirty.AddRange(0, uint64(numPages))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cachePath := t.TempDir() + "/cache"
+	cache, err := NewCacheFromMemfdAsync(ctx, pageSize, cachePath, memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	cancel()
+	require.NoError(t, cache.Wait(t.Context()))
+
+	fromFile, err := os.ReadFile(cachePath)
+	require.NoError(t, err)
+	require.Equal(t, expected, fromFile)
 }

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package block
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+func newTestMemfd(t *testing.T, size int64) (memfd *Memfd, data []byte) {
+	t.Helper()
+
+	fd, err := unix.MemfdCreate("test", 0)
+	require.NoError(t, err)
+	require.NoError(t, unix.Ftruncate(fd, size))
+
+	data = make([]byte, size)
+	_, err = rand.Read(data)
+	require.NoError(t, err)
+
+	_, err = unix.Pwrite(fd, data, 0)
+	require.NoError(t, err)
+
+	memfd, err = NewFromFd(fd)
+	require.NoError(t, err)
+
+	return memfd, data
+}
+
+func TestNewCacheFromMemfd_NonAdjacentBlocks(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	memfd, expected := newTestMemfd(t, pageSize*6)
+
+	// Non-adjacent blocks: BitsetRanges emits three separate ranges; the
+	// cache packs them in iteration order.
+	dirty := roaring.New()
+	dirty.AddMany([]uint32{0, 2, 5})
+
+	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	for i, srcBlock := range []int64{0, 2, 5} {
+		got := make([]byte, pageSize)
+		_, err := cache.ReadAt(got, int64(i)*pageSize)
+		require.NoError(t, err)
+		require.Equal(t, expected[srcBlock*pageSize:(srcBlock+1)*pageSize], got)
+	}
+}
+
+// Regression: the copy loop used to index src[srcOff:...] with srcOff in
+// guest-absolute space, panicking when the first range started past zero.
+func TestNewCacheFromMemfd_NonZeroRangeStart(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	memfd, expected := newTestMemfd(t, pageSize*8)
+
+	dirty := roaring.New()
+	dirty.AddMany([]uint32{3, 4})
+
+	cache, err := NewCacheFromMemfd(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	got := make([]byte, pageSize*2)
+	_, err = cache.ReadAt(got, 0)
+	require.NoError(t, err)
+	require.Equal(t, expected[pageSize*3:pageSize*5], got)
+}

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -295,8 +295,8 @@ func (c *Chunker) Close() error {
 	return c.cache.Close()
 }
 
-func (c *Chunker) FileSize() (int64, error) {
-	return c.cache.FileSize()
+func (c *Chunker) FileSize(ctx context.Context) (int64, error) {
+	return c.cache.FileSize(ctx)
 }
 
 const (

--- a/packages/orchestrator/pkg/sandbox/build/cache.go
+++ b/packages/orchestrator/pkg/sandbox/build/cache.go
@@ -268,7 +268,7 @@ func (s *DiffStore) deleteOldestFromCache(ctx context.Context) (suc bool, e erro
 			return true
 		}
 
-		sfSize, err := item.Value().FileSize()
+		sfSize, err := item.Value().FileSize(ctx)
 		if err != nil {
 			logger.L().Warn(ctx, "failed to get size of deleted item from cache", zap.Error(err))
 			sfSize = fallbackDiffSize

--- a/packages/orchestrator/pkg/sandbox/build/diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/diff.go
@@ -31,8 +31,8 @@ type Diff interface {
 	storage.SeekableReader
 	block.FramedSlicer
 	CacheKey() DiffStoreKey
-	CachePath() (string, error)
-	FileSize() (int64, error)
+	CachePath(ctx context.Context) (string, error)
+	FileSize(ctx context.Context) (int64, error)
 	BlockSize() int64
 	Init(ctx context.Context) error
 }
@@ -41,7 +41,7 @@ type NoDiff struct{}
 
 var _ Diff = (*NoDiff)(nil)
 
-func (n *NoDiff) CachePath() (string, error) {
+func (n *NoDiff) CachePath(context.Context) (string, error) {
 	return "", nil
 }
 
@@ -57,7 +57,7 @@ func (n *NoDiff) ReadAt(_ context.Context, _ []byte, _ int64, _ *storage.FrameTa
 	return 0, NoDiffError{}
 }
 
-func (n *NoDiff) FileSize() (int64, error) {
+func (n *NoDiff) FileSize(_ context.Context) (int64, error) {
 	return 0, NoDiffError{}
 }
 

--- a/packages/orchestrator/pkg/sandbox/build/local_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff.go
@@ -80,14 +80,14 @@ func (f *LocalDiffFile) CloseToDiff(
 
 type localDiff struct {
 	cacheKey DiffStoreKey
-	cache    *block.Cache
+	cache    block.DiffSource
 }
 
 var _ Diff = (*localDiff)(nil)
 
 func NewLocalDiffFromCache(
 	cacheKey DiffStoreKey,
-	cache *block.Cache,
+	cache block.DiffSource,
 ) (Diff, error) {
 	return &localDiff{
 		cache:    cache,
@@ -109,8 +109,8 @@ func newLocalDiff(
 	return NewLocalDiffFromCache(cacheKey, cache)
 }
 
-func (b *localDiff) CachePath() (string, error) {
-	return b.cache.Path(), nil
+func (b *localDiff) CachePath(ctx context.Context) (string, error) {
+	return b.cache.Path(ctx)
 }
 
 func (b *localDiff) Close() error {
@@ -129,8 +129,8 @@ func (b *localDiff) Size(_ context.Context) (int64, error) {
 	return b.cache.Size()
 }
 
-func (b *localDiff) FileSize() (int64, error) {
-	return b.cache.FileSize()
+func (b *localDiff) FileSize(ctx context.Context) (int64, error) {
+	return b.cache.FileSize(ctx)
 }
 
 func (b *localDiff) CacheKey() DiffStoreKey {

--- a/packages/orchestrator/pkg/sandbox/build/mocks/mockdiff.go
+++ b/packages/orchestrator/pkg/sandbox/build/mocks/mockdiff.go
@@ -130,8 +130,8 @@ func (_c *MockDiff_CacheKey_Call) RunAndReturn(run func() build.DiffStoreKey) *M
 }
 
 // CachePath provides a mock function for the type MockDiff
-func (_mock *MockDiff) CachePath() (string, error) {
-	ret := _mock.Called()
+func (_mock *MockDiff) CachePath(ctx context.Context) (string, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CachePath")
@@ -139,16 +139,16 @@ func (_mock *MockDiff) CachePath() (string, error) {
 
 	var r0 string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (string, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() string); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -161,13 +161,20 @@ type MockDiff_CachePath_Call struct {
 }
 
 // CachePath is a helper method to define mock.On call
-func (_e *MockDiff_Expecter) CachePath() *MockDiff_CachePath_Call {
-	return &MockDiff_CachePath_Call{Call: _e.mock.On("CachePath")}
+//   - ctx context.Context
+func (_e *MockDiff_Expecter) CachePath(ctx interface{}) *MockDiff_CachePath_Call {
+	return &MockDiff_CachePath_Call{Call: _e.mock.On("CachePath", ctx)}
 }
 
-func (_c *MockDiff_CachePath_Call) Run(run func()) *MockDiff_CachePath_Call {
+func (_c *MockDiff_CachePath_Call) Run(run func(ctx context.Context)) *MockDiff_CachePath_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -177,7 +184,7 @@ func (_c *MockDiff_CachePath_Call) Return(s string, err error) *MockDiff_CachePa
 	return _c
 }
 
-func (_c *MockDiff_CachePath_Call) RunAndReturn(run func() (string, error)) *MockDiff_CachePath_Call {
+func (_c *MockDiff_CachePath_Call) RunAndReturn(run func(ctx context.Context) (string, error)) *MockDiff_CachePath_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -227,8 +234,8 @@ func (_c *MockDiff_Close_Call) RunAndReturn(run func() error) *MockDiff_Close_Ca
 }
 
 // FileSize provides a mock function for the type MockDiff
-func (_mock *MockDiff) FileSize() (int64, error) {
-	ret := _mock.Called()
+func (_mock *MockDiff) FileSize(ctx context.Context) (int64, error) {
+	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FileSize")
@@ -236,16 +243,16 @@ func (_mock *MockDiff) FileSize() (int64, error) {
 
 	var r0 int64
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (int64, error)); ok {
-		return returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (int64, error)); ok {
+		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func() int64); ok {
-		r0 = returnFunc()
+	if returnFunc, ok := ret.Get(0).(func(context.Context) int64); ok {
+		r0 = returnFunc(ctx)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -258,13 +265,20 @@ type MockDiff_FileSize_Call struct {
 }
 
 // FileSize is a helper method to define mock.On call
-func (_e *MockDiff_Expecter) FileSize() *MockDiff_FileSize_Call {
-	return &MockDiff_FileSize_Call{Call: _e.mock.On("FileSize")}
+//   - ctx context.Context
+func (_e *MockDiff_Expecter) FileSize(ctx interface{}) *MockDiff_FileSize_Call {
+	return &MockDiff_FileSize_Call{Call: _e.mock.On("FileSize", ctx)}
 }
 
-func (_c *MockDiff_FileSize_Call) Run(run func()) *MockDiff_FileSize_Call {
+func (_c *MockDiff_FileSize_Call) Run(run func(ctx context.Context)) *MockDiff_FileSize_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
 	})
 	return _c
 }
@@ -274,7 +288,7 @@ func (_c *MockDiff_FileSize_Call) Return(n int64, err error) *MockDiff_FileSize_
 	return _c
 }
 
-func (_c *MockDiff_FileSize_Call) RunAndReturn(run func() (int64, error)) *MockDiff_FileSize_Call {
+func (_c *MockDiff_FileSize_Call) RunAndReturn(run func(ctx context.Context) (int64, error)) *MockDiff_FileSize_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -123,16 +123,16 @@ func (b *StorageDiff) Slice(ctx context.Context, off, length int64, ft *storage.
 }
 
 // The local file might not be synced.
-func (b *StorageDiff) CachePath() (string, error) {
+func (b *StorageDiff) CachePath(context.Context) (string, error) {
 	return b.cachePath, nil
 }
 
-func (b *StorageDiff) FileSize() (int64, error) {
-	return b.chunker.FileSize()
+func (b *StorageDiff) FileSize(ctx context.Context) (int64, error) {
+	return b.chunker.FileSize(ctx)
 }
 
-func (b *StorageDiff) Size(_ context.Context) (int64, error) {
-	return b.FileSize()
+func (b *StorageDiff) Size(ctx context.Context) (int64, error) {
+	return b.FileSize(ctx)
 }
 
 func (b *StorageDiff) BlockSize() int64 {

--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -14,12 +14,12 @@ import (
 )
 
 func (u *Upload) runV3(ctx context.Context) error {
-	memfilePath, err := u.snap.MemfileDiff.CachePath()
+	memfilePath, err := u.snap.MemfileDiff.CachePath(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting memfile diff path: %w", err)
 	}
 
-	rootfsPath, err := u.snap.RootfsDiff.CachePath()
+	rootfsPath, err := u.snap.RootfsDiff.CachePath(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting rootfs diff path: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -16,12 +16,12 @@ import (
 )
 
 func (u *Upload) runV4(ctx context.Context) error {
-	memSrc, err := u.snap.MemfileDiff.CachePath()
+	memSrc, err := u.snap.MemfileDiff.CachePath(ctx)
 	if err != nil {
 		return fmt.Errorf("memfile diff path: %w", err)
 	}
 
-	rootfsSrc, err := u.snap.RootfsDiff.CachePath()
+	rootfsSrc, err := u.snap.RootfsDiff.CachePath(ctx)
 	if err != nil {
 		return fmt.Errorf("rootfs diff path: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/fc/client.go
+++ b/packages/orchestrator/pkg/sandbox/fc/client.go
@@ -45,6 +45,7 @@ func (c *apiClient) loadSnapshot(
 	uffdSocketPath string,
 	uffdReady chan struct{},
 	snapfile template.File,
+	useMemfd bool,
 ) error {
 	ctx, span := tracer.Start(ctx, "load-snapshot")
 	defer span.End()
@@ -53,6 +54,9 @@ func (c *apiClient) loadSnapshot(
 	backend := &models.MemoryBackend{
 		BackendPath: &uffdSocketPath,
 		BackendType: &backendType,
+	}
+	if useMemfd {
+		backend.UseMemfd = &useMemfd
 	}
 
 	snapfilePath := snapfile.Path()

--- a/packages/orchestrator/pkg/sandbox/fc/fph_gates.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fph_gates.go
@@ -15,3 +15,15 @@ func FCSupportsFreePageHinting(fcVersion string) bool {
 
 	return info.HasFreePageHinting()
 }
+
+// FCSupportsMemfd reports whether the FC build accepts the use_memfd field
+// on snapshot load. Combined with UseMemFdFlag in sandbox.go so an old FC
+// won't reject the request even if the flag is on.
+func FCSupportsMemfd(fcVersion string) bool {
+	info, err := fcversion.New(fcVersion)
+	if err != nil {
+		return false
+	}
+
+	return info.HasMemfd()
+}

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -23,7 +23,7 @@ func (p *Process) DirtyMemory(ctx context.Context, blockSize int64) (*header.Dif
 	return p.client.dirtyMemory(ctx, blockSize)
 }
 
-func (p *Process) ExportMemory(
+func (p *Process) exportMemoryFromFc(
 	ctx context.Context,
 	include *roaring.Bitmap,
 	cachePath string,
@@ -56,4 +56,18 @@ func (p *Process) ExportMemory(
 	}
 
 	return cache, nil
+}
+
+func (p *Process) ExportMemory(
+	ctx context.Context,
+	include *roaring.Bitmap,
+	cachePath string,
+	blockSize int64,
+	memfd *block.Memfd,
+) (*block.Cache, error) {
+	if memfd == nil {
+		return p.exportMemoryFromFc(ctx, include, cachePath, blockSize)
+	}
+
+	return block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)
 }

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -28,7 +28,7 @@ func (p *Process) exportMemoryFromFc(
 	include *roaring.Bitmap,
 	cachePath string,
 	blockSize int64,
-) (*block.Cache, error) {
+) (block.DiffSource, error) {
 	m, err := p.client.memoryMapping(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memory mappings: %w", err)
@@ -64,9 +64,13 @@ func (p *Process) ExportMemory(
 	cachePath string,
 	blockSize int64,
 	memfd *block.Memfd,
-) (*block.Cache, error) {
+	bgCopy bool,
+) (block.DiffSource, error) {
 	if memfd == nil {
 		return p.exportMemoryFromFc(ctx, include, cachePath, blockSize)
+	}
+	if bgCopy {
+		return block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
 	}
 
 	return block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -29,6 +29,9 @@ func (p *Process) exportMemoryFromFc(
 	cachePath string,
 	blockSize int64,
 ) (block.DiffSource, error) {
+	ctx, span := tracer.Start(ctx, "export-memory-from-fc")
+	defer span.End()
+
 	m, err := p.client.memoryMapping(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memory mappings: %w", err)

--- a/packages/orchestrator/pkg/sandbox/fc/process.go
+++ b/packages/orchestrator/pkg/sandbox/fc/process.go
@@ -482,6 +482,7 @@ func (p *Process) Resume(
 	uffdReady chan struct{},
 	accessToken *string,
 	cgroupFD int,
+	useMemfd bool,
 	txRateLimit RateLimiterConfig,
 	driveRateLimit RateLimiterConfig,
 ) error {
@@ -570,6 +571,7 @@ func (p *Process) Resume(
 		uffdSocketPath,
 		uffdReady,
 		snapfile,
+		useMemfd,
 	)
 	if err != nil {
 		fcStopErr := p.Stop(ctx)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -180,6 +180,7 @@ func sandboxLDContext(runtime RuntimeMetadata, config *Config) ldcontext.Context
 		SetString(featureflags.SandboxTemplateAttribute, runtime.TemplateID).
 		SetString(featureflags.SandboxKernelVersionAttribute, config.FirecrackerConfig.KernelVersion).
 		SetString(featureflags.SandboxFirecrackerVersionAttribute, config.FirecrackerConfig.FirecrackerVersion).
+		SetString(featureflags.SandboxTypeAttribute, runtime.SandboxType.String()).
 		Build()
 }
 
@@ -831,7 +832,7 @@ func (f *Factory) ResumeSandbox(
 	}
 
 	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
-	useMemfd := f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag)
+	useMemfd := f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag, sandboxLDContext(runtime, config))
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox
 	// This is to prevent race condition of reporting unhealthy sandbox

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1134,6 +1134,7 @@ func (s *Sandbox) Pause(
 		memfileDiffMetadata,
 		s.config.DefaultCacheDir,
 		s.process,
+		s.memory.Memfd(ctx),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1201,25 +1202,21 @@ func pauseProcessMemory(
 	diffMetadata *header.DiffMetadata,
 	cacheDir string,
 	fc *fc.Process,
+	memfd *block.Memfd,
 ) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
-	header, err := diffMetadata.ToDiffHeader(ctx, originalHeader, buildID)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create memfile header: %w", err)
-	}
-
+	// ExportMemory owns memfd and closes it on all paths.
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
-
-	cache, err := fc.ExportMemory(
-		ctx,
-		diffMetadata.Dirty,
-		memfileDiffPath,
-		diffMetadata.BlockSize,
-	)
+	cache, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
+	}
+
+	header, err := diffMetadata.ToDiffHeader(ctx, originalHeader, buildID)
+	if err != nil {
+		return nil, nil, errors.Join(fmt.Errorf("failed to create memfile header: %w", err), cache.Close())
 	}
 
 	diff, err := build.NewLocalDiffFromCache(
@@ -1227,7 +1224,6 @@ func pauseProcessMemory(
 		cache,
 	)
 	if err != nil {
-		// Close the cache even if the diff creation fails.
 		return nil, nil, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
 	}
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -832,7 +832,8 @@ func (f *Factory) ResumeSandbox(
 	}
 
 	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
-	useMemfd := f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag, sandboxLDContext(runtime, config))
+	useMemfd := fc.FCSupportsMemfd(config.FirecrackerConfig.FirecrackerVersion) &&
+		f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag, sandboxLDContext(runtime, config))
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox
 	// This is to prevent race condition of reporting unhealthy sandbox

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -831,6 +831,7 @@ func (f *Factory) ResumeSandbox(
 	}
 
 	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
+	useMemfd := f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag)
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox
 	// This is to prevent race condition of reporting unhealthy sandbox
@@ -882,6 +883,7 @@ func (f *Factory) ResumeSandbox(
 		fcUffd.Ready(),
 		config.Envd.AccessToken,
 		cgroupFD,
+		useMemfd,
 		fc.RateLimiterConfig{
 			Ops:       fc.TokenBucketConfig(resumeThrottleConfig.Ops),
 			Bandwidth: fc.TokenBucketConfig(resumeThrottleConfig.Bandwidth),

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1139,6 +1139,7 @@ func (s *Sandbox) Pause(
 		s.config.DefaultCacheDir,
 		s.process,
 		s.memory.Memfd(ctx),
+		s.featureFlags.BoolFlag(ctx, featureflags.MemfdBackgroundCopyFlag, sandboxLDContext(s.Runtime, s.Config)),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1207,13 +1208,14 @@ func pauseProcessMemory(
 	cacheDir string,
 	fc *fc.Process,
 	memfd *block.Memfd,
+	bgCopy bool,
 ) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
 	// ExportMemory owns memfd and closes it on all paths.
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
-	cache, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd)
+	cache, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd, bgCopy)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/uffd/memory_backend.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/memory_backend.go
@@ -19,4 +19,5 @@ type MemoryBackend interface {
 	Stop() error
 	Ready() chan struct{}
 	Exit() *utils.ErrorOnce
+	Memfd(ctx context.Context) *block.Memfd
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/noop.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/noop.go
@@ -83,3 +83,7 @@ func (m *NoopMemory) Ready() chan struct{} {
 func (m *NoopMemory) Exit() *utils.ErrorOnce {
 	return m.exit
 }
+
+func (m *NoopMemory) Memfd(context.Context) *block.Memfd {
+	return nil
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -41,6 +42,7 @@ type Uffd struct {
 	lis        *net.UnixListener
 	socketPath string
 	memfile    block.ReadonlyDevice
+	memfd      atomic.Pointer[block.Memfd]
 	handler    utils.SetOnce[*userfaultfd.Userfaultfd]
 	fdExit     utils.SetOnce[*fdexit.FdExit]
 }
@@ -130,9 +132,10 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 	unixConn := conn.(*net.UnixConn)
 
 	regionMappingsBuf := make([]byte, regionMappingsSize)
-	uffdBuf := make([]byte, syscall.CmsgSpace(fdSize))
+	// Firecracker may send 1 fd (UFFD) or 2 (UFFD + memfd, on newer versions).
+	fdBuf := make([]byte, syscall.CmsgSpace(2*fdSize))
 
-	numBytesMappings, numBytesFd, _, _, err := unixConn.ReadMsgUnix(regionMappingsBuf, uffdBuf)
+	numBytesMappings, numBytesFd, _, _, err := unixConn.ReadMsgUnix(regionMappingsBuf, fdBuf)
 	if err != nil {
 		return fmt.Errorf("failed to read unix msg from connection: %w", err)
 	}
@@ -146,13 +149,13 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 		return fmt.Errorf("failed parsing memory mapping data: %w", err)
 	}
 
-	controlMsgs, err := syscall.ParseSocketControlMessage(uffdBuf[:numBytesFd])
+	controlMsgs, err := syscall.ParseSocketControlMessage(fdBuf[:numBytesFd])
 	if err != nil {
 		return fmt.Errorf("failed parsing control messages: %w", err)
 	}
 
 	if len(controlMsgs) != 1 {
-		return fmt.Errorf("expected 1 control message containing UFFD: found %d", len(controlMsgs))
+		return fmt.Errorf("expected 1 control message containing UFFD and (maybe) memfd: found %d", len(controlMsgs))
 	}
 
 	fds, err := syscall.ParseUnixRights(&controlMsgs[0])
@@ -160,8 +163,8 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 		return fmt.Errorf("failed parsing unix write: %w", err)
 	}
 
-	if len(fds) != 1 {
-		return fmt.Errorf("expected 1 fd: found %d", len(fds))
+	if len(fds) == 0 {
+		return errors.New("expected at least 1 file descriptor")
 	}
 
 	m := memory.NewMapping(regions)
@@ -173,17 +176,35 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 		logger.L().With(logger.WithSandboxID(sandboxId)),
 	)
 	if err != nil {
+		for _, fd := range fds {
+			_ = syscall.Close(fd)
+		}
+
 		return fmt.Errorf("failed to create uffd: %w", err)
 	}
-
-	u.handler.SetValue(uffd)
 
 	defer func() {
 		closeErr := uffd.Close()
 		if closeErr != nil {
 			logger.L().Error(ctx, "failed to close uffd", logger.WithSandboxID(sandboxId), zap.String("socket_path", u.socketPath), zap.Error(closeErr))
 		}
+
+		if m := u.memfd.Swap(nil); m != nil {
+			if closeErr := m.Close(); closeErr != nil {
+				logger.L().Error(ctx, "failed to close memfd", logger.WithSandboxID(sandboxId), zap.Error(closeErr))
+			}
+		}
 	}()
+
+	if len(fds) > 1 {
+		memfd, err := block.NewFromFd(fds[1])
+		if err != nil {
+			return fmt.Errorf("failed to wrap memfd: %w", err)
+		}
+		u.memfd.Store(memfd)
+	}
+
+	u.handler.SetValue(uffd)
 
 	u.readyOnce.Do(func() { close(u.readyCh) })
 
@@ -253,4 +274,10 @@ func (u *Uffd) PrefetchData(ctx context.Context) (block.PrefetchData, error) {
 	}
 
 	return uffd.PrefetchData(), nil
+}
+
+// Memfd returns the memfd received from Firecracker and transfers ownership to
+// the caller. The uffd teardown defer will no longer close it.
+func (u *Uffd) Memfd(_ context.Context) *block.Memfd {
+	return u.memfd.Swap(nil)
 }

--- a/packages/shared/pkg/fc/firecracker.yml
+++ b/packages/shared/pkg/fc/firecracker.yml
@@ -1546,6 +1546,13 @@ definitions:
           2) Path to the UDS where a process is listening for a UFFD initialization
           control payload and open file descriptor that it can use to serve this
           process's guest memory page faults
+      use_memfd:
+        type: boolean
+        description:
+          When true, guest memory is backed by a memfd and its file descriptor is
+          sent to the UFFD handler over the UFFD socket alongside the UFFD itself.
+          Only valid when 'backend_type' is 'Uffd'.
+        default: false
 
   Metrics:
     type: object

--- a/packages/shared/pkg/fc/models/memory_backend.go
+++ b/packages/shared/pkg/fc/models/memory_backend.go
@@ -25,6 +25,9 @@ type MemoryBackend struct {
 	// Required: true
 	// Enum: ["File","Uffd"]
 	BackendType *string `json:"backend_type"`
+
+	// When true, guest memory is backed by a memfd and its file descriptor is sent to the UFFD handler over the UFFD socket alongside the UFFD itself. Only valid when 'backend_type' is 'Uffd'.
+	UseMemfd *bool `json:"use_memfd,omitempty"`
 }
 
 // Validate validates this memory backend

--- a/packages/shared/pkg/fcversion/sandbox_features.go
+++ b/packages/shared/pkg/fcversion/sandbox_features.go
@@ -15,3 +15,7 @@ func (v *Info) HasFreePageReporting() bool {
 func (v *Info) HasFreePageHinting() bool {
 	return v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 14)
 }
+
+func (v *Info) HasMemfd() bool {
+	return v.lastReleaseVersion.Major() > 1 || (v.lastReleaseVersion.Major() == 1 && v.lastReleaseVersion.Minor() >= 14)
+}

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -127,6 +127,11 @@ var (
 	// directly instead of using process_vm_readv on pause.
 	UseMemFdFlag = NewBoolFlag("use-memfd", false)
 
+	// MemfdBackgroundCopyFlag streams the memfd into the snapshot cache on
+	// a goroutine so Pause returns as soon as the diff metadata is written.
+	// Only takes effect when UseMemFdFlag is also on.
+	MemfdBackgroundCopyFlag = NewBoolFlag("memfd-background-copy", false)
+
 	// PeerToPeerChunkTransferFlag enables peer-to-peer chunk routing.
 	PeerToPeerChunkTransferFlag = NewBoolFlag("peer-to-peer-chunk-transfer", false)
 	// PeerToPeerAsyncCheckpointFlag makes Checkpoint upload fire-and-forget instead

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -18,6 +18,8 @@ const (
 	SandboxTemplateAttribute           string         = "template-id"
 	SandboxKernelVersionAttribute      string         = "kernel-version"
 	SandboxFirecrackerVersionAttribute string         = "firecracker-version"
+	// SandboxTypeAttribute distinguishes "sandbox" from "build" runs.
+	SandboxTypeAttribute string = "sandbox-type"
 
 	TeamKind             ldcontext.Kind = "team"
 	UserKind             ldcontext.Kind = "user"
@@ -99,6 +101,13 @@ func NewBoolFlag(name string, fallback bool) BoolFlag {
 	return flag
 }
 
+// OverrideBoolFlag forces a bool flag to a specific value in the offline store.
+// Only takes effect when LAUNCH_DARKLY_API_KEY is not set (i.e. dev/CLI tools).
+func OverrideBoolFlag(flag BoolFlag, value bool) {
+	builder := launchDarklyOfflineStore.Flag(flag.name).VariationForAll(value)
+	launchDarklyOfflineStore.Update(builder)
+}
+
 var (
 	MetricsWriteFlag                    = NewBoolFlag("sandbox-metrics-write", true)
 	MetricsReadFlag                     = NewBoolFlag("sandbox-metrics-read", true)
@@ -112,6 +121,11 @@ var (
 	CreateStorageCacheSpansFlag         = NewBoolFlag("create-storage-cache-spans", env.IsDevelopment())
 	SandboxAutoResumeFlag               = NewBoolFlag("sandbox-auto-resume", env.IsDevelopment())
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)
+
+	// UseMemFdFlag asks Firecracker to back guest memory with a memfd and
+	// pass the fd over the UFFD socket; the orchestrator then mmaps it
+	// directly instead of using process_vm_readv on pause.
+	UseMemFdFlag = NewBoolFlag("use-memfd", false)
 
 	// PeerToPeerChunkTransferFlag enables peer-to-peer chunk routing.
 	PeerToPeerChunkTransferFlag = NewBoolFlag("peer-to-peer-chunk-transfer", false)

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -1046,13 +1046,13 @@ func TestRetryableClient_ActualRetryBehavior(t *testing.T) {
 	require.Len(t, retryDelays, 2)
 
 	// First retry delay should be jittered version of 50ms (0-50ms range)
-	// But in practice, with network overhead, it might be slightly higher
+	// But in practice, with network overhead and CI scheduling, it might be much higher
 	require.Greater(t, retryDelays[0], time.Duration(0))
-	require.Less(t, retryDelays[0], 200*time.Millisecond) // Allow some overhead
+	require.Less(t, retryDelays[0], 2*time.Second)
 
 	// Second retry delay should be jittered version of 100ms (0-100ms range)
 	require.Greater(t, retryDelays[1], time.Duration(0))
-	require.Less(t, retryDelays[1], 300*time.Millisecond) // Allow some overhead
+	require.Less(t, retryDelays[1], 2*time.Second)
 
 	totalTime := time.Since(startTime)
 	t.Logf("Total time: %v, Retry delays: %v", totalTime, retryDelays)


### PR DESCRIPTION
### What

In Unix OSs `memfd` is an anonymous file that can be used to back memory. Firecracker uses this construct when it needs to share memory with external processes (currently, when using vhost-user devices).

Currently, when we take a snapshot of the sandbox (for example, during `PAUSE` operations) we need to copy its memory using `process_vm_readv`. `memfd` allows us to do this in a more idiomatic way.

### Why

`memfd` allows us to have a direct view of the sandbox memory from the orchestrator without having to copy memory across processes. Moreover, if the orchestrator holds a reference to `memfd`, we can post process the sandbox memory after the Firecracker process is killed. This opens up possibilities for various latency and memory utilization optimizations.

What we do in this PR is that we change the cache logic to use memfd to copy Firecracker memory into the diff file if the memfd is present.