### PR TITLE
ci: aggregate integration tests matrix into single check

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,7 +10,7 @@ on:
     secrets:
       CODECOV_TOKEN: { required: false }
 jobs:
-  integration_tests:
+  run:
     runs-on: infra-tests
     timeout-minutes: 30
     permissions:
@@ -117,3 +117,16 @@ jobs:
         with:
           name: Service Logs (${{ matrix.name }})
           path: ~/logs/*.log
+
+  integration_tests:
+    needs: run
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix result
+        run: |
+          if [[ "${{ needs.run.result }}" != "success" ]]; then
+            echo "matrix result: ${{ needs.run.result }}"
+            exit 1
+          fi
+          echo "all matrix shards succeeded"


### PR DESCRIPTION
## Summary

Rename the matrix job from `integration_tests` to `run`, and add a non-matrix `integration_tests` aggregator job that depends on it.

This produces a single `integration-tests / integration_tests` status check that can be used as the required check in branch protection — independent of how many matrix shards there are. Individual shards still appear as `integration-tests / run (uncompressed)`, `integration-tests / run (zstd1)`, etc.

## Why

Today the matrix job is named `integration_tests`, so each shard renders as `integration-tests / integration_tests (<name>)`. There's no single aggregated check, which makes branch protection awkward (you have to list each shard explicitly, and adding/removing a shard requires updating branch protection).

## Test plan

- [ ] Verify the matrix shards still run as before (under `integration-tests / run (...)`).
- [ ] Verify a single `integration-tests / integration_tests` check appears at the end and reflects pass/fail of the matrix.
- [ ] If a shard fails, the aggregator should also fail (via the explicit `needs.run.result` check, which is required because `if: always()` would otherwise let the aggregator pass on a skipped/failed matrix).