### PR TITLE
feat(ext4): disable journal on rootfs mkfs

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -44,10 +44,21 @@ func Make(ctx context.Context, rootfsPath string, sizeMb int64, blockSize int64)
 		"-O", strings.Join([]string{
 			// Matches the final ext4 features used by tar2ext4 tool.
 			// But enables resize_inode, sparse_super (required for resize_inode),
-			// has_journal, and metadata_csum are kept as defaults.
+			// and metadata_csum is kept as default. has_journal is explicitly
+			// disabled below.
 			"^64bit",
 			"^dir_index",
 			"^dir_nlink",
+			// Disable the ext4 journal. The journal commits metadata every 5 s
+			// (jbd2/commit timer) which dirties journal blocks on a fixed cadence
+			// regardless of guest activity and inflates every snapshot diff.
+			// Snapshots are taken from a paused guest so all in-flight writes
+			// have already drained — the journal's crash-recovery guarantee
+			// across a clean pause/resume isn't needed. A guest kernel panic
+			// between snapshots can leave the rootfs inconsistent; resume always
+			// loads the previous good snapshot, so blast radius is bounded to
+			// one in-flight customer interaction.
+			"^has_journal",
 			"ext_attr",
 			"extent",
 			"extra_isize",


### PR DESCRIPTION
Drop `has_journal` from the rootfs mkfs feature list. The jbd2 commit timer dirties journal blocks every 5 s regardless of guest activity, inflating every snapshot diff. Also reclaims ~32 MiB at the front of the rootfs.

Snapshots come from a paused guest (no in-flight writes), so the journal's crash-recovery role across pause/resume is unused.

Risk: a guest kernel panic between snapshots can leave the rootfs inconsistent — resume always loads the previous good snapshot, so blast radius is bounded to one in-flight customer interaction. Want to discuss before flipping universally — feature flag is an easy follow-up.
