### PR TITLE
ci: fix shell injection via github.head_ref in auto-fixer

### DIFF
--- a/.github/workflows/pr-no-generated-changes.yml
+++ b/.github/workflows/pr-no-generated-changes.yml
@@ -76,18 +76,23 @@ jobs:
         run: make fmt
 
       - name: Commit generated changes if any
+        # head_ref is attacker-controlled (PR branch name); pass via env to avoid
+        # shell injection in the inline script.
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          COMMIT: ${{ inputs.commit }}
         run: |
           if [[ -z $(git status --porcelain) ]]; then
             echo "✅ No changes detected."
             exit 0
           fi
 
-          if [[ "${{ inputs.commit }}" != "true" ]]; then
+          if [[ "$COMMIT" != "true" ]]; then
             echo "❌ Generated files are not up to date. Please run 'make generate' and commit the changes."
             git status --short
             exit 1
           fi
-          
+
           echo "📝 Generated files are not up to date. Committing changes..."
           git status --short
 
@@ -96,7 +101,7 @@ jobs:
 
           git add -A
           git commit -m "chore: auto-commit generated changes"
-          git push origin HEAD:${{ github.head_ref }}
+          git push origin "HEAD:$HEAD_REF"
 
           echo "✅ Changes committed and pushed successfully."
 


### PR DESCRIPTION
## Bug

\`pr-no-generated-changes.yml\` interpolated \`github.head_ref\` (the PR branch name, attacker-controlled) directly into a shell command:

\`\`\`yaml
git push origin HEAD:\${{ github.head_ref }}
\`\`\`

A PR opened with a branch name like \`;rm -rf /;\` (or anything containing shell metacharacters) would execute arbitrary commands inside the auto-fixer job. That job runs with the \`AUTOFIXER_APP_SECRET\` GitHub App credentials, which have write access to the repo — so this is a real privilege-escalation vector for any external contributor opening a PR.

## Fix

Route \`github.head_ref\` and \`inputs.commit\` through env vars so the values are quoted shell data instead of inlined source:

\`\`\`yaml
env:
  HEAD_REF: \${{ github.head_ref }}
  COMMIT: \${{ inputs.commit }}
run: |
  ...
  git push origin "HEAD:\$HEAD_REF"
\`\`\`

Standard mitigation per [GitHub's secure-use guide](https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks).

## Diff

1 file, +8/−3.