### PR TITLE
ci: bump actions to Node 24 runtime

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -59,10 +59,10 @@ runs:
       shell: bash
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Build codegen image with caching
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: packages/clickhouse
         file: packages/clickhouse/Dockerfile

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -114,12 +114,13 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles('tests/integration/test-results.xml') != '' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/integration/test-results.xml
           flags: integration
           disable_search: true
+          report_type: test_results
 
       - name: Upload Service Logs
         if: ${{ always() && inputs.publish == true }}

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/coverage.txt
@@ -187,9 +187,10 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/junit.xml
           flags: ${{ matrix.flag }},unit
           disable_search: true
+          report_type: test_results

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -136,7 +136,7 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/coverage.txt
@@ -146,12 +146,13 @@ jobs:
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ matrix.package }}/junit.xml
           flags: ${{ matrix.flag }},unit
           disable_search: true
+          report_type: test_results
 
   validate-iac:
     name: Validate terraform


### PR DESCRIPTION
GitHub Actions runners are deprecating Node 20 (forced Node 24 default on June 2nd, 2026; Node 20 removed on September 16th, 2026). Update the affected actions:

- docker/setup-buildx-action: v3 -> v4 (Node 24)
- docker/build-push-action: v6 -> v7 (Node 24)
- codecov/codecov-action: v5 -> v6 (Node 24)
- codecov/test-results-action@v1 has been deprecated by Codecov and has no Node 24 release. Its functionality has been folded into codecov/codecov-action; migrate the existing test-results uploads to codecov/codecov-action@v6 with 'report_type: test_results'.

v6 of codecov-action and v7 of the docker actions require Actions Runner v2.327.1+, which is already provided by the ubuntu-24.04 / ubuntu-latest runners used in these workflows.