### PR TITLE
perf(storage): drop gRPC OTEL stats handler on GCS client

### DIFF
--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -16,7 +16,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googleapis/gax-go/v2"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	"google.golang.org/api/iterator"
@@ -104,7 +103,6 @@ func NewGCP(ctx context.Context, bucketName string, limiter *limit.Limiter) (Sto
 		option.WithGRPCConnectionPool(grpcPoolSize),
 		option.WithGRPCDialOption(grpc.WithInitialConnWindowSize(32 * megabyte)),
 		option.WithGRPCDialOption(grpc.WithInitialWindowSize(4 * megabyte)),
-		option.WithGRPCDialOption(grpc.WithStatsHandler(otelgrpc.NewClientHandler())),
 		internaloption.EnableDirectPath(defaultGCSEnableDirectPath),
 	}
 


### PR DESCRIPTION
Drops `otelgrpc.NewClientHandler()` from the GCS gRPC client. We already record GCS read latency via `googleReadTimerFactory`, so this per-RPC stats hook is redundant and adds cost on the chunk-fetch hot path. The 2026-03-15 DirectPath investigation already flagged client-side gRPC OTEL stats as a major allocation-rate contributor.

`orchestrator_storage_gcs_read_milliseconds` and `orchestrator_blocks_chunks_fetch_milliseconds` p95/p99 have been drifting up since this was rolled out in `ec97b44` (Apr 17). After deploy, expect both to drift back toward the pre-`ec97b44` baseline.

Server-side OTEL on incoming gRPC, Go runtime metrics, and `orchestrator.storage.gcs.*` / `orchestrator.blocks.chunks.*` are unchanged.