### PR TITLE
fix(orch): cgroup.kill backstop on rmdir EBUSY

### DIFF
--- a/packages/orchestrator/pkg/sandbox/cgroup/manager.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -124,16 +125,49 @@ func (h *CgroupHandle) Remove(ctx context.Context) error {
 		h.memoryPeakFile = nil
 	}
 
-	// Remove the cgroup directory.
-	// The kernel automatically cleans up when all processes have exited,
-	// so ENOENT is expected and not an error.
-	if err := os.Remove(h.path); err != nil {
-		if !os.IsNotExist(err) {
+	// Try plain rmdir first. The kernel removes the directory once the
+	// last process exits, so the common path is a single rmdir.
+	rmErr := os.Remove(h.path)
+	if rmErr == nil || os.IsNotExist(rmErr) {
+		logger.L().Debug(ctx, "removed cgroup for sandbox",
+			zap.String("cgroup_name", h.cgroupName),
+			zap.String("path", h.path))
+
+		return nil
+	}
+
+	// rmdir failed (almost always EBUSY because something is still in the
+	// cgroup, e.g. a leaked firecracker). Log so the leak is visible, then
+	// fall back to cgroup.kill (cgroups v2, kernel 5.14+) and retry rmdir.
+	logger.L().Warn(ctx, "cgroup rmdir failed, falling back to cgroup.kill",
+		zap.String("cgroup_name", h.cgroupName),
+		zap.String("path", h.path),
+		zap.Error(rmErr))
+
+	if err := os.WriteFile(filepath.Join(h.path, "cgroup.kill"), []byte("1"), 0); err != nil && !os.IsNotExist(err) {
+		logger.L().Warn(ctx, "failed to write cgroup.kill",
+			zap.String("cgroup_name", h.cgroupName),
+			zap.String("path", h.path),
+			zap.Error(err))
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := os.Remove(h.path)
+		if err == nil || os.IsNotExist(err) {
+			break
+		}
+		if time.Now().After(deadline) {
 			return fmt.Errorf("failed to remove cgroup: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(200 * time.Millisecond):
 		}
 	}
 
-	logger.L().Debug(ctx, "removed cgroup for sandbox",
+	logger.L().Debug(ctx, "removed cgroup for sandbox after cgroup.kill",
 		zap.String("cgroup_name", h.cgroupName),
 		zap.String("path", h.path))
 


### PR DESCRIPTION
INC-582: six firecracker processes for the same sandbox left running on `orch-client-n2-r8sb` after a burst of checkpoints. Root cause is `fc.Process.Stop` signaling only the `unshare/bash/ip-netns-exec` wrapper PID — `ip netns exec` forks firecracker as a child without forwarding signals, so firecracker is reparented to init and keeps running. The orchestrator never sees an error.

This PR is a defensive cleanup-only fix: in `cgroup.Remove` we keep the existing `rmdir` as the fast path, and on EBUSY (process still in the cgroup) log the original error and fall back to `cgroup.kill` + retry `rmdir` for up to 2s. The signal path in `fc.Process.Stop` is intentionally untouched — fixing the firecracker SIGTERM-propagation properly is a behavioral change to sandbox shutdown that needs its own PR.

Trade-off: we still leave firecracker running until the next `cgroup.Remove` call, but the sandbox will then actually die instead of accumulating, and the new `cgroup rmdir failed, falling back to cgroup.kill` warn is a queryable Loki signal we don't have today.

Related: PR #2453 (already merged Apr 21) fixes the duplicate-`SandboxID` overwrite in the sandboxes map, which compounded the leak when the deployed `ec97b441` orchestrator allowed multiple in-flight checkpoints to clobber each other's map entry. The next foxtrot deploy picks that up automatically.

Full evidence, code-path trace, empirical signal-propagation test and follow-up plan in `investigation/2026-05-04-inc-582-stale-checkpoint-fcs/REPORT.md` in the debugger repo.
