### PR TITLE
ci(integration): grant test team extra sandbox capacity

### DIFF
--- a/tests/integration/internal/utils/sandbox.go
+++ b/tests/integration/internal/utils/sandbox.go
@@ -15,10 +15,10 @@ import (
 	"github.com/e2b-dev/infra/tests/integration/internal/setup"
 )
 
-// MaxConcurrentSandboxes is the maximum number of sandboxes that can exist
-// simultaneously, the base tier's concurrent_instances limit is 20, leaveing
-// some headroom
-const MaxConcurrentSandboxes = 15
+// MaxConcurrentSandboxes gates parallel sandbox creation in tests. The
+// integration test team is granted extra capacity in seed.go (base tier 20 +
+// addon 200 = 220), so this can stay well below that ceiling.
+const MaxConcurrentSandboxes = 100
 
 // sandboxSemaphore gates sandbox creation so parallel tests don't exceed the
 // tier's concurrent instance limit. A slot is acquired before creation and

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -142,6 +142,16 @@ VALUES ($1, $2, $3, $4, $5, $6)
 		return fmt.Errorf("failed to create team: %w", err)
 	}
 
+	// Grant the integration test team extra capacity so parallel tests don't
+	// hit the base tier's 20-sandbox cap.
+	err = db.TestsRawSQL(ctx, `
+INSERT INTO addons (team_id, name, extra_concurrent_sandboxes, extra_concurrent_template_builds, added_by)
+VALUES ($1, 'integration-tests-extra-capacity', 200, 50, '00000000-0000-0000-0000-000000000000')
+`, data.TeamID)
+	if err != nil {
+		return fmt.Errorf("failed to create test team addon: %w", err)
+	}
+
 	// User-Team
 	err = authdb.TestsRawSQL(ctx, `
 INSERT INTO users_teams (user_id, team_id, is_default)


### PR DESCRIPTION
The base tier seeded by migration caps concurrent sandboxes at 20, which the parallel integration tests routinely hit on the shared runner (e.g. [run 25196513831](https://github.com/e2b-dev/infra/actions/runs/25196513831) — every failure was `429 concurrent sandbox limit (20) reached`).

Grant the integration test team an addon worth 200 extra concurrent sandboxes + 50 extra template builds, and bump the client-side semaphore from 15 to 100 so parallel suites can use the headroom.