### PR TITLE
fix(orch): GCS header request storm in Upload.Wait

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -324,7 +324,7 @@ func doBuild(
 	// their parents' header finalization. Redis is nil (CLI is single-host —
 	// no cross-orch signaling needed); local same-orch coordination via
 	// futures is what matters here.
-	uploads := sandbox.NewUploads(templateCache, persistenceTemplate, nil)
+	uploads := sandbox.NewUploads(templateCache, persistenceTemplate, peerclient.NopResolver(), nil)
 	defer uploads.Stop()
 
 	builder := build.NewBuilder(

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -548,7 +548,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 	builder := chrooted.NewBuilder(config)
 	volumeService := volumes.New(config, builder)
 
-	uploads := sandbox.NewUploads(templateCache, persistence, redisClient)
+	uploads := sandbox.NewUploads(templateCache, persistence, peerResolver, redisClient)
 	closers = append(closers, closer{"pending uploads", func(context.Context) error {
 		uploads.Stop()
 

--- a/packages/orchestrator/pkg/sandbox/block/empty.go
+++ b/packages/orchestrator/pkg/sandbox/block/empty.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"github.com/google/uuid"
 
@@ -12,7 +11,7 @@ import (
 )
 
 type Empty struct {
-	header atomic.Pointer[header.Header]
+	header *header.Header
 }
 
 var _ ReadonlyDevice = (*Empty)(nil)
@@ -27,10 +26,7 @@ func NewEmpty(size int64, blockSize int64, buildID uuid.UUID) (*Empty, error) {
 		return nil, fmt.Errorf("failed to create header: %w", err)
 	}
 
-	e := &Empty{}
-	e.header.Store(h)
-
-	return e, nil
+	return &Empty{header: h}, nil
 }
 
 func (e *Empty) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
@@ -43,11 +39,11 @@ func (e *Empty) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 }
 
 func (e *Empty) Size(_ context.Context) (int64, error) {
-	return int64(e.Header().Metadata.Size), nil
+	return int64(e.header.Metadata.Size), nil
 }
 
 func (e *Empty) BlockSize() int64 {
-	return int64(e.Header().Metadata.BlockSize)
+	return int64(e.header.Metadata.BlockSize)
 }
 
 func (e *Empty) Close() error {
@@ -56,7 +52,7 @@ func (e *Empty) Close() error {
 
 func (e *Empty) Slice(_ context.Context, off, length int64) ([]byte, error) {
 	end := off + length
-	size := int64(e.Header().Metadata.Size)
+	size := int64(e.header.Metadata.Size)
 	if end > size {
 		end = size
 		length = end - off
@@ -67,12 +63,10 @@ func (e *Empty) Slice(_ context.Context, off, length int64) ([]byte, error) {
 }
 
 func (e *Empty) Header() *header.Header {
-	return e.header.Load()
+	return e.header
 }
 
-func (e *Empty) SwapHeader(h *header.Header) {
-	e.header.Store(h)
-}
+func (e *Empty) SwapHeader(*header.Header) {}
 
 func (e *Empty) UpdateSize() error {
 	return errors.New("update size not supported for empty block")

--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
-	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -16,10 +15,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
-
-// swapReadHeaderBudget bounds how long the read-path swap polls GCS for the
-// V4 header to appear.
-const swapReadHeaderBudget = 30 * time.Second
 
 type File struct {
 	header      atomic.Pointer[header.Header]
@@ -165,6 +160,10 @@ func (b *File) Slice(ctx context.Context, off, _ int64) ([]byte, error) {
 // or (false, swapErr) if the swap itself failed. peerSeekable emits the
 // transition error at most once per seekable, so the loop is naturally
 // bounded — no retry counter needed here.
+//
+// The transition is signaled only after the source upload has finalized, so
+// the header object already exists in storage. A single LoadHeader is enough;
+// polling here would multiply GCS reads under high peer-transition rates.
 func (b *File) retryOnTransition(ctx context.Context, err error) (bool, error) {
 	var transErr *storage.PeerTransitionedError
 	if !errors.As(err, &transErr) {
@@ -175,7 +174,8 @@ func (b *File) retryOnTransition(ctx context.Context, err error) (bool, error) {
 		zap.String("file_type", string(b.fileType)),
 	)
 
-	h, loadErr := PollRemoteStorageForHeader(ctx, b.persistence, b.header.Load().Metadata.BuildId, b.fileType, nil, swapReadHeaderBudget)
+	hdrPath := storage.Paths{BuildID: b.header.Load().Metadata.BuildId.String()}.HeaderFile(string(b.fileType))
+	h, loadErr := header.LoadHeader(ctx, b.persistence, hdrPath)
 	if loadErr != nil {
 		return false, fmt.Errorf("failed to swap header: %w", loadErr)
 	}

--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -52,7 +52,7 @@ func (b *File) SwapHeader(h *header.Header) {
 
 func (b *File) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
 	for n < len(p) {
-		h := b.header.Load()
+		h := b.Header()
 
 		mappedToBuild, err := h.GetShiftedMapping(ctx, off+int64(n))
 		if err != nil {
@@ -121,7 +121,7 @@ func (b *File) ReadAt(ctx context.Context, p []byte, off int64) (n int, err erro
 // The slice access must be in the predefined blocksize of the build.
 func (b *File) Slice(ctx context.Context, off, _ int64) ([]byte, error) {
 	for {
-		h := b.header.Load()
+		h := b.Header()
 
 		mappedBuild, err := h.GetShiftedMapping(ctx, off)
 		if err != nil {
@@ -174,7 +174,7 @@ func (b *File) retryOnTransition(ctx context.Context, err error) (bool, error) {
 		zap.String("file_type", string(b.fileType)),
 	)
 
-	hdrPath := storage.Paths{BuildID: b.header.Load().Metadata.BuildId.String()}.HeaderFile(string(b.fileType))
+	hdrPath := storage.Paths{BuildID: b.Header().Metadata.BuildId.String()}.HeaderFile(string(b.fileType))
 	h, loadErr := header.LoadHeader(ctx, b.persistence, hdrPath)
 	if loadErr != nil {
 		return false, fmt.Errorf("failed to swap header: %w", loadErr)

--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -75,7 +75,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 	}
 
 	if u.snap.MemfileDiffHeader != nil {
-		if _, err := u.collectAncestorBuilds(ctx, u.snap.MemfileDiffHeader.Mapping, build.Memfile); err != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, u.snap.MemfileDiffHeader.Mapping, build.Memfile); err != nil {
 			return err
 		}
 	}
@@ -86,7 +86,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 	}
 
 	if u.snap.RootfsDiffHeader != nil {
-		if _, err := u.collectAncestorBuilds(ctx, u.snap.RootfsDiffHeader.Mapping, build.Rootfs); err != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, u.snap.RootfsDiffHeader.Mapping, build.Rootfs); err != nil {
 			return err
 		}
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"context"
 	"fmt"
-	"maps"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -76,27 +75,13 @@ func (u *Upload) uploadFramed(
 
 	h := srcHeader.CloneForUpload(headers.MetadataVersionV4)
 	h.IncompletePendingUpload = false
+	if h.Builds == nil {
+		h.Builds = make(map[uuid.UUID]headers.BuildData)
+	}
 
-	// Dependency closure is the set of buildIDs referenced by mappings, minus
-	// self. Each ancestor's BuildData lives in its own finalized header's
-	// self-entry; Wait routes to local future, peer, or remote storage as
-	// appropriate. Already-final ancestors resolve immediately (remote storage
-	// round-trip beats blocking on whatever the immediate parent's upload is
-	// doing).
-	ancestors, err := u.collectAncestorBuilds(ctx, srcHeader.Mapping, fileType)
-	if err != nil {
+	if err := u.appendAncestorBuilds(ctx, h.Builds, srcHeader.Mapping, fileType); err != nil {
 		return err
 	}
-
-	// Merge into the cloned srcHeader.Builds rather than overwriting: ancestors
-	// that collectAncestorBuilds skipped (Wait returned nil h because no local
-	// device existed) keep the BuildData carried through CloneForUpload from
-	// boot. Empty diffs represent a layer descendants must record as an
-	// ancestor.
-	if h.Builds == nil {
-		h.Builds = make(map[uuid.UUID]headers.BuildData, len(ancestors)+1)
-	}
-	maps.Copy(h.Builds, ancestors)
 	h.Builds[u.buildID] = selfBuild
 
 	if err := headers.StoreHeader(ctx, u.store, u.paths.HeaderFile(string(fileType)), h); err != nil {
@@ -106,51 +91,52 @@ func (u *Upload) uploadFramed(
 	return u.publish(ctx, fileType, h)
 }
 
-// collectAncestorBuilds resolves every unique buildID referenced by mappings
-// (excluding self) to its finalized BuildData. Local ancestors resolve from the
-// in-memory futures map without any I/O; cross-orch ancestors take a single
-// remote storage round-trip each. Sequential — the critical path is the slowest
-// pending Wait either way, and serial keeps the code simple.
-func (u *Upload) collectAncestorBuilds(
+// appendAncestorBuilds waits on every unique buildID referenced by mappings
+// (excluding self) — gating publish on parents' header finalization — and,
+// when dst is non-nil, writes the freshest BuildData into it. Existing dst
+// entries are overwritten (Wait is more authoritative than CloneForUpload).
+// Skips silently when Wait returns nil or the ancestor carries no Builds
+// entry (V3 ancestor); pre-existing dst entries are preserved.
+//
+// V3 callers pass dst=nil — they need the barrier but have no Builds map.
+//
+// Local ancestors resolve from the in-memory futures map without I/O;
+// cross-orch ancestors take a single remote storage round-trip. Sequential —
+// the critical path is the slowest pending Wait either way.
+func (u *Upload) appendAncestorBuilds(
 	ctx context.Context,
+	dst map[uuid.UUID]headers.BuildData,
 	mappings []headers.BuildMap,
 	fileType build.DiffType,
-) (map[uuid.UUID]headers.BuildData, error) {
-	out := make(map[uuid.UUID]headers.BuildData)
+) error {
 	if u.uploads == nil {
-		return out, nil
+		return nil
 	}
 
+	seen := make(map[uuid.UUID]struct{}, len(mappings))
 	for _, m := range mappings {
 		if m.BuildId == u.buildID || m.BuildId == uuid.Nil {
 			continue
 		}
-		if _, dup := out[m.BuildId]; dup {
+		if _, dup := seen[m.BuildId]; dup {
 			continue
 		}
+		seen[m.BuildId] = struct{}{}
 
 		h, err := u.uploads.Wait(ctx, m.BuildId, fileType)
 		if err != nil {
-			return nil, fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
+			return fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
 		}
-		// nil h means ancestor was never opened locally. The caller's
-		// srcHeader.Builds (preserved through CloneForUpload) carries the
-		// BuildData for ancestors.
-		if h == nil {
-			continue
-		}
-		// V3 ancestors have Builds=nil (FrameTable is V4-only); their data is
-		// raw bytes and the read path doesn't consult Builds for them. Skip
-		// silently so V4 descendants of V3 ancestors still upload.
-		bd, ok := h.Builds[m.BuildId]
-		if !ok {
+		if h == nil || dst == nil {
 			continue
 		}
 
-		out[m.BuildId] = bd
+		if bd, ok := h.Builds[m.BuildId]; ok {
+			dst[m.BuildId] = bd
+		}
 	}
 
-	return out, nil
+	return nil
 }
 
 func seekableTypeFor(fileType build.DiffType) storage.SeekableObjectType {

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -87,8 +88,15 @@ func (u *Upload) uploadFramed(
 		return err
 	}
 
-	// Empty diffs still represent a layer descendants must record as an ancestor.
-	h.Builds = ancestors
+	// Merge into the cloned srcHeader.Builds rather than overwriting: ancestors
+	// that collectAncestorBuilds skipped (Wait returned nil h because no local
+	// device existed) keep the BuildData carried through CloneForUpload from
+	// boot. Empty diffs represent a layer descendants must record as an
+	// ancestor.
+	if h.Builds == nil {
+		h.Builds = make(map[uuid.UUID]headers.BuildData, len(ancestors)+1)
+	}
+	maps.Copy(h.Builds, ancestors)
 	h.Builds[u.buildID] = selfBuild
 
 	if err := headers.StoreHeader(ctx, u.store, u.paths.HeaderFile(string(fileType)), h); err != nil {
@@ -124,6 +132,12 @@ func (u *Upload) collectAncestorBuilds(
 		h, err := u.uploads.Wait(ctx, m.BuildId, fileType)
 		if err != nil {
 			return nil, fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
+		}
+		// nil h means ancestor was never opened locally. The caller's
+		// srcHeader.Builds (preserved through CloneForUpload) carries the
+		// BuildData for ancestors.
+		if h == nil {
+			continue
 		}
 		// V3 ancestors have Builds=nil (FrameTable is V4-only); their data is
 		// raw bytes and the read path doesn't consult Builds for them. Skip

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
@@ -25,9 +25,20 @@ const peerConnectTimeout = 5 * time.Second
 //
 // The unexported resolve method restricts implementations to this package.
 type Resolver interface {
+	UploadChecker
 	resolve(ctx context.Context, buildID string) (attribute.KeyValue, resolveResult)
 	Purge(buildID string)
 	Close()
+}
+
+// UploadChecker answers whether a build's source upload is still in flight on
+// a peer orchestrator. False means the build is finalized in remote storage
+// (or was never registered as a peer to begin with) and is therefore safe to
+// read directly from the base provider. The narrow surface lets consumers
+// (e.g. sandbox.Uploads) take a dependency on upload state without pulling in
+// the full peer routing API.
+type UploadChecker interface {
+	IsUploading(ctx context.Context, buildID string) bool
 }
 
 type resolveResult struct {
@@ -44,8 +55,9 @@ type nopResolver struct{}
 func (nopResolver) resolve(context.Context, string) (attribute.KeyValue, resolveResult) {
 	return attrResolveNoPeer, resolveResult{}
 }
-func (nopResolver) Purge(string) {}
-func (nopResolver) Close()       {}
+func (nopResolver) IsUploading(context.Context, string) bool { return false }
+func (nopResolver) Purge(string)                             {}
+func (nopResolver) Close()                                   {}
 
 // peerResolver is the real implementation that looks up peers via the Registry.
 type peerResolver struct {
@@ -156,6 +168,12 @@ func (r *peerResolver) resolve(ctx context.Context, buildID string) (attribute.K
 		uploaded: uploaded,
 		addr:     addr,
 	}
+}
+
+func (r *peerResolver) IsUploading(ctx context.Context, buildID string) bool {
+	status, _ := r.resolve(ctx, buildID)
+
+	return status == attrResolvePeer
 }
 
 func (r *peerResolver) Close() {

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
@@ -25,20 +25,10 @@ const peerConnectTimeout = 5 * time.Second
 //
 // The unexported resolve method restricts implementations to this package.
 type Resolver interface {
-	UploadChecker
 	resolve(ctx context.Context, buildID string) (attribute.KeyValue, resolveResult)
+	IsActive(buildID string) bool
 	Purge(buildID string)
 	Close()
-}
-
-// UploadChecker answers whether a build's source upload is still in flight on
-// a peer orchestrator. False means the build is finalized in remote storage
-// (or was never registered as a peer to begin with) and is therefore safe to
-// read directly from the base provider. The narrow surface lets consumers
-// (e.g. sandbox.Uploads) take a dependency on upload state without pulling in
-// the full peer routing API.
-type UploadChecker interface {
-	IsUploading(ctx context.Context, buildID string) bool
 }
 
 type resolveResult struct {
@@ -55,9 +45,9 @@ type nopResolver struct{}
 func (nopResolver) resolve(context.Context, string) (attribute.KeyValue, resolveResult) {
 	return attrResolveNoPeer, resolveResult{}
 }
-func (nopResolver) IsUploading(context.Context, string) bool { return false }
-func (nopResolver) Purge(string)                             {}
-func (nopResolver) Close()                                   {}
+func (nopResolver) IsActive(string) bool { return false }
+func (nopResolver) Purge(string)         {}
+func (nopResolver) Close()               {}
 
 // peerResolver is the real implementation that looks up peers via the Registry.
 type peerResolver struct {
@@ -116,10 +106,13 @@ func (r *peerResolver) isSelfAddress(address string) bool {
 	return address == r.selfAddress
 }
 
-// uploadedFlag returns a shared atomic flag for the given build ID.
-// Once any reader sets the flag (via use_storage), all subsequent opens for
-// that build skip the peer.
-func (r *peerResolver) uploadedFlag(buildID string) *atomic.Bool {
+// peerFlag returns the shared atomic "switched-to-storage" flag for buildID,
+// creating it on first call. The presence of an entry in uploadedBuilds means
+// "this build is/was peer-served on this orch"; the flag's value tracks
+// whether a reader has observed the source switch to storage. Only resolve()
+// creates entries (in the peer-found branch) so absence is meaningful: no
+// peer ever existed for this build from this orch's perspective.
+func (r *peerResolver) peerFlag(buildID string) *atomic.Bool {
 	if v, ok := r.uploadedBuilds.Load(buildID); ok {
 		return v.(*atomic.Bool)
 	}
@@ -140,8 +133,9 @@ func (r *peerResolver) Purge(buildID string) {
 // a remote peer is found. Returns a nil client when the base provider should
 // be used instead (uploaded, no peer, self, or error).
 func (r *peerResolver) resolve(ctx context.Context, buildID string) (attribute.KeyValue, resolveResult) {
-	uploaded := r.uploadedFlag(buildID)
-	if uploaded.Load() {
+	// Fast path: a prior resolve flagged this build as peer-served and a
+	// reader has since observed the switch to storage.
+	if v, ok := r.uploadedBuilds.Load(buildID); ok && v.(*atomic.Bool).Load() {
 		return attrResolveUploaded, resolveResult{}
 	}
 
@@ -163,6 +157,13 @@ func (r *peerResolver) resolve(ctx context.Context, buildID string) (attribute.K
 		return attrResolveDialError, resolveResult{}
 	}
 
+	// Peer found and dialable — register the flag now so IsActive and
+	// future resolves can answer locally without touching Redis.
+	uploaded := r.peerFlag(buildID)
+	if uploaded.Load() {
+		return attrResolveUploaded, resolveResult{}
+	}
+
 	return attrResolvePeer, resolveResult{
 		client:   orchestrator.NewChunkServiceClient(conn),
 		uploaded: uploaded,
@@ -170,10 +171,16 @@ func (r *peerResolver) resolve(ctx context.Context, buildID string) (attribute.K
 	}
 }
 
-func (r *peerResolver) IsUploading(ctx context.Context, buildID string) bool {
-	status, _ := r.resolve(ctx, buildID)
+// IsActive reports whether a peer is currently serving this build's
+// chunks on this orch — i.e., resolve() found a peer and no reader has yet
+// observed the switch to storage. Pure local read; no Redis, no dial.
+//
+// Absence of an entry means no peer was ever seen for this build, which
+// implies the build is durable in storage.
+func (r *peerResolver) IsActive(buildID string) bool {
+	v, ok := r.uploadedBuilds.Load(buildID)
 
-	return status == attrResolvePeer
+	return ok && !v.(*atomic.Bool).Load()
 }
 
 func (r *peerResolver) Close() {

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -16,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template/peerclient"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
@@ -57,18 +58,19 @@ type templateLookup interface {
 type Uploads struct {
 	tc          templateLookup
 	persistence storage.StorageProvider
+	p2p         peerclient.UploadChecker
 	redis       redis.UniversalClient
 
 	futures *ttlcache.Cache[uuid.UUID, *utils.ErrorOnce]
 }
 
-func NewUploads(tc *template.Cache, persistence storage.StorageProvider, redisClient redis.UniversalClient) *Uploads {
+func NewUploads(tc *template.Cache, persistence storage.StorageProvider, p2p peerclient.UploadChecker, redisClient redis.UniversalClient) *Uploads {
 	futures := ttlcache.New(
 		ttlcache.WithTTL[uuid.UUID, *utils.ErrorOnce](futureTTL),
 	)
 	go futures.Start()
 
-	return &Uploads{tc: tc, persistence: persistence, redis: redisClient, futures: futures}
+	return &Uploads{tc: tc, persistence: persistence, p2p: p2p, redis: redisClient, futures: futures}
 }
 
 func (u *Uploads) Stop() {
@@ -93,7 +95,7 @@ func (u *Uploads) Start(buildID uuid.UUID) (*utils.ErrorOnce, error) {
 	return fut, nil
 }
 
-// Wait returns the parent's post-upload V4 header. Same-orch waits on the local
+// Wait returns the parent's post-upload header. Same-orch waits on the local
 // future; cross-orch refreshes from remote storage when the locally-cached
 // header is stale, optionally accelerated by a per-call Redis subscription.
 func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType) (*header.Header, error) {
@@ -103,37 +105,50 @@ func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType)
 	))
 	defer span.End()
 
+	d, err := u.find(ctx, buildID, t)
+	if err != nil && !errors.Is(err, ErrBuildNotInCache) {
+		return nil, err
+	}
+
+	// Already durable: SwapHeader has cleared the in-flight bit on the local
+	// device. The transition is monotonic (cleared → never set again), so we
+	// can return without waiting on anything.
+	if d != nil {
+		if h := d.Header(); !h.IncompletePendingUpload {
+			return h, nil
+		}
+	}
+
+	// Pending. Local upload in flight? Wait on its future and return the
+	// freshly-swapped header. Future fires after publish runs SwapHeader, so
+	// d.Header() reflects the finalized state on success. On upload error,
+	// WaitWithContext returns the error and we bubble it up.
 	if item := u.futures.Get(buildID); item != nil {
 		if err := item.Value().WaitWithContext(ctx); err != nil {
 			return nil, fmt.Errorf("wait for upload %s: %w", buildID, err)
 		}
+
+		return d.Header(), nil
 	}
 
-	d, err := u.find(ctx, buildID, t)
-	if errors.Is(err, ErrBuildNotInCache) {
-		// Ancestor never resumed locally (typical for grand-grandparents
-		// reached via mappings). It's necessarily finalized — load directly
-		// from remote storage without an in-memory device or future to track.
-		hdrPath := storage.Paths{BuildID: buildID.String()}.HeaderFile(string(t))
-
-		return header.LoadHeader(ctx, u.persistence, hdrPath)
+	// No local future. Either a P2P-served device whose source is still
+	// uploading on a peer, or an ancestor never added to the template cache.
+	// Return nil to inherit from srcHeader.Builds.
+	if d == nil && !u.p2p.IsUploading(ctx, buildID.String()) {
+		return nil, nil
 	}
+
+	// P2P pending: subscribe + poll until the source orchestrator finalizes
+	// the upload. SwapHeader on the local device (when we have one) so future
+	// readers hit the durable early-out.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	h, err := build.PollRemoteStorageForHeader(ctx, u.persistence, buildID, t, u.subscribe(ctx, buildID), refreshHeaderBudget)
 	if err != nil {
 		return nil, err
 	}
-
-	h := d.Header()
-	if h.IncompletePendingUpload {
-		// The only way we can still have an incomplete header at this point is
-		// the P2P path. We already waited on the local upload future and it did
-		// not finalize the header.
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		h, err = build.PollRemoteStorageForHeader(ctx, u.persistence, buildID, t, u.subscribe(ctx, buildID), refreshHeaderBudget)
-		if err != nil {
-			return nil, err
-		}
+	if d != nil {
 		d.SwapHeader(h)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -105,20 +105,15 @@ func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType)
 	))
 	defer span.End()
 
+	if item := u.futures.Get(buildID); item != nil {
+		if err := item.Value().WaitWithContext(ctx); err != nil {
+			return nil, fmt.Errorf("wait for upload %s: %w", buildID, err)
+		}
+	}
+
 	d, err := u.find(ctx, buildID, t)
 	if err != nil && !errors.Is(err, ErrBuildNotInCache) {
 		return nil, err
-	}
-
-	if item := u.futures.Get(buildID); item != nil {
-		if waitErr := item.Value().WaitWithContext(ctx); waitErr != nil {
-			return nil, fmt.Errorf("wait for upload %s: %w", buildID, waitErr)
-		}
-		if d == nil {
-			return nil, nil
-		}
-
-		return d.Header(), nil
 	}
 
 	if d != nil && !d.Header().IncompletePendingUpload {

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -105,15 +105,20 @@ func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType)
 	))
 	defer span.End()
 
+	d, err := u.find(ctx, buildID, t)
+	if err != nil && !errors.Is(err, ErrBuildNotInCache) {
+		return nil, err
+	}
+
 	if item := u.futures.Get(buildID); item != nil {
 		if err := item.Value().WaitWithContext(ctx); err != nil {
 			return nil, fmt.Errorf("wait for upload %s: %w", buildID, err)
 		}
-	}
+		if d == nil {
+			return nil, fmt.Errorf("future fired but build %s not in template cache", buildID)
+		}
 
-	d, err := u.find(ctx, buildID, t)
-	if err != nil && !errors.Is(err, ErrBuildNotInCache) {
-		return nil, err
+		return d.Header(), nil
 	}
 
 	if d != nil && !d.Header().IncompletePendingUpload {

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -58,13 +58,13 @@ type templateLookup interface {
 type Uploads struct {
 	tc          templateLookup
 	persistence storage.StorageProvider
-	p2p         peerclient.UploadChecker
+	p2p         peerclient.Resolver
 	redis       redis.UniversalClient
 
 	futures *ttlcache.Cache[uuid.UUID, *utils.ErrorOnce]
 }
 
-func NewUploads(tc *template.Cache, persistence storage.StorageProvider, p2p peerclient.UploadChecker, redisClient redis.UniversalClient) *Uploads {
+func NewUploads(tc *template.Cache, persistence storage.StorageProvider, p2p peerclient.Resolver, redisClient redis.UniversalClient) *Uploads {
 	futures := ttlcache.New(
 		ttlcache.WithTTL[uuid.UUID, *utils.ErrorOnce](futureTTL),
 	)
@@ -95,9 +95,9 @@ func (u *Uploads) Start(buildID uuid.UUID) (*utils.ErrorOnce, error) {
 	return fut, nil
 }
 
-// Wait returns the parent's post-upload header. Same-orch waits on the local
-// future; cross-orch refreshes from remote storage when the locally-cached
-// header is stale, optionally accelerated by a per-call Redis subscription.
+// Wait returns the parent's post-upload header, or (nil, nil) when the
+// ancestor was never opened locally and no peer is mid-upload — the caller
+// already carries its BuildData through srcHeader.Builds.
 func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType) (*header.Header, error) {
 	ctx, span := tracer.Start(ctx, "wait-for-parent-upload", trace.WithAttributes(
 		telemetry.WithBuildID(buildID.String()),
@@ -110,37 +110,26 @@ func (u *Uploads) Wait(ctx context.Context, buildID uuid.UUID, t build.DiffType)
 		return nil, err
 	}
 
-	// Already durable: SwapHeader has cleared the in-flight bit on the local
-	// device. The transition is monotonic (cleared → never set again), so we
-	// can return without waiting on anything.
-	if d != nil {
-		if h := d.Header(); !h.IncompletePendingUpload {
-			return h, nil
-		}
-	}
-
-	// Pending. Local upload in flight? Wait on its future and return the
-	// freshly-swapped header. Future fires after publish runs SwapHeader, so
-	// d.Header() reflects the finalized state on success. On upload error,
-	// WaitWithContext returns the error and we bubble it up.
 	if item := u.futures.Get(buildID); item != nil {
-		if err := item.Value().WaitWithContext(ctx); err != nil {
-			return nil, fmt.Errorf("wait for upload %s: %w", buildID, err)
+		if waitErr := item.Value().WaitWithContext(ctx); waitErr != nil {
+			return nil, fmt.Errorf("wait for upload %s: %w", buildID, waitErr)
+		}
+		if d == nil {
+			return nil, nil
 		}
 
 		return d.Header(), nil
 	}
 
-	// No local future. Either a P2P-served device whose source is still
-	// uploading on a peer, or an ancestor never added to the template cache.
-	// Return nil to inherit from srcHeader.Builds.
-	if d == nil && !u.p2p.IsUploading(ctx, buildID.String()) {
+	if d != nil && !d.Header().IncompletePendingUpload {
+		return d.Header(), nil
+	}
+
+	if d == nil && !u.p2p.IsActive(buildID.String()) {
 		return nil, nil
 	}
 
-	// P2P pending: subscribe + poll until the source orchestrator finalizes
-	// the upload. SwapHeader on the local device (when we have one) so future
-	// readers hit the durable early-out.
+	// P2P mid-upload. Poll remote storage, then swap onto the local device.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/packages/orchestrator/pkg/sandbox/uploads_test.go
+++ b/packages/orchestrator/pkg/sandbox/uploads_test.go
@@ -60,13 +60,14 @@ func newUploads(t *testing.T) (*Uploads, *fakeCache) {
 	}, cache
 }
 
-func putFinalHeader(t *testing.T, cache *fakeCache, buildID uuid.UUID, fileType build.DiffType) {
+func putHeader(t *testing.T, cache *fakeCache, buildID uuid.UUID, fileType build.DiffType, pending bool) {
 	t.Helper()
 	tpl := templatemocks.NewMockTemplate(t)
 	dev := blockmocks.NewMockReadonlyDevice(t)
 	dev.EXPECT().Header().Return(&headers.Header{
-		Metadata: &headers.Metadata{Version: headers.MetadataVersionV4},
-		Builds:   map[uuid.UUID]headers.BuildData{buildID: {}}, // self-entry → not stale
+		Metadata:                &headers.Metadata{Version: headers.MetadataVersionV4},
+		Builds:                  map[uuid.UUID]headers.BuildData{buildID: {}}, // self-entry → not stale
+		IncompletePendingUpload: pending,
 	}).Maybe()
 
 	switch fileType {
@@ -77,6 +78,11 @@ func putFinalHeader(t *testing.T, cache *fakeCache, buildID uuid.UUID, fileType 
 	}
 
 	cache.put(buildID.String(), tpl)
+}
+
+func putPendingHeader(t *testing.T, cache *fakeCache, buildID uuid.UUID, fileType build.DiffType) {
+	t.Helper()
+	putHeader(t, cache, buildID, fileType, true)
 }
 
 func TestUploads_BeginDistinctIDsAreIndependent(t *testing.T) {
@@ -106,7 +112,9 @@ func TestUploads_Wait_BlocksUntilSet(t *testing.T) {
 	c, cache := newUploads(t)
 
 	id := uuid.New()
-	putFinalHeader(t, cache, id, build.Memfile)
+	// Pending header → Wait reaches the future-wait branch instead of
+	// short-circuiting on the cleared bit.
+	putPendingHeader(t, cache, id, build.Memfile)
 	fut, err := c.Start(id)
 	require.NoError(t, err)
 
@@ -136,7 +144,7 @@ func TestUploads_Wait_PropagatesUploadError(t *testing.T) {
 	c, cache := newUploads(t)
 
 	id := uuid.New()
-	putFinalHeader(t, cache, id, build.Memfile)
+	putPendingHeader(t, cache, id, build.Memfile)
 	fut, err := c.Start(id)
 	require.NoError(t, err)
 
@@ -204,7 +212,7 @@ func TestUploads_ConcurrentBeginsAndWaits(t *testing.T) {
 	futs := make([]*utils.ErrorOnce, n)
 	for i := range n {
 		ids[i] = uuid.New()
-		putFinalHeader(t, cache, ids[i], build.Memfile)
+		putPendingHeader(t, cache, ids[i], build.Memfile)
 		fut, err := c.Start(ids[i])
 		require.NoError(t, err)
 		futs[i] = fut


### PR DESCRIPTION
Two fixes that drop orchestrator GCS header traffic on staging from
  ~2700 reads per pause/resume + layered-build trio down to 2.

  ### 1. `fix(build): one-shot LoadHeader on peer transition`

  `File.retryOnTransition` polled `PollRemoteStorageForHeader` with a
  30s budget. The transition is signaled only after the source upload
  finalized, so the header is already in storage — one `LoadHeader`
  suffices. Polling under high peer-transition rates (staging traffic
  sim) inflated GCS reads via backoff retries.

  ### 2. `fix(orch): stop O(ancestors×uploads) GCS header storm in Wait`

  Every pause / template build called `collectAncestorBuilds` → `Wait`
  per ancestor. `Wait` fell through to `LoadHeader` whenever the
  ancestor wasn't in the local templateCache (typical for
  grand-grandparents reached only via mappings). V3 discarded the
  result entirely (sync gate); V4 kept only `BuildData` it already had
  on `srcHeader.Builds`.

  `Wait` now returns immediately when the device's
  `IncompletePendingUpload` bit is clear, waits on the local future
  when one exists, and only polls remote storage when the new
  `peerclient.UploadChecker` confirms a peer is mid-upload.