### PR TITLE
ci: add Codecov coverage + test analytics uploads

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -9,7 +9,6 @@ on:
         required: true
     secrets:
       CODECOV_TOKEN: { required: false }
-      TRUNK_API_TOKEN: { required: false }
 jobs:
   integration_tests:
     runs-on: infra-tests
@@ -20,7 +19,6 @@ jobs:
     env:
       # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
     steps:
       - name: Checkout Code
@@ -93,16 +91,6 @@ jobs:
           files: tests/integration/test-results.xml
           flags: integration
           disable_search: true
-
-      - name: Upload test results to Trunk
-        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}
-        continue-on-error: true
-        uses: trunk-io/analytics-uploader@v2
-        with:
-          junit-paths: tests/integration/test-results.xml
-          org-slug: e2b
-          token: ${{ secrets.TRUNK_API_TOKEN }}
-          variant: integration
 
       - name: Upload Service Logs
         if: ${{ always() && inputs.publish == true }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,9 +8,7 @@ on:
         description: "Whether to publish the results"
         required: true
     secrets:
-      TRUNK_API_TOKEN:
-        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
-        required: false
+      TRUNK_API_TOKEN: { required: false }
 jobs:
   integration_tests:
     runs-on: infra-tests
@@ -19,8 +17,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      # Surfaced as env so the upload step can gate on its presence
-      # (fork PRs never receive the secret).
+      # Surfaced as env so the upload step can gate on presence (skipped on fork PRs).
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
     steps:
@@ -88,7 +85,6 @@ jobs:
 
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}
-        # Don't fail the job if the analytics upload itself errors out.
         continue-on-error: true
         uses: trunk-io/analytics-uploader@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,6 +7,10 @@ on:
         type: boolean
         description: "Whether to publish the results"
         required: true
+    secrets:
+      TRUNK_API_TOKEN:
+        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
+        required: false
 jobs:
   integration_tests:
     runs-on: infra-tests
@@ -14,6 +18,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      # Surfaced as env so the upload step can gate on its presence
+      # (fork PRs never receive the secret).
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
     steps:
       - name: Checkout Code
@@ -77,6 +85,17 @@ jobs:
         with:
           name: Integration Tests Results
           path: ./tests/integration/test-results.xml
+
+      - name: Upload test results to Trunk
+        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}
+        # Don't fail the job if the analytics upload itself errors out.
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: tests/integration/test-results.xml
+          org-slug: e2b
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+          variant: integration
 
       - name: Upload Service Logs
         if: ${{ always() && inputs.publish == true }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -8,6 +8,7 @@ on:
         description: "Whether to publish the results"
         required: true
     secrets:
+      CODECOV_TOKEN: { required: false }
       TRUNK_API_TOKEN: { required: false }
 jobs:
   integration_tests:
@@ -17,7 +18,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      # Surfaced as env so the upload step can gate on presence (skipped on fork PRs).
+      # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
 
     steps:
@@ -82,6 +84,15 @@ jobs:
         with:
           name: Integration Tests Results
           path: ./tests/integration/test-results.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: tests/integration/test-results.xml
+          flags: integration
+          disable_search: true
 
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     secrets:
       CODECOV_TOKEN: { required: false }
-      TRUNK_API_TOKEN: { required: false }
 
 permissions:
   contents: read
@@ -53,7 +52,6 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: "true"
       # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
       matrix:
         include:
@@ -195,13 +193,3 @@ jobs:
           files: ${{ matrix.package }}/junit.xml
           flags: ${{ matrix.flag }}
           disable_search: true
-
-      - name: Upload test results to Trunk
-        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        continue-on-error: true
-        uses: trunk-io/analytics-uploader@v2
-        with:
-          junit-paths: ${{ matrix.package }}/junit.xml
-          org-slug: e2b
-          token: ${{ secrets.TRUNK_API_TOKEN }}
-          variant: unit-arm64

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -3,12 +3,8 @@ name: ARM64 tests on PRs
 on:
   workflow_call:
     secrets:
-      CODECOV_TOKEN:
-        description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
-        required: false
-      TRUNK_API_TOKEN:
-        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
-        required: false
+      CODECOV_TOKEN: { required: false }
+      TRUNK_API_TOKEN: { required: false }
 
 permissions:
   contents: read
@@ -55,8 +51,7 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
-      # Surfaced as env so the upload steps can gate on their presence
-      # (fork PRs never receive secrets).
+      # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
@@ -153,8 +148,6 @@ jobs:
         if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        # Wraps `go test` to emit JUnit XML for Trunk while passing through
-        # -coverprofile to go test for Codecov.
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Compile test binaries
@@ -162,13 +155,11 @@ jobs:
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
         if: matrix.sudo == true
 
+      # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
+      # toolchain (1.25.9) instead of /usr/bin/go. Trap chowns reports back to
+      # the runner so uploads can read them even when tests fail.
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
-        # `sudo` strips PATH via secure_path, so we pass it explicitly via `env`
-        # to make the runner-installed go (1.25.9) and gotestsum visible to the
-        # root shell. `-E` keeps the rest of the env (HOST_BUSYBOX_DIR, GIN_MODE,
-        # etc). The trap hands the root-written reports back to the runner user
-        # even if tests fail, so the upload steps can still read them.
         run: |
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
@@ -198,12 +189,10 @@ jobs:
 
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        # Don't fail the job if the analytics upload itself errors out.
         continue-on-error: true
         uses: trunk-io/analytics-uploader@v2
         with:
           junit-paths: ${{ matrix.package }}/junit.xml
           org-slug: e2b
           token: ${{ secrets.TRUNK_API_TOKEN }}
-          # Variant keeps x86_64 and arm64 runs of the same test distinguishable in Trunk.
           variant: unit-arm64

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -187,6 +187,15 @@ jobs:
           flags: ${{ matrix.flag }}
           disable_search: true
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package }}/junit.xml
+          flags: ${{ matrix.flag }}
+          disable_search: true
+
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         continue-on-error: true

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -1,6 +1,11 @@
 name: ARM64 tests on PRs
 
-on: [workflow_call]
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
+        required: false
 
 permissions:
   contents: read
@@ -47,28 +52,38 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      # Surfaced as env so the codecov upload step can gate on its presence
+      # (fork PRs never receive the secret).
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         include:
           - package: packages/api
+            flag: arm64-api
             test_path: ./...
             sudo: false
           - package: packages/client-proxy
+            flag: arm64-client-proxy
             test_path: ./...
             sudo: false
           - package: packages/db
+            flag: arm64-db
             test_path: ./...
             sudo: false
           - package: packages/docker-reverse-proxy
+            flag: arm64-docker-reverse-proxy
             test_path: ./...
             sudo: false
           - package: packages/envd
+            flag: arm64-envd
             test_path: ./...
             sudo: true
           - package: packages/orchestrator
+            flag: arm64-orchestrator
             test_path: ./...
             sudo: true
           - package: packages/shared
+            flag: arm64-shared
             test_path: ./pkg/...
             sudo: false
       fail-fast: false
@@ -140,7 +155,10 @@ jobs:
 
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
-        run: sudo -E `which go` test -v -timeout 20m ${{ matrix.test_path }}
+        run: |
+          sudo -E `which go` test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+          # Hand the root-written profile back to the runner user so codecov-action can read it.
+          sudo chown "$(id -u):$(id -g)" coverage.txt
         if: matrix.sudo == true
 
       - name: Compile test binaries
@@ -150,5 +168,14 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -v -timeout 20m ${{ matrix.test_path }}
+        run: go test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == false
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package }}/coverage.txt
+          flags: ${{ matrix.flag }}
+          disable_search: true

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -6,6 +6,9 @@ on:
       CODECOV_TOKEN:
         description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
         required: false
+      TRUNK_API_TOKEN:
+        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
+        required: false
 
 permissions:
   contents: read
@@ -52,9 +55,10 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
-      # Surfaced as env so the codecov upload step can gate on its presence
-      # (fork PRs never receive the secret).
+      # Surfaced as env so the upload steps can gate on their presence
+      # (fork PRs never receive secrets).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
       matrix:
         include:
@@ -148,6 +152,11 @@ jobs:
           sudo udevadm trigger
         if: matrix.package == 'packages/orchestrator'
 
+      - name: Install gotestsum
+        # Wraps `go test` to emit JUnit XML for Trunk while passing through
+        # -coverprofile to go test for Codecov.
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
@@ -156,9 +165,10 @@ jobs:
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
         run: |
-          sudo -E `which go` test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-          # Hand the root-written profile back to the runner user so codecov-action can read it.
-          sudo chown "$(id -u):$(id -g)" coverage.txt
+          sudo -E "$(which gotestsum)" --junitfile=junit.xml --format=standard-verbose \
+            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+          # Hand the root-written reports back to the runner user so the upload actions can read them.
+          sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml
         if: matrix.sudo == true
 
       - name: Compile test binaries
@@ -168,7 +178,9 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+        run: |
+          gotestsum --junitfile=junit.xml --format=standard-verbose \
+            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
@@ -179,3 +191,15 @@ jobs:
           files: ${{ matrix.package }}/coverage.txt
           flags: ${{ matrix.flag }}
           disable_search: true
+
+      - name: Upload test results to Trunk
+        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        # Don't fail the job if the analytics upload itself errors out.
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: ${{ matrix.package }}/junit.xml
+          org-slug: e2b
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+          # Variant keeps x86_64 and arm64 runs of the same test distinguishable in Trunk.
+          variant: unit-arm64

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -164,11 +164,15 @@ jobs:
 
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
+        # `sudo` strips PATH via secure_path, so we pass it explicitly via `env`
+        # to make the runner-installed go (1.25.9) and gotestsum visible to the
+        # root shell. `-E` keeps the rest of the env (HOST_BUSYBOX_DIR, GIN_MODE,
+        # etc). The trap hands the root-written reports back to the runner user
+        # even if tests fail, so the upload steps can still read them.
         run: |
-          sudo -E "$(which gotestsum)" --junitfile=junit.xml --format=standard-verbose \
+          trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
+          sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-          # Hand the root-written reports back to the runner user so the upload actions can read them.
-          sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml
         if: matrix.sudo == true
 
       - name: Compile test binaries

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -136,7 +136,8 @@ jobs:
         if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+          hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -145,7 +146,8 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Trunk
-        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' &&
+          hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         continue-on-error: true
         uses: trunk-io/analytics-uploader@v2
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
     secrets:
       CODECOV_TOKEN: { required: false }
-      TRUNK_API_TOKEN: { required: false }
 
 permissions:
   contents: read
@@ -21,7 +20,6 @@ jobs:
       TESTCONTAINERS_RYUK_DISABLED: "true"
       # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
       matrix:
         include:
@@ -154,17 +152,6 @@ jobs:
           files: ${{ matrix.package }}/junit.xml
           flags: ${{ matrix.flag }}
           disable_search: true
-
-      - name: Upload test results to Trunk
-        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' &&
-          hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        continue-on-error: true
-        uses: trunk-io/analytics-uploader@v2
-        with:
-          junit-paths: ${{ matrix.package }}/junit.xml
-          org-slug: e2b
-          token: ${{ secrets.TRUNK_API_TOKEN }}
-          variant: unit-x86_64
 
   validate-iac:
     name: Validate terraform

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -145,6 +145,16 @@ jobs:
           flags: ${{ matrix.flag }}
           disable_search: true
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+          hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package }}/junit.xml
+          flags: ${{ matrix.flag }}
+          disable_search: true
+
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,6 +1,11 @@
 name: Run tests on PRs
 
-on: [ workflow_call ]
+on:
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
+        required: false
 
 permissions:
   contents: read
@@ -15,28 +20,38 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
+      # Surfaced as env so the codecov upload step can gate on its presence
+      # (fork PRs never receive the secret).
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
         include:
           - package: packages/api
+            flag: unit-api
             test_path: ./...
             sudo: false
           - package: packages/client-proxy
+            flag: unit-client-proxy
             test_path: ./...
             sudo: false
           - package: packages/db
+            flag: unit-db
             test_path: ./...
             sudo: false
           - package: packages/docker-reverse-proxy
+            flag: unit-docker-reverse-proxy
             test_path: ./...
             sudo: false
           - package: packages/envd
+            flag: unit-envd
             test_path: ./...
             sudo: true
           - package: packages/orchestrator
+            flag: unit-orchestrator
             test_path: ./...
             sudo: true
           - package: packages/shared
+            flag: unit-shared
             test_path: ./pkg/...
             sudo: false
       fail-fast: false
@@ -104,13 +119,24 @@ jobs:
         working-directory: ${{ matrix.package }}
         run: |
           # Run tests. The '-E' flag is required to allow root to use the correct cache path.
-          sudo -E `which go` test -v -timeout 20m ${{ matrix.test_path }}
+          sudo -E `which go` test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+          # Hand the root-written profile back to the runner user so codecov-action can read it.
+          sudo chown "$(id -u):$(id -g)" coverage.txt
         if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -v -timeout 20m ${{ matrix.test_path }}
+        run: go test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == false
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ matrix.package }}/coverage.txt
+          flags: ${{ matrix.flag }}
+          disable_search: true
 
   validate-iac:
     name: Validate terraform

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -3,12 +3,8 @@ name: Run tests on PRs
 on:
   workflow_call:
     secrets:
-      CODECOV_TOKEN:
-        description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
-        required: false
-      TRUNK_API_TOKEN:
-        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
-        required: false
+      CODECOV_TOKEN: { required: false }
+      TRUNK_API_TOKEN: { required: false }
 
 permissions:
   contents: read
@@ -23,8 +19,7 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
-      # Surfaced as env so the upload steps can gate on their presence
-      # (fork PRs never receive secrets).
+      # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
@@ -120,17 +115,13 @@ jobs:
         if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        # Wraps `go test` to emit JUnit XML for Trunk while passing through
-        # -coverprofile to go test for Codecov.
         run: go install gotest.tools/gotestsum@v1.13.0
 
+      # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
+      # toolchain (1.25.9) instead of /usr/bin/go. Trap chowns reports back to
+      # the runner so uploads can read them even when tests fail.
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
-        # `sudo` strips PATH via secure_path, so we pass it explicitly via `env`
-        # to make the runner-installed go (1.25.9) and gotestsum visible to the
-        # root shell. `-E` keeps the rest of the env (HOST_BUSYBOX_DIR, GIN_MODE,
-        # etc). The trap hands the root-written reports back to the runner user
-        # even if tests fail, so the upload steps can still read them.
         run: |
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
@@ -155,14 +146,12 @@ jobs:
 
       - name: Upload test results to Trunk
         if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        # Don't fail the job if the analytics upload itself errors out.
         continue-on-error: true
         uses: trunk-io/analytics-uploader@v2
         with:
           junit-paths: ${{ matrix.package }}/junit.xml
           org-slug: e2b
           token: ${{ secrets.TRUNK_API_TOKEN }}
-          # Variant keeps x86_64 and arm64 runs of the same test distinguishable in Trunk.
           variant: unit-x86_64
 
   validate-iac:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -126,12 +126,15 @@ jobs:
 
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
+        # `sudo` strips PATH via secure_path, so we pass it explicitly via `env`
+        # to make the runner-installed go (1.25.9) and gotestsum visible to the
+        # root shell. `-E` keeps the rest of the env (HOST_BUSYBOX_DIR, GIN_MODE,
+        # etc). The trap hands the root-written reports back to the runner user
+        # even if tests fail, so the upload steps can still read them.
         run: |
-          # The '-E' flag preserves PATH so sudo finds the runner-installed gotestsum.
-          sudo -E "$(which gotestsum)" --junitfile=junit.xml --format=standard-verbose \
+          trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
+          sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-          # Hand the root-written reports back to the runner user so the upload actions can read them.
-          sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml
         if: matrix.sudo == true
 
       - name: Run tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -6,6 +6,9 @@ on:
       CODECOV_TOKEN:
         description: "Codecov upload token; absent on fork PRs (upload step is skipped)."
         required: false
+      TRUNK_API_TOKEN:
+        description: "Trunk Flaky Tests upload token; absent on fork PRs (upload step is skipped)."
+        required: false
 
 permissions:
   contents: read
@@ -20,9 +23,10 @@ jobs:
       # and race on `reaper_<hash>` creation. Disable Ryuk; t.Cleanup
       # handles normal exit, the prune step below handles abnormal exit.
       TESTCONTAINERS_RYUK_DISABLED: "true"
-      # Surfaced as env so the codecov upload step can gate on its presence
-      # (fork PRs never receive the secret).
+      # Surfaced as env so the upload steps can gate on their presence
+      # (fork PRs never receive secrets).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
     strategy:
       matrix:
         include:
@@ -115,18 +119,26 @@ jobs:
 
         if: matrix.package == 'packages/orchestrator'
 
+      - name: Install gotestsum
+        # Wraps `go test` to emit JUnit XML for Trunk while passing through
+        # -coverprofile to go test for Codecov.
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Run tests that require sudo
         working-directory: ${{ matrix.package }}
         run: |
-          # Run tests. The '-E' flag is required to allow root to use the correct cache path.
-          sudo -E `which go` test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-          # Hand the root-written profile back to the runner user so codecov-action can read it.
-          sudo chown "$(id -u):$(id -g)" coverage.txt
+          # The '-E' flag preserves PATH so sudo finds the runner-installed gotestsum.
+          sudo -E "$(which gotestsum)" --junitfile=junit.xml --format=standard-verbose \
+            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+          # Hand the root-written reports back to the runner user so the upload actions can read them.
+          sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml
         if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
-        run: go test -v -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+        run: |
+          gotestsum --junitfile=junit.xml --format=standard-verbose \
+            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
@@ -137,6 +149,18 @@ jobs:
           files: ${{ matrix.package }}/coverage.txt
           flags: ${{ matrix.flag }}
           disable_search: true
+
+      - name: Upload test results to Trunk
+        if: ${{ !cancelled() && env.TRUNK_API_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        # Don't fail the job if the analytics upload itself errors out.
+        continue-on-error: true
+        uses: trunk-io/analytics-uploader@v2
+        with:
+          junit-paths: ${{ matrix.package }}/junit.xml
+          org-slug: e2b
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+          # Variant keeps x86_64 and arm64 runs of the same test distinguishable in Trunk.
+          variant: unit-x86_64
 
   validate-iac:
     name: Validate terraform

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,8 +28,12 @@ jobs:
     uses: ./.github/workflows/out-of-order-migrations.yml
   unit-tests:
     uses: ./.github/workflows/pr-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   arm64-tests:
     uses: ./.github/workflows/pr-tests-arm64.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   integration-tests:
     needs: [out-of-order-migrations]
     uses: ./.github/workflows/integration_tests.yml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,6 +43,7 @@ jobs:
       # Only publish the results for same-repo PRs
       publish: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,12 +30,10 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   arm64-tests:
     uses: ./.github/workflows/pr-tests-arm64.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   integration-tests:
     needs: [out-of-order-migrations]
     uses: ./.github/workflows/integration_tests.yml
@@ -44,7 +42,6 @@ jobs:
       publish: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:
       - unit-tests

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,16 +30,20 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   arm64-tests:
     uses: ./.github/workflows/pr-tests-arm64.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   integration-tests:
     needs: [out-of-order-migrations]
     uses: ./.github/workflows/integration_tests.yml
     with:
       # Only publish the results for same-repo PRs
       publish: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    secrets:
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:
       - unit-tests

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,14 +19,12 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   integration-tests:
     uses: ./.github/workflows/integration_tests.yml
     with:
       publish: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:
       - unit-tests

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -25,6 +25,7 @@ jobs:
     with:
       publish: true
     secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -17,6 +17,8 @@ jobs:
 
   unit-tests:
     uses: ./.github/workflows/pr-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   integration-tests:
     uses: ./.github/workflows/integration_tests.yml
     with:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,10 +19,13 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   integration-tests:
     uses: ./.github/workflows/integration_tests.yml
     with:
       publish: true
+    secrets:
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN }}
   publish-test-results:
     needs:
       - unit-tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,93 @@
+# Coverage is informational, not gating. We upload one report per matrix shard
+# (one per package × arch) — the flags below mirror those uploaded by the
+# pr-tests / pr-tests-arm64 workflows.
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    # Wait for every expected upload before posting the check, otherwise a fast
+    # shard's number lands on the PR before slower shards finish.
+    wait_for_ci: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%       # Don't fail the project check on sub-1% drift.
+        informational: true # Never block merges on coverage.
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+# Carry forward each flag's last-known coverage on commits that didn't run it,
+# so a single missing shard doesn't show up as 0% for that package.
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit-api
+      paths: [packages/api/]
+    - name: unit-client-proxy
+      paths: [packages/client-proxy/]
+    - name: unit-db
+      paths: [packages/db/]
+    - name: unit-docker-reverse-proxy
+      paths: [packages/docker-reverse-proxy/]
+    - name: unit-envd
+      paths: [packages/envd/]
+    - name: unit-orchestrator
+      paths: [packages/orchestrator/]
+    - name: unit-shared
+      paths: [packages/shared/]
+    - name: arm64-api
+      paths: [packages/api/]
+    - name: arm64-client-proxy
+      paths: [packages/client-proxy/]
+    - name: arm64-db
+      paths: [packages/db/]
+    - name: arm64-docker-reverse-proxy
+      paths: [packages/docker-reverse-proxy/]
+    - name: arm64-envd
+      paths: [packages/envd/]
+    - name: arm64-orchestrator
+      paths: [packages/orchestrator/]
+    - name: arm64-shared
+      paths: [packages/shared/]
+
+# Codecov component groupings — surfaces a coverage trend per package
+# regardless of which arch ran the test.
+component_management:
+  individual_components:
+    - component_id: api
+      paths: [packages/api/**]
+    - component_id: client-proxy
+      paths: [packages/client-proxy/**]
+    - component_id: db
+      paths: [packages/db/**]
+    - component_id: docker-reverse-proxy
+      paths: [packages/docker-reverse-proxy/**]
+    - component_id: envd
+      paths: [packages/envd/**]
+    - component_id: orchestrator
+      paths: [packages/orchestrator/**]
+    - component_id: shared
+      paths: [packages/shared/**]
+
+# Skip generated and vendored code so the metric reflects hand-written Go.
+ignore:
+  - "**/*.gen.go"
+  - "**/*_gen.go"
+  - "**/mocks/**"
+  - "**/internal/db/**"          # sqlc output
+  - "packages/shared/pkg/grpc/**" # protoc output
+  - "packages/api/internal/api/**" # oapi-codegen output
+  - "**/testdata/**"
+  - "vendor/**"
+
+comment:
+  layout: "header, diff, components, flags, files"
+  behavior: default
+  require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,93 +1,31 @@
-# Coverage is informational, not gating. We upload one report per matrix shard
-# (one per package × arch) — the flags below mirror those uploaded by the
-# pr-tests / pr-tests-arm64 workflows.
-
-codecov:
-  require_ci_to_pass: false
-  notify:
-    # Wait for every expected upload before posting the check, otherwise a fast
-    # shard's number lands on the PR before slower shards finish.
-    wait_for_ci: true
+# Coverage signal only — never gates merges. Carries forward per-flag so
+# shards that didn't run keep their last-known number instead of dropping to 0%.
 
 coverage:
   status:
     project:
-      default:
-        target: auto
-        threshold: 1%       # Don't fail the project check on sub-1% drift.
-        informational: true # Never block merges on coverage.
+      default: { informational: true }
     patch:
-      default:
-        target: auto
-        threshold: 1%
-        informational: true
+      default: { informational: true }
 
-# Carry forward each flag's last-known coverage on commits that didn't run it,
-# so a single missing shard doesn't show up as 0% for that package.
 flag_management:
   default_rules:
     carryforward: true
-  individual_flags:
-    - name: unit-api
-      paths: [packages/api/]
-    - name: unit-client-proxy
-      paths: [packages/client-proxy/]
-    - name: unit-db
-      paths: [packages/db/]
-    - name: unit-docker-reverse-proxy
-      paths: [packages/docker-reverse-proxy/]
-    - name: unit-envd
-      paths: [packages/envd/]
-    - name: unit-orchestrator
-      paths: [packages/orchestrator/]
-    - name: unit-shared
-      paths: [packages/shared/]
-    - name: arm64-api
-      paths: [packages/api/]
-    - name: arm64-client-proxy
-      paths: [packages/client-proxy/]
-    - name: arm64-db
-      paths: [packages/db/]
-    - name: arm64-docker-reverse-proxy
-      paths: [packages/docker-reverse-proxy/]
-    - name: arm64-envd
-      paths: [packages/envd/]
-    - name: arm64-orchestrator
-      paths: [packages/orchestrator/]
-    - name: arm64-shared
-      paths: [packages/shared/]
 
-# Codecov component groupings — surfaces a coverage trend per package
-# regardless of which arch ran the test.
 component_management:
   individual_components:
-    - component_id: api
-      paths: [packages/api/**]
-    - component_id: client-proxy
-      paths: [packages/client-proxy/**]
-    - component_id: db
-      paths: [packages/db/**]
-    - component_id: docker-reverse-proxy
-      paths: [packages/docker-reverse-proxy/**]
-    - component_id: envd
-      paths: [packages/envd/**]
-    - component_id: orchestrator
-      paths: [packages/orchestrator/**]
-    - component_id: shared
-      paths: [packages/shared/**]
+    - { component_id: api, paths: ["packages/api/**"] }
+    - { component_id: client-proxy, paths: ["packages/client-proxy/**"] }
+    - { component_id: db, paths: ["packages/db/**"] }
+    - { component_id: docker-reverse-proxy, paths: ["packages/docker-reverse-proxy/**"] }
+    - { component_id: envd, paths: ["packages/envd/**"] }
+    - { component_id: orchestrator, paths: ["packages/orchestrator/**"] }
+    - { component_id: shared, paths: ["packages/shared/**"] }
 
-# Skip generated and vendored code so the metric reflects hand-written Go.
 ignore:
   - "**/*.gen.go"
-  - "**/*_gen.go"
   - "**/mocks/**"
-  - "**/internal/db/**"          # sqlc output
-  - "packages/shared/pkg/grpc/**" # protoc output
-  - "packages/api/internal/api/**" # oapi-codegen output
+  - "**/internal/db/**"            # sqlc
+  - "packages/shared/pkg/grpc/**"  # protoc
+  - "packages/api/internal/api/**" # oapi-codegen
   - "**/testdata/**"
-  - "vendor/**"
-
-comment:
-  layout: "header, diff, components, flags, files"
-  behavior: default
-  require_changes: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,9 +23,8 @@ component_management:
     - { component_id: shared, paths: ["packages/shared/**"] }
 
 ignore:
-  - "**/*.gen.go"
-  - "**/mocks/**"
-  - "**/internal/db/**"            # sqlc
-  - "packages/shared/pkg/grpc/**"  # protoc
-  - "packages/api/internal/api/**" # oapi-codegen
+  - "**/*.gen.go"   # oapi-codegen
+  - "**/*.sql.go"   # sqlc
+  - "**/*.pb.go"    # protoc (message + grpc)
+  - "**/mocks/**"   # mockery
   - "**/testdata/**"


### PR DESCRIPTION
## What

`gotestsum` wraps `go test` so coverage and JUnit XML come from one invocation. Each test job uploads to:

- **Codecov Coverage** — `coverage.txt` per package × arch.
- **Codecov Test Analytics** — `junit.xml` per package × arch (failed-test reports in PR comments, dashboard).

Coverage is informational; nothing blocks merges.

## Required before this delivers value

Add `CODECOV_TOKEN` to repo secrets. Without it every upload step skips itself and the workflow runs as before.

## Out of scope

Coverage on integration tests (would need a `tests/integration/Makefile` change). Codecov Test Analytics already gets the integration JUnit.