### PR TITLE
fix(template): retry apt fetches via apt.conf to survive mirror flakes

### DIFF
--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -32,6 +32,14 @@ done
 
 if [ -n "$MISSING" ]; then
     echo "Missing packages detected, installing:$MISSING"
+    # Bake retry config into the image so user RUN apt-get steps and
+    # provision.sh both survive transient mirror flakiness.
+    mkdir -p /etc/apt/apt.conf.d
+    cat >/etc/apt/apt.conf.d/80-retries <<'EOF'
+Acquire::Retries "10";
+Acquire::http::Timeout "30";
+Acquire::https::Timeout "30";
+EOF
     apt-get -q update
     DEBIAN_FRONTEND=noninteractive DEBCONF_NOWARNINGS=yes apt-get -qq -o=Dpkg::Use-Pty=0 install -y --no-install-recommends $MISSING
 else

--- a/tests/e2b.Dockerfile
+++ b/tests/e2b.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
+RUN printf 'Acquire::Retries "10";\nAcquire::http::Timeout "30";\nAcquire::https::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries && \
+    apt-get update && \
     apt-get install -y fio zstd gzip


### PR DESCRIPTION
## What

Drops a small `/etc/apt/apt.conf.d/80-retries` snippet inside `provision.sh` (Ubuntu base templates) so apt retries 10x with bounded timeouts.

```
Acquire::Retries "10";
Acquire::http::Timeout "30";
Acquire::https::Timeout "30";
```

Same snippet added to `tests/e2b.Dockerfile`.

## Why

`archive.ubuntu.com` periodically blackholes connections from GHA runners (e.g. `91.189.91.81`, `91.189.92.23`, `185.125.190.81`...). Without retries, `provision.sh`'s single `apt-get update` blocks the whole template build until the 300 s API or 20 min smoketest timeout fires, cascading into ~80 integration test failures (`TestEgressFirewall*`, `TestTemplateBuildRUN`, `TestSmokeAllFCVersions`, ...). Same outage takes down `main`'s periodic test runs too.

Retries are written before `apt-get update`, and because the file lives in `/etc/apt/apt.conf.d/`, they apply to user `RUN apt-get` steps in customer templates as well.