### PR TITLE
fix(local-dev): rename API_GRPC_ADDRESS to API_INTERNAL_GRPC_ADDRESS in local dev env

### DIFF
--- a/packages/client-proxy/.env.local
+++ b/packages/client-proxy/.env.local
@@ -1,4 +1,4 @@
-API_GRPC_ADDRESS=localhost:5009
+API_INTERNAL_GRPC_ADDRESS=localhost:5009
 EDGE_SECRET=--edge-secret--
 EDGE_URL=http://localhost:3000
 ENVIRONMENT=local


### PR DESCRIPTION
The env var was added as API_GRPC_ADDRESS in PR #2523 but the config struct was renamed to expect API_INTERNAL_GRPC_ADDRESS in PR #2470.

Fixes: 26923dfdea5d ("chore(client-proxy): set API_GRPC_ADDRESS in dev env (#2523)")

---

Original PR #2523 was opened before #2470 landed. Unfortunately, I didn't notice it.