### PR TITLE
feat(sandbox): Allow support for adding to sandbox hosts entries

### DIFF
--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -118,6 +118,9 @@ GCP_REDIS_ENGINE_VERSION=
 # Creates SSD-backed zonal read caches in every zone of the deploy region.
 ANYWHERE_CACHE_ENABLED=
 
+# Extra /etc/hosts entries for sandboxes, semicolon-separated (e.g. "10.0.0.1 host.example.com;10.0.0.2 other.example.com")
+# SANDBOX_HOSTS_FILE_OVERRIDE=
+
 # Default persistent volume type (default: "")
 DEFAULT_PERSISTENT_VOLUME_TYPE=
 # Persistent volume types (default: {})

--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -72,6 +72,7 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         OTEL_COLLECTOR_GRPC_ENDPOINT = "${otel_collector_grpc_endpoint}"
         ALLOW_SANDBOX_INTERNET       = "${allow_sandbox_internet}"
         CLICKHOUSE_CONNECTION_STRING = "${clickhouse_connection_string}"
+        SANDBOX_HOSTS_FILE_OVERRIDE  = "${sandbox_hosts_file_override}"
         REDIS_POOL_SIZE              = "${redis_pool_size}"
         REDIS_CLUSTER_URL            = "${redis_cluster_url}"
         REDIS_TLS_CA_BASE64          = "${redis_tls_ca_base64}"

--- a/iac/modules/job-orchestrator/main.tf
+++ b/iac/modules/job-orchestrator/main.tf
@@ -11,6 +11,7 @@ locals {
     template_bucket_name         = var.template_bucket_name
     allow_sandbox_internet       = var.allow_sandbox_internet
     clickhouse_connection_string = var.clickhouse_connection_string
+    sandbox_hosts_file_override  = var.sandbox_hosts_file_override
     redis_url                    = var.redis_url
     redis_cluster_url            = var.redis_cluster_url
     redis_tls_ca_base64          = var.redis_tls_ca_base64

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -83,6 +83,12 @@ variable "clickhouse_connection_string" {
   sensitive = true
 }
 
+variable "sandbox_hosts_file_override" {
+  type        = string
+  description = "Extra /etc/hosts entries for sandboxes, semicolon-separated"
+  default     = ""
+}
+
 variable "redis_url" {
   type      = string
   sensitive = true

--- a/iac/provider-aws/Makefile
+++ b/iac/provider-aws/Makefile
@@ -30,6 +30,7 @@ tf_vars := AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) \
 	$(call tfvar, CLIENT_CLUSTER_SIZE) \
 	$(call tfvar, CLIENT_SERVER_MACHINE_TYPE) \
 	$(call tfvar, CLIENT_SERVER_NESTED_VIRTUALIZATION) \
+	$(call tfvar, SANDBOX_HOSTS_FILE_OVERRIDE) \
 	$(call tfvar, CLICKHOUSE_CLUSTER_SIZE) \
 	$(call tfvar, REDIS_INSTANCE_TYPE) \
 	$(call tfvar, REDIS_MANAGED) \

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -202,6 +202,7 @@ module "nomad" {
   orchestrator_port                   = var.orchestrator_port
   orchestrator_proxy_port             = var.orchestrator_proxy_port
   envd_timeout                        = var.envd_timeout
+  sandbox_hosts_file_override         = var.sandbox_hosts_file_override
   fc_env_pipeline_bucket_name         = module.init.fc_env_pipeline_bucket_name
   template_bucket_name                = module.init.fc_template_bucket_name
   build_cache_bucket_name             = module.init.fc_template_build_cache_bucket_name

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -181,6 +181,7 @@ module "orchestrator" {
   template_bucket_name         = var.template_bucket_name
   allow_sandbox_internet       = var.allow_sandbox_internet
   clickhouse_connection_string = local.clickhouse_connection_string
+  sandbox_hosts_file_override  = var.sandbox_hosts_file_override
   redis_url                    = var.redis_url
   redis_cluster_url            = var.redis_cluster_url
   redis_tls_ca_base64          = var.redis_tls_ca_base64

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -223,6 +223,12 @@ variable "envd_timeout" {
   default = "40s"
 }
 
+variable "sandbox_hosts_file_override" {
+  type        = string
+  description = "Extra /etc/hosts entries for sandboxes, semicolon-separated"
+  default     = ""
+}
+
 variable "fc_env_pipeline_bucket_name" {
   type = string
 }

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -130,6 +130,12 @@ variable "envd_timeout" {
   default = "40s"
 }
 
+variable "sandbox_hosts_file_override" {
+  type        = string
+  description = "Extra /etc/hosts entries for sandboxes, semicolon-separated (e.g. 10.0.0.1 host.example.com;10.0.0.2 other.example.com)"
+  default     = ""
+}
+
 variable "build_cluster_size" {
   type    = number
   default = 1

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -44,6 +44,7 @@ tf_vars := \
 	$(call tfvar, ORCHESTRATOR_ENABLED) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \
 	$(call tfvar, API_SERVER_COUNT) \
+	$(call tfvar, SANDBOX_HOSTS_FILE_OVERRIDE) \
 	$(call tfvar, API_RESOURCES_CPU_COUNT) \
 	$(call tfvar, API_RESOURCES_MEMORY_MB) \
 	$(call tfvar, INGRESS_COUNT) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -302,6 +302,7 @@ module "nomad" {
   orchestrator_proxy_port        = var.orchestrator_proxy_port
   fc_env_pipeline_bucket_name    = module.init.fc_env_pipeline_bucket_name
   envd_timeout                   = var.envd_timeout
+  sandbox_hosts_file_override    = var.sandbox_hosts_file_override
   persistent_volume_mounts       = { for key, config in local.persistent_volume_types : key => config["local_mount_path"] }
   default_persistent_volume_type = var.default_persistent_volume_type
   orchestrator_env_vars          = var.orchestrator_env_vars

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -458,6 +458,7 @@ module "orchestrator" {
   template_bucket_name         = var.template_bucket_name
   allow_sandbox_internet       = var.allow_sandbox_internet
   clickhouse_connection_string = local.clickhouse_connection_string
+  sandbox_hosts_file_override  = var.sandbox_hosts_file_override
   redis_url                    = local.redis_url
   redis_cluster_url            = local.redis_cluster_url
   redis_tls_ca_base64          = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -323,6 +323,12 @@ variable "template_manages_clusters_size_gt_1" {
   type = bool
 }
 
+variable "sandbox_hosts_file_override" {
+  type        = string
+  description = "Extra /etc/hosts entries for sandboxes, semicolon-separated"
+  default     = ""
+}
+
 variable "nomad_autoscaler_version" {
   type        = string
   description = "Version of the Nomad Autoscaler to deploy"

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -298,6 +298,12 @@ variable "envd_timeout" {
   default = "40s"
 }
 
+variable "sandbox_hosts_file_override" {
+  type        = string
+  description = "Extra /etc/hosts entries for sandboxes, semicolon-separated (e.g. 10.0.0.1 host.example.com;10.0.0.2 other.example.com)"
+  default     = ""
+}
+
 variable "environment" {
   type    = string
   default = "prod"

--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -199,6 +199,9 @@ type PostInitJSONBody struct {
 	// EnvVars Environment variables to set
 	EnvVars *EnvVars `json:"envVars,omitempty"`
 
+	// HostsFileOverride Extra /etc/hosts entries, semicolon-separated (e.g. "10.0.0.1 host1.example.com;10.0.0.2 host2.example.com")
+	HostsFileOverride *string `json:"hostsFileOverride,omitempty"`
+
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -202,8 +202,8 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 		a.accessToken.Destroy()
 	}
 
-	if data.HyperloopIP != nil {
-		go a.SetupHyperloop(*data.HyperloopIP)
+	if data.HyperloopIP != nil || (data.HostsFileOverride != nil && *data.HostsFileOverride != "") {
+		go a.setupHostsFile(logger, data.HyperloopIP, data.HostsFileOverride)
 	}
 
 	if data.DefaultUser != nil && *data.DefaultUser != "" {
@@ -392,14 +392,58 @@ func asString(v any) string {
 }
 
 func (a *API) SetupHyperloop(address string) {
+	a.setupHostsFile(*a.logger, &address, nil)
+}
+
+// setupHostsFile serialises all /etc/hosts mutations under hyperloopLock so
+// that concurrent HyperloopIP and HostsFileOverride writes cannot clobber each other.
+func (a *API) setupHostsFile(logger zerolog.Logger, hyperloopIP *string, hostsFileOverride *string) {
 	a.hyperloopLock.Lock()
 	defer a.hyperloopLock.Unlock()
 
-	if err := rewriteHostsFile(address, "/etc/hosts"); err != nil {
-		a.logger.Error().Err(err).Msg("failed to modify hosts file")
-	} else {
-		a.defaults.EnvVars.Store("E2B_EVENTS_ADDRESS", fmt.Sprintf("http://%s", address))
+	if hyperloopIP != nil {
+		if err := rewriteHostsFile(*hyperloopIP, "/etc/hosts"); err != nil {
+			logger.Error().Err(err).Msg("failed to modify hosts file")
+		} else {
+			a.defaults.EnvVars.Store("E2B_EVENTS_ADDRESS", fmt.Sprintf("http://%s", *hyperloopIP))
+		}
 	}
+
+	if hostsFileOverride != nil && *hostsFileOverride != "" {
+		if err := applyHostsOverride(*hostsFileOverride, "/etc/hosts"); err != nil {
+			logger.Error().Err(err).Msg("failed to apply hosts file override")
+		}
+	}
+}
+
+func applyHostsOverride(override, path string) error {
+	hosts, err := txeh.NewHosts(&txeh.HostsConfig{
+		ReadFilePath:  path,
+		WriteFilePath: path,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to read hosts file: %w", err)
+	}
+
+	for line := range strings.SplitSeq(override, ";") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		ip := fields[0]
+		hostnames := fields[1:]
+		for _, h := range hostnames {
+			hosts.AddHost(ip, h)
+		}
+	}
+
+	return hosts.Save()
 }
 
 const eventsHost = "events.e2b.local"

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -70,6 +70,9 @@ paths:
                 caBundle:
                   type: string
                   description: PEM-encoded CA certificates to install into the system trust store (may contain multiple concatenated PEM blocks)
+                hostsFileOverride:
+                  type: string
+                  description: Extra /etc/hosts entries, semicolon-separated (e.g. "10.0.0.1 host1.example.com;10.0.0.2 host2.example.com")
 
       responses:
         "204":

--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -35,6 +35,8 @@ type BuilderConfig struct {
 
 	Provider string `env:"PROVIDER" envDefault:"gcp"`
 
+	SandboxHostsFileOverride string `env:"SANDBOX_HOSTS_FILE_OVERRIDE" envDefault:""`
+
 	StorageConfig storage.Config
 	NetworkConfig network.Config
 }

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -36,14 +36,15 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 	requestCount := int64(0)
 
 	jsonBody := &envd.PostInitJSONBody{
-		LifecycleID:    s.LifecycleID,
-		EnvVars:        s.Config.Envd.Vars,
-		HyperloopIP:    s.config.NetworkConfig.OrchestratorInSandboxIPAddress,
-		AccessToken:    utils.DerefOrDefault(s.Config.Envd.AccessToken, ""),
-		DefaultUser:    utils.DerefOrDefault(s.Config.Envd.DefaultUser, ""),
-		DefaultWorkdir: utils.DerefOrDefault(s.Config.Envd.DefaultWorkdir, ""),
-		VolumeMounts:   s.convertMounts(s.Config.VolumeMounts),
-		CaBundle:       s.CABundle,
+		LifecycleID:       s.LifecycleID,
+		EnvVars:           s.Config.Envd.Vars,
+		HyperloopIP:       s.config.NetworkConfig.OrchestratorInSandboxIPAddress,
+		AccessToken:       utils.DerefOrDefault(s.Config.Envd.AccessToken, ""),
+		DefaultUser:       utils.DerefOrDefault(s.Config.Envd.DefaultUser, ""),
+		DefaultWorkdir:    utils.DerefOrDefault(s.Config.Envd.DefaultWorkdir, ""),
+		VolumeMounts:      s.convertMounts(s.Config.VolumeMounts),
+		CaBundle:          s.CABundle,
+		HostsFileOverride: s.config.SandboxHostsFileOverride,
 	}
 
 	for {

--- a/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
+++ b/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
@@ -194,6 +194,9 @@ type PostInitJSONBody struct {
 	// EnvVars Environment variables to set
 	EnvVars EnvVars `json:"envVars,omitempty"`
 
+	// HostsFileOverride Extra /etc/hosts entries, semicolon-separated (e.g. "10.0.0.1 host1.example.com;10.0.0.2 host2.example.com")
+	HostsFileOverride string `json:"hostsFileOverride,omitempty"`
+
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP string `json:"hyperloopIP,omitempty"`
 

--- a/tests/integration/internal/envd/generated.go
+++ b/tests/integration/internal/envd/generated.go
@@ -203,6 +203,9 @@ type PostInitJSONBody struct {
 	// EnvVars Environment variables to set
 	EnvVars *EnvVars `json:"envVars,omitempty"`
 
+	// HostsFileOverride Extra /etc/hosts entries, semicolon-separated (e.g. "10.0.0.1 host1.example.com;10.0.0.2 host2.example.com")
+	HostsFileOverride *string `json:"hostsFileOverride,omitempty"`
+
 	// HyperloopIP IP address of the hyperloop server to connect to
 	HyperloopIP *string `json:"hyperloopIP,omitempty"`
 


### PR DESCRIPTION
Allow sandboxes the ability to override with specific hosts file entries.

Today sandboxes reaches out to 8.8.8.8, but for our use cases we don't really want to expose those dns out externally everywhere. This way we can add specific dns entries without breaking the current resolver behavior for some of our internal dns needs within sandbox.