### PR TITLE
chore: pin golangci-lint to version compatible with Go 1.25

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ buf 1.28.1
 bun 1.3.2
 gcloud 534.0.0
 golang 1.25.9
-golangci-lint 2.8.0
+golangci-lint 2.7.2
 packer 1.13.1
 protoc 29.3
 protoc-gen-connect-go 1.18.1


### PR DESCRIPTION
golangci-lint 2.8.0 is built with Go 1.26, which causes a panic when linting code pinned to Go 1.25 ("file requires newer Go version go1.26"). Downgrade golangci-lint to a release built against Go 1.25 to match the toolchain specified in .tool-versions.