### PR TITLE
feat(base): disable proactive memory compaction in guest

### DIFF
--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -75,6 +75,14 @@ EOF
 echo "Increasing inotify watch limit"
 echo 'fs.inotify.max_user_watches=65536' | tee -a /etc/sysctl.conf
 
+# Disable kcompactd background page migration. With 2 MiB host-side hugepage
+# backing of guest RAM, every migration dirties a destination hugepage from
+# the host UFFD's perspective and lands in the next memfile diff, with no
+# corresponding workload benefit between snapshots. We trigger compaction
+# explicitly pre-pause instead.
+echo "Disabling proactive memory compaction"
+echo 'vm.compaction_proactiveness=0' | tee -a /etc/sysctl.conf
+
 echo "Don't wait for ttyS0 (serial console kernel logs)"
 # This is required when the Firecracker kernel args has specified console=ttyS0
 systemctl mask serial-getty@ttyS0.service


### PR DESCRIPTION
Adds `vm.compaction_proactiveness=0` to the base template's `/etc/sysctl.conf` so kcompactd no longer runs background page migrations in the guest.

With 2 MiB host-side hugepage backing of guest RAM, every migration dirties a destination hugepage from the host UFFD's perspective and lands in the next memfile diff — with no snapshot-aligned benefit. The pre-pause `compact_memory` write (#2551) does the work deterministically right before we capture state.

Existing templates inherit the change on rebuild.