### PR TITLE
feat(featureflags): add build-kernel-version flag for new builds

### DIFF
--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/caarlos0/env/v11"
 	"github.com/golang-jwt/jwt/v5"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
 const (
@@ -66,9 +64,6 @@ type Config struct {
 	// More secrets are possible in the case of JWT secret rotation where we need to accept
 	// tokens signed with the old secret for some time.
 	SupabaseJWTSecrets []string `env:"SUPABASE_JWT_SECRETS"`
-
-	// Deprecated: Template manager should use its own
-	DefaultKernelVersion string `env:"DEFAULT_KERNEL_VERSION"`
 
 	DefaultPersistentVolumeType string `env:"DEFAULT_PERSISTENT_VOLUME_TYPE"`
 
@@ -136,10 +131,6 @@ func Parse() (Config, error) {
 	})
 	if err != nil {
 		return Config{}, err
-	}
-
-	if config.DefaultKernelVersion == "" {
-		config.DefaultKernelVersion = featureflags.DefaultKernelVersion
 	}
 
 	if config.AuthDBConnectionString == "" {

--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -164,7 +164,7 @@ func (a *APIStore) buildTemplate(
 	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
 	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
-	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, a.featureFlags)
+	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 
 	var alias *string
 	var tags []string

--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -164,7 +164,7 @@ func (a *APIStore) buildTemplate(
 	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
 	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
-	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
+	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, a.featureFlags)
 
 	var alias *string
 	var tags []string

--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -160,10 +160,11 @@ func (a *APIStore) buildTemplate(
 	templateID api.TemplateID,
 	body api.TemplateBuildRequest,
 ) (*template.RegisterBuildResponse, *api.APIError) {
-	// TODO(ENG-3852): Stop sending the firecracker version from the API. The orchestrator
-	// now resolves its own FC version via the FirecrackerVersions feature flag
-	// (see packages/orchestrator/pkg/template/build/builder.go)
+	// TODO(ENG-3852): Stop sending the firecracker/kernel versions from the API.
+	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
+	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
+	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 
 	var alias *string
 	var tags []string
@@ -206,7 +207,7 @@ func (a *APIStore) buildTemplate(
 		CpuCount:           body.CpuCount,
 		MemoryMB:           body.MemoryMB,
 		Version:            templates.TemplateV1Version,
-		KernelVersion:      a.config.DefaultKernelVersion,
+		KernelVersion:      kernelVersion,
 		FirecrackerVersion: firecrackerVersion,
 	}
 

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -119,7 +119,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
 	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
-	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
+	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, a.featureFlags)
 	buildReq := template.RegisterBuildData{
 		ClusterID:          clusters.WithClusterFallback(team.ClusterID),
 		TemplateID:         templateID,

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -119,7 +119,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
 	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
-	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, a.featureFlags)
+	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 	buildReq := template.RegisterBuildData{
 		ClusterID:          clusters.WithClusterFallback(team.ClusterID),
 		TemplateID:         templateID,

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -115,10 +115,11 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	}
 	span.End()
 
-	// TODO(ENG-3852): Stop sending the firecracker version from the API. The orchestrator
-	// now resolves its own FC version via the FirecrackerVersions feature flag
-	// (see packages/orchestrator/pkg/template/build/builder.go)
+	// TODO(ENG-3852): Stop sending the firecracker/kernel versions from the API.
+	// The orchestrator resolves them itself via the BuildFirecrackerVersion /
+	// BuildKernelVersion feature flags (see packages/orchestrator/pkg/template/server/create_template.go).
 	firecrackerVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
+	kernelVersion := a.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 	buildReq := template.RegisterBuildData{
 		ClusterID:          clusters.WithClusterFallback(team.ClusterID),
 		TemplateID:         templateID,
@@ -129,7 +130,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 		CpuCount:           body.CpuCount,
 		MemoryMB:           body.MemoryMB,
 		Version:            templates.TemplateV2LatestVersion,
-		KernelVersion:      a.config.DefaultKernelVersion,
+		KernelVersion:      kernelVersion,
 		FirecrackerVersion: firecrackerVersion,
 	}
 

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -57,7 +57,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 		featureflags.TeamContext(cfg.GetTeamID()),
 	)
 
-	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, s.featureFlags)
+	kernelVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 	firecrackerVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
 
 	fcInfo, err := fcversion.New(firecrackerVersion)

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -57,7 +57,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 		featureflags.TeamContext(cfg.GetTeamID()),
 	)
 
-	kernelVersion := featureflags.DefaultKernelVersion
+	kernelVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
 	firecrackerVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
 
 	fcInfo, err := fcversion.New(firecrackerVersion)

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -57,7 +57,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 		featureflags.TeamContext(cfg.GetTeamID()),
 	)
 
-	kernelVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildKernelVersion)
+	kernelVersion := featureflags.ResolveBuildKernelVersion(ctx, s.featureFlags)
 	firecrackerVersion := s.featureFlags.StringFlag(ctx, featureflags.BuildFirecrackerVersion)
 
 	fcInfo, err := fcversion.New(firecrackerVersion)

--- a/packages/shared/pkg/featureflags/client.go
+++ b/packages/shared/pkg/featureflags/client.go
@@ -110,7 +110,12 @@ func (c *Client) IntFlag(ctx context.Context, flag IntFlag, contexts ...ldcontex
 }
 
 func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ldcontext.Context) string {
-	return getFlag(ctx, c.ld, c.ld.StringVariationCtx, flag, c.allContexts(contexts))
+	v := getFlag(ctx, c.ld, c.ld.StringVariationCtx, flag, c.allContexts(contexts))
+	if v == "" && flag.FallbackWhenEmpty() {
+		return flag.Fallback()
+	}
+
+	return v
 }
 
 type typedFlag[T any] interface {

--- a/packages/shared/pkg/featureflags/client.go
+++ b/packages/shared/pkg/featureflags/client.go
@@ -110,12 +110,7 @@ func (c *Client) IntFlag(ctx context.Context, flag IntFlag, contexts ...ldcontex
 }
 
 func (c *Client) StringFlag(ctx context.Context, flag StringFlag, contexts ...ldcontext.Context) string {
-	v := getFlag(ctx, c.ld, c.ld.StringVariationCtx, flag, c.allContexts(contexts))
-	if v == "" && flag.FallbackWhenEmpty() {
-		return flag.Fallback()
-	}
-
-	return v
+	return getFlag(ctx, c.ld, c.ld.StringVariationCtx, flag, c.allContexts(contexts))
 }
 
 type typedFlag[T any] interface {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -267,6 +267,18 @@ var (
 	FirecrackerVersions         = NewJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 )
 
+// ResolveBuildKernelVersion returns the kernel version for new template builds.
+// Falls back to DefaultKernelVersion when the LD flag is empty so that defining
+// the flag in LD without a value does not produce a "" kernel version downstream.
+func ResolveBuildKernelVersion(ctx context.Context, ff *Client) string {
+	v := ff.StringFlag(ctx, BuildKernelVersion)
+	if v == "" {
+		return DefaultKernelVersion
+	}
+
+	return v
+}
+
 // ResolveFirecrackerVersion resolves the firecracker version using the FirecrackerVersions feature flag.
 // The buildVersion format is "v1.12.1_210cbac" — we extract "v1.12" as the lookup key.
 func ResolveFirecrackerVersion(ctx context.Context, ff *Client, buildVersion string) string {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -214,8 +214,9 @@ var (
 )
 
 type StringFlag struct {
-	name     string
-	fallback string
+	name              string
+	fallback          string
+	fallbackWhenEmpty bool
 }
 
 func (f StringFlag) Key() string {
@@ -230,10 +231,25 @@ func (f StringFlag) Fallback() string {
 	return f.fallback
 }
 
+// FallbackWhenEmpty reports whether the fallback should also be used when LD
+// returns an empty string (e.g. flag defined in LD without a value).
+func (f StringFlag) FallbackWhenEmpty() bool {
+	return f.fallbackWhenEmpty
+}
+
 func NewStringFlag(name string, fallback string) StringFlag {
 	flag := StringFlag{name: name, fallback: fallback}
 	builder := launchDarklyOfflineStore.Flag(flag.name).ValueForAll(ldvalue.String(fallback))
 	launchDarklyOfflineStore.Update(builder)
+
+	return flag
+}
+
+// NewStringFlagFallbackOnEmpty is like NewStringFlag but also returns the
+// fallback when LD evaluates the flag to an empty string.
+func NewStringFlagFallbackOnEmpty(name string, fallback string) StringFlag {
+	flag := NewStringFlag(name, fallback)
+	flag.fallbackWhenEmpty = true
 
 	return flag
 }
@@ -260,24 +276,12 @@ var FirecrackerVersionMap = map[string]string{
 // BuildIoEngine Sync is used by default as there seems to be a bad interaction between Async and a lot of io operations.
 var (
 	BuildFirecrackerVersion     = NewStringFlag("build-firecracker-version", env.GetEnv("DEFAULT_FIRECRACKER_VERSION", DefaultFirecrackerVersion))
-	BuildKernelVersion          = NewStringFlag("build-kernel-version", env.GetEnv("DEFAULT_KERNEL_VERSION", DefaultKernelVersion))
+	BuildKernelVersion          = NewStringFlagFallbackOnEmpty("build-kernel-version", env.GetEnv("DEFAULT_KERNEL_VERSION", DefaultKernelVersion))
 	BuildIoEngine               = NewStringFlag("build-io-engine", "Sync")
 	DefaultPersistentVolumeType = NewStringFlag("default-persistent-volume-type", "")
 	BuildNodeInfo               = NewJSONFlag("preferred-build-node", ldvalue.Null())
 	FirecrackerVersions         = NewJSONFlag("firecracker-versions", ldvalue.FromJSONMarshal(FirecrackerVersionMap))
 )
-
-// ResolveBuildKernelVersion returns the kernel version for new template builds.
-// Falls back to DefaultKernelVersion when the LD flag is empty so that defining
-// the flag in LD without a value does not produce a "" kernel version downstream.
-func ResolveBuildKernelVersion(ctx context.Context, ff *Client) string {
-	v := ff.StringFlag(ctx, BuildKernelVersion)
-	if v == "" {
-		return DefaultKernelVersion
-	}
-
-	return v
-}
 
 // ResolveFirecrackerVersion resolves the firecracker version using the FirecrackerVersions feature flag.
 // The buildVersion format is "v1.12.1_210cbac" — we extract "v1.12" as the lookup key.

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -214,9 +214,8 @@ var (
 )
 
 type StringFlag struct {
-	name              string
-	fallback          string
-	fallbackWhenEmpty bool
+	name     string
+	fallback string
 }
 
 func (f StringFlag) Key() string {
@@ -231,25 +230,10 @@ func (f StringFlag) Fallback() string {
 	return f.fallback
 }
 
-// FallbackWhenEmpty reports whether the fallback should also be used when LD
-// returns an empty string (e.g. flag defined in LD without a value).
-func (f StringFlag) FallbackWhenEmpty() bool {
-	return f.fallbackWhenEmpty
-}
-
 func NewStringFlag(name string, fallback string) StringFlag {
 	flag := StringFlag{name: name, fallback: fallback}
 	builder := launchDarklyOfflineStore.Flag(flag.name).ValueForAll(ldvalue.String(fallback))
 	launchDarklyOfflineStore.Update(builder)
-
-	return flag
-}
-
-// NewStringFlagFallbackOnEmpty is like NewStringFlag but also returns the
-// fallback when LD evaluates the flag to an empty string.
-func NewStringFlagFallbackOnEmpty(name string, fallback string) StringFlag {
-	flag := NewStringFlag(name, fallback)
-	flag.fallbackWhenEmpty = true
 
 	return flag
 }
@@ -276,7 +260,7 @@ var FirecrackerVersionMap = map[string]string{
 // BuildIoEngine Sync is used by default as there seems to be a bad interaction between Async and a lot of io operations.
 var (
 	BuildFirecrackerVersion     = NewStringFlag("build-firecracker-version", env.GetEnv("DEFAULT_FIRECRACKER_VERSION", DefaultFirecrackerVersion))
-	BuildKernelVersion          = NewStringFlagFallbackOnEmpty("build-kernel-version", env.GetEnv("DEFAULT_KERNEL_VERSION", DefaultKernelVersion))
+	BuildKernelVersion          = NewStringFlag("build-kernel-version", env.GetEnv("DEFAULT_KERNEL_VERSION", DefaultKernelVersion))
 	BuildIoEngine               = NewStringFlag("build-io-engine", "Sync")
 	DefaultPersistentVolumeType = NewStringFlag("default-persistent-volume-type", "")
 	BuildNodeInfo               = NewJSONFlag("preferred-build-node", ldvalue.Null())

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -238,7 +238,6 @@ func NewStringFlag(name string, fallback string) StringFlag {
 	return flag
 }
 
-// This is currently not configurable via feature flags.
 const (
 	DefaultKernelVersion = "vmlinux-6.1.158"
 )
@@ -261,6 +260,7 @@ var FirecrackerVersionMap = map[string]string{
 // BuildIoEngine Sync is used by default as there seems to be a bad interaction between Async and a lot of io operations.
 var (
 	BuildFirecrackerVersion     = NewStringFlag("build-firecracker-version", env.GetEnv("DEFAULT_FIRECRACKER_VERSION", DefaultFirecrackerVersion))
+	BuildKernelVersion          = NewStringFlag("build-kernel-version", env.GetEnv("DEFAULT_KERNEL_VERSION", DefaultKernelVersion))
 	BuildIoEngine               = NewStringFlag("build-io-engine", "Sync")
 	DefaultPersistentVolumeType = NewStringFlag("default-persistent-volume-type", "")
 	BuildNodeInfo               = NewJSONFlag("preferred-build-node", ldvalue.Null())


### PR DESCRIPTION
Mirrors the existing `build-firecracker-version` flag with a new `build-kernel-version` flag so the kernel baked into NEW template builds can be rolled forward via LaunchDarkly without a code change. Existing snapshots/builds keep their pinned kernel version (`env_builds.kernel_version` is set at build time and not touched on resume).

Flag name matches what orbit (belt) already references (`LD_FLAG_BUILD_KERNEL_VERSION = 'build-kernel-version'`).

Default value falls back to `DEFAULT_KERNEL_VERSION` env var, then to the in-tree `DefaultKernelVersion` constant — same shape as the FC flag.