### PR TITLE
fix(api): catch db no rows

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,11 +59,20 @@ linters:
     - wsl
     - wsl_v5
 
+  exclusions:
+    rules:
+      - path: '^packages/db/pkg/dberrors/dberrors\.go$'
+        linters:
+          - forbidigo
+
   settings:
     forbidigo:
       forbid:
         - pattern: "^new$"
           msg: "Use &Type{} instead."
+        - pattern: '.*\.ErrNoRows$'
+          pkg: '^database/sql$'
+          msg: "Use github.com/e2b-dev/infra/packages/db/pkg/dberrors.IsNotFoundError instead."
     #        - pattern: os\.Getenv
     #          msg: "Add your field to the configuration model instead."
         - pattern: 'zap\.New$'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,10 @@ linters:
       - path: '^packages/db/pkg/dberrors/dberrors\.go$'
         linters:
           - forbidigo
+      - path: '.*_test\.go$'
+        text: "Use github.com/e2b-dev/infra/packages/db/pkg/dberrors.IsNotFoundError instead."
+        linters:
+          - forbidigo
 
   settings:
     forbidigo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,9 @@ linters:
         - pattern: '.*\.ErrNoRows$'
           pkg: '^database/sql$'
           msg: "Use github.com/e2b-dev/infra/packages/db/pkg/dberrors.IsNotFoundError instead."
+        - pattern: '.*\.ErrNoRows$'
+          pkg: '^github\.com/jackc/pgx/v5$'
+          msg: "Use github.com/e2b-dev/infra/packages/db/pkg/dberrors.IsNotFoundError instead."
     #        - pattern: os\.Getenv
     #          msg: "Add your field to the configuration model instead."
         - pattern: 'zap\.New$'

--- a/packages/api/internal/cache/snapshots/snapshot_cache.go
+++ b/packages/api/internal/cache/snapshots/snapshot_cache.go
@@ -2,7 +2,6 @@ package snapshotcache
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel"
 
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
+	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/cache"
 )
@@ -79,7 +79,7 @@ func (c *SnapshotCache) fetchFromDB(ctx context.Context, sandboxID string) (*Sna
 
 	row, err := c.db.GetLastSnapshot(ctx, sandboxID)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if dberrors.IsNotFoundError(err) {
 			return errNotFoundSentinel, nil
 		}
 

--- a/packages/api/internal/cache/templates/template_build.go
+++ b/packages/api/internal/cache/templates/template_build.go
@@ -2,7 +2,6 @@ package templatecache
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
+	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/cache"
@@ -76,7 +76,7 @@ func (c *TemplatesBuildCache) fetchFromDB(templateID string, buildID uuid.UUID) 
 			BuildID:    buildID,
 		})
 		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
+			if dberrors.IsNotFoundError(err) {
 				return TemplateBuildInfo{}, ErrTemplateBuildInfoNotFound
 			}
 

--- a/packages/api/internal/handlers/accesstoken.go
+++ b/packages/api/internal/handlers/accesstoken.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -12,6 +10,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/ginutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/keys"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -90,7 +89,7 @@ func (a *APIStore) DeleteAccessTokensAccessTokenID(c *gin.Context, accessTokenID
 		ID:     accessTokenIDParsed,
 		UserID: userID,
 	})
-	if errors.Is(err, sql.ErrNoRows) {
+	if dberrors.IsNotFoundError(err) {
 		c.String(http.StatusNotFound, "id not found")
 
 		return

--- a/packages/api/internal/handlers/apikey.go
+++ b/packages/api/internal/handlers/apikey.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"database/sql"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -15,6 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/team"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/shared/pkg/ginutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -50,7 +49,7 @@ func (a *APIStore) PatchApiKeysApiKeyID(c *gin.Context, apiKeyID string) {
 		ID:        apiKeyIDParsed,
 		TeamID:    teamID,
 	})
-	if errors.Is(err, sql.ErrNoRows) {
+	if dberrors.IsNotFoundError(err) {
 		c.String(http.StatusNotFound, "id not found")
 
 		return


### PR DESCRIPTION
Use `dberrors.IsNotFoundError` for API no-row handling so pgx no-row errors map to not-found paths.