### PR TITLE
fix(volumes): broadcast volume directory creation to all cluster nodes

### DIFF
--- a/packages/api/internal/handlers/volume_create.go
+++ b/packages/api/internal/handlers/volume_create.go
@@ -181,7 +181,10 @@ func isValidVolumeName(name string) bool {
 }
 
 func (a *APIStore) createVolume(ctx context.Context, clusterID uuid.UUID, volume queries.Volume) error {
-	return a.executeOnOrchestratorByClusterID(ctx, clusterID, func(ctx context.Context, client *clusters.GRPCClient) error {
+	// Broadcast to all nodes so the volume directory exists on every orchestrator
+	// node. Sandbox placement is independent of volume creation and may schedule
+	// a sandbox on any node in the cluster.
+	return a.executeOnAllClusterNodes(ctx, clusterID, func(ctx context.Context, client *clusters.GRPCClient) error {
 		_, err := client.Volumes.CreateVolume(ctx, &orchestrator.CreateVolumeRequest{
 			Volume: toVolumeKey(volume),
 		})

--- a/packages/api/internal/handlers/volume_delete.go
+++ b/packages/api/internal/handlers/volume_delete.go
@@ -53,7 +53,8 @@ func (a *APIStore) DeleteVolumesVolumeID(c *gin.Context, volumeID api.VolumeID) 
 }
 
 func (a *APIStore) deleteVolume(ctx context.Context, clusterID uuid.UUID, volume queries.Volume) error {
-	return a.executeOnOrchestratorByClusterID(ctx, clusterID, func(ctx context.Context, client *clusters.GRPCClient) error {
+	// Broadcast to all nodes to clean up the volume directory everywhere it was created.
+	return a.executeOnAllClusterNodes(ctx, clusterID, func(ctx context.Context, client *clusters.GRPCClient) error {
 		_, err := client.Volumes.DeleteVolume(ctx, &orchestrator.DeleteVolumeRequest{
 			Volume: toVolumeKey(volume),
 		})

--- a/packages/api/internal/handlers/volume_util.go
+++ b/packages/api/internal/handlers/volume_util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/status"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
@@ -180,4 +181,44 @@ func isRetryableError(err error) bool {
 	}
 
 	return false
+}
+
+// executeOnAllClusterNodes calls fn concurrently on every ready node in the
+// cluster and returns a combined error if any node fails. This is used for
+// volume operations so that the volume directory exists on every orchestrator
+// node, regardless of which node a sandbox is later scheduled on.
+func (a *APIStore) executeOnAllClusterNodes(
+	ctx context.Context,
+	clusterID uuid.UUID,
+	fn func(context.Context, *clusters.GRPCClient) error,
+) error {
+	nodes := a.orchestrator.GetClusterNodes(clusterID)
+
+	if len(nodes) == 0 {
+		return ErrClusterNotFound
+	}
+
+	wg, wgCtx := errgroup.WithContext(ctx)
+
+	for _, node := range nodes {
+		if node.Status() != api.NodeStatusReady {
+			continue
+		}
+
+		wg.Go(func() error {
+			c, clientCtx := node.GetClient(wgCtx)
+
+			if err := fn(clientCtx, c); err != nil {
+				if volumeType, ok := isUnknownVolumeTypeError(err); ok {
+					return fmt.Errorf("%w: %s", ErrUnknownVolumeType, volumeType)
+				}
+
+				return fmt.Errorf("node %s: %w", node.ID, err)
+			}
+
+			return nil
+		})
+	}
+
+	return wg.Wait()
 }

--- a/packages/api/internal/handlers/volume_util.go
+++ b/packages/api/internal/handlers/volume_util.go
@@ -187,6 +187,10 @@ func isRetryableError(err error) bool {
 // cluster and returns a combined error if any node fails. This is used for
 // volume operations so that the volume directory exists on every orchestrator
 // node, regardless of which node a sandbox is later scheduled on.
+//
+// All goroutines always run to completion regardless of individual failures so
+// that partial state (e.g. a volume directory left on some nodes but not
+// others) is avoided.
 func (a *APIStore) executeOnAllClusterNodes(
 	ctx context.Context,
 	clusterID uuid.UUID,
@@ -198,15 +202,24 @@ func (a *APIStore) executeOnAllClusterNodes(
 		return ErrClusterNotFound
 	}
 
-	wg, wgCtx := errgroup.WithContext(ctx)
+	// Use a plain errgroup without context so that a failure on one node does
+	// not cancel in-flight or pending RPCs on other nodes.
+	var wg errgroup.Group
+
+	readyNodeCount := 0
 
 	for _, node := range nodes {
 		if node.Status() != api.NodeStatusReady {
 			continue
 		}
 
+		readyNodeCount++
+
 		wg.Go(func() error {
-			c, clientCtx := node.GetClient(wgCtx)
+			// Derive a per-call context from the original request context so
+			// that the caller's deadline/cancellation is still respected, but
+			// a failure on one node does not affect the others.
+			c, clientCtx := node.GetClient(ctx)
 
 			if err := fn(clientCtx, c); err != nil {
 				if volumeType, ok := isUnknownVolumeTypeError(err); ok {
@@ -218,6 +231,10 @@ func (a *APIStore) executeOnAllClusterNodes(
 
 			return nil
 		})
+	}
+
+	if readyNodeCount == 0 {
+		return ErrNoHealthyOrchestratorFound
 	}
 
 	return wg.Wait()

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -258,7 +258,7 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID *
 	if !a.isMountingNFS.CompareAndSwap(false, true) {
 		logger.Debug().Msg("NFS volumes already mounting")
 
-		return e
+		return fmt.Errorf("NFS mount already in progress")
 	}
 	defer a.isMountingNFS.Store(false)
 


### PR DESCRIPTION
## Problem

When a volume is created via POST /volumes, the directory is only
created on a single randomly-selected orchestrator node
(`executeOnOrchestratorByClusterID` uses rand.Shuffle and returns on
the first success). Sandbox placement (PlaceSandbox) is independent
and selects nodes based on CPU/RAM availability, with no awareness of
which node holds the volume directory.

This causes an intermittent failure: sandboxes that land on the same
node as the volume get a working NFS mount; sandboxes that land on any
other node fail to mount because the NFS proxy calls
syscall.Mount(path, path, MS_BIND) on a path that does not exist on
that node.

A second, related bug exists in `envd/internal/api/init.go`: when two
concurrent `/init` requests race on `isMountingNFS`, the second request
silently returns `nil`, causing the sandbox to start successfully with
no NFS mount.

## Changes

**volume_util.go**
- Add `executeOnAllClusterNodes`: fans out a gRPC call concurrently to
  every ready node in the cluster using errgroup, returning a combined
  error if any node fails.

**volume_create.go**
- `createVolume` now calls `executeOnAllClusterNodes` instead of
  `executeOnOrchestratorByClusterID`, so the volume directory is
  created on every orchestrator node at creation time.

**volume_delete.go**
- `deleteVolume` likewise broadcasts to all nodes to clean up the
  directory everywhere it was created.

**init.go**
- `setupNFS`: when `isMountingNFS` CAS fails (concurrent request),
  return an explicit error instead of `nil` so the caller receives a
  `400` and can retry, rather than silently succeeding with no mount.

## Testing

- `go build ./packages/api/... ./packages/envd/... packages.` ✅
- `go vet ./packages/api/internal/handlers/... internal.` ✅
- `go test internal.` ✅
- Manual: on a staging cluster with ≥2 orchestrator nodes, creating a
  volume and then creating 10 sandboxes with that volume mount all
  succeed with a valid NFS mount (mount | grep nfs non-empty in every
  sandbox).