### PR TITLE
Configure GCP Redis node type

### DIFF
--- a/.env.gcp.template
+++ b/.env.gcp.template
@@ -108,6 +108,8 @@ CLICKHOUSE_STATEFUL_DISK_SIZE_GB=
 REDIS_MANAGED=
 # Redis shard count (default: 1)
 REDIS_SHARD_COUNT=
+# GCP managed Redis/Valkey node type (default: STANDARD_SMALL)
+GCP_REDIS_NODE_TYPE=
 # GCP managed Redis/Valkey engine version (default: VALKEY_8_0)
 GCP_REDIS_ENGINE_VERSION=
 

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -66,6 +66,7 @@ tf_vars := \
 	$(call tfvar, ENVD_TIMEOUT) \
 	$(call tfvar, REDIS_MANAGED) \
 	$(call tfvar, REDIS_SHARD_COUNT) \
+	$(call tfvar, GCP_REDIS_NODE_TYPE) \
 	$(call tfvar, GCP_REDIS_ENGINE_VERSION) \
 	$(call tfvar, GRAFANA_MANAGED) \
 	$(call tfvar, FILESTORE_CACHE_ENABLED) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -361,6 +361,7 @@ module "redis" {
 
   shard_count    = var.redis_shard_count
   engine_version = var.gcp_redis_engine_version
+  node_type      = var.gcp_redis_node_type
   prefix         = var.prefix
 }
 

--- a/iac/provider-gcp/redis/main.tf
+++ b/iac/provider-gcp/redis/main.tf
@@ -80,7 +80,7 @@ resource "google_memorystore_instance" "valkey_cluster" {
 
   shard_count             = var.shard_count
   replica_count           = var.replica_count
-  node_type               = "STANDARD_SMALL"
+  node_type               = var.node_type
   transit_encryption_mode = "SERVER_AUTHENTICATION"
   authorization_mode      = "AUTH_DISABLED"
 

--- a/iac/provider-gcp/redis/variables.tf
+++ b/iac/provider-gcp/redis/variables.tf
@@ -29,6 +29,11 @@ variable "engine_version" {
   type = string
 }
 
+variable "node_type" {
+  type    = string
+  default = "STANDARD_SMALL"
+}
+
 // https://registry.terraform.io/providers/hashicorp/google/6.38.0/docs/resources/memorystore_instance#replica_count-1
 variable "replica_count" {
   type    = number

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -417,6 +417,12 @@ variable "redis_shard_count" {
   default = 1
 }
 
+variable "gcp_redis_node_type" {
+  type        = string
+  description = "The node type for managed GCP Redis/Valkey. Can be set via TF_VAR_gcp_redis_node_type or GCP_REDIS_NODE_TYPE env var."
+  default     = "STANDARD_SMALL"
+}
+
 variable "gcp_redis_engine_version" {
   type        = string
   description = "The engine version for managed GCP Redis/Valkey. Can be set via TF_VAR_gcp_redis_engine_version or GCP_REDIS_ENGINE_VERSION env var."


### PR DESCRIPTION
Managed Redis/Valkey capacity sometimes needs to be adjusted per environment, but the node type was hard-coded in Terraform. That makes emergency or environment-specific capacity changes difficult to represent through the normal infrastructure workflow and increases the chance of configuration drift.

This PR makes the node type configurable while preserving the existing default for environments that do not override it.