### PR TITLE
feat(ext4): enable inline_data on rootfs mkfs

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -54,6 +54,8 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 			"filetype",
 			"flex_bg",
 			"huge_file",
+			// Pack file data <~160 B inside the inode to avoid a 4 KiB data block per tiny file.
+			"inline_data",
 			"large_file",
 			"sparse_super2",
 		}, ","),

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -42,9 +42,9 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 	cmd := exec.CommandContext(ctx,
 		"mkfs.ext4",
 		"-O", strings.Join([]string{
-			// Matches the final ext4 features used by tar2ext4 tool.
-			// But enables resize_inode, sparse_super (required for resize_inode),
-			// has_journal, and metadata_csum are kept as defaults.
+			// Explicit feature list for the rootfs. Defaults (resize_inode,
+			// sparse_super, has_journal, metadata_csum) are kept; we toggle
+			// only what we want to add or strip below.
 			"^64bit",
 			"^dir_index",
 			"^dir_nlink",


### PR DESCRIPTION
Enable ext4 `inline_data` on rootfs mkfs. Files <~160 B (with default 256 B inodes) live inside the inode instead of allocating a 4 KiB data block — shrinks rootfs diff for small-file churn and improves locality (dirties cluster on inode-table blocks).

mkfs-time only. Affects newly-built bases. No semantic change for guest workloads.
