### PR TITLE
fix: use net.JoinHostPort for host:port formatting

### DIFF
--- a/packages/api/internal/analytics_collector/client.go
+++ b/packages/api/internal/analytics_collector/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
@@ -38,7 +39,7 @@ func NewAnalytics(host, grpcAPIKey string) (*Analytics, error) {
 		})
 
 		conn, err := grpc.NewClient(
-			fmt.Sprintf("%s:443", host),
+			net.JoinHostPort(host, "443"),
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
 			grpc.WithPerRPCCredentials(newGRPCAPIKey(grpcAPIKey)),
 			grpc.WithAuthority(host),

--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -80,7 +82,7 @@ func newLocalCluster(
 	instances := smap.New[*Instance]()
 	instanceCreation := func(ctx context.Context, item discovery.Item) (*Instance, error) {
 		// For local cluster we are doing direct connection to instance IP and API port and without additional cluster auth.
-		return newInstance(ctx, tel, nil, clusterID, item, fmt.Sprintf("%s:%d", item.LocalIPAddress, item.LocalInstanceApiPort), false)
+		return newInstance(ctx, tel, nil, clusterID, item, net.JoinHostPort(item.LocalIPAddress, strconv.FormatUint(uint64(item.LocalInstanceApiPort), 10)), false)
 	}
 
 	store := instancesSyncStore{clusterID: clusterID, instances: instances, discovery: storeDiscovery, instanceCreation: instanceCreation}

--- a/packages/api/internal/orchestrator/discovery/nomad.go
+++ b/packages/api/internal/orchestrator/discovery/nomad.go
@@ -3,6 +3,8 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 
 	nomadapi "github.com/hashicorp/nomad/api"
 
@@ -48,7 +50,7 @@ func (d *nomadDiscovery) ListNodes(ctx context.Context) ([]Node, error) {
 		out = append(out, Node{
 			ShortID:             shortID,
 			IPAddress:           n.Address,
-			OrchestratorAddress: fmt.Sprintf("%s:%d", n.Address, consts.OrchestratorAPIPort),
+			OrchestratorAddress: net.JoinHostPort(n.Address, strconv.FormatUint(uint64(consts.OrchestratorAPIPort), 10)),
 		})
 	}
 

--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -2,9 +2,11 @@ package cfg
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -108,7 +110,7 @@ func (c Config) NodeAddress() *string {
 		return nil
 	}
 
-	addr := fmt.Sprintf("%s:%d", c.NodeIP, c.GRPCPort)
+	addr := net.JoinHostPort(c.NodeIP, strconv.FormatUint(uint64(c.GRPCPort), 10))
 
 	return &addr
 }

--- a/packages/orchestrator/pkg/proxy/proxy.go
+++ b/packages/orchestrator/pkg/proxy/proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/subtle"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -96,7 +97,7 @@ func NewSandboxProxy(meterProvider metric.MeterProvider, port uint16, sandboxes 
 
 			url := &url.URL{
 				Scheme: "http",
-				Host:   fmt.Sprintf("%s:%d", sbx.Slot.HostIPString(), port),
+				Host:   net.JoinHostPort(sbx.Slot.HostIPString(), strconv.FormatUint(port, 10)),
 			}
 
 			logger := logger.L().With(


### PR DESCRIPTION
Replace fmt.Sprintf("%s:%d", ...) with net.JoinHostPort across the orchestrator, API discovery, cluster instance creation, and sandbox proxy code paths.

Building host:port strings via fmt.Sprintf produces invalid addresses for IPv6 hosts because the IP literal is not wrapped in brackets, making the result indistinguishable from "host:port" parsers and breaking dialing/URL parsing. net.JoinHostPort handles both IPv4 and IPv6 correctly by bracketing IPv6 literals as required by RFC 3986.