### PR TITLE
fix(test): TestSandboxMemoryIntegrity move apt-get to template

### DIFF
--- a/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
+++ b/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
@@ -20,18 +20,29 @@ func TestSandboxMemoryIntegrity(t *testing.T) {
 
 	c := setup.GetAPIClient()
 
+	// Build a template with stress-ng and time pre-installed so subtests
+	// skip the page-fault-heavy apt-get phase that saturates decompression
+	// under parallel load.
+	tmpl := utils.BuildTemplate(t, utils.TemplateBuildOptions{
+		Name: "memory-integrity-deps",
+		BuildData: api.TemplateBuildStartV2{
+			FromTemplate: &setup.SandboxTemplateID,
+			Steps: &[]api.TemplateStep{{
+				Type: "RUN",
+				Args: &[]string{"apt-get update && apt-get install -y stress-ng time", "root"},
+			}},
+		},
+		ReqEditors: []api.RequestEditorFn{setup.WithAPIKey()},
+	})
+
 	t.Run("tmpfs hash", func(t *testing.T) {
 		t.Parallel()
 
 		// Create a sandbox with auto-pause disabled
-		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(false))
+		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(false), utils.WithTemplateID(tmpl.TemplateID))
 		sbxId := sbx.SandboxID
 
 		envdClient := setup.GetEnvdClient(t, t.Context())
-
-		installCmd := `apt-get update && apt-get install -y time`
-		err := utils.ExecCommandAsRoot(t, t.Context(), sbx, envdClient, "bash", "-c", installCmd)
-		require.NoError(t, err)
 
 		tmpfsFile := "/mnt/testfile"
 
@@ -56,7 +67,7 @@ USED_MEM_MB_AFTER=$(free -m | awk '/^Mem:/ {print $3}')
 echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 `, percentageOfFreeMemoryToUse, percentageOfFreeMemoryToUse, percentageOfFreeMemoryToUse, tmpfsFile)
 
-		_, err = utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", memCmd)
+		_, err := utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", memCmd)
 		require.NoError(t, err)
 
 		hashCmd := fmt.Sprintf(`sha256sum "%s" | awk '{print $1}'`, tmpfsFile)
@@ -133,13 +144,9 @@ echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 		t.Parallel()
 
 		// Create a sandbox with auto-pause disabled
-		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(false))
+		sbx := utils.SetupSandboxWithCleanup(t, c, utils.WithAutoPause(false), utils.WithTemplateID(tmpl.TemplateID))
 
 		envdClient := setup.GetEnvdClient(t, t.Context())
-
-		installCmd := `apt-get update && apt-get install -y stress-ng time`
-		err := utils.ExecCommandAsRoot(t, t.Context(), sbx, envdClient, "bash", "-c", installCmd)
-		require.NoError(t, err)
 
 		// get 80% size of the free memory and use it as the vm-bytes
 		percentageOfFreeMemoryToUse := 80


### PR DESCRIPTION
This test was flaky, especially with compression used.

Moved `apt-get install` into a shared template for the 3 tests to lighten up each individual sandbox fetches