### PR TITLE
ci: tag unit suite for Codecov + skip publish on cancel

### DIFF
--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/coverage.txt
-          flags: ${{ matrix.flag }}
+          flags: ${{ matrix.flag }},unit
           disable_search: true
 
       - name: Upload test results to Codecov
@@ -191,5 +191,5 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/junit.xml
-          flags: ${{ matrix.flag }}
+          flags: ${{ matrix.flag }},unit
           disable_search: true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/coverage.txt
-          flags: ${{ matrix.flag }}
+          flags: ${{ matrix.flag }},unit
           disable_search: true
 
       - name: Upload test results to Codecov
@@ -150,7 +150,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/junit.xml
-          flags: ${{ matrix.flag }}
+          flags: ${{ matrix.flag }},unit
           disable_search: true
 
   validate-iac:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-    if: always()
+    # Skip on cancellation (e.g. superseded by a newer push) so partial
+    # artifacts aren't published as failed tests.
+    if: ${{ !cancelled() }}
 
     steps:
       - name: Download Artifacts
@@ -62,7 +64,6 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
         with:
           comment_mode: off
           fail_on: "errors"

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -32,7 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
-    if: always()
+    # Skip on cancellation so partial artifacts aren't published as failed tests.
+    if: ${{ !cancelled() }}
 
     steps:
       - name: Download Artifacts
@@ -45,7 +46,6 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
         with:
           comment_mode: off
           fail_on: "errors"


### PR DESCRIPTION
Two minimal CI fixes, no new tools.

## 1. Distinguish unit vs integration suite in Codecov

Each unit test upload now carries two flags: the existing per-package one (`unit-orchestrator`, `arm64-api`, …) **plus** a top-level `unit`. Integration uploads already carry `integration`. So in the Codecov dashboard you can now filter by `unit` to see all unit tests across packages and architectures, or `integration` for the e2e suite.

Existing flags unchanged — purely additive.

## 2. Don't publish cancelled runs as failed tests

The `publish-test-results` job ran with `if: always()`, which meant a workflow cancelled by a newer push (`cancel-in-progress: true`) would still try to publish whatever JUnit XMLs got uploaded as artifacts before the cancel — appearing as a failed check. Changed to `if: !cancelled()` in both `pull-request.yml` and `push-main.yml`.

The Codecov upload steps were already guarded with `!cancelled()`, so they were fine.

## Diff

4 files, +9/−8.

The shell-injection fix from the previous draft is split into a separate PR.