### PR TITLE
fix(envd): fix process cleanup in cgroup test to prevent OOM and data race

### DIFF
--- a/packages/envd/internal/services/cgroups/cgroup2_test.go
+++ b/packages/envd/internal/services/cgroups/cgroup2_test.go
@@ -157,7 +157,7 @@ func createCgroupPath(t *testing.T, s string) string {
 func startProcess(t *testing.T, m *Cgroup2Manager, pt ProcessType) *exec.Cmd {
 	t.Helper()
 
-	cmdName, args := "bash", []string{"-c", `sleep 1 && exec tail /dev/zero`}
+	cmdName, args := "bash", []string{"-c", `sleep 1 && exec perl -e 'my $x = "A" x (512*1024*1024); sleep 300'`}
 	cmd := exec.CommandContext(t.Context(), cmdName, args...)
 
 	fd, ok := m.GetFileDescriptor(pt)

--- a/packages/envd/internal/services/cgroups/cgroup2_test.go
+++ b/packages/envd/internal/services/cgroups/cgroup2_test.go
@@ -157,19 +157,32 @@ func createCgroupPath(t *testing.T, s string) string {
 func startProcess(t *testing.T, m *Cgroup2Manager, pt ProcessType) *exec.Cmd {
 	t.Helper()
 
-	cmdName, args := "bash", []string{"-c", `sleep 1 && tail /dev/zero`}
+	cmdName, args := "bash", []string{"-c", `sleep 1 && exec tail /dev/zero`}
 	cmd := exec.CommandContext(t.Context(), cmdName, args...)
 
 	fd, ok := m.GetFileDescriptor(pt)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		UseCgroupFD: ok,
 		CgroupFD:    fd,
+		Setpgid:     true,
 	}
 
 	err := cmd.Start()
 	require.NoError(t, err)
 
+	t.Cleanup(func() { killProcessGroup(cmd) })
+
 	return cmd
+}
+
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		_ = cmd.Process.Kill()
+	}
 }
 
 func waitForProcess(t *testing.T, cmd *exec.Cmd, timeout time.Duration) error {
@@ -183,10 +196,13 @@ func waitForProcess(t *testing.T, cmd *exec.Cmd, timeout time.Duration) error {
 	}()
 
 	ctx, cancel := context.WithTimeout(t.Context(), timeout)
-	t.Cleanup(cancel)
+	defer cancel()
 
 	select {
 	case <-ctx.Done():
+		killProcessGroup(cmd)
+		<-done
+
 		return ctx.Err()
 	case err := <-done:
 		return err


### PR DESCRIPTION
The cgroup round-trip test spawns `tail /dev/zero` under a memory-limited cgroup to verify the OOM kill. Three problems caused host OOM and flaky failures when running with `-count` or `-race`:

Killing only bash left `tail` running as an orphan that ate unbounded memory. The fix starts the child in its own process group (`Setpgid`) and kills the entire group on timeout and in `t.Cleanup`. The command now uses `exec` so bash replaces itself with the child process.

Both `waitForProcess` and `t.Cleanup` called `cmd.Wait()`, causing a data race. Now `t.Cleanup` only kills, and `waitForProcess` owns the wait — it drains the goroutine after killing on timeout so there's no leak or race.

The second commit replaces `tail /dev/zero` with a perl one-liner that allocates a fixed 512 MiB and sleeps. If the process escapes cleanup it holds bounded memory rather than growing until the kernel intervenes.