### PR TITLE
ci: enable -race + add actionlint and govulncheck

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,5 @@
+self-hosted-runner:
+  labels:
+    - ci-builder
+    - infra-tests
+    - infra-runner-arm

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,30 @@
+name: govulncheck
+
+on: [workflow_call]
+
+permissions:
+  contents: read
+
+jobs:
+  detect-modules:
+    runs-on: ubuntu-24.04
+    outputs:
+      modules: ${{ steps.set-modules.outputs.modules }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: set-modules
+        run: echo "modules=$(go list -m -json | jq -s '.' | jq -c '[.[].Dir]')" >> "$GITHUB_OUTPUT"
+
+  govulncheck:
+    needs: detect-modules
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        module: ${{ fromJSON(needs.detect-modules.outputs.modules) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.work
+          work-dir: ${{ matrix.module }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,3 +44,12 @@ jobs:
           # disable, as it randomly fails with the following error:
           # The command is terminated due to an error: [../../.golangci.yml] validate: compile schema: failing loading "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json": Get "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
           verify: 'false'
+
+  actionlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: raven-actions/actionlint@v2
+        with:
+          # Style noise; re-enable in a follow-up after fixing existing findings.
+          shellcheck: 'false'

--- a/.github/workflows/pr-no-generated-changes.yml
+++ b/.github/workflows/pr-no-generated-changes.yml
@@ -76,18 +76,23 @@ jobs:
         run: make fmt
 
       - name: Commit generated changes if any
+        # head_ref is attacker-controlled (PR branch name); pass via env to avoid
+        # shell injection in the inline script.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT: ${{ inputs.commit }}
         run: |
           if [[ -z $(git status --porcelain) ]]; then
             echo "✅ No changes detected."
             exit 0
           fi
 
-          if [[ "${{ inputs.commit }}" != "true" ]]; then
+          if [[ "$COMMIT" != "true" ]]; then
             echo "❌ Generated files are not up to date. Please run 'make generate' and commit the changes."
             git status --short
             exit 1
           fi
-          
+
           echo "📝 Generated files are not up to date. Committing changes..."
           git status --short
 
@@ -96,7 +101,7 @@ jobs:
 
           git add -A
           git commit -m "chore: auto-commit generated changes"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin "HEAD:$HEAD_REF"
 
           echo "✅ Changes committed and pushed successfully."
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -123,14 +123,14 @@ jobs:
         run: |
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
-            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+            -- -race -timeout 30m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
-            -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
+            -- -race -timeout 30m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
         if: matrix.sudo == false
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,6 +30,8 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  govulncheck:
+    uses: ./.github/workflows/govulncheck.yml
   arm64-tests:
     uses: ./.github/workflows/pr-tests-arm64.yml
     secrets:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -19,6 +19,8 @@ jobs:
     uses: ./.github/workflows/pr-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  govulncheck:
+    uses: ./.github/workflows/govulncheck.yml
   integration-tests:
     uses: ./.github/workflows/integration_tests.yml
     with:


### PR DESCRIPTION
## What

Three small, high-signal CI additions:

- **`-race` in unit tests.** `CLAUDE.md` documents that tests should run with `-race`, but the workflow command didn't pass the flag. Enabled now; per-test timeout bumped 20m → 30m to absorb the slowdown. x86 only — race detection is architecture-independent so ARM64 doesn't gain extra coverage.
- **`actionlint`.** Lints workflow YAML; catches expression typos, deprecated runners, and most importantly script-injection patterns. Already paid for itself in this PR (see below). Shellcheck integration disabled on first introduction (~28 mostly style-level findings in pre-existing scripts; will clean up separately).
- **`govulncheck`.** Go team's official vulnerability scanner, matrixed per `go.work` module. Reachability-aware so it only flags CVEs in code paths actually called.

## Side effect: a real injection finding fixed

`actionlint` flagged `pr-no-generated-changes.yml:99`:

```yaml
git push origin HEAD:${{ github.head_ref }}
```

`github.head_ref` is the PR branch name, attacker-controlled. Routed through an env var so it can't be interpreted as shell metacharacters. Same treatment for `inputs.commit`.

## Why these specifically

Of the broader CI-quality candidates I considered, only these made the cut for "real signal, low ongoing maintenance, no platform lock-in". Skipped (each deserves its own PR/owner):

- **CodeQL** — overlaps with GitHub's UI-based "default setup". Verify in repo Security settings before adding a workflow.
- **tflint / tfsec** — large initial findings backlog; better with platform owner.
- **typos / dependabot.yml / container scan** — lower signal or different scope.

## Risk

The `-race` change is the only behavioral one; if pre-existing races surface and block CI, drop it from `pr-tests.yml` and land the rest. Both new workflows are pure additions.