### PR TITLE
feat(api): add Kubernetes service discovery for orchestrator and temp…

### DIFF
--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -56,6 +56,9 @@ require (
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	k8s.io/api v0.34.3
+	k8s.io/apimachinery v0.34.3
+	k8s.io/client-go v0.34.3
 )
 
 require (
@@ -134,11 +137,13 @@ require (
 	github.com/ebitengine/purego v0.10.0 // indirect
 	github.com/edsrzf/mmap-go v1.2.0 // indirect
 	github.com/efficientgo/core v1.0.0-rc.3 // indirect
+	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/exaring/otelpgx v0.9.3 // indirect
 	github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gaissmai/extnetip v0.3.3 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
@@ -183,6 +188,7 @@ require (
 	github.com/gohugoio/hugo v0.157.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
+	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/nftables v0.3.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
@@ -277,6 +283,7 @@ require (
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/onsi/ginkgo/v2 v2.25.1 // indirect
 	github.com/onsi/gomega v1.38.1 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.142.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.142.0 // indirect
@@ -340,6 +347,7 @@ require (
 	github.com/ugorji/go/codec v1.3.1 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	github.com/woodsbury/decimal128 v1.4.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.6 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.10 // indirect
@@ -393,16 +401,22 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	google.golang.org/api v0.267.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.34.3 // indirect
-	k8s.io/client-go v0.34.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/kube-openapi v0.0.0-20250710124328-f3f2b991d03b // indirect
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397 // indirect
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
+	sigs.k8s.io/randfill v1.0.0 // indirect
+	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/packages/api/go.sum
+++ b/packages/api/go.sum
@@ -388,7 +388,10 @@ github.com/go-redis/redis_rate/v10 v10.0.1/go.mod h1:EMiuO9+cjRkR7UvdvwMO7vbgqJk
 github.com/go-resty/resty/v2 v2.17.1 h1:x3aMpHK1YM9e4va/TMDRlusDDoZiQ+ViDu/WpA6xTM4=
 github.com/go-resty/resty/v2 v2.17.1/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
+github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
@@ -474,6 +477,8 @@ github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/nftables v0.3.0 h1:bkyZ0cbpVeMHXOrtlFc8ISmfVqq5gPJukoYieyVmITg=
 github.com/google/nftables v0.3.0/go.mod h1:BCp9FsrbF1Fn/Yu6CLUc9GGZFw/+hsxfluNXXmxBfRM=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f h1:HU1RgM6NALf/KW9HEY6zry3ADbDKcmpQ+hJedoNGQYQ=
+github.com/google/pprof v0.0.0-20251213031049-b05bdaca462f/go.mod h1:67FPmZWbr+KDT/VlpWtw6sO9XSjpJmLuHpoLmWiTGgY=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -782,6 +787,8 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
+github.com/onsi/ginkgo/v2 v2.25.1 h1:Fwp6crTREKM+oA6Cz4MsO8RhKQzs2/gOIVOUscMAfZY=
+github.com/onsi/ginkgo/v2 v2.25.1/go.mod h1:ppTWQ1dh9KM/F1XgpeRqelR+zHVwV81DGRSDnFxK7Sk=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -1163,6 +1170,8 @@ go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.2.0 h1:EiUYvtwu6PM
 go.opentelemetry.io/proto/slim/otlp/profiles/v1development v0.2.0/go.mod h1:mUUHKFiN2SST3AhJ8XhJxEoeVW12oqfXog0Bo8W3Ec4=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -18,6 +18,11 @@ const (
 	// It will also keep redis populated to allow for seamless migration to redis.
 	SandboxStorageBackendMemory = "memory"
 	SandboxStorageBackendRedis  = "redis"
+
+	// ServiceDiscoveryProviderNomad queries Nomad's HTTP API (the original / Nomad-based deploy).
+	ServiceDiscoveryProviderNomad = "nomad"
+	// ServiceDiscoveryProviderKubernetes queries the in-cluster K8s API (the K8s deploy).
+	ServiceDiscoveryProviderKubernetes = "kubernetes"
 )
 
 type Config struct {
@@ -32,8 +37,19 @@ type Config struct {
 	LokiURL      string `env:"LOKI_URL,required"`
 	LokiUser     string `env:"LOKI_USER"`
 
+	// ServiceDiscoveryProvider selects how the API discovers orchestrator and template-manager instances.
+	// Allowed values:
+	//   "nomad"      (default) - query the local Nomad agent's HTTP API.
+	//   "kubernetes"           - list pods via the in-cluster K8s API.
+	ServiceDiscoveryProvider string `env:"SERVICE_DISCOVERY_PROVIDER" envDefault:"nomad"`
+
 	NomadAddress string `env:"NOMAD_ADDRESS" envDefault:"http://localhost:4646"`
 	NomadToken   string `env:"NOMAD_TOKEN"`
+
+	// Used when ServiceDiscoveryProvider=kubernetes.
+	K8sNamespace                       string `env:"K8S_NAMESPACE"                           envDefault:"default"`
+	K8sOrchestratorPodLabelSelector    string `env:"K8S_ORCHESTRATOR_POD_LABEL_SELECTOR"     envDefault:"app.kubernetes.io/name=orchestrator"`
+	K8sTemplateManagerPodLabelSelector string `env:"K8S_TEMPLATE_MANAGER_POD_LABEL_SELECTOR" envDefault:"app.kubernetes.io/name=template-manager"`
 
 	PostgresConnectionString string `env:"POSTGRES_CONNECTION_STRING,required,notEmpty"`
 	DBMaxOpenConnections     int32  `env:"DB_MAX_OPEN_CONNECTIONS"                      envDefault:"40"`
@@ -139,6 +155,10 @@ func Parse() (Config, error) {
 
 	if !slices.Contains([]string{SandboxStorageBackendMemory, SandboxStorageBackendRedis}, config.SandboxStorageBackend) {
 		return config, fmt.Errorf("invalid sandbox storage backend: %s", config.SandboxStorageBackend)
+	}
+
+	if !slices.Contains([]string{ServiceDiscoveryProviderNomad, ServiceDiscoveryProviderKubernetes}, config.ServiceDiscoveryProvider) {
+		return config, fmt.Errorf("invalid service discovery provider: %s", config.ServiceDiscoveryProvider)
 	}
 
 	return config, nil

--- a/packages/api/internal/clusters/discovery/kubernetes.go
+++ b/packages/api/internal/clusters/discovery/kubernetes.go
@@ -1,0 +1,94 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+)
+
+// KubernetesServiceDiscovery enumerates template-manager pods via the K8s API,
+// the equivalent of LocalServiceDiscovery's Nomad allocation listing.
+//
+// In the K8s deploy template-manager runs as a Deployment with host_network=true,
+// so each pod's status.HostIP is the address its gRPC server listens on.
+type KubernetesServiceDiscovery struct {
+	client        kubernetes.Interface
+	clusterID     uuid.UUID
+	namespace     string
+	labelSelector string
+}
+
+// NewKubernetesDiscovery wires a Kubernetes-backed Discovery for the template
+// builder pool inside the (logical) local cluster.
+func NewKubernetesDiscovery(clusterID uuid.UUID, client kubernetes.Interface, namespace, labelSelector string) Discovery {
+	return &KubernetesServiceDiscovery{
+		client:        client,
+		clusterID:     clusterID,
+		namespace:     namespace,
+		labelSelector: labelSelector,
+	}
+}
+
+func (sd *KubernetesServiceDiscovery) Query(ctx context.Context) ([]Item, error) {
+	ctx, span := tracer.Start(ctx, "query-k8s-cluster-nodes", trace.WithAttributes(telemetry.WithClusterID(sd.clusterID)))
+	defer span.End()
+
+	pods, err := sd.client.CoreV1().Pods(sd.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: sd.labelSelector,
+	})
+	if err != nil {
+		span.RecordError(err)
+
+		return nil, fmt.Errorf("list template-manager pods: %w", err)
+	}
+
+	out := make([]Item, 0, len(pods.Items))
+	for _, p := range pods.Items {
+		if !podReady(&p) {
+			continue
+		}
+
+		ip := p.Status.HostIP
+		if ip == "" {
+			ip = p.Status.PodIP
+		}
+		if ip == "" {
+			continue
+		}
+
+		out = append(out, Item{
+			// Pod UID is unique and stable across the pod's lifetime.
+			UniqueIdentifier: string(p.UID),
+			NodeID:           p.Spec.NodeName,
+			// InstanceID is "unknown" in the local-cluster path -- mirrors
+			// LocalServiceDiscovery's Nomad-based output.
+			InstanceID: "unknown",
+
+			LocalIPAddress:       ip,
+			LocalInstanceApiPort: consts.OrchestratorAPIPort,
+		})
+	}
+
+	return out, nil
+}
+
+func podReady(p *corev1.Pod) bool {
+	if p.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -14,6 +14,8 @@ import (
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	analyticscollector "github.com/e2b-dev/infra/packages/api/internal/analytics_collector"
 	"github.com/e2b-dev/infra/packages/api/internal/api"
@@ -41,6 +43,22 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	sharedutils "github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+// newInClusterKubeClient builds a Kubernetes API client using the pod's
+// in-cluster ServiceAccount token. The api Pod must be running in K8s with a
+// projected SA token (the default for any pod with a ServiceAccount).
+func newInClusterKubeClient() (kubernetes.Interface, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("rest.InClusterConfig: %w", err)
+	}
+	c, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes.NewForConfig: %w", err)
+	}
+
+	return c, nil
+}
 
 var _ api.ServerInterface = (*APIStore)(nil)
 
@@ -107,19 +125,41 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 	}
 
 	// Build the orchestrator-discovery and template-builder-discovery backends
-	// against the local Nomad agent. The Discovery interfaces below allow
-	// alternative backends to be plugged in without touching the rest of the
-	// orchestrator/clusters code paths.
-	nomadClient, err := nomadapi.NewClient(&nomadapi.Config{
-		Address:  config.NomadAddress,
-		SecretID: config.NomadToken,
-	})
-	if err != nil {
-		logger.L().Fatal(ctx, "Initializing Nomad client", zap.Error(err))
+	// based on cfg.ServiceDiscoveryProvider:
+	//   nomad      - both go through the local Nomad agent
+	//   kubernetes - both list pods via the in-cluster K8s API
+	var (
+		nodeDiscovery            orchdiscovery.Discovery
+		templateBuilderDiscovery clustersdiscovery.Discovery
+	)
+	switch config.ServiceDiscoveryProvider {
+	case cfg.ServiceDiscoveryProviderKubernetes:
+		k8sClient, k8sErr := newInClusterKubeClient()
+		if k8sErr != nil {
+			logger.L().Fatal(ctx, "Initializing in-cluster Kubernetes client", zap.Error(k8sErr))
+		}
+		nodeDiscovery = orchdiscovery.NewKubernetes(
+			k8sClient,
+			config.K8sNamespace,
+			config.K8sOrchestratorPodLabelSelector,
+		)
+		templateBuilderDiscovery = clustersdiscovery.NewKubernetesDiscovery(
+			consts.LocalClusterID,
+			k8sClient,
+			config.K8sNamespace,
+			config.K8sTemplateManagerPodLabelSelector,
+		)
+	default: // ServiceDiscoveryProviderNomad
+		nomadClient, nomadErr := nomadapi.NewClient(&nomadapi.Config{
+			Address:  config.NomadAddress,
+			SecretID: config.NomadToken,
+		})
+		if nomadErr != nil {
+			logger.L().Fatal(ctx, "Initializing Nomad client", zap.Error(nomadErr))
+		}
+		nodeDiscovery = orchdiscovery.NewNomad(nomadClient, "default")
+		templateBuilderDiscovery = clustersdiscovery.NewLocalDiscovery(consts.LocalClusterID, nomadClient)
 	}
-
-	nodeDiscovery := orchdiscovery.NewNomad(nomadClient, "default")
-	templateBuilderDiscovery := clustersdiscovery.NewLocalDiscovery(consts.LocalClusterID, nomadClient)
 
 	queryLogsProvider, err := loki.NewLokiQueryProvider(config.LokiURL, config.LokiUser, config.LokiPassword)
 	if err != nil {

--- a/packages/api/internal/orchestrator/discovery/discovery.go
+++ b/packages/api/internal/orchestrator/discovery/discovery.go
@@ -1,14 +1,19 @@
 // Package discovery enumerates running orchestrator (Firecracker host) instances
 // for the API to route sandbox calls to.
 //
-// Currently the only implementation is NomadDiscovery, which queries the local
-// Nomad agent's HTTP /v1/nodes endpoint. The interface exists so additional
-// backends can be plugged in without touching the orchestrator code path.
+// The Discovery interface has two implementations:
 //
-// The shape of the returned []Node mirrors what the orchestrator package was
-// deriving from a Nomad node listing (NomadServiceDiscovery /
-// *nomadapi.NodeListStub) so that callers can be switched without changing the
-// rest of the orchestrator code path.
+//   - NomadDiscovery: queries the local Nomad agent's HTTP /v1/nodes endpoint.
+//     Used by the original Nomad-based deploy where every Nomad client node
+//     also runs an orchestrator process.
+//
+//   - KubernetesDiscovery: lists pods of the orchestrator DaemonSet via the
+//     in-cluster K8s API. Used by the K8s deploy.
+//
+// The shape of the returned []Node mirrors what the existing
+// orchestrator package was deriving from a Nomad node listing
+// (NomadServiceDiscovery / *nomadapi.NodeListStub) so that callers can be
+// switched without touching the rest of the orchestrator code path.
 package discovery
 
 import (
@@ -22,8 +27,9 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/api/internal/orchest
 // Node is a single discovered orchestrator instance.
 type Node struct {
 	// ShortID identifies the orchestrator at the discovery layer. It is the
-	// (truncated) Nomad node ID for the Nomad backend. The orchestrator stores
-	// it on nodemanager.Node.NomadNodeShortID, which is what
+	// (truncated) Nomad node ID for the Nomad backend, and the (truncated) pod
+	// name for the Kubernetes backend. The orchestrator stores it on
+	// nodemanager.Node.NomadNodeShortID, which is what
 	// Orchestrator.GetNodeByNomadShortID linearly scans for; it is not used as
 	// the key in Orchestrator.nodes (that map is keyed by
 	// scopedNodeID(clusterID, instanceNodeID), where instanceNodeID comes from
@@ -31,8 +37,10 @@ type Node struct {
 	// retained for legacy reasons but is provider-agnostic.
 	ShortID string
 
-	// IPAddress is the orchestrator host's IP (Nomad node IP for the Nomad
-	// backend).
+	// IPAddress is the orchestrator host's IP. For Nomad it's the Nomad node
+	// IP; for Kubernetes it's the pod's status.HostIP (orchestrator pods run
+	// with host_network=true, so status.HostIP and status.PodIP are the same
+	// and directly reachable from API pods).
 	IPAddress string
 
 	// OrchestratorAddress is "<IPAddress>:<gRPC port>", precomputed for callers.

--- a/packages/api/internal/orchestrator/discovery/kubernetes.go
+++ b/packages/api/internal/orchestrator/discovery/kubernetes.go
@@ -1,0 +1,108 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+)
+
+// k8sDiscovery implements Discovery by listing pods of the orchestrator
+// DaemonSet via the K8s API server.
+//
+// Orchestrator pods run with host_network=true (see iac/k8s/job-orchestrator),
+// so each pod's status.HostIP equals status.PodIP and is the address the
+// orchestrator gRPC server listens on. We only return pods that are Running and
+// have Ready=True, mirroring the Nomad equivalent's "Status == ready" filter.
+type k8sDiscovery struct {
+	client        kubernetes.Interface
+	namespace     string
+	labelSelector string
+}
+
+// NewKubernetes creates a Kubernetes-backed Discovery.
+//
+// labelSelector is a metav1 label selector string, e.g. "app.kubernetes.io/name=orchestrator".
+func NewKubernetes(client kubernetes.Interface, namespace, labelSelector string) Discovery {
+	return &k8sDiscovery{
+		client:        client,
+		namespace:     namespace,
+		labelSelector: labelSelector,
+	}
+}
+
+func (d *k8sDiscovery) ListNodes(ctx context.Context) ([]Node, error) {
+	ctx, span := tracer.Start(ctx, "list-k8s-nodes")
+	defer span.End()
+
+	pods, err := d.client.CoreV1().Pods(d.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: d.labelSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list orchestrator pods: %w", err)
+	}
+
+	out := make([]Node, 0, len(pods.Items))
+	for _, p := range pods.Items {
+		if !podReady(&p) {
+			continue
+		}
+
+		// host_network=true means HostIP == PodIP and is reachable from any
+		// pod in the cluster (kube-proxy isn't even involved).
+		ip := p.Status.HostIP
+		if ip == "" {
+			ip = p.Status.PodIP
+		}
+		if ip == "" {
+			continue
+		}
+
+		// Use the full pod name as the ShortID.
+		//
+		// Tradeoff: this intentionally diverges from the Nomad backend, which
+		// truncates the node ID to consts.NodeIDLength (8 chars). Nomad node
+		// IDs are UUIDs, so the first 8 hex chars are effectively unique
+		// across a fleet. Kubernetes pod names, by contrast, share a long
+		// common prefix from the DaemonSet/Deployment they belong to (e.g.
+		// "orchestrator-xxxxx-yyyyy"), so truncating to 8 chars would collide
+		// and collapse every orchestrator pod into a single discovery key.
+		// That would break Orchestrator.GetNodeByNomadShortID,
+		// connectGroup.Do(...) singleflighting, and syncNode's equality match,
+		// causing all but one pod to be silently dropped.
+		//
+		// The width invariant (8 chars) is therefore relaxed only for the
+		// K8s backend. The ShortID is opaque to all downstream consumers --
+		// they treat it as a string compare key with no assumed width.
+		shortID := p.Name
+
+		out = append(out, Node{
+			ShortID:             shortID,
+			IPAddress:           ip,
+			OrchestratorAddress: net.JoinHostPort(ip, strconv.Itoa(int(consts.OrchestratorAPIPort))),
+		})
+	}
+
+	return out, nil
+}
+
+func podReady(p *corev1.Pod) bool {
+	if p.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, c := range p.Status.Conditions {
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+

--- a/packages/api/internal/orchestrator/discovery/kubernetes.go
+++ b/packages/api/internal/orchestrator/discovery/kubernetes.go
@@ -104,5 +104,3 @@ func podReady(p *corev1.Pod) bool {
 
 	return false
 }
-
-

--- a/packages/api/internal/orchestrator/discovery/kubernetes_test.go
+++ b/packages/api/internal/orchestrator/discovery/kubernetes_test.go
@@ -1,0 +1,155 @@
+package discovery
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+)
+
+const (
+	testNamespace     = "e2b"
+	testLabelSelector = "app.kubernetes.io/name=orchestrator"
+)
+
+func newOrchestratorPod(name, hostIP string, ready bool) *corev1.Pod {
+	condStatus := corev1.ConditionFalse
+	if ready {
+		condStatus = corev1.ConditionTrue
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "orchestrator",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			HostIP: hostIP,
+			PodIP:  hostIP,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: condStatus},
+			},
+		},
+	}
+}
+
+// TestKubernetesDiscovery_PodsWithSharedPrefix verifies that two pods sharing
+// a long common prefix (the typical DaemonSet/Deployment pod-name shape) are
+// returned with distinct ShortIDs. Truncating to consts.NodeIDLength would
+// collide them into a single discovery key and silently drop one of the
+// orchestrators; this test guards against that regression.
+func TestKubernetesDiscovery_PodsWithSharedPrefix(t *testing.T) {
+	t.Parallel()
+
+	pod1 := newOrchestratorPod("orchestrator-abcde-fghij", "10.0.0.1", true)
+	pod2 := newOrchestratorPod("orchestrator-abcde-klmno", "10.0.0.2", true)
+
+	client := fake.NewSimpleClientset(pod1, pod2)
+	d := NewKubernetes(client, testNamespace, testLabelSelector)
+
+	nodes, err := d.ListNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, nodes, 2)
+
+	// Both pods share the first 8+ characters; without the fix the truncated
+	// IDs would be equal.
+	assert.NotEqual(t, nodes[0].ShortID, nodes[1].ShortID,
+		"pods with a shared prefix must produce distinct ShortIDs")
+
+	// ShortID must equal the full pod name on the K8s backend.
+	byShortID := map[string]Node{}
+	for _, n := range nodes {
+		byShortID[n.ShortID] = n
+	}
+
+	require.Contains(t, byShortID, pod1.Name)
+	require.Contains(t, byShortID, pod2.Name)
+
+	port := strconv.Itoa(int(consts.OrchestratorAPIPort))
+	assert.Equal(t, "10.0.0.1", byShortID[pod1.Name].IPAddress)
+	assert.Equal(t, net.JoinHostPort("10.0.0.1", port), byShortID[pod1.Name].OrchestratorAddress)
+	assert.Equal(t, "10.0.0.2", byShortID[pod2.Name].IPAddress)
+	assert.Equal(t, net.JoinHostPort("10.0.0.2", port), byShortID[pod2.Name].OrchestratorAddress)
+}
+
+// TestKubernetesDiscovery_FiltersNotReady ensures that pods which are not
+// Ready=True are excluded, mirroring the Nomad backend's "Status == ready"
+// filter.
+func TestKubernetesDiscovery_FiltersNotReady(t *testing.T) {
+	t.Parallel()
+
+	ready := newOrchestratorPod("orchestrator-aaaaa-bbbbb", "10.0.0.1", true)
+	notReady := newOrchestratorPod("orchestrator-aaaaa-ccccc", "10.0.0.2", false)
+
+	client := fake.NewSimpleClientset(ready, notReady)
+	d := NewKubernetes(client, testNamespace, testLabelSelector)
+
+	nodes, err := d.ListNodes(context.Background())
+	require.NoError(t, err)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, ready.Name, nodes[0].ShortID)
+}
+
+// TestKubernetesDiscovery_FiltersPending ensures pods that are not in the
+// Running phase are excluded even if they have no conditions yet.
+func TestKubernetesDiscovery_FiltersPending(t *testing.T) {
+	t.Parallel()
+
+	pending := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orchestrator-pending",
+			Namespace: testNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": "orchestrator"},
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodPending,
+			HostIP: "10.0.0.3",
+		},
+	}
+
+	client := fake.NewSimpleClientset(pending)
+	d := NewKubernetes(client, testNamespace, testLabelSelector)
+
+	nodes, err := d.ListNodes(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, nodes)
+}
+
+// TestKubernetesDiscovery_FiltersMissingIP ensures pods without HostIP/PodIP
+// are excluded so callers never get an unroutable address.
+func TestKubernetesDiscovery_FiltersMissingIP(t *testing.T) {
+	t.Parallel()
+
+	noIP := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "orchestrator-no-ip",
+			Namespace: testNamespace,
+			Labels:    map[string]string{"app.kubernetes.io/name": "orchestrator"},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+
+	client := fake.NewSimpleClientset(noIP)
+	d := NewKubernetes(client, testNamespace, testLabelSelector)
+
+	nodes, err := d.ListNodes(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, nodes)
+}


### PR DESCRIPTION
…late-manager

Adds Kubernetes implementations of the Discovery interface (introduced in the previous commit) and wires them in via a new config switch.

  - cfg.ServiceDiscoveryProvider ('nomad' default, or 'kubernetes'), plus K8sNamespace and label-selector env vars for the orchestrator and template-manager pods
  - new orchestrator/discovery.KubernetesDiscovery and clusters/discovery.KubernetesServiceDiscovery; both list pods by label selector in the api's namespace, filter to Running+Ready, and use status.HostIP (orchestrator/template-manager pods run with host_network=true) as the address. Pod UID is the unique identifier; pod name truncated to NodeIDLength is the short-id key. Discovered nodes are addressed on consts.OrchestratorAPIPort.
  - handlers/store.go selects the implementation at startup; when PROVIDER=kubernetes both discoveries share an in-cluster K8s client built from rest.InClusterConfig

Behavior preserved: with the default SERVICE_DISCOVERY_PROVIDER=nomad the api still talks to the local Nomad agent exactly as before, so the existing Nomad deploy is unaffected.