### PR TITLE
feat(orchestrator): allow overriding with specific ip allow for internal

### DIFF
--- a/.env.aws.template
+++ b/.env.aws.template
@@ -18,3 +18,9 @@ PREFIX=e2b-
 
 # prod, staging, dev
 TERRAFORM_ENVIRONMENT=dev
+
+# ------------------------------------------- Optional block -----------------------------------------------------------
+# Following variables are optional and doesn't have to be set
+
+# Sandbox firewall: comma-separated CIDRs to allow through the private-range deny list
+# ALLOW_SANDBOX_INTERNAL_CIDRS=

--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -123,6 +123,9 @@ DEFAULT_PERSISTENT_VOLUME_TYPE=
 # Persistent volume types (default: {})
 PERSISTENT_VOLUME_TYPES=
 
+# Sandbox firewall: comma-separated CIDRs to allow through the private-range deny list
+# ALLOW_SANDBOX_INTERNAL_CIDRS=
+
 # -------------------------------------- Variables for integration tests -----------------------------------------------
 # Hash seed used for generating sandbox access tokens, not needed if you are not using them
 SANDBOX_ACCESS_TOKEN_HASH_SEED=abcdefghijklmnopqrstuvwxyz

--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -71,6 +71,7 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         TEMPLATE_BUCKET_NAME         = "${template_bucket_name}"
         OTEL_COLLECTOR_GRPC_ENDPOINT = "${otel_collector_grpc_endpoint}"
         ALLOW_SANDBOX_INTERNET       = "${allow_sandbox_internet}"
+        ALLOW_SANDBOX_INTERNAL_CIDRS = "${allow_sandbox_internal_cidrs}"
         CLICKHOUSE_CONNECTION_STRING = "${clickhouse_connection_string}"
         REDIS_POOL_SIZE              = "${redis_pool_size}"
         REDIS_CLUSTER_URL            = "${redis_cluster_url}"

--- a/iac/modules/job-orchestrator/main.tf
+++ b/iac/modules/job-orchestrator/main.tf
@@ -10,6 +10,7 @@ locals {
     envd_timeout                 = var.envd_timeout
     template_bucket_name         = var.template_bucket_name
     allow_sandbox_internet       = var.allow_sandbox_internet
+    allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
     clickhouse_connection_string = var.clickhouse_connection_string
     redis_url                    = var.redis_url
     redis_cluster_url            = var.redis_cluster_url

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -77,6 +77,12 @@ variable "allow_sandbox_internet" {
   type = string
 }
 
+variable "allow_sandbox_internal_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"
+  default     = ""
+}
+
 variable "clickhouse_connection_string" {
   type      = string
   default   = ""

--- a/iac/provider-aws/Makefile
+++ b/iac/provider-aws/Makefile
@@ -45,7 +45,8 @@ tf_vars := AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) \
 	$(call tfvar, DB_MAX_OPEN_CONNECTIONS) \
 	$(call tfvar, DB_MIN_IDLE_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MAX_OPEN_CONNECTIONS) \
-	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS)
+	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS) \
+	$(call tfvar, ALLOW_SANDBOX_INTERNAL_CIDRS)
 
 .PHONY: provider-login
 provider-login:

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -199,6 +199,7 @@ module "nomad" {
 
   orchestrator_node_pool              = local.client_pool_name
   allow_sandbox_internet              = var.allow_sandbox_internet
+  allow_sandbox_internal_cidrs        = var.allow_sandbox_internal_cidrs
   orchestrator_port                   = var.orchestrator_port
   orchestrator_proxy_port             = var.orchestrator_proxy_port
   envd_timeout                        = var.envd_timeout

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -180,6 +180,7 @@ module "orchestrator" {
   envd_timeout                 = var.envd_timeout
   template_bucket_name         = var.template_bucket_name
   allow_sandbox_internet       = var.allow_sandbox_internet
+  allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
   clickhouse_connection_string = local.clickhouse_connection_string
   redis_url                    = var.redis_url
   redis_cluster_url            = var.redis_cluster_url

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -218,6 +218,12 @@ variable "allow_sandbox_internet" {
   default = true
 }
 
+variable "allow_sandbox_internal_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs to allow through the sandbox firewall deny list"
+  default     = ""
+}
+
 variable "envd_timeout" {
   type    = string
   default = "40s"

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -125,6 +125,12 @@ variable "allow_sandbox_internet" {
   default = true
 }
 
+variable "allow_sandbox_internal_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"
+  default     = ""
+}
+
 variable "envd_timeout" {
   type    = string
   default = "40s"

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -43,6 +43,7 @@ tf_vars := \
 	$(call tfvar, SANDBOX_STORAGE_BACKEND) \
 	$(call tfvar, ORCHESTRATOR_ENABLED) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \
+	$(call tfvar, ALLOW_SANDBOX_INTERNAL_CIDRS) \
 	$(call tfvar, API_SERVER_COUNT) \
 	$(call tfvar, API_RESOURCES_CPU_COUNT) \
 	$(call tfvar, API_RESOURCES_MEMORY_MB) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -298,6 +298,7 @@ module "nomad" {
   # Orchestrator
   orchestrator_node_pool         = var.orchestrator_node_pool
   allow_sandbox_internet         = var.allow_sandbox_internet
+  allow_sandbox_internal_cidrs   = var.allow_sandbox_internal_cidrs
   orchestrator_port              = var.orchestrator_port
   orchestrator_proxy_port        = var.orchestrator_proxy_port
   fc_env_pipeline_bucket_name    = module.init.fc_env_pipeline_bucket_name

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -457,6 +457,7 @@ module "orchestrator" {
   envd_timeout                 = var.envd_timeout
   template_bucket_name         = var.template_bucket_name
   allow_sandbox_internet       = var.allow_sandbox_internet
+  allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
   clickhouse_connection_string = local.clickhouse_connection_string
   redis_url                    = local.redis_url
   redis_cluster_url            = local.redis_cluster_url

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -314,6 +314,12 @@ variable "allow_sandbox_internet" {
   type = bool
 }
 
+variable "allow_sandbox_internal_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs to allow through the sandbox firewall deny list"
+  default     = ""
+}
+
 # Template manager
 variable "template_manager_port" {
   type = number

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -273,6 +273,12 @@ variable "allow_sandbox_internet" {
   default = true
 }
 
+variable "allow_sandbox_internal_cidrs" {
+  type        = string
+  description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"
+  default     = ""
+}
+
 variable "orchestrator_node_pool" {
   type    = string
   default = "default"

--- a/packages/orchestrator/pkg/sandbox/network/firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/firewall.go
@@ -35,7 +35,7 @@ type Firewall struct {
 	allowedRanges []string
 }
 
-func NewFirewall(tapIf string, orchestratorInternalIP string) (*Firewall, error) {
+func NewFirewall(tapIf string, orchestratorInternalIP string, extraAllowedCIDRs []string) (*Firewall, error) {
 	conn, err := nftables.New(nftables.AsLasting())
 	if err != nil {
 		return nil, fmt.Errorf("new nftables conn: %w", err)
@@ -85,8 +85,11 @@ func NewFirewall(tapIf string, orchestratorInternalIP string) (*Firewall, error)
 		userDenySet:        denySet,
 		userAllowSet:       allowSet,
 		tapInterface:       tapIf,
-		allowedRanges:      []string{fmt.Sprintf("%s/32", orchestratorInternalIP)},
-		filterChain:        filterChain,
+		allowedRanges: append(
+			[]string{fmt.Sprintf("%s/32", orchestratorInternalIP)},
+			extraAllowedCIDRs...,
+		),
+		filterChain: filterChain,
 	}
 
 	// Add firewall rules to the chain

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -66,6 +66,11 @@ type Config struct {
 
 	UseLocalNamespaceStorage bool `env:"USE_LOCAL_NAMESPACE_STORAGE"`
 
+	// Comma-separated CIDRs to allow through the predefined firewall deny list.
+	// These are allowed before the private-range deny rules, so they can
+	// reach hosts in the 10.0.0.0/8, 172.16.0.0/12, etc. blocks.
+	AllowSandboxInternalCIDRs []string `env:"ALLOW_SANDBOX_INTERNAL_CIDRS" envDefault:"" envSeparator:","`
+
 	// TCP firewall ports - separate ports for different traffic types to avoid
 	// protocol detection blocking on server-first protocols like SSH.
 	// - HTTP port: for traffic destined to port 80 (HTTP Host header inspection)

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -224,7 +224,7 @@ func (s *Slot) InitializeFirewall() error {
 		return fmt.Errorf("firewall is already initialized for slot %s", s.Key)
 	}
 
-	fw, err := NewFirewall(s.TapName(), s.config.OrchestratorInSandboxIPAddress)
+	fw, err := NewFirewall(s.TapName(), s.config.OrchestratorInSandboxIPAddress, s.config.AllowSandboxInternalCIDRs)
 	if err != nil {
 		return fmt.Errorf("error initializing firewall: %w", err)
 	}


### PR DESCRIPTION
Currently DeniedSandboxCIDRs has blocks of denies causing some of our internal endpoints we want to expose to sandbox to be blocked.

I'm adding support here to allow users to configure in .env.* files to allow opening specific cidrs / IPs for internal usage on sandbox if necessary.