### PR TITLE
refactor(header): replace IsEmptyBlock with fast IsZero short-circuit

### DIFF
--- a/packages/shared/pkg/storage/header/diff.go
+++ b/packages/shared/pkg/storage/header/diff.go
@@ -18,8 +18,9 @@ var EmptyHugePage = make([]byte, HugepageSize)
 
 // IsZero reports whether b is all-zero. Samples first/middle/last byte to
 // reject most non-zero buffers from one cache line, then falls back to
-// bytes.Equal(b[:n-1], b[1:]) — true iff every adjacent pair is equal, i.e.
-// all bytes equal b[0] (which the sample already proved is zero).
+// bytes.Equal(b[:n-1], b[1:]): true exactly when every adjacent pair of
+// bytes is equal, i.e. all bytes equal b[0] (which the sample already
+// proved is zero).
 func IsZero(b []byte) bool {
 	n := len(b)
 	if n == 0 {

--- a/packages/shared/pkg/storage/header/diff.go
+++ b/packages/shared/pkg/storage/header/diff.go
@@ -2,7 +2,6 @@ package header
 
 import (
 	"bytes"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 )
@@ -15,21 +14,23 @@ const (
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/shared/pkg/storage/header")
 
-var (
-	EmptyHugePage = make([]byte, HugepageSize)
-	EmptyBlock    = make([]byte, RootfsBlockSize)
-)
+var EmptyHugePage = make([]byte, HugepageSize)
 
-func IsEmptyBlock(block []byte, blockSize int64) (bool, error) {
-	var emptyBuf []byte
-	switch blockSize {
-	case HugepageSize:
-		emptyBuf = EmptyHugePage
-	case RootfsBlockSize:
-		emptyBuf = EmptyBlock
-	default:
-		return false, fmt.Errorf("block size not supported: %d", blockSize)
+// IsZero reports whether b is all-zero. Samples first/middle/last byte to
+// reject most non-zero buffers from one cache line, then falls back to
+// bytes.Equal(b[:n-1], b[1:]) — true iff every adjacent pair is equal, i.e.
+// all bytes equal b[0] (which the sample already proved is zero).
+func IsZero(b []byte) bool {
+	n := len(b)
+	if n == 0 {
+		return true
+	}
+	if b[0]|b[n-1]|b[n/2] != 0 {
+		return false
+	}
+	if n <= 3 {
+		return true
 	}
 
-	return bytes.Equal(block, emptyBuf), nil
+	return bytes.Equal(b[:n-1], b[1:])
 }

--- a/packages/shared/pkg/storage/header/diff_test.go
+++ b/packages/shared/pkg/storage/header/diff_test.go
@@ -1,0 +1,24 @@
+package header
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsZero(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsZero(make([]byte, RootfsBlockSize)))
+	assert.False(t, IsZero([]byte{0, 1, 0}), "middle byte is sampled")
+
+	// Non-zero byte buried where the 3-sample short-circuit cannot see it
+	// must still be caught by the SIMD fallback.
+	buf := make([]byte, RootfsBlockSize)
+	buf[100] = 0xFF
+	assert.False(t, IsZero(buf))
+
+	buf = make([]byte, RootfsBlockSize)
+	buf[RootfsBlockSize-2] = 0xFF
+	assert.False(t, IsZero(buf), "non-zero just before the last sampled byte")
+}

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -132,11 +132,7 @@ func NewDiffMetadataBuilder(blockSize int64) *DiffMetadataBuilder {
 func (b *DiffMetadataBuilder) Process(ctx context.Context, block []byte, out io.Writer, offset int64) error {
 	blockIdx := BlockIdx(offset, b.blockSize)
 
-	isEmpty, err := IsEmptyBlock(block, b.blockSize)
-	if err != nil {
-		return fmt.Errorf("error checking empty block: %w", err)
-	}
-	if isEmpty {
+	if IsZero(block) {
 		b.empty.Add(uint32(blockIdx))
 
 		return nil


### PR DESCRIPTION
`IsEmptyBlock` was the per-block hot path of `DiffMetadataBuilder.Process` — one call per block during the rootfs scan in `DirectProvider.exportToDiff`. It paid a full SIMD `memcmp` (4 KiB or, on hugepages, 2 MiB) before it could short-circuit, and required two static zero buffers (`EmptyBlock`, `EmptyHugePage`) to compare against.

Replace it with a small `IsZero` helper that uses QEMU's `buffer_is_zero` trick: sample three bytes (first, last, middle) so most non-zero blocks reject from a single cache line. The fallback uses `bytes.Equal` on `b` shifted by one (`b[1:] == b[:n-1]`), which dispatches to the runtime's SIMD `memequal` on amd64/arm64 — same speed as the old comparison against a static buffer when the short-circuit doesn't fire.

`DiffMetadataBuilder.Process` calls `IsZero` directly (the size validation `IsEmptyBlock` did was unreachable in practice). `EmptyBlock` is removed; `EmptyHugePage` stays — `build.go` uses it as the literal zero buffer for `uuid.Nil` reads in `Build.ReadAt`.

Pre-factored from #2546 so it can land on its own.
