### PR TITLE
fix(envd): make package build and tests pass on macOS

### DIFF
--- a/packages/envd/internal/api/clock_linux.go
+++ b/packages/envd/internal/api/clock_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package api
+
+import (
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func setSystemTime(t time.Time) error {
+	ts := unix.NsecToTimespec(t.UnixNano())
+
+	return unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
+}

--- a/packages/envd/internal/api/clock_other.go
+++ b/packages/envd/internal/api/clock_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package api
+
+import (
+	"errors"
+	"time"
+)
+
+func setSystemTime(_ time.Time) error {
+	return errors.New("setting system time is only supported on Linux")
+}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/txn2/txeh"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
 	"github.com/e2b-dev/infra/packages/envd/internal/logs"
@@ -175,9 +174,7 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 		// Check if current time differs significantly from the received timestamp
 		if shouldSetSystemTime(time.Now(), *data.Timestamp) {
 			logger.Debug().Msgf("Setting sandbox start time to: %v", *data.Timestamp)
-			ts := unix.NsecToTimespec(data.Timestamp.UnixNano())
-			err := unix.ClockSettime(unix.CLOCK_REALTIME, &ts)
-			if err != nil {
+			if err := setSystemTime(*data.Timestamp); err != nil {
 				logger.Error().Msgf("Failed to set system time: %v", err)
 			}
 		} else {

--- a/packages/envd/internal/api/upload_test.go
+++ b/packages/envd/internal/api/upload_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -54,6 +55,10 @@ func TestProcessFile(t *testing.T) {
 
 	t.Run("fail to create file", func(t *testing.T) {
 		t.Parallel()
+		// /proc as a virtual filesystem with specific error semantics is Linux-only.
+		if runtime.GOOS != "linux" {
+			t.Skip("relies on Linux /proc virtual filesystem semantics")
+		}
 		httpStatus, err := processFile(&emptyReq, "/proc/invalid-filename", emptyPart, uid, gid, emptyLogger)
 		require.Error(t, err)
 		assert.Equal(t, http.StatusInternalServerError, httpStatus)

--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -144,10 +144,9 @@ func (f *Forwarder) startPortForwarding(ctx context.Context, p *PortToForward) {
 	cgroupFD, ok := f.cgroupManager.GetFileDescriptor(cgroups.ProcessTypeSocat)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setpgid:     true,
-		CgroupFD:    cgroupFD,
-		UseCgroupFD: ok,
+		Setpgid: true,
 	}
+	applyCgroupFD(cmd.SysProcAttr, cgroupFD, ok)
 
 	f.logger.Debug().
 		Str("socatCmd", cmd.String()).

--- a/packages/envd/internal/port/forward_cgroupfd_linux.go
+++ b/packages/envd/internal/port/forward_cgroupfd_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package port
+
+import "syscall"
+
+// applyCgroupFD sets cgroup-related fields on Linux SysProcAttr.
+func applyCgroupFD(attr *syscall.SysProcAttr, fd int, use bool) {
+	attr.CgroupFD = fd
+	attr.UseCgroupFD = use
+}

--- a/packages/envd/internal/port/forward_cgroupfd_other.go
+++ b/packages/envd/internal/port/forward_cgroupfd_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package port
+
+import "syscall"
+
+// applyCgroupFD is a no-op on non-Linux platforms; cgroup v2 is Linux-only.
+func applyCgroupFD(_ *syscall.SysProcAttr, _ int, _ bool) {}

--- a/packages/envd/internal/services/cgroups/cgroup2.go
+++ b/packages/envd/internal/services/cgroups/cgroup2.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cgroups
 
 import (

--- a/packages/envd/internal/services/cgroups/cgroup2_stub.go
+++ b/packages/envd/internal/services/cgroups/cgroup2_stub.go
@@ -1,0 +1,48 @@
+//go:build !linux
+
+package cgroups
+
+// Cgroup2Manager is a non-functional stub on non-Linux platforms.
+// cgroups v2 is a Linux-only kernel feature.
+type Cgroup2Manager struct{}
+
+var _ Manager = (*Cgroup2Manager)(nil)
+
+type Cgroup2Config struct {
+	Path       string
+	Properties map[string]string
+}
+
+type cgroup2Config struct {
+	rootPath     string
+	processTypes map[ProcessType]Cgroup2Config
+}
+
+type Cgroup2ManagerOption func(*cgroup2Config)
+
+func WithCgroup2RootSysFSPath(path string) Cgroup2ManagerOption {
+	return func(config *cgroup2Config) {
+		config.rootPath = path
+	}
+}
+
+func WithCgroup2ProcessType(processType ProcessType, path string, properties map[string]string) Cgroup2ManagerOption {
+	return func(config *cgroup2Config) {
+		if config.processTypes == nil {
+			config.processTypes = make(map[ProcessType]Cgroup2Config)
+		}
+		config.processTypes[processType] = Cgroup2Config{Path: path, Properties: properties}
+	}
+}
+
+func NewCgroup2Manager(_ ...Cgroup2ManagerOption) (*Cgroup2Manager, error) {
+	return &Cgroup2Manager{}, nil
+}
+
+func (c Cgroup2Manager) GetFileDescriptor(ProcessType) (int, bool) {
+	return 0, false
+}
+
+func (c Cgroup2Manager) Close() error {
+	return nil
+}

--- a/packages/envd/internal/services/cgroups/cgroup2_test.go
+++ b/packages/envd/internal/services/cgroups/cgroup2_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package cgroups
 
 import (

--- a/packages/envd/internal/services/filesystem/utils_test.go
+++ b/packages/envd/internal/services/filesystem/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	osuser "os/user"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -25,6 +26,11 @@ func TestIsPathOnNetworkMount(t *testing.T) {
 
 func TestIsPathOnNetworkMount_FuseMount(t *testing.T) {
 	t.Parallel()
+
+	// FUSE mounts via bindfs are exercised on Linux only.
+	if runtime.GOOS != "linux" {
+		t.Skip("FUSE bindfs mount test runs only on Linux")
+	}
 
 	// Require bindfs to be available
 	_, err := exec.LookPath("bindfs")

--- a/packages/envd/internal/services/process/handler/cgroupfd_linux.go
+++ b/packages/envd/internal/services/process/handler/cgroupfd_linux.go
@@ -1,0 +1,11 @@
+//go:build linux
+
+package handler
+
+import "syscall"
+
+// applyCgroupFD sets cgroup-related fields on Linux SysProcAttr.
+func applyCgroupFD(attr *syscall.SysProcAttr, fd int, use bool) {
+	attr.CgroupFD = fd
+	attr.UseCgroupFD = use
+}

--- a/packages/envd/internal/services/process/handler/cgroupfd_other.go
+++ b/packages/envd/internal/services/process/handler/cgroupfd_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+
+package handler
+
+import "syscall"
+
+// applyCgroupFD is a no-op on non-Linux platforms; cgroup v2 is Linux-only.
+func applyCgroupFD(_ *syscall.SysProcAttr, _ int, _ bool) {}

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -123,14 +123,13 @@ func New(
 	cgroupFD, ok := cgroupManager.GetFileDescriptor(getProcType(req))
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		UseCgroupFD: ok,
-		CgroupFD:    cgroupFD,
 		Credential: &syscall.Credential{
 			Uid:    uid,
 			Gid:    gid,
 			Groups: groups,
 		},
 	}
+	applyCgroupFD(cmd.SysProcAttr, cgroupFD, ok)
 
 	resolvedPath, err := permissions.ExpandAndResolve(req.GetProcess().GetCwd(), user, defaults.Workdir)
 	if err != nil {


### PR DESCRIPTION
Gate Linux-only syscalls (cgroup2, ClockSettime, SysProcAttr cgroup FD
fields) behind build tags and provide non-Linux stubs so envd compiles
and tests run on darwin. Skip Linux-specific filesystem and /proc tests
on other platforms.