### PR TITLE
fix: allow header-based routing when Host is an IP address

### DIFF
--- a/packages/shared/pkg/proxy/host.go
+++ b/packages/shared/pkg/proxy/host.go
@@ -56,7 +56,9 @@ func isLocalRequestHost(host string) bool {
 	host = requestHostname(host)
 	ip := net.ParseIP(host)
 
-	return host == "localhost" || (ip != nil && ip.IsLoopback())
+	// An IP address cannot encode sandbox routing info (like {port}-{sandboxId}.{domain}),
+	// so header-based routing is the only mechanism that can work for IP hosts.
+	return host == "localhost" || ip != nil
 }
 
 func SandboxSharedHostDomain(host string) (string, bool) {

--- a/packages/shared/pkg/proxy/host_test.go
+++ b/packages/shared/pkg/proxy/host_test.go
@@ -173,6 +173,36 @@ func TestGetTargetFromRequest(t *testing.T) {
 			wantPort: 49983,
 		},
 		{
+			name: "headers: private IPv4 (bridge/LAN)",
+			host: "192.168.100.66:3002",
+			headers: http.Header{
+				headerSandboxID:   []string{"isv6ril5xadwn1k9t2jye"},
+				headerSandboxPort: []string{"49983"},
+			},
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+		},
+		{
+			name: "headers: private IPv4 (10.x network)",
+			host: "10.0.0.5:3002",
+			headers: http.Header{
+				headerSandboxID:   []string{"isv6ril5xadwn1k9t2jye"},
+				headerSandboxPort: []string{"49983"},
+			},
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+		},
+		{
+			name: "headers: public IPv4",
+			host: "34.120.5.10:3002",
+			headers: http.Header{
+				headerSandboxID:   []string{"isv6ril5xadwn1k9t2jye"},
+				headerSandboxPort: []string{"49983"},
+			},
+			wantID:   "isv6ril5xadwn1k9t2jye",
+			wantPort: 49983,
+		},
+		{
 			name: "headers: ignored on regular sandbox host",
 			host: "49983-isv6ril5xadwn1k9t2jye.e2b.app",
 			headers: http.Header{


### PR DESCRIPTION
## Summary

Fixes a regression from #2540 that broke SDK connectivity for any IP-based access to the client-proxy (bridge networks, LAN, on-prem deployments, e2b-local).

- `isLocalRequestHost()` only accepted `localhost` and loopback IPs (`127.0.0.1`, `::1`)
- When the SDK connects via an IP like `192.168.100.66:3002`, routing headers (`E2b-Sandbox-Id`, `E2b-Sandbox-Port`) were silently ignored
- `parseHost()` then tried to extract a sandbox ID from the IP address and failed with `ErrInvalidHost` → HTTP 400

**The fix:** widen `isLocalRequestHost()` from `ip.IsLoopback()` to `ip != nil`.

This is safe because the `shouldParseHeaders` guard exists to prevent header spoofing on per-sandbox hostnames like `49983-sbx.e2b.app`, where the hostname is authoritative. An IP address can never contain sandbox routing info — `parseHost()` will always fail on it — so there is nothing for headers to conflict with. Headers are the only routing mechanism that can work for IP hosts.

The per-sandbox hostname guard is unaffected: headers are still ignored when `r.Host` is a domain like `49983-sbx.e2b.app`.

## How it was found

e2b-local nightly build on `2026-05-05` failed the sandbox smoke test. The build itself succeeded, but `sandbox.commands.run()` returned `HTTP 400` because the client-proxy rejected the bridge network host `192.168.100.66:3002`:

```
WARN  invalid host  {"host": "192.168.100.66:3002"}  handler.go:30
```

The previous night's build (using commit `92ea305dd`, before #2540) passed. Today's build (using `ae68b805a`, after #2540) failed.

## Test plan

- [x] All existing `TestGetTargetFromRequest` tests pass
- [x] Added test cases for private IPv4, 10.x network, and public IPv4 hosts
- [ ] Verify e2b-local nightly build passes with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)