### PR TITLE
feat(api): emit firecracker_version + kernel_version on created_instance posthog event

### DIFF
--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -87,6 +87,8 @@ func (o *Orchestrator) emitCreatedInstancePosthog(ctx context.Context, sbx sandb
 		Set("resume", meta.IsResume).
 		Set("build_id", sbx.BuildID).
 		Set("envd_version", sbx.EnvdVersion).
+		Set("firecracker_version", sbx.FirecrackerVersion).
+		Set("kernel_version", sbx.KernelVersion).
 		Set("node_id", sbx.NodeID).
 		Set("vcpu", sbx.VCpu).
 		Set("ram_mb", sbx.RamMB).


### PR DESCRIPTION
## Summary

Adds two properties to the `created_instance` PostHog event in `packages/api/internal/orchestrator/analytics.go`:

- `firecracker_version` — `sbx.FirecrackerVersion`
- `kernel_version` — `sbx.KernelVersion`

Both fields already exist on `sandbox.Sandbox` (set from the build at sandbox start), so no upstream changes needed.
