### PR TITLE
chore(client-proxy): set API_GRPC_ADDRESS in dev env

### DIFF
--- a/packages/client-proxy/.env.local
+++ b/packages/client-proxy/.env.local
@@ -1,3 +1,4 @@
+API_GRPC_ADDRESS=localhost:5009
 EDGE_SECRET=--edge-secret--
 EDGE_URL=http://localhost:3000
 ENVIRONMENT=local


### PR DESCRIPTION
PR #1862 wired the gRPC paused-sandbox resumer conditionally on API_GRPC_ADDRESS but never set the variable in client-proxy/.env.local. Local dev has been silently running without HTTP-driven auto-resume since then; the warning "API gRPC address not set; paused sandbox checks disabled" is the only indicator. Production sets it via the Nomad job template.

Setting it to the API service's gRPC port (5009, the envDefault from packages/api/internal/cfg/model.go) so HTTP requests to paused sandboxes can be live-tested locally.

Commit: 1eae0a6cce00 ("Feature: Sandbox AutoResume (#1862)")
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Configure gRPC API endpoint for client-proxy service in local development environment.

Main changes:
- Added API_GRPC_ADDRESS environment variable pointing to localhost:5009 for local gRPC communication

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
