### PR TITLE
Fix devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/go:2.0.3-1.25-bookworm
+
+# The base image includes a Yarn apt source with an expired/missing key, which
+# breaks feature installation when apt-get update runs.
+RUN rm -f /etc/apt/sources.list.d/yarn.list

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,9 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
   "name": "Go",
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/go:2.0.3-1.25-bookworm",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "1.5.7"
@@ -13,7 +14,9 @@
     },
     "ghcr.io/wxw-matt/devcontainer-features/command_runner:0": {},
     "ghcr.io/wxw-matt/devcontainer-features/script_runner:0": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "none"
+    },
     "ghcr.io/devcontainers-extra/features/mise:1": {}
   },
   "customizations": {


### PR DESCRIPTION
## Summary
- Build the devcontainer from a local Dockerfile so the stale Yarn apt source in the base image is removed before features install.
- Disable the redundant standalone docker-compose download in the docker-in-docker feature; the Moby compose package is installed by the feature already.

## Validation
- npx --yes @devcontainers/cli build --workspace-folder .