### PR TITLE
fix(uffd): mark received uffd fd FD_CLOEXEC

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/fc"
@@ -162,6 +163,11 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 		return fmt.Errorf("expected 1 fd: found %d", len(fds))
 	}
 
+	// ParseUnixRights doesn't set FD_CLOEXEC; mark it so a later fork can't leak.
+	if err := setCloexec(fds[0]); err != nil {
+		return fmt.Errorf("failed to set FD_CLOEXEC on uffd fd: %w", err)
+	}
+
 	m := memory.NewMapping(regions)
 
 	uffd, err := userfaultfd.NewUserfaultfdFromFd(
@@ -218,6 +224,12 @@ func (u *Uffd) Exit() *utils.ErrorOnce {
 // It *MUST* be only called after the sandbox was successfully paused via API and after the snapshot endpoint was called.
 func (u *Uffd) DiffMetadata(ctx context.Context, f *fc.Process) (*header.DiffMetadata, error) {
 	return f.DirtyMemory(ctx, u.memfile.BlockSize())
+}
+
+func setCloexec(fd int) error {
+	_, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC)
+
+	return err
 }
 
 // PrefetchData returns page fault data for prefetch mapping.

--- a/packages/orchestrator/pkg/sandbox/uffd/uffd_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd_test.go
@@ -1,0 +1,34 @@
+package uffd
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestSetCloexec verifies that setCloexec sets FD_CLOEXEC on a freshly-created
+// fd that starts without it — confirming the helper works before production
+// calls it on the received uffd fd.
+func TestSetCloexec(t *testing.T) {
+	t.Parallel()
+
+	var p [2]int
+	require.NoError(t, syscall.Pipe(p[:]))
+	t.Cleanup(func() {
+		_ = syscall.Close(p[0])
+		_ = syscall.Close(p[1])
+	})
+
+	flags, err := unix.FcntlInt(uintptr(p[0]), unix.F_GETFD, 0)
+	require.NoError(t, err)
+	require.Zerof(t, flags&unix.FD_CLOEXEC, "syscall.Pipe fd must start without FD_CLOEXEC; got flags=%#x", flags)
+
+	require.NoError(t, setCloexec(p[0]))
+
+	flags, err = unix.FcntlInt(uintptr(p[0]), unix.F_GETFD, 0)
+	require.NoError(t, err)
+	assert.NotZerof(t, flags&unix.FD_CLOEXEC, "setCloexec must set FD_CLOEXEC; got flags=%#x", flags)
+}


### PR DESCRIPTION
\`recvmsg\` for the uffd fd doesn't pass \`MSG_CMSG_CLOEXEC\`, and \`ParseUnixRights\`
doesn't set the flag itself. Any later fork/exec in the orchestrator would
inherit the fd. Mark it CLOEXEC right after we parse it. Defensive — no
observed leak today, but cheap insurance.