### PR TITLE
Attach `team_id` metadata to uploaded storage objects

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -108,7 +108,7 @@ func (o *osFileBlob) Exists(_ context.Context) (bool, error) {
 	return true, nil
 }
 
-func (o *osFileBlob) Put(_ context.Context, _ []byte) error {
+func (o *osFileBlob) Put(_ context.Context, _ []byte, _ ...storage.PutOption) error {
 	return errors.New("not implemented")
 }
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -641,13 +641,13 @@ func (r *runner) pauseOnce(ctx context.Context, opts pauseOptions, verbose bool)
 		paths := storage.Paths{BuildID: opts.newBuildID}
 		if opts.isRemoteStorage {
 			fmt.Println("📤 Uploading snapshot...")
-			if err := snapshot.Upload(ctx, r.storage, paths, storage.SnapshotUploadMetadata{}); err != nil {
+			if err := snapshot.Upload(ctx, r.storage, paths, nil); err != nil {
 				return timings, fmt.Errorf("failed to upload snapshot: %w", err)
 			}
 			fmt.Println("✅ Snapshot uploaded successfully")
 		} else {
 			fmt.Println("💾 Saving snapshot to local storage...")
-			if err := snapshot.Upload(ctx, r.storage, paths, storage.SnapshotUploadMetadata{}); err != nil {
+			if err := snapshot.Upload(ctx, r.storage, paths, nil); err != nil {
 				return timings, fmt.Errorf("failed to save snapshot: %w", err)
 			}
 			fmt.Println("✅ Snapshot saved successfully")

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -641,13 +641,13 @@ func (r *runner) pauseOnce(ctx context.Context, opts pauseOptions, verbose bool)
 		paths := storage.Paths{BuildID: opts.newBuildID}
 		if opts.isRemoteStorage {
 			fmt.Println("📤 Uploading snapshot...")
-			if err := snapshot.Upload(ctx, r.storage, paths); err != nil {
+			if err := snapshot.Upload(ctx, r.storage, paths, storage.SnapshotUploadMetadata{}); err != nil {
 				return timings, fmt.Errorf("failed to upload snapshot: %w", err)
 			}
 			fmt.Println("✅ Snapshot uploaded successfully")
 		} else {
 			fmt.Println("💾 Saving snapshot to local storage...")
-			if err := snapshot.Upload(ctx, r.storage, paths); err != nil {
+			if err := snapshot.Upload(ctx, r.storage, paths, storage.SnapshotUploadMetadata{}); err != nil {
 				return timings, fmt.Errorf("failed to save snapshot: %w", err)
 			}
 			fmt.Println("✅ Snapshot saved successfully")
@@ -864,7 +864,7 @@ func (r *runner) collectAndUploadPrefetch(ctx context.Context, opts pauseOptions
 		Memory: mapping,
 	})
 
-	if err := metadata.UploadMetadata(ctx, r.storage, updatedMeta); err != nil {
+	if err := metadata.UploadMetadata(ctx, r.storage, updatedMeta, nil); err != nil {
 		return fmt.Errorf("upload metadata: %w", err)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -21,10 +21,13 @@ type Snapshot struct {
 	cleanup *Cleanup
 }
 
+// Upload writes snapshot artifacts to persistence under paths. uploadMetadata
+// labels are applied to the uploaded objects; pass a zero value to skip.
 func (s *Snapshot) Upload(
 	ctx context.Context,
 	persistence storage.StorageProvider,
 	paths storage.Paths,
+	uploadMetadata storage.SnapshotUploadMetadata,
 ) error {
 	var memfilePath *string
 	switch r := s.MemfileDiff.(type) {
@@ -55,6 +58,7 @@ func (s *Snapshot) Upload(
 		s.RootfsDiffHeader,
 		persistence,
 		paths,
+		uploadMetadata,
 	)
 
 	if err := templateBuild.Upload(

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -21,13 +21,13 @@ type Snapshot struct {
 	cleanup *Cleanup
 }
 
-// Upload writes snapshot artifacts to persistence under paths. uploadMetadata
-// labels are applied to the uploaded objects; pass a zero value to skip.
+// Upload writes snapshot artifacts to persistence under paths. objectMetadata
+// is attached to every uploaded object; pass nil to skip.
 func (s *Snapshot) Upload(
 	ctx context.Context,
 	persistence storage.StorageProvider,
 	paths storage.Paths,
-	uploadMetadata storage.SnapshotUploadMetadata,
+	objectMetadata storage.ObjectMetadata,
 ) error {
 	var memfilePath *string
 	switch r := s.MemfileDiff.(type) {
@@ -58,7 +58,7 @@ func (s *Snapshot) Upload(
 		s.RootfsDiffHeader,
 		persistence,
 		paths,
-		uploadMetadata,
+		objectMetadata,
 	)
 
 	if err := templateBuild.Upload(

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
@@ -76,14 +76,14 @@ func (b *peerBlob) Exists(ctx context.Context) (bool, error) {
 	)
 }
 
-func (b *peerBlob) Put(ctx context.Context, data []byte) error {
+func (b *peerBlob) Put(ctx context.Context, data []byte, opts ...storage.PutOption) error {
 	// Writes always go to the base provider (GCS/S3); the peer is read-only.
 	fallback, err := b.getOrOpenBase(ctx)
 	if err != nil {
 		return err
 	}
 
-	return fallback.Put(ctx, data)
+	return fallback.Put(ctx, data, opts...)
 }
 
 // openPeerBlobStream opens a GetBuildBlob stream, checks peer availability,

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
@@ -120,14 +120,14 @@ func (s *peerSeekable) OpenRangeReader(ctx context.Context, off, length int64) (
 	)
 }
 
-func (s *peerSeekable) StoreFile(ctx context.Context, path string) error {
+func (s *peerSeekable) StoreFile(ctx context.Context, path string, opts ...storage.PutOption) error {
 	// Writes always go to the base provider (GCS/S3); the peer is read-only.
 	fallback, err := s.getOrOpenBase(ctx)
 	if err != nil {
 		return err
 	}
 
-	return fallback.StoreFile(ctx, path)
+	return fallback.StoreFile(ctx, path, opts...)
 }
 
 // openPeerSeekableStream opens a ReadAtBuildSeekable stream, checks peer availability,

--- a/packages/orchestrator/pkg/sandbox/template_build.go
+++ b/packages/orchestrator/pkg/sandbox/template_build.go
@@ -51,6 +51,7 @@ func (t *TemplateBuild) commonPutOpts() []storage.PutOption {
 	if len(t.uploadLabels.Common) == 0 {
 		return nil
 	}
+
 	return []storage.PutOption{storage.WithMetadata(t.uploadLabels.Common)}
 }
 
@@ -59,6 +60,7 @@ func (t *TemplateBuild) metadataPutOpts() []storage.PutOption {
 	if len(merged) == 0 {
 		return nil
 	}
+
 	return []storage.PutOption{storage.WithMetadata(merged)}
 }
 

--- a/packages/orchestrator/pkg/sandbox/template_build.go
+++ b/packages/orchestrator/pkg/sandbox/template_build.go
@@ -13,9 +13,9 @@ import (
 )
 
 type TemplateBuild struct {
-	paths        storage.Paths
-	persistence  storage.StorageProvider
-	uploadLabels storage.SnapshotUploadMetadata
+	paths          storage.Paths
+	persistence    storage.StorageProvider
+	objectMetadata storage.ObjectMetadata
 
 	memfileHeader *headers.Header
 	rootfsHeader  *headers.Header
@@ -26,12 +26,12 @@ func NewTemplateBuild(
 	rootfsHeader *headers.Header,
 	persistence storage.StorageProvider,
 	paths storage.Paths,
-	uploadLabels storage.SnapshotUploadMetadata,
+	objectMetadata storage.ObjectMetadata,
 ) *TemplateBuild {
 	return &TemplateBuild{
-		persistence:  persistence,
-		paths:        paths,
-		uploadLabels: uploadLabels,
+		persistence:    persistence,
+		paths:          paths,
+		objectMetadata: objectMetadata,
 
 		memfileHeader: memfileHeader,
 		rootfsHeader:  rootfsHeader,
@@ -47,21 +47,12 @@ func (t *TemplateBuild) Remove(ctx context.Context) error {
 	return nil
 }
 
-func (t *TemplateBuild) commonPutOpts() []storage.PutOption {
-	if len(t.uploadLabels.Common) == 0 {
+func (t *TemplateBuild) putOpts() []storage.PutOption {
+	if len(t.objectMetadata) == 0 {
 		return nil
 	}
 
-	return []storage.PutOption{storage.WithMetadata(t.uploadLabels.Common)}
-}
-
-func (t *TemplateBuild) metadataPutOpts() []storage.PutOption {
-	merged := t.uploadLabels.MergedForMetadata()
-	if len(merged) == 0 {
-		return nil
-	}
-
-	return []storage.PutOption{storage.WithMetadata(merged)}
+	return []storage.PutOption{storage.WithMetadata(t.objectMetadata)}
 }
 
 func (t *TemplateBuild) uploadMemfileHeader(ctx context.Context, h *headers.Header) error {
@@ -75,7 +66,7 @@ func (t *TemplateBuild) uploadMemfileHeader(ctx context.Context, h *headers.Head
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	err = object.Put(ctx, serialized, t.commonPutOpts()...)
+	err = object.Put(ctx, serialized, t.putOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -89,7 +80,7 @@ func (t *TemplateBuild) uploadMemfile(ctx context.Context, memfilePath string) e
 		return err
 	}
 
-	err = object.StoreFile(ctx, memfilePath, t.commonPutOpts()...)
+	err = object.StoreFile(ctx, memfilePath, t.putOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile: %w", err)
 	}
@@ -108,7 +99,7 @@ func (t *TemplateBuild) uploadRootfsHeader(ctx context.Context, h *headers.Heade
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	err = object.Put(ctx, serialized, t.commonPutOpts()...)
+	err = object.Put(ctx, serialized, t.putOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -122,7 +113,7 @@ func (t *TemplateBuild) uploadRootfs(ctx context.Context, rootfsPath string) err
 		return err
 	}
 
-	err = object.StoreFile(ctx, rootfsPath, t.commonPutOpts()...)
+	err = object.StoreFile(ctx, rootfsPath, t.putOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading rootfs: %w", err)
 	}
@@ -137,7 +128,7 @@ func (t *TemplateBuild) uploadSnapfile(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err = uploadFileAsBlob(ctx, object, path, t.commonPutOpts()...); err != nil {
+	if err = uploadFileAsBlob(ctx, object, path, t.putOpts()...); err != nil {
 		return fmt.Errorf("error when uploading snapfile: %w", err)
 	}
 
@@ -151,7 +142,7 @@ func (t *TemplateBuild) uploadMetadata(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err := uploadFileAsBlob(ctx, object, path, t.metadataPutOpts()...); err != nil {
+	if err := uploadFileAsBlob(ctx, object, path, t.putOpts()...); err != nil {
 		return fmt.Errorf("error when uploading metadata: %w", err)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/template_build.go
+++ b/packages/orchestrator/pkg/sandbox/template_build.go
@@ -13,17 +13,25 @@ import (
 )
 
 type TemplateBuild struct {
-	paths       storage.Paths
-	persistence storage.StorageProvider
+	paths        storage.Paths
+	persistence  storage.StorageProvider
+	uploadLabels storage.SnapshotUploadMetadata
 
 	memfileHeader *headers.Header
 	rootfsHeader  *headers.Header
 }
 
-func NewTemplateBuild(memfileHeader *headers.Header, rootfsHeader *headers.Header, persistence storage.StorageProvider, paths storage.Paths) *TemplateBuild {
+func NewTemplateBuild(
+	memfileHeader *headers.Header,
+	rootfsHeader *headers.Header,
+	persistence storage.StorageProvider,
+	paths storage.Paths,
+	uploadLabels storage.SnapshotUploadMetadata,
+) *TemplateBuild {
 	return &TemplateBuild{
-		persistence: persistence,
-		paths:       paths,
+		persistence:  persistence,
+		paths:        paths,
+		uploadLabels: uploadLabels,
 
 		memfileHeader: memfileHeader,
 		rootfsHeader:  rootfsHeader,
@@ -39,6 +47,21 @@ func (t *TemplateBuild) Remove(ctx context.Context) error {
 	return nil
 }
 
+func (t *TemplateBuild) commonPutOpts() []storage.PutOption {
+	if len(t.uploadLabels.Common) == 0 {
+		return nil
+	}
+	return []storage.PutOption{storage.WithMetadata(t.uploadLabels.Common)}
+}
+
+func (t *TemplateBuild) metadataPutOpts() []storage.PutOption {
+	merged := t.uploadLabels.MergedForMetadata()
+	if len(merged) == 0 {
+		return nil
+	}
+	return []storage.PutOption{storage.WithMetadata(merged)}
+}
+
 func (t *TemplateBuild) uploadMemfileHeader(ctx context.Context, h *headers.Header) error {
 	object, err := t.persistence.OpenBlob(ctx, t.paths.MemfileHeader(), storage.MemfileHeaderObjectType)
 	if err != nil {
@@ -50,7 +73,7 @@ func (t *TemplateBuild) uploadMemfileHeader(ctx context.Context, h *headers.Head
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	err = object.Put(ctx, serialized)
+	err = object.Put(ctx, serialized, t.commonPutOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -64,7 +87,7 @@ func (t *TemplateBuild) uploadMemfile(ctx context.Context, memfilePath string) e
 		return err
 	}
 
-	err = object.StoreFile(ctx, memfilePath)
+	err = object.StoreFile(ctx, memfilePath, t.commonPutOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile: %w", err)
 	}
@@ -83,7 +106,7 @@ func (t *TemplateBuild) uploadRootfsHeader(ctx context.Context, h *headers.Heade
 		return fmt.Errorf("error when serializing memfile header: %w", err)
 	}
 
-	err = object.Put(ctx, serialized)
+	err = object.Put(ctx, serialized, t.commonPutOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading memfile header: %w", err)
 	}
@@ -97,7 +120,7 @@ func (t *TemplateBuild) uploadRootfs(ctx context.Context, rootfsPath string) err
 		return err
 	}
 
-	err = object.StoreFile(ctx, rootfsPath)
+	err = object.StoreFile(ctx, rootfsPath, t.commonPutOpts()...)
 	if err != nil {
 		return fmt.Errorf("error when uploading rootfs: %w", err)
 	}
@@ -112,7 +135,7 @@ func (t *TemplateBuild) uploadSnapfile(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err = uploadFileAsBlob(ctx, object, path); err != nil {
+	if err = uploadFileAsBlob(ctx, object, path, t.commonPutOpts()...); err != nil {
 		return fmt.Errorf("error when uploading snapfile: %w", err)
 	}
 
@@ -126,14 +149,14 @@ func (t *TemplateBuild) uploadMetadata(ctx context.Context, path string) error {
 		return err
 	}
 
-	if err := uploadFileAsBlob(ctx, object, path); err != nil {
+	if err := uploadFileAsBlob(ctx, object, path, t.metadataPutOpts()...); err != nil {
 		return fmt.Errorf("error when uploading metadata: %w", err)
 	}
 
 	return nil
 }
 
-func uploadFileAsBlob(ctx context.Context, b storage.Blob, path string) error {
+func uploadFileAsBlob(ctx context.Context, b storage.Blob, path string, opts ...storage.PutOption) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", path, err)
@@ -145,7 +168,7 @@ func uploadFileAsBlob(ctx context.Context, b storage.Blob, path string) error {
 		return fmt.Errorf("failed to read file %s: %w", path, err)
 	}
 
-	err = b.Put(ctx, data)
+	err = b.Put(ctx, data, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to write data to object: %w", err)
 	}

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -767,17 +767,17 @@ func (s *Server) snapshotAndCacheSandbox(
 	telemetry.ReportEvent(ctx, "added snapshot to template cache")
 
 	paths := storage.Paths{BuildID: meta.Template.BuildID}
-	// root_build_id = diff-chain root (originating template), preserved across
-	// pause -> resume -> pause chains.
-	rootBuildID := meta.Template.BuildID
+	// root_build_id = diff-chain root (the very first build in the lineage),
+	// preserved across pause -> resume -> pause chains. Omitted if the header
+	// doesn't carry a usable base build ID.
+	common := storage.ObjectMetadata{
+		storage.ObjectMetadataTeamID: sbx.Runtime.TeamID,
+	}
 	if h := snapshot.MemfileDiffHeader; h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
-		rootBuildID = h.Metadata.BaseBuildId.String()
+		common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
 	}
 	uploadMetadata := storage.SnapshotUploadMetadata{
-		Common: storage.ObjectMetadata{
-			storage.ObjectMetadataTeamID:      sbx.Runtime.TeamID,
-			storage.ObjectMetadataRootBuildID: rootBuildID,
-		},
+		Common:       common,
 		MetadataOnly: storage.BuildLineageMetadata(buildKind, sbx.Runtime.BuildID),
 	}
 

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -512,7 +512,7 @@ func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 	defer s.stopSandboxAsync(context.WithoutCancel(ctx), sbx)
 
 	// Fire and forget - upload completes in the background
-	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId())
+	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId(), storage.BuildKindSandboxPause)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error snapshotting sandbox", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
@@ -591,7 +591,7 @@ func (s *Server) Checkpoint(ctx context.Context, in *orchestrator.SandboxCheckpo
 
 	sbxlogger.E(sbx).Info(ctx, "Checkpointing sandbox")
 
-	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId())
+	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId(), storage.BuildKindSandboxCheckpoint)
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error snapshotting sandbox for checkpoint", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
@@ -667,7 +667,7 @@ func (s *Server) Checkpoint(ctx context.Context, in *orchestrator.SandboxCheckpo
 		defer cancel()
 		defer res.completeUpload(uploadCtx)
 
-		if err := res.snapshot.Upload(uploadCtx, s.persistence, res.paths); err != nil {
+		if err := res.snapshot.Upload(uploadCtx, s.persistence, res.paths, res.uploadMetadata); err != nil {
 			telemetry.ReportCriticalError(ctx, "error uploading snapshot for checkpoint", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
 			s.sandboxFactory.Sandboxes.MarkStopping(ctx, resumedSbx.Runtime.SandboxID, resumedSbx.LifecycleID)
@@ -721,6 +721,7 @@ type snapshotResult struct {
 	meta           metadata.Template
 	snapshot       *sandbox.Snapshot
 	paths          storage.Paths
+	uploadMetadata storage.SnapshotUploadMetadata
 	completeUpload func(ctx context.Context)
 }
 
@@ -731,6 +732,7 @@ func (s *Server) snapshotAndCacheSandbox(
 	ctx context.Context,
 	sbx *sandbox.Sandbox,
 	buildID string,
+	buildKind string,
 ) (*snapshotResult, error) {
 	meta, err := sbx.Template.Metadata()
 	if err != nil {
@@ -765,6 +767,13 @@ func (s *Server) snapshotAndCacheSandbox(
 	telemetry.ReportEvent(ctx, "added snapshot to template cache")
 
 	paths := storage.Paths{BuildID: meta.Template.BuildID}
+	uploadMetadata := storage.SnapshotUploadMetadata{
+		Common: storage.ObjectMetadata{
+			storage.ObjectMetadataTeamID:      sbx.Runtime.TeamID,
+			storage.ObjectMetadataRootBuildID: meta.Template.BuildID,
+		},
+		MetadataOnly: storage.BuildLineageMetadata(buildKind, sbx.Runtime.BuildID),
+	}
 
 	// Register in Redis so other orchestrators can find us for peer routing.
 	if s.featureFlags.BoolFlag(ctx, featureflags.PeerToPeerChunkTransferFlag) {
@@ -786,6 +795,7 @@ func (s *Server) snapshotAndCacheSandbox(
 			meta:           meta,
 			snapshot:       snapshot,
 			paths:          paths,
+			uploadMetadata: uploadMetadata,
 			completeUpload: completeUpload,
 		}, nil
 	}
@@ -794,6 +804,7 @@ func (s *Server) snapshotAndCacheSandbox(
 		meta:           meta,
 		snapshot:       snapshot,
 		paths:          paths,
+		uploadMetadata: uploadMetadata,
 		completeUpload: func(context.Context) {},
 	}, nil
 }
@@ -808,7 +819,7 @@ func (s *Server) uploadSnapshotAsync(ctx context.Context, sbx *sandbox.Sandbox, 
 		defer cancel()
 		defer res.completeUpload(ctx)
 
-		err := res.snapshot.Upload(ctx, s.persistence, res.paths)
+		err := res.snapshot.Upload(ctx, s.persistence, res.paths, res.uploadMetadata)
 		if err != nil {
 			sbxlogger.I(sbx).Error(ctx, "error uploading snapshot files", zap.Error(err))
 

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -512,7 +512,7 @@ func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest
 	defer s.stopSandboxAsync(context.WithoutCancel(ctx), sbx)
 
 	// Fire and forget - upload completes in the background
-	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId(), storage.BuildKindSandboxPause)
+	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId())
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error snapshotting sandbox", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
@@ -591,7 +591,7 @@ func (s *Server) Checkpoint(ctx context.Context, in *orchestrator.SandboxCheckpo
 
 	sbxlogger.E(sbx).Info(ctx, "Checkpointing sandbox")
 
-	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId(), storage.BuildKindSandboxCheckpoint)
+	res, err := s.snapshotAndCacheSandbox(ctx, sbx, in.GetBuildId())
 	if err != nil {
 		telemetry.ReportCriticalError(ctx, "error snapshotting sandbox for checkpoint", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
@@ -667,7 +667,7 @@ func (s *Server) Checkpoint(ctx context.Context, in *orchestrator.SandboxCheckpo
 		defer cancel()
 		defer res.completeUpload(uploadCtx)
 
-		if err := res.snapshot.Upload(uploadCtx, s.persistence, res.paths, res.uploadMetadata); err != nil {
+		if err := res.snapshot.Upload(uploadCtx, s.persistence, res.paths, res.objectMetadata); err != nil {
 			telemetry.ReportCriticalError(ctx, "error uploading snapshot for checkpoint", err, telemetry.WithSandboxID(in.GetSandboxId()))
 
 			s.sandboxFactory.Sandboxes.MarkStopping(ctx, resumedSbx.Runtime.SandboxID, resumedSbx.LifecycleID)
@@ -721,7 +721,7 @@ type snapshotResult struct {
 	meta           metadata.Template
 	snapshot       *sandbox.Snapshot
 	paths          storage.Paths
-	uploadMetadata storage.SnapshotUploadMetadata
+	objectMetadata storage.ObjectMetadata
 	completeUpload func(ctx context.Context)
 }
 
@@ -732,7 +732,6 @@ func (s *Server) snapshotAndCacheSandbox(
 	ctx context.Context,
 	sbx *sandbox.Sandbox,
 	buildID string,
-	buildKind string,
 ) (*snapshotResult, error) {
 	meta, err := sbx.Template.Metadata()
 	if err != nil {
@@ -767,18 +766,8 @@ func (s *Server) snapshotAndCacheSandbox(
 	telemetry.ReportEvent(ctx, "added snapshot to template cache")
 
 	paths := storage.Paths{BuildID: meta.Template.BuildID}
-	// root_build_id = diff-chain root (the very first build in the lineage),
-	// preserved across pause -> resume -> pause chains. Omitted if the header
-	// doesn't carry a usable base build ID.
-	common := storage.ObjectMetadata{
+	objectMetadata := storage.ObjectMetadata{
 		storage.ObjectMetadataTeamID: sbx.Runtime.TeamID,
-	}
-	if h := snapshot.MemfileDiffHeader; h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
-		common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
-	}
-	uploadMetadata := storage.SnapshotUploadMetadata{
-		Common:       common,
-		MetadataOnly: storage.BuildLineageMetadata(buildKind, sbx.Runtime.BuildID),
 	}
 
 	// Register in Redis so other orchestrators can find us for peer routing.
@@ -801,7 +790,7 @@ func (s *Server) snapshotAndCacheSandbox(
 			meta:           meta,
 			snapshot:       snapshot,
 			paths:          paths,
-			uploadMetadata: uploadMetadata,
+			objectMetadata: objectMetadata,
 			completeUpload: completeUpload,
 		}, nil
 	}
@@ -810,7 +799,7 @@ func (s *Server) snapshotAndCacheSandbox(
 		meta:           meta,
 		snapshot:       snapshot,
 		paths:          paths,
-		uploadMetadata: uploadMetadata,
+		objectMetadata: objectMetadata,
 		completeUpload: func(context.Context) {},
 	}, nil
 }
@@ -825,7 +814,7 @@ func (s *Server) uploadSnapshotAsync(ctx context.Context, sbx *sandbox.Sandbox, 
 		defer cancel()
 		defer res.completeUpload(ctx)
 
-		err := res.snapshot.Upload(ctx, s.persistence, res.paths, res.uploadMetadata)
+		err := res.snapshot.Upload(ctx, s.persistence, res.paths, res.objectMetadata)
 		if err != nil {
 			sbxlogger.I(sbx).Error(ctx, "error uploading snapshot files", zap.Error(err))
 

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -767,10 +767,16 @@ func (s *Server) snapshotAndCacheSandbox(
 	telemetry.ReportEvent(ctx, "added snapshot to template cache")
 
 	paths := storage.Paths{BuildID: meta.Template.BuildID}
+	// root_build_id = diff-chain root (originating template), preserved across
+	// pause -> resume -> pause chains.
+	rootBuildID := meta.Template.BuildID
+	if h := snapshot.MemfileDiffHeader; h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
+		rootBuildID = h.Metadata.BaseBuildId.String()
+	}
 	uploadMetadata := storage.SnapshotUploadMetadata{
 		Common: storage.ObjectMetadata{
 			storage.ObjectMetadataTeamID:      sbx.Runtime.TeamID,
-			storage.ObjectMetadataRootBuildID: meta.Template.BuildID,
+			storage.ObjectMetadataRootBuildID: rootBuildID,
 		},
 		MetadataOnly: storage.BuildLineageMetadata(buildKind, sbx.Runtime.BuildID),
 	}

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
@@ -298,15 +299,21 @@ func (lb *LayerExecutor) PauseAndUpload(
 		// still unblock and the errgroup can properly collect all errors.
 		defer completeUpload()
 
+		// root_build_id = diff-chain root (the very first build in the lineage),
+		// derived from the memfile header so it's stable across the layer chain.
+		common := storage.ObjectMetadata{
+			storage.ObjectMetadataTeamID: lb.BuildContext.Config.TeamID,
+		}
+		if h := snapshot.MemfileDiffHeader; h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
+			common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
+		}
+
 		err := snapshot.Upload(
 			ctx,
 			lb.templateStorage,
 			storage.Paths{BuildID: meta.Template.BuildID},
 			storage.SnapshotUploadMetadata{
-				Common: storage.ObjectMetadata{
-					storage.ObjectMetadataTeamID:      lb.BuildContext.Config.TeamID,
-					storage.ObjectMetadataRootBuildID: lb.BuildContext.Template.BuildID,
-				},
+				Common:       common,
 				MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, parentBuildID),
 			},
 		)

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -76,6 +76,11 @@ func (lb *LayerExecutor) BuildLayer(
 		return metadata.Template{}, fmt.Errorf("get template snapshot: %w", err)
 	}
 
+	var parentBuildID string
+	if sourceMeta, sourceMetaErr := localTemplate.Metadata(); sourceMetaErr == nil {
+		parentBuildID = sourceMeta.Template.BuildID
+	}
+
 	// Create or resume sandbox
 	sbx, err := cmd.SandboxCreator.Sandbox(ctx, lb, localTemplate)
 	if err != nil {
@@ -140,6 +145,7 @@ func (lb *LayerExecutor) BuildLayer(
 		sbx,
 		cmd.Hash,
 		meta,
+		parentBuildID,
 	)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("pause and upload: %w", err)
@@ -241,6 +247,7 @@ func (lb *LayerExecutor) PauseAndUpload(
 	sbx *sandbox.Sandbox,
 	hash string,
 	meta metadata.Template,
+	parentBuildID string,
 ) (e error) {
 	ctx, childSpan := tracer.Start(ctx, "pause-and-upload")
 	defer childSpan.End()
@@ -293,6 +300,13 @@ func (lb *LayerExecutor) PauseAndUpload(
 			ctx,
 			lb.templateStorage,
 			storage.Paths{BuildID: meta.Template.BuildID},
+			storage.SnapshotUploadMetadata{
+				Common: storage.ObjectMetadata{
+					storage.ObjectMetadataTeamID:      lb.BuildContext.Config.TeamID,
+					storage.ObjectMetadataRootBuildID: lb.BuildContext.Template.BuildID,
+				},
+				MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, parentBuildID),
+			},
 		)
 		if err != nil {
 			return fmt.Errorf("error uploading snapshot: %w", err)

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -79,6 +79,8 @@ func (lb *LayerExecutor) BuildLayer(
 	var parentBuildID string
 	if sourceMeta, sourceMetaErr := localTemplate.Metadata(); sourceMetaErr == nil {
 		parentBuildID = sourceMeta.Template.BuildID
+	} else {
+		lb.logger.Warn(ctx, "could not read source template metadata, parent_build_id will be omitted", zap.Error(sourceMetaErr))
 	}
 
 	// Create or resume sandbox

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
@@ -77,13 +76,6 @@ func (lb *LayerExecutor) BuildLayer(
 		return metadata.Template{}, fmt.Errorf("get template snapshot: %w", err)
 	}
 
-	var parentBuildID string
-	if sourceMeta, sourceMetaErr := localTemplate.Metadata(); sourceMetaErr == nil {
-		parentBuildID = sourceMeta.Template.BuildID
-	} else {
-		lb.logger.Warn(ctx, "could not read source template metadata, parent_build_id will be omitted", zap.Error(sourceMetaErr))
-	}
-
 	// Create or resume sandbox
 	sbx, err := cmd.SandboxCreator.Sandbox(ctx, lb, localTemplate)
 	if err != nil {
@@ -148,7 +140,6 @@ func (lb *LayerExecutor) BuildLayer(
 		sbx,
 		cmd.Hash,
 		meta,
-		parentBuildID,
 	)
 	if err != nil {
 		return metadata.Template{}, fmt.Errorf("pause and upload: %w", err)
@@ -250,7 +241,6 @@ func (lb *LayerExecutor) PauseAndUpload(
 	sbx *sandbox.Sandbox,
 	hash string,
 	meta metadata.Template,
-	parentBuildID string,
 ) (e error) {
 	ctx, childSpan := tracer.Start(ctx, "pause-and-upload")
 	defer childSpan.End()
@@ -299,22 +289,12 @@ func (lb *LayerExecutor) PauseAndUpload(
 		// still unblock and the errgroup can properly collect all errors.
 		defer completeUpload()
 
-		// root_build_id = diff-chain root (the very first build in the lineage),
-		// derived from the memfile header so it's stable across the layer chain.
-		common := storage.ObjectMetadata{
-			storage.ObjectMetadataTeamID: lb.BuildContext.Config.TeamID,
-		}
-		if h := snapshot.MemfileDiffHeader; h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
-			common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
-		}
-
 		err := snapshot.Upload(
 			ctx,
 			lb.templateStorage,
 			storage.Paths{BuildID: meta.Template.BuildID},
-			storage.SnapshotUploadMetadata{
-				Common:       common,
-				MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, parentBuildID),
+			storage.ObjectMetadata{
+				storage.ObjectMetadataTeamID: lb.BuildContext.Config.TeamID,
 			},
 		)
 		if err != nil {

--- a/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
@@ -152,7 +153,7 @@ func (pb *OptimizeBuilder) Build(
 	})
 
 	// Upload the updated metadata
-	err = pb.updateMetadata(ctx, updatedMetadata)
+	err = pb.updateMetadata(ctx, updatedMetadata, localTemplate)
 	if err != nil {
 		pb.logger.Warn(ctx, "failed to upload prefetch metadata, continuing without prefetch",
 			zap.Error(err),
@@ -255,13 +256,18 @@ func (pb *OptimizeBuilder) runSandboxAndCollectPrefetch(
 }
 
 // updateMetadata updates the template metadata in storages.
-func (pb *OptimizeBuilder) updateMetadata(ctx context.Context, t metadata.Template) error {
+func (pb *OptimizeBuilder) updateMetadata(ctx context.Context, t metadata.Template, localTemplate sbxtemplate.Template) error {
 	// parent_build_id isn't plumbed through this phase, so it's omitted on rewrite.
+	common := storage.ObjectMetadata{
+		storage.ObjectMetadataTeamID: pb.BuildContext.Config.TeamID,
+	}
+	if memfile, memErr := localTemplate.Memfile(ctx); memErr == nil {
+		if h := memfile.Header(); h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
+			common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
+		}
+	}
 	uploadMeta := storage.SnapshotUploadMetadata{
-		Common: storage.ObjectMetadata{
-			storage.ObjectMetadataTeamID:      pb.BuildContext.Config.TeamID,
-			storage.ObjectMetadataRootBuildID: pb.BuildContext.Template.BuildID,
-		},
+		Common:       common,
 		MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, ""),
 	}
 

--- a/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
@@ -256,7 +256,16 @@ func (pb *OptimizeBuilder) runSandboxAndCollectPrefetch(
 
 // updateMetadata updates the template metadata in storages.
 func (pb *OptimizeBuilder) updateMetadata(ctx context.Context, t metadata.Template) error {
-	err := metadata.UploadMetadata(ctx, pb.templateStorage, t)
+	// parent_build_id isn't plumbed through this phase, so it's omitted on rewrite.
+	uploadMeta := storage.SnapshotUploadMetadata{
+		Common: storage.ObjectMetadata{
+			storage.ObjectMetadataTeamID:      pb.BuildContext.Config.TeamID,
+			storage.ObjectMetadataRootBuildID: pb.BuildContext.Template.BuildID,
+		},
+		MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, ""),
+	}
+
+	err := metadata.UploadMetadata(ctx, pb.templateStorage, t, uploadMeta.MergedForMetadata())
 	if err != nil {
 		return err
 	}

--- a/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
@@ -153,7 +152,7 @@ func (pb *OptimizeBuilder) Build(
 	})
 
 	// Upload the updated metadata
-	err = pb.updateMetadata(ctx, updatedMetadata, localTemplate)
+	err = pb.updateMetadata(ctx, updatedMetadata)
 	if err != nil {
 		pb.logger.Warn(ctx, "failed to upload prefetch metadata, continuing without prefetch",
 			zap.Error(err),
@@ -256,22 +255,10 @@ func (pb *OptimizeBuilder) runSandboxAndCollectPrefetch(
 }
 
 // updateMetadata updates the template metadata in storages.
-func (pb *OptimizeBuilder) updateMetadata(ctx context.Context, t metadata.Template, localTemplate sbxtemplate.Template) error {
-	// parent_build_id isn't plumbed through this phase, so it's omitted on rewrite.
-	common := storage.ObjectMetadata{
+func (pb *OptimizeBuilder) updateMetadata(ctx context.Context, t metadata.Template) error {
+	err := metadata.UploadMetadata(ctx, pb.templateStorage, t, storage.ObjectMetadata{
 		storage.ObjectMetadataTeamID: pb.BuildContext.Config.TeamID,
-	}
-	if memfile, memErr := localTemplate.Memfile(ctx); memErr == nil {
-		if h := memfile.Header(); h != nil && h.Metadata != nil && h.Metadata.BaseBuildId != uuid.Nil {
-			common[storage.ObjectMetadataRootBuildID] = h.Metadata.BaseBuildId.String()
-		}
-	}
-	uploadMeta := storage.SnapshotUploadMetadata{
-		Common:       common,
-		MetadataOnly: storage.BuildLineageMetadata(storage.BuildKindTemplateLayer, ""),
-	}
-
-	err := metadata.UploadMetadata(ctx, pb.templateStorage, t, uploadMeta.MergedForMetadata())
+	})
 	if err != nil {
 		return err
 	}

--- a/packages/orchestrator/pkg/template/metadata/prefetch.go
+++ b/packages/orchestrator/pkg/template/metadata/prefetch.go
@@ -43,8 +43,8 @@ func PrefetchEntriesToMapping(entries []block.PrefetchBlockEntry, blockSize int6
 	}
 }
 
-// UploadMetadata uploads the template metadata to storage. objectMetadata is
-// applied as custom metadata on the object; pass nil to skip.
+// UploadMetadata uploads the template metadata to storage. objectMetadata
+// is attached to the object; pass nil to skip.
 func UploadMetadata(ctx context.Context, persistence storage.StorageProvider, t Template, objectMetadata storage.ObjectMetadata) error {
 	ctx, span := tracer.Start(ctx, "upload-metadata")
 	defer span.End()

--- a/packages/orchestrator/pkg/template/metadata/prefetch.go
+++ b/packages/orchestrator/pkg/template/metadata/prefetch.go
@@ -43,8 +43,9 @@ func PrefetchEntriesToMapping(entries []block.PrefetchBlockEntry, blockSize int6
 	}
 }
 
-// UploadMetadata uploads the template metadata to storage.
-func UploadMetadata(ctx context.Context, persistence storage.StorageProvider, t Template) error {
+// UploadMetadata uploads the template metadata to storage. objectMetadata is
+// applied as custom metadata on the object; pass nil to skip.
+func UploadMetadata(ctx context.Context, persistence storage.StorageProvider, t Template, objectMetadata storage.ObjectMetadata) error {
 	ctx, span := tracer.Start(ctx, "upload-metadata")
 	defer span.End()
 
@@ -60,7 +61,12 @@ func UploadMetadata(ctx context.Context, persistence storage.StorageProvider, t 
 		return fmt.Errorf("failed to serialize metadata: %w", err)
 	}
 
-	err = object.Put(ctx, metaBytes)
+	var opts []storage.PutOption
+	if len(objectMetadata) > 0 {
+		opts = append(opts, storage.WithMetadata(objectMetadata))
+	}
+
+	err = object.Put(ctx, metaBytes, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to write metadata: %w", err)
 	}

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -138,10 +138,11 @@ type MultipartUploader struct {
 	token       string
 	client      *retryablehttp.Client
 	retryConfig RetryConfig
+	metadata    ObjectMetadata
 	baseURL     string // Allow overriding for testing
 }
 
-func NewMultipartUploaderWithRetryConfig(ctx context.Context, bucketName, objectName string, retryConfig RetryConfig) (*MultipartUploader, error) {
+func NewMultipartUploaderWithRetryConfig(ctx context.Context, bucketName, objectName string, retryConfig RetryConfig, metadata ObjectMetadata) (*MultipartUploader, error) {
 	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)
@@ -158,6 +159,7 @@ func NewMultipartUploaderWithRetryConfig(ctx context.Context, bucketName, object
 		token:       token.AccessToken,
 		client:      createRetryableClient(ctx, retryConfig),
 		retryConfig: retryConfig,
+		metadata:    metadata,
 		baseURL:     fmt.Sprintf("https://%s.storage.googleapis.com", bucketName),
 	}, nil
 }
@@ -173,6 +175,11 @@ func (m *MultipartUploader) initiateUpload(ctx context.Context) (string, error) 
 	req.Header.Set("Authorization", "Bearer "+m.token)
 	req.Header.Set("Content-Length", "0")
 	req.Header.Set("Content-Type", "application/octet-stream")
+	// Custom user metadata is set on the initiate request only; subsequent
+	// part uploads and the complete request inherit it on the final object.
+	for k, v := range m.metadata {
+		req.Header.Set("x-goog-meta-"+k, v)
+	}
 
 	resp, err := m.client.Do(req)
 	if err != nil {

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -175,8 +175,7 @@ func (m *MultipartUploader) initiateUpload(ctx context.Context) (string, error) 
 	req.Header.Set("Authorization", "Bearer "+m.token)
 	req.Header.Set("Content-Length", "0")
 	req.Header.Set("Content-Type", "application/octet-stream")
-	// Custom user metadata is set on the initiate request only; subsequent
-	// part uploads and the complete request inherit it on the final object.
+	// Custom user metadata is set on initiate; the final object inherits it.
 	for k, v := range m.metadata {
 		req.Header.Set("x-goog-meta-"+k, v)
 	}

--- a/packages/shared/pkg/storage/mocks/mockobjectprovider.go
+++ b/packages/shared/pkg/storage/mocks/mockobjectprovider.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/storageopts"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -99,16 +100,22 @@ func (_c *MockBlob_Exists_Call) RunAndReturn(run func(ctx context.Context) (bool
 }
 
 // Put provides a mock function for the type MockBlob
-func (_mock *MockBlob) Put(ctx context.Context, data []byte) error {
-	ret := _mock.Called(ctx, data)
+func (_mock *MockBlob) Put(ctx context.Context, data []byte, opts ...storageopts.PutOption) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, data, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, data)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for Put")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte) error); ok {
-		r0 = returnFunc(ctx, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, []byte, ...storageopts.PutOption) error); ok {
+		r0 = returnFunc(ctx, data, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -123,11 +130,13 @@ type MockBlob_Put_Call struct {
 // Put is a helper method to define mock.On call
 //   - ctx context.Context
 //   - data []byte
-func (_e *MockBlob_Expecter) Put(ctx interface{}, data interface{}) *MockBlob_Put_Call {
-	return &MockBlob_Put_Call{Call: _e.mock.On("Put", ctx, data)}
+//   - opts ...storageopts.PutOption
+func (_e *MockBlob_Expecter) Put(ctx interface{}, data interface{}, opts ...interface{}) *MockBlob_Put_Call {
+	return &MockBlob_Put_Call{Call: _e.mock.On("Put",
+		append([]interface{}{ctx, data}, opts...)...)}
 }
 
-func (_c *MockBlob_Put_Call) Run(run func(ctx context.Context, data []byte)) *MockBlob_Put_Call {
+func (_c *MockBlob_Put_Call) Run(run func(ctx context.Context, data []byte, opts ...storageopts.PutOption)) *MockBlob_Put_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -137,9 +146,16 @@ func (_c *MockBlob_Put_Call) Run(run func(ctx context.Context, data []byte)) *Mo
 		if args[1] != nil {
 			arg1 = args[1].([]byte)
 		}
+		var arg2 []storageopts.PutOption
+		var variadicArgs []storageopts.PutOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]storageopts.PutOption)
+		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
+			arg2...,
 		)
 	})
 	return _c
@@ -150,7 +166,7 @@ func (_c *MockBlob_Put_Call) Return(err error) *MockBlob_Put_Call {
 	return _c
 }
 
-func (_c *MockBlob_Put_Call) RunAndReturn(run func(ctx context.Context, data []byte) error) *MockBlob_Put_Call {
+func (_c *MockBlob_Put_Call) RunAndReturn(run func(ctx context.Context, data []byte, opts ...storageopts.PutOption) error) *MockBlob_Put_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/shared/pkg/storage/mocks/mockseekableobjectprovider.go
+++ b/packages/shared/pkg/storage/mocks/mockseekableobjectprovider.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/storageopts"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -245,16 +246,22 @@ func (_c *MockSeekable_Size_Call) RunAndReturn(run func(ctx context.Context) (in
 }
 
 // StoreFile provides a mock function for the type MockSeekable
-func (_mock *MockSeekable) StoreFile(ctx context.Context, path string) error {
-	ret := _mock.Called(ctx, path)
+func (_mock *MockSeekable) StoreFile(ctx context.Context, path string, opts ...storageopts.PutOption) error {
+	var tmpRet mock.Arguments
+	if len(opts) > 0 {
+		tmpRet = _mock.Called(ctx, path, opts)
+	} else {
+		tmpRet = _mock.Called(ctx, path)
+	}
+	ret := tmpRet
 
 	if len(ret) == 0 {
 		panic("no return value specified for StoreFile")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
-		r0 = returnFunc(ctx, path)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...storageopts.PutOption) error); ok {
+		r0 = returnFunc(ctx, path, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -269,11 +276,13 @@ type MockSeekable_StoreFile_Call struct {
 // StoreFile is a helper method to define mock.On call
 //   - ctx context.Context
 //   - path string
-func (_e *MockSeekable_Expecter) StoreFile(ctx interface{}, path interface{}) *MockSeekable_StoreFile_Call {
-	return &MockSeekable_StoreFile_Call{Call: _e.mock.On("StoreFile", ctx, path)}
+//   - opts ...storageopts.PutOption
+func (_e *MockSeekable_Expecter) StoreFile(ctx interface{}, path interface{}, opts ...interface{}) *MockSeekable_StoreFile_Call {
+	return &MockSeekable_StoreFile_Call{Call: _e.mock.On("StoreFile",
+		append([]interface{}{ctx, path}, opts...)...)}
 }
 
-func (_c *MockSeekable_StoreFile_Call) Run(run func(ctx context.Context, path string)) *MockSeekable_StoreFile_Call {
+func (_c *MockSeekable_StoreFile_Call) Run(run func(ctx context.Context, path string, opts ...storageopts.PutOption)) *MockSeekable_StoreFile_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -283,9 +292,16 @@ func (_c *MockSeekable_StoreFile_Call) Run(run func(ctx context.Context, path st
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
+		var arg2 []storageopts.PutOption
+		var variadicArgs []storageopts.PutOption
+		if len(args) > 2 {
+			variadicArgs = args[2].([]storageopts.PutOption)
+		}
+		arg2 = variadicArgs
 		run(
 			arg0,
 			arg1,
+			arg2...,
 		)
 	})
 	return _c
@@ -296,7 +312,7 @@ func (_c *MockSeekable_StoreFile_Call) Return(err error) *MockSeekable_StoreFile
 	return _c
 }
 
-func (_c *MockSeekable_StoreFile_Call) RunAndReturn(run func(ctx context.Context, path string) error) *MockSeekable_StoreFile_Call {
+func (_c *MockSeekable_StoreFile_Call) RunAndReturn(run func(ctx context.Context, path string, opts ...storageopts.PutOption) error) *MockSeekable_StoreFile_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -84,36 +84,17 @@ type StorageProvider interface {
 	GetDetails() string
 }
 
-// Re-exports from storageopts so callers don't need to import the subpackage.
 type (
-	ObjectMetadata         = storageopts.ObjectMetadata
-	PutOptions             = storageopts.PutOptions
-	PutOption              = storageopts.PutOption
-	SnapshotUploadMetadata = storageopts.SnapshotUploadMetadata
+	ObjectMetadata = storageopts.ObjectMetadata
+	PutOptions     = storageopts.PutOptions
+	PutOption      = storageopts.PutOption
 )
 
-const (
-	ObjectMetadataTeamID        = storageopts.ObjectMetadataTeamID
-	ObjectMetadataRootBuildID   = storageopts.ObjectMetadataRootBuildID
-	ObjectMetadataParentBuildID = storageopts.ObjectMetadataParentBuildID
-	ObjectMetadataBuildKind     = storageopts.ObjectMetadataBuildKind
+const ObjectMetadataTeamID = storageopts.ObjectMetadataTeamID
 
-	BuildKindTemplateLayer     = storageopts.BuildKindTemplateLayer
-	BuildKindSandboxPause      = storageopts.BuildKindSandboxPause
-	BuildKindSandboxCheckpoint = storageopts.BuildKindSandboxCheckpoint
-)
+func WithMetadata(metadata ObjectMetadata) PutOption { return storageopts.WithMetadata(metadata) }
 
-func BuildLineageMetadata(buildKind, parentBuildID string) ObjectMetadata {
-	return storageopts.BuildLineageMetadata(buildKind, parentBuildID)
-}
-
-func WithMetadata(metadata ObjectMetadata) PutOption {
-	return storageopts.WithMetadata(metadata)
-}
-
-func ApplyPutOptions(opts []PutOption) PutOptions {
-	return storageopts.Apply(opts)
-}
+func ApplyPutOptions(opts []PutOption) PutOptions { return storageopts.Apply(opts) }
 
 type Blob interface {
 	WriteTo(ctx context.Context, dst io.Writer) (int64, error)

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/storageopts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
@@ -83,9 +84,40 @@ type StorageProvider interface {
 	GetDetails() string
 }
 
+// Re-exports from storageopts so callers don't need to import the subpackage.
+type (
+	ObjectMetadata         = storageopts.ObjectMetadata
+	PutOptions             = storageopts.PutOptions
+	PutOption              = storageopts.PutOption
+	SnapshotUploadMetadata = storageopts.SnapshotUploadMetadata
+)
+
+const (
+	ObjectMetadataTeamID        = storageopts.ObjectMetadataTeamID
+	ObjectMetadataRootBuildID   = storageopts.ObjectMetadataRootBuildID
+	ObjectMetadataParentBuildID = storageopts.ObjectMetadataParentBuildID
+	ObjectMetadataBuildKind     = storageopts.ObjectMetadataBuildKind
+
+	BuildKindTemplateLayer     = storageopts.BuildKindTemplateLayer
+	BuildKindSandboxPause      = storageopts.BuildKindSandboxPause
+	BuildKindSandboxCheckpoint = storageopts.BuildKindSandboxCheckpoint
+)
+
+func BuildLineageMetadata(buildKind, parentBuildID string) ObjectMetadata {
+	return storageopts.BuildLineageMetadata(buildKind, parentBuildID)
+}
+
+func WithMetadata(metadata ObjectMetadata) PutOption {
+	return storageopts.WithMetadata(metadata)
+}
+
+func ApplyPutOptions(opts []PutOption) PutOptions {
+	return storageopts.Apply(opts)
+}
+
 type Blob interface {
 	WriteTo(ctx context.Context, dst io.Writer) (int64, error)
-	Put(ctx context.Context, data []byte) error
+	Put(ctx context.Context, data []byte, opts ...storageopts.PutOption) error
 	Exists(ctx context.Context) (bool, error)
 }
 
@@ -102,7 +134,7 @@ type StreamingReader interface {
 
 type SeekableWriter interface {
 	// Store entire file
-	StoreFile(ctx context.Context, path string) error
+	StoreFile(ctx context.Context, path string, opts ...storageopts.PutOption) error
 }
 
 type Seekable interface {

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -162,7 +162,7 @@ func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
 	return io.Copy(dst, resp.Body)
 }
 
-func (o *awsObject) StoreFile(ctx context.Context, path string) error {
+func (o *awsObject) StoreFile(ctx context.Context, path string, opts ...PutOption) error {
 	ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
 	defer cancel()
 
@@ -183,25 +183,27 @@ func (o *awsObject) StoreFile(ctx context.Context, path string) error {
 	_, err = uploader.Upload(
 		ctx,
 		&s3.PutObjectInput{
-			Bucket: &o.bucketName,
-			Key:    &o.path,
-			Body:   f,
+			Bucket:   &o.bucketName,
+			Key:      &o.path,
+			Body:     f,
+			Metadata: ApplyPutOptions(opts).Metadata,
 		},
 	)
 
 	return err
 }
 
-func (o *awsObject) Put(ctx context.Context, data []byte) error {
+func (o *awsObject) Put(ctx context.Context, data []byte, opts ...PutOption) error {
 	ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
 	defer cancel()
 
 	_, err := o.client.PutObject(
 		ctx,
 		&s3.PutObjectInput{
-			Bucket: &o.bucketName,
-			Key:    &o.path,
-			Body:   bytes.NewReader(data),
+			Bucket:   &o.bucketName,
+			Key:      &o.path,
+			Body:     bytes.NewReader(data),
+			Metadata: ApplyPutOptions(opts).Metadata,
 		},
 	)
 	if err != nil {

--- a/packages/shared/pkg/storage/storage_cache_blob.go
+++ b/packages/shared/pkg/storage/storage_cache_blob.go
@@ -95,7 +95,7 @@ func (b *cachedBlob) WriteTo(ctx context.Context, dst io.Writer) (n int64, e err
 
 // Write pushes data to the wrapped object provider, and optionally pushes the data to a fast ephemeral cache as well.
 // `p` is considered immutable, and won't change if we access it after the function returns.
-func (b *cachedBlob) Put(ctx context.Context, data []byte) (e error) {
+func (b *cachedBlob) Put(ctx context.Context, data []byte, opts ...PutOption) (e error) {
 	ctx, span := b.tracer.Start(ctx, "write data to object storage")
 	defer func() {
 		recordError(span, e)
@@ -117,7 +117,7 @@ func (b *cachedBlob) Put(ctx context.Context, data []byte) (e error) {
 		})
 	}
 
-	return b.inner.Put(ctx, data)
+	return b.inner.Put(ctx, data, opts...)
 }
 
 func (b *cachedBlob) goCtxWithoutCancel(ctx context.Context, fn func(context.Context)) {

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -266,7 +266,7 @@ func (c *cachedSeekable) Size(ctx context.Context) (n int64, e error) {
 	return size, nil
 }
 
-func (c *cachedSeekable) StoreFile(ctx context.Context, path string) (e error) {
+func (c *cachedSeekable) StoreFile(ctx context.Context, path string, opts ...PutOption) (e error) {
 	ctx, span := c.tracer.Start(ctx, "write object from file system",
 		trace.WithAttributes(attribute.String("path", path)),
 	)
@@ -301,7 +301,7 @@ func (c *cachedSeekable) StoreFile(ctx context.Context, path string) (e error) {
 		})
 	}
 
-	return c.inner.StoreFile(ctx, path)
+	return c.inner.StoreFile(ctx, path, opts...)
 }
 
 func (c *cachedSeekable) goCtx(ctx context.Context, fn func(context.Context)) {

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -113,7 +113,7 @@ func (o *fsObject) WriteTo(_ context.Context, dst io.Writer) (int64, error) {
 	return io.Copy(dst, handle)
 }
 
-func (o *fsObject) Put(_ context.Context, data []byte) error {
+func (o *fsObject) Put(_ context.Context, data []byte, _ ...PutOption) error {
 	handle, err := o.getHandle(false)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func (o *fsObject) Put(_ context.Context, data []byte) error {
 	return err
 }
 
-func (o *fsObject) StoreFile(_ context.Context, path string) error {
+func (o *fsObject) StoreFile(_ context.Context, path string, _ ...PutOption) error {
 	r, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("failed to open file %s: %w", path, err)

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -307,10 +307,13 @@ func (o *gcpObject) ReadAt(ctx context.Context, buff []byte, off int64) (n int, 
 	return n, err
 }
 
-func (o *gcpObject) Put(ctx context.Context, data []byte) error {
+func (o *gcpObject) Put(ctx context.Context, data []byte, opts ...PutOption) error {
 	timer := googleWriteTimerFactory.Begin(attribute.String(gcsOperationAttr, gcsOperationAttrWrite))
 
 	w := o.handle.NewWriter(ctx)
+	if putOpts := ApplyPutOptions(opts); len(putOpts.Metadata) > 0 {
+		w.Metadata = putOpts.Metadata
+	}
 
 	c, err := io.Copy(w, bytes.NewReader(data))
 	if err != nil && !errors.Is(err, io.EOF) {
@@ -384,12 +387,14 @@ func (o *gcpObject) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
 	return n, nil
 }
 
-func (o *gcpObject) StoreFile(ctx context.Context, path string) (e error) {
+func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOption) (e error) {
 	ctx, span := tracer.Start(ctx, "write to gcp from file system")
 	defer func() {
 		recordError(span, e)
 		span.End()
 	}()
+
+	putOpts := ApplyPutOptions(opts)
 
 	bucketName := o.storage.bucket.BucketName()
 	objectName := o.path
@@ -413,7 +418,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string) (e error) {
 			return fmt.Errorf("failed to read file: %w", err)
 		}
 
-		err = o.Put(ctx, data)
+		err = o.Put(ctx, data, opts...)
 		if err != nil {
 			timer.Failure(ctx, int64(len(data)))
 
@@ -450,6 +455,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string) (e error) {
 		bucketName,
 		objectName,
 		DefaultRetryConfig(),
+		putOpts.Metadata,
 	)
 	if err != nil {
 		timer.Failure(ctx, 0)

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -1,0 +1,86 @@
+// Package storageopts holds option types for the storage package, kept in a
+// separate package so generated mocks can reference them without an import
+// cycle.
+package storageopts
+
+import "maps"
+
+// ObjectMetadata is custom user metadata attached to objects on upload.
+// Backends without custom metadata silently ignore it.
+type ObjectMetadata map[string]string
+
+const (
+	ObjectMetadataTeamID        = "team_id"
+	ObjectMetadataRootBuildID   = "root_build_id"
+	ObjectMetadataParentBuildID = "parent_build_id"
+	ObjectMetadataBuildKind     = "build_kind"
+)
+
+// Values for ObjectMetadataBuildKind.
+const (
+	BuildKindTemplateLayer     = "template_layer"
+	BuildKindSandboxPause      = "sandbox_pause"
+	BuildKindSandboxCheckpoint = "sandbox_checkpoint"
+)
+
+// SnapshotUploadMetadata splits labels by attachment scope: Common goes on
+// every uploaded artifact, MetadataOnly goes only on metadata.json.
+type SnapshotUploadMetadata struct {
+	Common       ObjectMetadata
+	MetadataOnly ObjectMetadata
+}
+
+// BuildLineageMetadata returns the per-build label map. parentBuildID is
+// omitted when empty.
+func BuildLineageMetadata(buildKind, parentBuildID string) ObjectMetadata {
+	out := ObjectMetadata{
+		ObjectMetadataBuildKind: buildKind,
+	}
+	if parentBuildID != "" {
+		out[ObjectMetadataParentBuildID] = parentBuildID
+	}
+
+	return out
+}
+
+// MergedForMetadata returns Common ∪ MetadataOnly. MetadataOnly wins on collision.
+func (m SnapshotUploadMetadata) MergedForMetadata() ObjectMetadata {
+	if len(m.Common) == 0 && len(m.MetadataOnly) == 0 {
+		return nil
+	}
+	out := make(ObjectMetadata, len(m.Common)+len(m.MetadataOnly))
+	maps.Copy(out, m.Common)
+	maps.Copy(out, m.MetadataOnly)
+
+	return out
+}
+
+// PutOptions are applied per-write by storage backends.
+type PutOptions struct {
+	Metadata ObjectMetadata
+}
+
+type PutOption func(*PutOptions)
+
+// WithMetadata attaches custom metadata to the upload. nil/empty is a no-op.
+func WithMetadata(metadata ObjectMetadata) PutOption {
+	return func(o *PutOptions) {
+		if len(metadata) == 0 {
+			return
+		}
+		if o.Metadata == nil {
+			o.Metadata = make(ObjectMetadata, len(metadata))
+		}
+		maps.Copy(o.Metadata, metadata)
+	}
+}
+
+// Apply reduces a list of options into a single PutOptions value.
+func Apply(opts []PutOption) PutOptions {
+	var p PutOptions
+	for _, opt := range opts {
+		opt(&p)
+	}
+
+	return p
+}

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -1,68 +1,19 @@
-// Package storageopts holds option types for the storage package, kept in a
-// separate package so generated mocks can reference them without an import
-// cycle.
+// Package storageopts holds option types for the storage package, kept
+// separate so generated mocks can reference them without an import cycle.
 package storageopts
 
 import "maps"
 
-// ObjectMetadata is custom user metadata attached to objects on upload.
-// Backends without custom metadata silently ignore it.
 type ObjectMetadata map[string]string
 
-const (
-	ObjectMetadataTeamID        = "team_id"
-	ObjectMetadataRootBuildID   = "root_build_id"
-	ObjectMetadataParentBuildID = "parent_build_id"
-	ObjectMetadataBuildKind     = "build_kind"
-)
+const ObjectMetadataTeamID = "team_id"
 
-// Values for ObjectMetadataBuildKind.
-const (
-	BuildKindTemplateLayer     = "template_layer"
-	BuildKindSandboxPause      = "sandbox_pause"
-	BuildKindSandboxCheckpoint = "sandbox_checkpoint"
-)
-
-// SnapshotUploadMetadata splits labels by attachment scope: Common goes on
-// every uploaded artifact, MetadataOnly goes only on metadata.json.
-type SnapshotUploadMetadata struct {
-	Common       ObjectMetadata
-	MetadataOnly ObjectMetadata
-}
-
-// BuildLineageMetadata returns the per-build label map. parentBuildID is
-// omitted when empty.
-func BuildLineageMetadata(buildKind, parentBuildID string) ObjectMetadata {
-	out := ObjectMetadata{
-		ObjectMetadataBuildKind: buildKind,
-	}
-	if parentBuildID != "" {
-		out[ObjectMetadataParentBuildID] = parentBuildID
-	}
-
-	return out
-}
-
-// MergedForMetadata returns Common ∪ MetadataOnly. MetadataOnly wins on collision.
-func (m SnapshotUploadMetadata) MergedForMetadata() ObjectMetadata {
-	if len(m.Common) == 0 && len(m.MetadataOnly) == 0 {
-		return nil
-	}
-	out := make(ObjectMetadata, len(m.Common)+len(m.MetadataOnly))
-	maps.Copy(out, m.Common)
-	maps.Copy(out, m.MetadataOnly)
-
-	return out
-}
-
-// PutOptions are applied per-write by storage backends.
 type PutOptions struct {
 	Metadata ObjectMetadata
 }
 
 type PutOption func(*PutOptions)
 
-// WithMetadata attaches custom metadata to the upload. nil/empty is a no-op.
 func WithMetadata(metadata ObjectMetadata) PutOption {
 	return func(o *PutOptions) {
 		if len(metadata) == 0 {
@@ -75,7 +26,6 @@ func WithMetadata(metadata ObjectMetadata) PutOption {
 	}
 }
 
-// Apply reduces a list of options into a single PutOptions value.
 func Apply(opts []PutOption) PutOptions {
 	var p PutOptions
 	for _, opt := range opts {


### PR DESCRIPTION
Attaches `team_id` as custom object metadata on every GCS/S3 upload from snapshot and template builds. Local FS backend is a no-op.

`Blob.Put` / `Seekable.StoreFile` gain a variadic `PutOption` (`WithMetadata`). Option types live in a new `storage/storageopts` subpackage to avoid an import cycle with the generated mocks.