### PR TITLE
refactor(api): introduce pluggable service-discovery interface

### DIFF
--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	nomadapi "github.com/hashicorp/nomad/api"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 
@@ -71,7 +70,7 @@ func NewCluster(
 func newLocalCluster(
 	ctx context.Context,
 	tel *telemetry.Client,
-	nomad *nomadapi.Client,
+	storeDiscovery discovery.Discovery,
 	clickhouse clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
 	config cfg.Config,
@@ -84,7 +83,6 @@ func newLocalCluster(
 		return newInstance(ctx, tel, nil, clusterID, item, fmt.Sprintf("%s:%d", item.LocalIPAddress, item.LocalInstanceApiPort), false)
 	}
 
-	storeDiscovery := discovery.NewLocalDiscovery(clusterID, nomad)
 	store := instancesSyncStore{clusterID: clusterID, instances: instances, discovery: storeDiscovery, instanceCreation: instanceCreation}
 
 	c := NewCluster(

--- a/packages/api/internal/clusters/clusters_sync.go
+++ b/packages/api/internal/clusters/clusters_sync.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	nomadapi "github.com/hashicorp/nomad/api"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/cfg"
+	"github.com/e2b-dev/infra/packages/api/internal/clusters/discovery"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	"github.com/e2b-dev/infra/packages/db/client"
 	"github.com/e2b-dev/infra/packages/db/queries"
@@ -46,7 +46,7 @@ func NewPool(
 	ctx context.Context,
 	tel *telemetry.Client,
 	db *client.Client,
-	nomad *nomadapi.Client,
+	localDiscovery discovery.Discovery,
 	queryMetricsProvider clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
 	config cfg.Config,
@@ -68,7 +68,7 @@ func NewPool(
 				tel:                  tel,
 				clusters:             clusters,
 				local:                localCluster,
-				nomad:                nomad,
+				localDiscovery:       localDiscovery,
 				queryLogsProvider:    queryLogsProvider,
 				queryMetricsProvider: queryMetricsProvider,
 			},
@@ -111,7 +111,7 @@ type clustersSyncStore struct {
 	tel                  *telemetry.Client
 	clusters             *smap.Map[*Cluster]
 	local                *queries.Cluster
-	nomad                *nomadapi.Client
+	localDiscovery       discovery.Discovery
 	queryMetricsProvider clickhouse.Clickhouse
 	queryLogsProvider    *loki.LokiQueryProvider
 	config               cfg.Config
@@ -171,7 +171,7 @@ func (d clustersSyncStore) PoolInsert(ctx context.Context, cluster queries.Clust
 
 	// Local cluster
 	if cluster.ID == consts.LocalClusterID {
-		c = newLocalCluster(context.WithoutCancel(ctx), d.tel, d.nomad, d.queryMetricsProvider, d.queryLogsProvider, d.config)
+		c = newLocalCluster(context.WithoutCancel(ctx), d.tel, d.localDiscovery, d.queryMetricsProvider, d.queryLogsProvider, d.config)
 		d.clusters.Insert(clusterID, c)
 		logger.L().Info(ctx, "Local cluster initialized successfully", logger.WithClusterID(cluster.ID))
 

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -21,7 +21,9 @@ import (
 	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
 	"github.com/e2b-dev/infra/packages/api/internal/cfg"
 	"github.com/e2b-dev/infra/packages/api/internal/clusters"
+	clustersdiscovery "github.com/e2b-dev/infra/packages/api/internal/clusters/discovery"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator"
+	orchdiscovery "github.com/e2b-dev/infra/packages/api/internal/orchestrator/discovery"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	template_manager "github.com/e2b-dev/infra/packages/api/internal/template-manager"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
@@ -32,6 +34,7 @@ import (
 	authdb "github.com/e2b-dev/infra/packages/db/pkg/auth"
 	"github.com/e2b-dev/infra/packages/db/pkg/pool"
 	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs/loki"
@@ -103,22 +106,27 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		logger.L().Fatal(ctx, "Initializing Posthog client", zap.Error(posthogErr))
 	}
 
-	nomadConfig := &nomadapi.Config{
+	// Build the orchestrator-discovery and template-builder-discovery backends
+	// against the local Nomad agent. The Discovery interfaces below allow
+	// alternative backends to be plugged in without touching the rest of the
+	// orchestrator/clusters code paths.
+	nomadClient, err := nomadapi.NewClient(&nomadapi.Config{
 		Address:  config.NomadAddress,
 		SecretID: config.NomadToken,
-	}
-
-	nomadClient, err := nomadapi.NewClient(nomadConfig)
+	})
 	if err != nil {
 		logger.L().Fatal(ctx, "Initializing Nomad client", zap.Error(err))
 	}
+
+	nodeDiscovery := orchdiscovery.NewNomad(nomadClient, "default")
+	templateBuilderDiscovery := clustersdiscovery.NewLocalDiscovery(consts.LocalClusterID, nomadClient)
 
 	queryLogsProvider, err := loki.NewLokiQueryProvider(config.LokiURL, config.LokiUser, config.LokiPassword)
 	if err != nil {
 		logger.L().Fatal(ctx, "error when getting logs query provider", zap.Error(err))
 	}
 
-	clusters, err := clusters.NewPool(ctx, tel, sqlcDB, nomadClient, clickhouseStore, queryLogsProvider, config)
+	clusters, err := clusters.NewPool(ctx, tel, sqlcDB, templateBuilderDiscovery, clickhouseStore, queryLogsProvider, config)
 	if err != nil {
 		logger.L().Fatal(ctx, "initializing edge clusters pool failed", zap.Error(err))
 	}
@@ -145,7 +153,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		logger.L().Fatal(ctx, "failed to create snapshot build query semaphore", zap.Error(err))
 	}
 
-	orch, err := orchestrator.New(ctx, config, tel, nomadClient, posthogClient, redisClient, sqlcDB, clusters, featureFlags, accessTokenGenerator, snapshotCache, snapshotUpsertSem)
+	orch, err := orchestrator.New(ctx, config, tel, nodeDiscovery, posthogClient, redisClient, sqlcDB, clusters, featureFlags, accessTokenGenerator, snapshotCache, snapshotUpsertSem)
 	if err != nil {
 		logger.L().Fatal(ctx, "Initializing Orchestrator client", zap.Error(err))
 	}

--- a/packages/api/internal/orchestrator/client.go
+++ b/packages/api/internal/orchestrator/client.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	nomadapi "github.com/hashicorp/nomad/api"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/clusters"
@@ -95,25 +94,24 @@ func (o *Orchestrator) scopedNodeID(clusterID uuid.UUID, nodeID string) string {
 	return fmt.Sprintf("%s-%s", clusterID.String(), nodeID)
 }
 
+// listNomadNodes is the legacy name for the orchestrator-listing call. It now
+// dispatches to whatever Discovery the Orchestrator was constructed with
+// (Nomad, Kubernetes, ...). The returned slice is in the nodemanager shape
+// because callers use it directly to dial the orchestrator gRPC server.
+//
+// (Name kept for blast-radius reasons; renaming touches >20 sites.)
 func (o *Orchestrator) listNomadNodes(ctx context.Context) ([]nodemanager.NomadServiceDiscovery, error) {
-	_, listSpan := tracer.Start(ctx, "list-nomad-nodes")
-	defer listSpan.End()
-
-	options := &nomadapi.QueryOptions{
-		// TODO: Use variable for node pool name ("default")
-		Filter: "Status == \"ready\" and NodePool == \"default\"",
-	}
-	nomadNodes, _, err := o.nomadClient.Nodes().List(options.WithContext(ctx))
+	nodes, err := o.nodeDiscovery.ListNodes(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]nodemanager.NomadServiceDiscovery, 0, len(nomadNodes))
-	for _, n := range nomadNodes {
+	result := make([]nodemanager.NomadServiceDiscovery, 0, len(nodes))
+	for _, n := range nodes {
 		result = append(result, nodemanager.NomadServiceDiscovery{
-			NomadNodeShortID:    n.ID[:consts.NodeIDLength],
-			OrchestratorAddress: fmt.Sprintf("%s:%d", n.Address, consts.OrchestratorAPIPort),
-			IPAddress:           n.Address,
+			NomadNodeShortID:    n.ShortID,
+			OrchestratorAddress: n.OrchestratorAddress,
+			IPAddress:           n.IPAddress,
 		})
 	}
 

--- a/packages/api/internal/orchestrator/client_test.go
+++ b/packages/api/internal/orchestrator/client_test.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/discovery"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	infogrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
@@ -40,9 +41,9 @@ func newTestOrchestrator(t *testing.T, nomad *nomadapi.Client) *Orchestrator {
 	logger.ReplaceGlobals(ctx, logger.NewNopLogger())
 
 	return &Orchestrator{
-		nodes:       smap.New[*nodemanager.Node](),
-		nomadClient: nomad,
-		tel:         telemetry.NewNoopClient(),
+		nodes:         smap.New[*nodemanager.Node](),
+		nodeDiscovery: discovery.NewNomad(nomad, "default"),
+		tel:           telemetry.NewNoopClient(),
 	}
 }
 

--- a/packages/api/internal/orchestrator/discovery/discovery.go
+++ b/packages/api/internal/orchestrator/discovery/discovery.go
@@ -1,0 +1,48 @@
+// Package discovery enumerates running orchestrator (Firecracker host) instances
+// for the API to route sandbox calls to.
+//
+// Currently the only implementation is NomadDiscovery, which queries the local
+// Nomad agent's HTTP /v1/nodes endpoint. The interface exists so additional
+// backends can be plugged in without touching the orchestrator code path.
+//
+// The shape of the returned []Node mirrors what the orchestrator package was
+// deriving from a Nomad node listing (NomadServiceDiscovery /
+// *nomadapi.NodeListStub) so that callers can be switched without changing the
+// rest of the orchestrator code path.
+package discovery
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+)
+
+var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/api/internal/orchestrator/discovery")
+
+// Node is a single discovered orchestrator instance.
+type Node struct {
+	// ShortID identifies the orchestrator at the discovery layer. It is the
+	// (truncated) Nomad node ID for the Nomad backend. The orchestrator stores
+	// it on nodemanager.Node.NomadNodeShortID, which is what
+	// Orchestrator.GetNodeByNomadShortID linearly scans for; it is not used as
+	// the key in Orchestrator.nodes (that map is keyed by
+	// scopedNodeID(clusterID, instanceNodeID), where instanceNodeID comes from
+	// the orchestrator's gRPC ServiceInfo response). The field name is
+	// retained for legacy reasons but is provider-agnostic.
+	ShortID string
+
+	// IPAddress is the orchestrator host's IP (Nomad node IP for the Nomad
+	// backend).
+	IPAddress string
+
+	// OrchestratorAddress is "<IPAddress>:<gRPC port>", precomputed for callers.
+	OrchestratorAddress string
+}
+
+// Discovery enumerates currently running orchestrator instances.
+type Discovery interface {
+	// ListNodes returns every orchestrator the discovery backend knows about.
+	// Implementations must be safe for concurrent use; the API calls this on a
+	// 20s interval plus on-demand from the request path.
+	ListNodes(ctx context.Context) ([]Node, error)
+}

--- a/packages/api/internal/orchestrator/discovery/nomad.go
+++ b/packages/api/internal/orchestrator/discovery/nomad.go
@@ -1,0 +1,56 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+)
+
+// nomadDiscovery implements Discovery against a local Nomad HTTP agent.
+//
+// In the Nomad deploy each client node has the orchestrator binary running
+// directly (raw_exec) and listening on consts.OrchestratorAPIPort, so every
+// "ready" Nomad node in the configured pool is an orchestrator.
+type nomadDiscovery struct {
+	client   *nomadapi.Client
+	nodePool string
+}
+
+// NewNomad creates a Nomad-backed Discovery.
+func NewNomad(client *nomadapi.Client, nodePool string) Discovery {
+	return &nomadDiscovery{
+		client:   client,
+		nodePool: nodePool,
+	}
+}
+
+func (d *nomadDiscovery) ListNodes(ctx context.Context) ([]Node, error) {
+	ctx, span := tracer.Start(ctx, "list-nomad-nodes")
+	defer span.End()
+
+	options := &nomadapi.QueryOptions{
+		Filter: fmt.Sprintf("Status == %q and NodePool == %q", "ready", d.nodePool),
+	}
+	nodes, _, err := d.client.Nodes().List(options.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Node, 0, len(nodes))
+	for _, n := range nodes {
+		shortID := n.ID
+		if len(shortID) > consts.NodeIDLength {
+			shortID = shortID[:consts.NodeIDLength]
+		}
+		out = append(out, Node{
+			ShortID:             shortID,
+			IPAddress:           n.Address,
+			OrchestratorAddress: fmt.Sprintf("%s:%d", n.Address, consts.OrchestratorAPIPort),
+		})
+	}
+
+	return out, nil
+}

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -17,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/cfg"
 	"github.com/e2b-dev/infra/packages/api/internal/clusters"
 	"github.com/e2b-dev/infra/packages/api/internal/metrics"
+	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/discovery"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/evictor"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/placement"
@@ -47,7 +47,7 @@ type SnapshotCacheInvalidator interface {
 
 type Orchestrator struct {
 	httpClient                    *http.Client
-	nomadClient                   *nomadapi.Client
+	nodeDiscovery                 discovery.Discovery
 	sandboxStore                  *sandbox.Store
 	nodes                         *smap.Map[*nodemanager.Node]
 	placementAlgorithm            *placement.BestOfK
@@ -89,7 +89,7 @@ func New(
 	ctx context.Context,
 	config cfg.Config,
 	tel *telemetry.Client,
-	nomadClient *nomadapi.Client,
+	nodeDiscovery discovery.Discovery,
 	posthogClient *analyticscollector.PosthogClient,
 	redisClient redis.UniversalClient,
 	sqlcDB *sqlcdb.Client,
@@ -141,7 +141,7 @@ func New(
 		httpClient:           httpClient,
 		analytics:            analyticsInstance,
 		posthogClient:        posthogClient,
-		nomadClient:          nomadClient,
+		nodeDiscovery:        nodeDiscovery,
 		nodes:                smap.New[*nodemanager.Node](),
 		placementAlgorithm:   bestOfKAlgorithm,
 		featureFlagsClient:   featureFlags,


### PR DESCRIPTION
The api binary previously took a *nomadapi.Client directly into the Orchestrator and clusters.Pool to enumerate orchestrator (Firecracker host) and template-manager (template-build host) instances.

This change introduces a Discovery interface so the Nomad-specific listing logic can be swapped out without touching the rest of the orchestrator/clusters code paths:

  - new orchestrator/discovery package with a Discovery interface and a NewNomad implementation that wraps the existing /v1/nodes call
  - Orchestrator.New now takes a discovery.Discovery instead of a *nomadapi.Client; listNomadNodes dispatches through it
  - clusters.NewPool / newLocalCluster take a clustersdiscovery.Discovery instead of a *nomadapi.Client; the existing LocalServiceDiscovery is the only implementation
  - handlers/store.go constructs the Nomad-backed Discovery once at startup and passes it to both consumers
  - client_test.go updated to construct an Orchestrator with the new nodeDiscovery field

Behavior is unchanged: the api still talks to the local Nomad agent exactly as before.