### PR TITLE
test: replace context.Background() with t.Context()/b.Context() in tests

### DIFF
--- a/packages/api/internal/handlers/proxy_grpc_test.go
+++ b/packages/api/internal/handlers/proxy_grpc_test.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +60,7 @@ func TestIsNonEnvdTrafficRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := isNonEnvdTrafficRequest(context.Background(), tt.md, "test-sandbox")
+			result := isNonEnvdTrafficRequest(t.Context(), tt.md, "test-sandbox")
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/packages/api/internal/handlers/sandbox_create_test.go
+++ b/packages/api/internal/handlers/sandbox_create_test.go
@@ -280,7 +280,7 @@ func TestValidateNetworkConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mockFF := handlersmocks.NewMockFeatureFlagsClient(t)
-			err := validateNetworkConfig(context.Background(), mockFF, uuid.Nil, "", tt.network)
+			err := validateNetworkConfig(t.Context(), mockFF, uuid.Nil, "", tt.network)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1038,7 +1038,7 @@ func TestValidateNetworkRules(t *testing.T) {
 			t.Parallel()
 
 			ff := tt.setupFF(t)
-			apiErr := validateNetworkRules(context.Background(), ff, teamID, tt.envdVersion, tt.rules)
+			apiErr := validateNetworkRules(t.Context(), ff, teamID, tt.envdVersion, tt.rules)
 
 			if tt.wantMsg == "" {
 				assert.Nil(t, apiErr)

--- a/packages/api/internal/middleware/ratelimit/ratelimit_test.go
+++ b/packages/api/internal/middleware/ratelimit/ratelimit_test.go
@@ -1,7 +1,6 @@
 package ratelimit
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -55,9 +54,11 @@ func routeConfig(rate, burst int) map[string]map[string]int {
 }
 
 // doRequest performs a POST /sandboxes/test-sbx/connect.
-func doRequest(r *gin.Engine) *httptest.ResponseRecorder {
+func doRequest(t *testing.T, r *gin.Engine) *httptest.ResponseRecorder {
+	t.Helper()
+
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "/sandboxes/test-sbx/connect", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodPost, "/sandboxes/test-sbx/connect", nil)
 	r.ServeHTTP(w, req)
 
 	return w
@@ -99,7 +100,7 @@ func TestMiddleware_SkipsUnauthenticated(t *testing.T) {
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -117,7 +118,7 @@ func TestMiddleware_FailOpen(t *testing.T) {
 	limiter := redis_rate.NewLimiter(badClient)
 	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -134,7 +135,7 @@ func TestMiddleware_FailClosed(t *testing.T) {
 	limiter := redis_rate.NewLimiter(badClient)
 	r := newRouterWithTeam(limiter, Config{FailOpen: false}, ff, uuid.New())
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
@@ -149,7 +150,7 @@ func TestMiddleware_UnconfiguredRouteAllowsThrough(t *testing.T) {
 	limiter := redis_rate.NewLimiter(badClient)
 	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 	// No rate limit headers should be set for unconfigured routes.
 	assert.Empty(t, w.Header().Get("RateLimit-Limit"))
@@ -170,7 +171,7 @@ func TestIntegration_AllowedRequestSetsHeaders(t *testing.T) {
 
 	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
 
-	w := doRequest(r)
+	w := doRequest(t, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "20", w.Header().Get("RateLimit-Limit"))
@@ -193,12 +194,12 @@ func TestIntegration_BurstThenDeny(t *testing.T) {
 
 	// First 3 requests should succeed (burst).
 	for i := range 3 {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		assert.Equal(t, http.StatusOK, w.Code, "request %d should be allowed", i+1)
 	}
 
 	// 4th should be denied.
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
 	assert.NotEmpty(t, w.Header().Get("Retry-After"))
 
@@ -227,16 +228,16 @@ func TestIntegration_Refill(t *testing.T) {
 
 	// Exhaust burst.
 	for range 2 {
-		w := doRequest(r)
+		w := doRequest(t, r)
 		assert.Equal(t, http.StatusOK, w.Code)
 	}
-	w := doRequest(r)
+	w := doRequest(t, r)
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
 
 	// Wait for refill (rate=10/s → one token every 100ms).
 	time.Sleep(200 * time.Millisecond)
 
-	w = doRequest(r)
+	w = doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -260,13 +261,13 @@ func TestIntegration_IndependentTeams(t *testing.T) {
 	rB := newRouterWithTeam(limiter, cfg, ff, teamB)
 
 	// Team A uses its quota.
-	w := doRequest(rA)
+	w := doRequest(t, rA)
 	assert.Equal(t, http.StatusOK, w.Code)
-	w = doRequest(rA)
+	w = doRequest(t, rA)
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
 
 	// Team B should still have quota.
-	w = doRequest(rB)
+	w = doRequest(t, rB)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -295,7 +296,7 @@ func TestIntegration_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			w := doRequest(r)
+			w := doRequest(t, r)
 			results[idx] = w.Code
 		}(i)
 	}

--- a/packages/api/internal/oauth/oauth_test.go
+++ b/packages/api/internal/oauth/oauth_test.go
@@ -34,7 +34,7 @@ func TestNewVerifierConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			verifier, err := NewVerifier(context.Background(), tt.issuerURL)
+			verifier, err := NewVerifier(t.Context(), tt.issuerURL)
 			require.NoError(t, err)
 			require.NotNil(t, verifier)
 		})
@@ -44,10 +44,10 @@ func TestNewVerifierConfig(t *testing.T) {
 func TestNoopVerifierRejectsClaims(t *testing.T) {
 	t.Parallel()
 
-	verifier, err := NewVerifier(context.Background(), "")
+	verifier, err := NewVerifier(t.Context(), "")
 	require.NoError(t, err)
 
-	claims, err := verifier.VerifyClaims(context.Background(), "token")
+	claims, err := verifier.VerifyClaims(t.Context(), "token")
 	require.Error(t, err)
 	require.Empty(t, claims)
 }
@@ -72,7 +72,7 @@ func TestNewVerifierLoadsOIDCProvider(t *testing.T) {
 	t.Cleanup(server.Close)
 	issuerURL = server.URL
 
-	verifier, err := NewVerifier(context.Background(), server.URL)
+	verifier, err := NewVerifier(t.Context(), server.URL)
 	require.NoError(t, err)
 	require.NotNil(t, verifier)
 }
@@ -179,7 +179,7 @@ func TestRequireClaims(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			claims, err := RequireClaims(context.Background(), tt.md, tt.verifier)
+			claims, err := RequireClaims(t.Context(), tt.md, tt.verifier)
 			if tt.wantErr {
 				require.Error(t, err)
 

--- a/packages/api/internal/orchestrator/discovery/kubernetes_test.go
+++ b/packages/api/internal/orchestrator/discovery/kubernetes_test.go
@@ -1,7 +1,6 @@
 package discovery
 
 import (
-	"context"
 	"net"
 	"strconv"
 	"testing"
@@ -59,7 +58,7 @@ func TestKubernetesDiscovery_PodsWithSharedPrefix(t *testing.T) {
 	client := fake.NewSimpleClientset(pod1, pod2)
 	d := NewKubernetes(client, testNamespace, testLabelSelector)
 
-	nodes, err := d.ListNodes(context.Background())
+	nodes, err := d.ListNodes(t.Context())
 	require.NoError(t, err)
 	require.Len(t, nodes, 2)
 
@@ -96,7 +95,7 @@ func TestKubernetesDiscovery_FiltersNotReady(t *testing.T) {
 	client := fake.NewSimpleClientset(ready, notReady)
 	d := NewKubernetes(client, testNamespace, testLabelSelector)
 
-	nodes, err := d.ListNodes(context.Background())
+	nodes, err := d.ListNodes(t.Context())
 	require.NoError(t, err)
 	require.Len(t, nodes, 1)
 	assert.Equal(t, ready.Name, nodes[0].ShortID)
@@ -122,7 +121,7 @@ func TestKubernetesDiscovery_FiltersPending(t *testing.T) {
 	client := fake.NewSimpleClientset(pending)
 	d := NewKubernetes(client, testNamespace, testLabelSelector)
 
-	nodes, err := d.ListNodes(context.Background())
+	nodes, err := d.ListNodes(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, nodes)
 }
@@ -149,7 +148,7 @@ func TestKubernetesDiscovery_FiltersMissingIP(t *testing.T) {
 	client := fake.NewSimpleClientset(noIP)
 	d := NewKubernetes(client, testNamespace, testLabelSelector)
 
-	nodes, err := d.ListNodes(context.Background())
+	nodes, err := d.ListNodes(t.Context())
 	require.NoError(t, err)
 	assert.Empty(t, nodes)
 }

--- a/packages/api/internal/orchestrator/nodemanager/node_test.go
+++ b/packages/api/internal/orchestrator/nodemanager/node_test.go
@@ -1,7 +1,6 @@
 package nodemanager_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
@@ -35,7 +34,7 @@ func TestNode_OptimisticAdd_FlagEnabled(t *testing.T) {
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
-	node.OptimisticAdd(context.Background(), res)
+	node.OptimisticAdd(t.Context(), res)
 
 	// 6. Assert: When flag is enabled, resources should be successfully accumulated
 	newMetrics := node.Metrics()
@@ -65,7 +64,7 @@ func TestNode_OptimisticAdd_FlagDisabled(t *testing.T) {
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
-	node.OptimisticAdd(context.Background(), res)
+	node.OptimisticAdd(t.Context(), res)
 
 	// 6. Assert: When flag is disabled, return early, resources should not be accumulated
 	newMetrics := node.Metrics()
@@ -95,7 +94,7 @@ func TestNode_OptimisticRemove_FlagEnabled(t *testing.T) {
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
-	node.OptimisticRemove(context.Background(), res)
+	node.OptimisticRemove(t.Context(), res)
 
 	// 6. Assert: When flag is enabled, resources should be successfully deducted
 	newMetrics := node.Metrics()
@@ -125,7 +124,7 @@ func TestNode_OptimisticRemove_FlagDisabled(t *testing.T) {
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
-	node.OptimisticRemove(context.Background(), res)
+	node.OptimisticRemove(t.Context(), res)
 
 	// 6. Assert: When flag is disabled, return early, resources should remain unchanged
 	newMetrics := node.Metrics()

--- a/packages/api/internal/sandbox/storage/memory/operations_benchmark_test.go
+++ b/packages/api/internal/sandbox/storage/memory/operations_benchmark_test.go
@@ -1,7 +1,6 @@
 package memory
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -105,7 +104,7 @@ func BenchmarkStorageGetItemsRunningByTeam(b *testing.B) {
 }
 
 func BenchmarkStorageExpiredItems(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 	benchmarkSizes(b, func(b *testing.B, f benchFixture) {
 		b.Helper()
 
@@ -116,7 +115,7 @@ func BenchmarkStorageExpiredItems(b *testing.B) {
 }
 
 func BenchmarkStorageTeamsWithSandboxCount(b *testing.B) {
-	ctx := context.Background()
+	ctx := b.Context()
 	benchmarkSizes(b, func(b *testing.B, f benchFixture) {
 		b.Helper()
 

--- a/packages/api/internal/sandbox/storage/redis/state_change_test.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change_test.go
@@ -68,7 +68,7 @@ func TestStartRemoving_BasicTransitions(t *testing.T) {
 			t.Parallel()
 
 			storage, _ := setupTestStorage(t)
-			ctx := context.Background()
+			ctx := t.Context()
 
 			sbx := createTestSandbox("test-" + tt.name)
 			sbx.State = tt.fromState
@@ -114,7 +114,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("pause-then-kill")
 	err := storage.Add(ctx, sbx)
@@ -173,7 +173,7 @@ func TestStartRemoving_ConcurrentSameState(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("concurrent-same")
 	err := storage.Add(ctx, sbx)
@@ -250,7 +250,7 @@ func TestStartRemoving_NotFound(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	teamID := uuid.New()
 	_, alreadyDone, callback, err := storage.StartRemoving(ctx, teamID, "non-existent", sandbox.RemoveOpts{Action: sandbox.StateActionKill})
@@ -267,17 +267,17 @@ func TestStartRemoving_ContextCancellation(t *testing.T) {
 	storage, _ := setupTestStorage(t)
 
 	sbx := createTestSandbox("context-cancel")
-	err := storage.Add(context.Background(), sbx)
+	err := storage.Add(t.Context(), sbx)
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone1, callback1, err := storage.StartRemoving(context.Background(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone1, callback1, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone1)
 	require.NotNil(t, callback1)
 
 	// Another request with a short timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
 	defer cancel()
 
 	start := time.Now()
@@ -299,7 +299,7 @@ func TestWaitForStateChange_NoTransition(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("no-transition")
 	err := storage.Add(ctx, sbx)
@@ -314,7 +314,7 @@ func TestWaitForStateChange_WaitForCompletion(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("wait-completion")
 	err := storage.Add(ctx, sbx)
@@ -356,17 +356,17 @@ func TestWaitForStateChange_ContextCancellation(t *testing.T) {
 	storage, _ := setupTestStorage(t)
 
 	sbx := createTestSandbox("wait-cancel")
-	err := storage.Add(context.Background(), sbx)
+	err := storage.Add(t.Context(), sbx)
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(context.Background(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
 
 	// Wait with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Millisecond)
 	defer cancel()
 
 	var waitErr error
@@ -394,7 +394,7 @@ func TestWaitForStateChange_MultipleWaiters(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("multi-waiters")
 	err := storage.Add(ctx, sbx)
@@ -438,7 +438,7 @@ func TestStartRemoving_TransitionKeyTTL(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("ttl-test")
 	err := storage.Add(ctx, sbx)
@@ -466,7 +466,7 @@ func TestStartRemoving_CallbackMarksTransitionCompleted(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("callback-complete")
 	err := storage.Add(ctx, sbx)
@@ -508,7 +508,7 @@ func TestStartRemoving_CallbackSetsErrorOnFailure(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("callback-error")
 	err := storage.Add(ctx, sbx)
@@ -550,7 +550,7 @@ func TestStartRemoving_SetsEndTimeWhenNotExpired(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("end-time-test")
 	sbx.EndTime = time.Now().Add(time.Hour) // Not expired
@@ -580,7 +580,7 @@ func TestStartRemoving_WaiterCompletesOnCallbackSuccess(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("waiter-complete-success")
 	err := storage.Add(ctx, sbx)
@@ -626,7 +626,7 @@ func TestStartRemoving_WaiterReceivesErrorOnCallbackFailure(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("waiter-complete-error")
 	err := storage.Add(ctx, sbx)
@@ -668,7 +668,7 @@ func TestStartRemoving_DifferentExecutionID(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("exec-id-test")
 	sbx.State = sandbox.StateRunning
@@ -802,7 +802,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		t.Parallel()
 
 		storage, _ := setupTestStorage(t)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		sbx := createTestSandbox("evict-ok")
 		sbx.StartTime = time.Now().Add(-2 * time.Hour)
@@ -827,7 +827,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		t.Parallel()
 
 		storage, _ := setupTestStorage(t)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		sbx := createTestSandbox("evict-not-expired")
 		// EndTime defaults to 1 hour from now (not expired)
@@ -850,7 +850,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		t.Parallel()
 
 		storage, _ := setupTestStorage(t)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		sbx := createTestSandbox("evict-in-transition")
 		sbx.StartTime = time.Now().Add(-2 * time.Hour)
@@ -882,7 +882,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		t.Parallel()
 
 		storage, _ := setupTestStorage(t)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		sbx := createTestSandbox("evict-autopause")
 		sbx.StartTime = time.Now().Add(-2 * time.Hour)
@@ -911,7 +911,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		// If EndTime is extended mid-flight (simulating KeepAliveFor),
 		// the retry must still proceed because it is not an eviction.
 		storage, _ := setupTestStorage(t)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		sbx := createTestSandbox("evict-retry-no-flag")
 		sbx.StartTime = time.Now().Add(-2 * time.Hour)
@@ -972,7 +972,7 @@ func TestWaitForStateChange_PubSubWakesWaiterFast(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("pubsub-fast-wake")
 	err := storage.Add(ctx, sbx)
@@ -1020,7 +1020,7 @@ func TestWaitForStateChange_MultipleWaitersPubSub(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("pubsub-multi-waiters")
 	err := storage.Add(ctx, sbx)
@@ -1080,7 +1080,7 @@ func TestCallback_PublishesNotification(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("callback-publishes")
 	err := storage.Add(ctx, sbx)
@@ -1127,7 +1127,7 @@ func TestStartRemoving_PauseThenKill_PubSubFastWake(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("pubsub-pause-kill")
 	err := storage.Add(ctx, sbx)
@@ -1243,7 +1243,7 @@ func TestStartRemoving_CompletedTransitionAllowsNewTransition(t *testing.T) {
 	t.Parallel()
 
 	storage, _ := setupTestStorage(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sbx := createTestSandbox("completed-allows-new")
 	sbx.State = sandbox.StateRunning

--- a/packages/client-proxy/internal/proxy/grpc_resume_auth_test.go
+++ b/packages/client-proxy/internal/proxy/grpc_resume_auth_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -30,7 +29,7 @@ func TestNewGRPCResumeAuth(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		t.Parallel()
 
-		auth, err := newGrpcResumeAuth(context.Background(), GRPCOAuthConfig{})
+		auth, err := newGrpcResumeAuth(t.Context(), GRPCOAuthConfig{})
 		require.NoError(t, err)
 		require.IsType(t, noopGrpcResumeAuth{}, auth)
 	})
@@ -38,7 +37,7 @@ func TestNewGRPCResumeAuth(t *testing.T) {
 	t.Run("partial config", func(t *testing.T) {
 		t.Parallel()
 
-		auth, err := newGrpcResumeAuth(context.Background(), GRPCOAuthConfig{ClientID: "client-id"})
+		auth, err := newGrpcResumeAuth(t.Context(), GRPCOAuthConfig{ClientID: "client-id"})
 		require.Error(t, err)
 		require.Nil(t, auth)
 	})
@@ -46,7 +45,7 @@ func TestNewGRPCResumeAuth(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		t.Parallel()
 
-		auth, err := newGrpcResumeAuth(context.Background(), GRPCOAuthConfig{
+		auth, err := newGrpcResumeAuth(t.Context(), GRPCOAuthConfig{
 			ClientID:     " client-id ",
 			ClientSecret: " secret ",
 			TokenURL:     " https://tokens.example.com ",
@@ -81,14 +80,14 @@ func TestOAuthGrpcResumeAuthRequestsAutoresumeScope(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	auth, err := newGrpcResumeAuth(context.Background(), GRPCOAuthConfig{
+	auth, err := newGrpcResumeAuth(t.Context(), GRPCOAuthConfig{
 		ClientID:     "client-id",
 		ClientSecret: "secret",
 		TokenURL:     server.URL,
 	})
 	require.NoError(t, err)
 
-	ctx, err := auth.authorize(context.Background())
+	ctx, err := auth.authorize(t.Context())
 	require.NoError(t, err)
 
 	md, ok := metadata.FromOutgoingContext(ctx)
@@ -101,7 +100,7 @@ func TestOAuthGrpcResumeAuthRequestsAutoresumeScope(t *testing.T) {
 func TestNoopGrpcResumeAuthAuthorize(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := (noopGrpcResumeAuth{}).authorize(context.Background())
+	ctx, err := (noopGrpcResumeAuth{}).authorize(t.Context())
 	require.NoError(t, err)
 
 	md, ok := metadata.FromOutgoingContext(ctx)
@@ -112,7 +111,7 @@ func TestNoopGrpcResumeAuthAuthorize(t *testing.T) {
 func TestOAuthGrpcResumeAuthAuthorize(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := (oauthGrpcResumeAuth{tokenSource: stubTokenSource{token: &oauth2.Token{AccessToken: "token"}}}).authorize(context.Background())
+	ctx, err := (oauthGrpcResumeAuth{tokenSource: stubTokenSource{token: &oauth2.Token{AccessToken: "token"}}}).authorize(t.Context())
 	require.NoError(t, err)
 
 	md, ok := metadata.FromOutgoingContext(ctx)
@@ -124,7 +123,7 @@ func TestOAuthGrpcResumeAuthAuthorizeError(t *testing.T) {
 	t.Parallel()
 
 	tokenErr := errors.New("token failed")
-	ctx, err := (oauthGrpcResumeAuth{tokenSource: stubTokenSource{err: tokenErr}}).authorize(context.Background())
+	ctx, err := (oauthGrpcResumeAuth{tokenSource: stubTokenSource{err: tokenErr}}).authorize(t.Context())
 	require.ErrorIs(t, err, tokenErr)
 
 	md, ok := metadata.FromOutgoingContext(ctx)

--- a/packages/dashboard-api/internal/handlers/sandbox_record_test.go
+++ b/packages/dashboard-api/internal/handlers/sandbox_record_test.go
@@ -45,7 +45,7 @@ func TestGetSandboxesSandboxIDRecordReturns404WhenRecordRetentionNotMet(t *testi
 
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
-	ctx.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/sandboxes/sbx_1/record", nil)
+	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/sandboxes/sbx_1/record", nil)
 
 	teamID := uuid.New()
 	auth.SetTeamInfo(ctx, &authtypes.Team{

--- a/packages/db/pkg/retry/wrapper_test.go
+++ b/packages/db/pkg/retry/wrapper_test.go
@@ -89,7 +89,7 @@ func TestExec_SuccessOnFirstAttempt(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := wrapped.Exec(ctx, "INSERT INTO test VALUES (1)")
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestExec_RetryOnConnectionError(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := wrapped.Exec(ctx, "INSERT INTO test VALUES (1)")
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestExec_NoRetryOnDeadlock(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := wrapped.Exec(ctx, "UPDATE test SET val = 1")
 	require.Error(t, err)
@@ -155,7 +155,7 @@ func TestExec_NoRetryOnConstraintViolation(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := wrapped.Exec(ctx, "INSERT INTO test VALUES (1)")
 	require.Error(t, err)
@@ -180,7 +180,7 @@ func TestExec_MaxAttemptsExceeded(t *testing.T) {
 	config := testConfig()
 	config.MaxAttempts = 3
 	wrapped := Wrap(mock, config)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	_, err := wrapped.Exec(ctx, "INSERT INTO test VALUES (1)")
 	require.Error(t, err)
@@ -201,7 +201,7 @@ func TestExec_ContextCancellation(t *testing.T) {
 	config := testConfig()
 	config.InitialBackoff = 100 * time.Millisecond
 	wrapped := Wrap(mock, config)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	// Cancel context after a short delay
 	go func() {
@@ -230,7 +230,7 @@ func TestQuery_RetryOnConnectionError(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	rows, err := wrapped.Query(ctx, "SELECT id FROM test")
 	if rows != nil {
@@ -265,7 +265,7 @@ func TestQueryRow_RetryOnConnectionError(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var result int
 	err := wrapped.QueryRow(ctx, "SELECT count(*) FROM test").Scan(&result)
@@ -290,7 +290,7 @@ func TestQueryRow_NoRetryOnNoRows(t *testing.T) {
 	}
 
 	wrapped := Wrap(mock, testConfig())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	var result int
 	err := wrapped.QueryRow(ctx, "SELECT count(*) FROM test").Scan(&result)

--- a/packages/db/pkg/tests/snapshots/upsert_snapshot_test.go
+++ b/packages/db/pkg/tests/snapshots/upsert_snapshot_test.go
@@ -1,7 +1,6 @@
 package snapshots
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -19,7 +18,7 @@ func TestUpsertSnapshot_NewSnapshot(t *testing.T) {
 	t.Parallel()
 	// Setup test database with migrations
 	client := testutils.SetupDatabase(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test team first (required by foreign key constraint)
 	teamID := testutils.CreateTestTeam(t, client)
@@ -103,7 +102,7 @@ func TestUpsertSnapshot_ExistingSnapshot(t *testing.T) {
 	t.Parallel()
 	// Setup test database with migrations
 	client := testutils.SetupDatabase(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test team first (required by foreign key constraint)
 	teamID := testutils.CreateTestTeam(t, client)

--- a/packages/db/pkg/tests/template_aliases/delete_template_aliases_test.go
+++ b/packages/db/pkg/tests/template_aliases/delete_template_aliases_test.go
@@ -1,7 +1,6 @@
 package aliases
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +13,7 @@ func TestDeleteTemplateAliases_Success(t *testing.T) {
 	t.Parallel()
 	// Setup test database with migrations
 	client := testutils.SetupDatabase(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test team first (required by foreign key constraint)
 	teamID := testutils.CreateTestTeam(t, client)
@@ -31,7 +30,7 @@ func TestDeleteTemplateAliases_NoAlias(t *testing.T) {
 	t.Parallel()
 	// Setup test database with migrations
 	client := testutils.SetupDatabase(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test team first (required by foreign key constraint)
 	teamID := testutils.CreateTestTeam(t, client)

--- a/packages/envd/internal/api/init_test.go
+++ b/packages/envd/internal/api/init_test.go
@@ -340,7 +340,7 @@ func TestCheckMMDSHash(t *testing.T) {
 
 func TestSetData(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := zerolog.Nop()
 
 	t.Run("access token updates", func(t *testing.T) {

--- a/packages/envd/internal/host/cacerts_test.go
+++ b/packages/envd/internal/host/cacerts_test.go
@@ -1,7 +1,6 @@
 package host
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,7 +91,7 @@ func TestInstallCACert_FirstTime(t *testing.T) {
 	bundlePath, extraPath := testPaths(t)
 	c := newTestInstaller(t)
 
-	c.install(context.Background(), certA, bundlePath, extraPath)
+	c.install(t.Context(), certA, bundlePath, extraPath)
 	waitForFile(t, extraPath)
 
 	bundle, err := os.ReadFile(bundlePath)
@@ -109,11 +108,11 @@ func TestInstallCACert_SameCert(t *testing.T) {
 	bundlePath, extraPath := testPaths(t)
 	c := newTestInstaller(t)
 
-	c.install(context.Background(), certA, bundlePath, extraPath)
+	c.install(t.Context(), certA, bundlePath, extraPath)
 	waitForFile(t, extraPath) // drain the background goroutine before the hot-path call
 
-	c.install(context.Background(), certA, bundlePath, extraPath) // resume — hot path hit
-	waitForFile(t, extraPath)                                     // file already written by first goroutine; guards TempDir cleanup
+	c.install(t.Context(), certA, bundlePath, extraPath) // resume — hot path hit
+	waitForFile(t, extraPath)                            // file already written by first goroutine; guards TempDir cleanup
 
 	bundle, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)
@@ -127,9 +126,9 @@ func TestInstallCACert_DifferentCert(t *testing.T) {
 	bundlePath, extraPath := testPaths(t)
 	c := newTestInstaller(t)
 
-	c.install(context.Background(), certA, bundlePath, extraPath)
+	c.install(t.Context(), certA, bundlePath, extraPath)
 
-	c.install(context.Background(), certB, bundlePath, extraPath)
+	c.install(t.Context(), certB, bundlePath, extraPath)
 
 	normalizedA := strings.TrimRight(certA, "\n") + "\n"
 	normalizedB := strings.TrimRight(certB, "\n") + "\n"
@@ -147,7 +146,7 @@ func TestInstallCACert_EmptyCert(t *testing.T) {
 	bundlePath, extraPath := testPaths(t)
 	c := newTestInstaller(t)
 
-	c.install(context.Background(), "", bundlePath, extraPath)
+	c.install(t.Context(), "", bundlePath, extraPath)
 
 	bundle, err := os.ReadFile(bundlePath)
 	require.NoError(t, err)
@@ -170,7 +169,7 @@ func TestInstallCACert_RestartSameCert(t *testing.T) {
 	// State of the VM after a previous envd run.
 	require.NoError(t, os.WriteFile(bundlePath, []byte(baseBundle+normalizedA), 0o644))
 
-	c.install(context.Background(), certA, bundlePath, extraPath)
+	c.install(t.Context(), certA, bundlePath, extraPath)
 	waitForFile(t, extraPath)
 
 	bundle, err := os.ReadFile(bundlePath)
@@ -194,7 +193,7 @@ func TestInstallCACert_RestartDifferentCert(t *testing.T) {
 	// State of the VM after a previous envd run that installed certA.
 	require.NoError(t, os.WriteFile(bundlePath, []byte(baseBundle+normalizedA), 0o644))
 
-	c.install(context.Background(), certB, bundlePath, extraPath)
+	c.install(t.Context(), certB, bundlePath, extraPath)
 	waitForFile(t, extraPath)
 
 	bundle, err := os.ReadFile(bundlePath)
@@ -211,13 +210,13 @@ func TestInstallCACert_ConcurrentResume(t *testing.T) {
 	bundlePath, extraPath := testPaths(t)
 	c := newTestInstaller(t)
 
-	c.install(context.Background(), certA, bundlePath, extraPath)
+	c.install(t.Context(), certA, bundlePath, extraPath)
 
 	var wg sync.WaitGroup
 
 	for range 10 {
 		wg.Go(func() {
-			c.install(context.Background(), certA, bundlePath, extraPath)
+			c.install(t.Context(), certA, bundlePath, extraPath)
 		})
 	}
 

--- a/packages/envd/internal/services/filesystem/utils_test.go
+++ b/packages/envd/internal/services/filesystem/utils_test.go
@@ -45,7 +45,7 @@ func TestIsPathOnNetworkMount_FuseMount(t *testing.T) {
 	mountDir := t.TempDir()
 
 	// Mount sourceDir onto mountDir using bindfs (FUSE)
-	ctx := context.Background()
+	ctx := t.Context()
 	cmd := exec.CommandContext(ctx, "bindfs", sourceDir, mountDir)
 	require.NoError(t, cmd.Run(), "failed to mount bindfs")
 

--- a/packages/envd/internal/services/process/start_test.go
+++ b/packages/envd/internal/services/process/start_test.go
@@ -60,7 +60,7 @@ func TestStart_ShortCommand(t *testing.T) {
 	client, cleanup := newTestService(t)
 	defer cleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	stream, err := client.Start(ctx, connect.NewRequest(&rpc.StartRequest{
@@ -97,7 +97,7 @@ func TestStart_ClientDisconnectMidStream(t *testing.T) {
 	client, cleanup := newTestService(t)
 	defer cleanup()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	// Use a long-running command so there's data flowing when we cancel.

--- a/packages/orchestrator/cmd/clean-nfs-cache/cleaner/scan_test.go
+++ b/packages/orchestrator/cmd/clean-nfs-cache/cleaner/scan_test.go
@@ -25,7 +25,7 @@ func TestScanDir(t *testing.T) {
 		Path: path,
 	}, logger.NewNopLogger())
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	c.statRequestCh = make(chan *statReq, 1)

--- a/packages/orchestrator/pkg/sandbox/block/fetch_session_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/fetch_session_test.go
@@ -38,8 +38,8 @@ func TestFetchSession_FastPath(t *testing.T) {
 
 	// All blocks already covered — must return immediately via atomic fast path.
 	start := time.Now()
-	require.NoError(t, s.registerAndWait(context.Background(), 0))
-	require.NoError(t, s.registerAndWait(context.Background(), 3*blockSize))
+	require.NoError(t, s.registerAndWait(t.Context(), 0))
+	require.NoError(t, s.registerAndWait(t.Context(), 3*blockSize))
 	require.Less(t, time.Since(start), time.Millisecond)
 }
 
@@ -62,7 +62,7 @@ func TestFetchSession_ProgressiveAdvance(t *testing.T) {
 
 	for i := range numBlocks {
 		go func(idx int) {
-			err := s.registerAndWait(context.Background(), int64(idx)*blockSize)
+			err := s.registerAndWait(t.Context(), int64(idx)*blockSize)
 			returned.Add(1)
 			ch <- result{idx, err}
 		}(i)
@@ -106,7 +106,7 @@ func TestFetchSession_SetDoneUnblocksAll(t *testing.T) {
 
 	for i := range numBlocks {
 		go func(idx int) {
-			err := s.registerAndWait(context.Background(), int64(idx)*blockSize)
+			err := s.registerAndWait(t.Context(), int64(idx)*blockSize)
 			returned.Add(1)
 			ch <- err
 		}(i)
@@ -135,7 +135,7 @@ func TestFetchSession_FailPropagatesError(t *testing.T) {
 	ch := make(chan error, 1)
 
 	go func() {
-		err := s.registerAndWait(context.Background(), 0)
+		err := s.registerAndWait(t.Context(), 0)
 		returned.Add(1)
 		ch <- err
 	}()
@@ -157,7 +157,7 @@ func TestFetchSession_ContextCancellation(t *testing.T) {
 	cache := makeTestCacheForSession(t, 4)
 	s := newFetchSession(0, 4*blockSize, cache)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	var returned atomic.Int64
 	ch := make(chan error, 1)
@@ -190,7 +190,7 @@ func TestFetchSession_TerminatedButCachedByPriorSession(t *testing.T) {
 	// Fail this session — but block 0 is already in the cache.
 	s.fail(errors.New("some error"))
 
-	err := s.registerAndWait(context.Background(), 0)
+	err := s.registerAndWait(t.Context(), 0)
 	require.NoError(t, err)
 }
 
@@ -209,7 +209,7 @@ func TestFetchSession_TerminatedNoErrorBlockNotCached(t *testing.T) {
 	s.mu.Unlock()
 	s.cond.Broadcast()
 
-	err := s.registerAndWait(context.Background(), 2*blockSize)
+	err := s.registerAndWait(t.Context(), 2*blockSize)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "terminated without error but block")
 }
@@ -226,8 +226,8 @@ func TestFetchSession_FailIfRunning_NoOpAfterSetDone(t *testing.T) {
 	s.failIfRunning(errors.New("should be ignored"))
 
 	// setDone set bytesReady = chunkLen, so all blocks are covered.
-	require.NoError(t, s.registerAndWait(context.Background(), 0))
-	require.NoError(t, s.registerAndWait(context.Background(), 3*blockSize))
+	require.NoError(t, s.registerAndWait(t.Context(), 0))
+	require.NoError(t, s.registerAndWait(t.Context(), 3*blockSize))
 	require.NoError(t, s.fetchErr)
 }
 
@@ -242,7 +242,7 @@ func TestFetchSession_FailIfRunning_BeforeDone(t *testing.T) {
 	sentinel := errors.New("panic recovery")
 	s.failIfRunning(sentinel)
 
-	err := s.registerAndWait(context.Background(), 0)
+	err := s.registerAndWait(t.Context(), 0)
 	require.ErrorIs(t, err, sentinel)
 }
 
@@ -262,7 +262,7 @@ func TestFetchSession_NonZeroChunkOffset(t *testing.T) {
 	ch := make(chan error, 2)
 
 	go func() {
-		err := s.registerAndWait(context.Background(), chunkOff) // block 2
+		err := s.registerAndWait(t.Context(), chunkOff) // block 2
 		returned.Add(1)
 		ch <- err
 	}()
@@ -271,7 +271,7 @@ func TestFetchSession_NonZeroChunkOffset(t *testing.T) {
 		// Block 3 extends past chunkOff+chunkLen, so endByte is clamped to chunkLen.
 		// relEnd = lastBlockOff + blockSize - chunkOff = 2*blockSize = 8192
 		// endByte = min(8192, 5096) = 5096 (chunkLen)
-		err := s.registerAndWait(context.Background(), lastBlockOff)
+		err := s.registerAndWait(t.Context(), lastBlockOff)
 		returned.Add(1)
 		ch <- err
 	}()
@@ -301,7 +301,7 @@ func TestFetchSession_ConcurrentWaitersAndCancel(t *testing.T) {
 	cache := makeTestCacheForSession(t, 8)
 	s := newFetchSession(0, 8*blockSize, cache)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	var returned atomic.Int64
 
@@ -322,7 +322,7 @@ func TestFetchSession_ConcurrentWaitersAndCancel(t *testing.T) {
 
 		go func(idx int) {
 			defer wg.Done()
-			bgErrs[idx] = s.registerAndWait(context.Background(), int64(idx+4)*blockSize)
+			bgErrs[idx] = s.registerAndWait(t.Context(), int64(idx+4)*blockSize)
 			returned.Add(1)
 		}(i)
 	}

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
@@ -136,7 +136,7 @@ func (s *fakeSeekable) OpenRangeReader(_ context.Context, offsetU int64, length 
 func makeCompressedTestData(tb testing.TB, data []byte) (*storage.FrameTable, *fakeSeekable) {
 	tb.Helper()
 
-	ft, compressed, _, err := storage.CompressBytes(context.Background(), data, storage.CompressConfig{
+	ft, compressed, _, err := storage.CompressBytes(tb.Context(), data, storage.CompressConfig{
 		Enabled:            true,
 		Type:               "lz4",
 		EncoderConcurrency: 1,

--- a/packages/orchestrator/pkg/sandbox/cgroup/manager_test.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/manager_test.go
@@ -3,7 +3,6 @@
 package cgroup
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -36,7 +35,7 @@ func TestManagerInitialize(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mgr := &managerImpl{}
 
@@ -63,7 +62,7 @@ func TestCgroupHandleLifecycle(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -101,7 +100,7 @@ func TestCgroupHandleWithProcessCreation(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -156,7 +155,7 @@ func TestCgroupHandleNoRaceOnQuickExit(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -193,7 +192,7 @@ func TestCgroupHandleGetStats(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -242,7 +241,7 @@ func TestCgroupHandleGetStatsNonExistent(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -270,7 +269,7 @@ func TestCgroupHandleRemoveNonExistent(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 
@@ -312,7 +311,7 @@ burst_usec 0`
 	err = os.WriteFile(filepath.Join(cgroupPath, "memory.current"), []byte("536870912"), 0o644)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr := &managerImpl{}
 
 	// nil memoryPeakFile: regular files don't support the per-FD reset of cgroup pseudo-files
@@ -334,7 +333,7 @@ func TestCgroupHandlePeakReset(t *testing.T) {
 		t.Skip("test requires root privileges")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := NewManager()
 	require.NoError(t, err)
 

--- a/packages/orchestrator/pkg/sandbox/envd_test.go
+++ b/packages/orchestrator/pkg/sandbox/envd_test.go
@@ -67,7 +67,7 @@ func TestEnvdInitSendsCaBundle(t *testing.T) { //nolint:paralleltest
 	sandboxHttpClient = http.Client{Timeout: 5 * time.Second}
 	defer func() { sandboxHttpClient = orig }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	resp, _, err := sbx.doRequestWithInfiniteRetries(ctx, http.MethodPost, server.URL+"/init")
@@ -93,7 +93,7 @@ func TestEnvdInitEmptyCaBundle(t *testing.T) { //nolint:paralleltest
 	sandboxHttpClient = http.Client{Timeout: 5 * time.Second}
 	defer func() { sandboxHttpClient = orig }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	resp, _, err := sbx.doRequestWithInfiniteRetries(ctx, http.MethodPost, server.URL+"/init")

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
@@ -104,7 +104,7 @@ func TestSlowBackend_ShortTimeout(t *testing.T) {
 	// The 8s backend delay exceeds the 5s I/O timeout, so the kernel
 	// will declare the connection dead and return EIO.
 	devicePath, cleanup, err := testutils.GetNBDDevice(
-		context.Background(), overlay, featureFlags,
+		t.Context(), overlay, featureFlags,
 		nbd.WithIOTimeout(5*time.Second),
 		nbd.WithDeadconnTimeout(5*time.Second),
 	)
@@ -155,7 +155,7 @@ func TestSlowBackend_SufficientTimeout(t *testing.T) {
 
 	// Kernel I/O timeout of 30s — well above the 3s backend delay.
 	devicePath, cleanup, err := testutils.GetNBDDevice(
-		context.Background(), overlay, featureFlags,
+		t.Context(), overlay, featureFlags,
 		nbd.WithIOTimeout(30*time.Second),
 		nbd.WithDeadconnTimeout(30*time.Second),
 	)

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
@@ -3,7 +3,6 @@
 package nbd_test
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -269,8 +268,7 @@ func setupNBDDevice(t *testing.T, featureFlags *featureflags.Client, size int64,
 		overlay.Close()
 	})
 
-	nbdContext := context.Background()
-	devicePath, deviceCleanup, err := testutils.GetNBDDevice(nbdContext, overlay, featureFlags)
+	devicePath, deviceCleanup, err := testutils.GetNBDDevice(t.Context(), overlay, featureFlags)
 	t.Cleanup(func() {
 		deviceCleanup.Run(t.Context(), 30*time.Second)
 	})

--- a/packages/orchestrator/pkg/sandbox/uploads_test.go
+++ b/packages/orchestrator/pkg/sandbox/uploads_test.go
@@ -122,7 +122,7 @@ func TestUploads_Wait_BlocksUntilSet(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		_, _ = c.Wait(context.Background(), id, build.Memfile)
+		_, _ = c.Wait(t.Context(), id, build.Memfile)
 		close(done)
 	}()
 
@@ -153,7 +153,7 @@ func TestUploads_Wait_PropagatesUploadError(t *testing.T) {
 	uploadErr := errors.New("upload exploded")
 	require.NoError(t, fut.SetError(uploadErr))
 
-	_, err = c.Wait(context.Background(), id, build.Memfile)
+	_, err = c.Wait(t.Context(), id, build.Memfile)
 	require.ErrorIs(t, err, uploadErr)
 }
 
@@ -165,7 +165,7 @@ func TestUploads_Wait_ContextCancellation(t *testing.T) {
 	_, err := c.Start(id) // never signaled
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -199,7 +199,7 @@ func TestUploads_Wait_NoFuture_ReadsFromCache(t *testing.T) {
 	tpl.EXPECT().Rootfs().Return(dev, nil)
 	cache.put(id.String(), tpl)
 
-	got, err := c.Wait(context.Background(), id, build.Rootfs)
+	got, err := c.Wait(t.Context(), id, build.Rootfs)
 	require.NoError(t, err)
 	require.Same(t, want, got)
 }
@@ -226,7 +226,7 @@ func TestUploads_ConcurrentBeginsAndWaits(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			if _, err := c.Wait(context.Background(), ids[i], build.Memfile); err == nil {
+			if _, err := c.Wait(t.Context(), ids[i], build.Memfile); err == nil {
 				done.Add(1)
 			}
 		}(i)

--- a/packages/shared/pkg/cache/memory_test.go
+++ b/packages/shared/pkg/cache/memory_test.go
@@ -133,7 +133,7 @@ func TestCache_GetOrSet_CacheMiss(t *testing.T) {
 		return fmt.Sprintf("value-%s", key), nil
 	}
 
-	value, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, "value-key1", value)
 	assert.Equal(t, 1, callCount)
@@ -161,13 +161,13 @@ func TestCache_GetOrSet_CacheHit(t *testing.T) {
 	}
 
 	// First call - cache miss
-	value1, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value1, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, "value-key1", value1)
 	assert.Equal(t, 1, callCount)
 
 	// Second call - cache hit
-	value2, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value2, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, "value-key1", value2)
 	assert.Equal(t, 1, callCount) // Callback should not be called again
@@ -186,7 +186,7 @@ func TestCache_GetOrSet_CallbackError(t *testing.T) {
 		return "", expectedErr
 	}
 
-	value, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "callback error")
 	assert.Empty(t, value)
@@ -213,13 +213,13 @@ func TestCache_GetOrSet_WithRefreshInterval(t *testing.T) {
 	}
 
 	// Initial call - cache miss
-	value1, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value1, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, 1, value1)
 	assert.Equal(t, int32(1), callCount.Load())
 
 	// Immediate second call - cache hit, no refresh yet
-	value2, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value2, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, 1, value2) // Still returns original value
 	assert.Equal(t, int32(1), callCount.Load())
@@ -228,7 +228,7 @@ func TestCache_GetOrSet_WithRefreshInterval(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// This call should trigger background refresh but still return stale value
-	value3, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value3, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, 1, value3) // Still returns stale value immediately
 
@@ -260,7 +260,7 @@ func TestCache_GetOrSet_RefreshOnlyOnce(t *testing.T) {
 	}
 
 	// Initial call
-	value1, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value1, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, 1, value1)
 
@@ -272,7 +272,7 @@ func TestCache_GetOrSet_RefreshOnlyOnce(t *testing.T) {
 	results := make([]int, 10)
 	for i := range 10 {
 		wg.Go(func() error {
-			value, err := cache.GetOrSet(context.Background(), "key1", callback)
+			value, err := cache.GetOrSet(t.Context(), "key1", callback)
 			if err != nil {
 				return err
 			}
@@ -318,7 +318,7 @@ func TestCache_GetOrSet_CacheMissSingleflight(t *testing.T) {
 	results := make([]int, 10)
 	for i := range 10 {
 		wg.Go(func() error {
-			value, err := cache.GetOrSet(context.Background(), "key1", callback)
+			value, err := cache.GetOrSet(t.Context(), "key1", callback)
 			if err != nil {
 				return err
 			}
@@ -366,7 +366,7 @@ func TestCache_Refresh_DeletesOnError(t *testing.T) {
 	}
 
 	// Initial successful call
-	value, err := cache.GetOrSet(context.Background(), "key1", callback)
+	value, err := cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err)
 	assert.Equal(t, "success", value)
 
@@ -381,7 +381,7 @@ func TestCache_Refresh_DeletesOnError(t *testing.T) {
 	shouldFail.Store(true)
 
 	// Trigger refresh
-	_, err = cache.GetOrSet(context.Background(), "key1", callback)
+	_, err = cache.GetOrSet(t.Context(), "key1", callback)
 	require.NoError(t, err) // GetOrSet returns the stale value
 
 	// Wait for refresh to complete
@@ -400,7 +400,7 @@ func TestCache_ContextCancellation(t *testing.T) {
 	}
 	cache := NewMemoryCache[string](config)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
 	callback := func(ctx context.Context, _ string) (string, error) {
@@ -426,7 +426,7 @@ func TestCache_CallbackTimeout(t *testing.T) {
 	}
 	cache := NewMemoryCache[string](config)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
 	callback := func(ctx context.Context, _ string) (string, error) {
@@ -467,7 +467,7 @@ func TestCache_ExtractKeyFunc(t *testing.T) {
 		}
 
 		// Call with a different key, but ExtractKeyFunc should use the ID from the value
-		value, err := cache.GetOrSet(context.Background(), "any-key", callback)
+		value, err := cache.GetOrSet(t.Context(), "any-key", callback)
 		require.NoError(t, err)
 		assert.Equal(t, "user-123", value.ID)
 		assert.Equal(t, "Alice", value.Name)
@@ -495,7 +495,7 @@ func TestCache_ExtractKeyFunc(t *testing.T) {
 		}
 
 		// Without ExtractKeyFunc, should use the provided key
-		value, err := cache.GetOrSet(context.Background(), "custom-key", callback)
+		value, err := cache.GetOrSet(t.Context(), "custom-key", callback)
 		require.NoError(t, err)
 		assert.Equal(t, "user-456", value.ID)
 		assert.Equal(t, "Bob", value.Name)

--- a/packages/shared/pkg/featureflags/context_test.go
+++ b/packages/shared/pkg/featureflags/context_test.go
@@ -1,7 +1,6 @@
 package featureflags
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -164,7 +163,7 @@ func TestSetContext(t *testing.T) {
 	t.Run("empty_contexts_returns_original_context", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		result := AddToContext(ctx)
 
 		assert.Equal(t, ctx, result)
@@ -175,7 +174,7 @@ func TestSetContext(t *testing.T) {
 	t.Run("single_context", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		teamCtx := TeamContext("team-123")
 
 		result := AddToContext(ctx, teamCtx)
@@ -189,7 +188,7 @@ func TestSetContext(t *testing.T) {
 	t.Run("multiple_contexts", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		teamCtx := TeamContext("team-123")
 		userCtx := UserContext("user-456")
 
@@ -207,7 +206,7 @@ func TestSetContext(t *testing.T) {
 	t.Run("sequential_calls_merge_contexts", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// First call adds team context
 		ctx = AddToContext(ctx, TeamContext("team-123"))
@@ -227,7 +226,7 @@ func TestSetContext(t *testing.T) {
 	t.Run("same_kind_second_takes_precedence", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// First call with team-123
 		ctx = AddToContext(ctx, TeamContextWithName("team-123", "First Team"))

--- a/packages/shared/pkg/middleware/timeout_test.go
+++ b/packages/shared/pkg/middleware/timeout_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,7 +44,7 @@ func TestRequestTimeout_CancelsBlockingHandler(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/slow", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "/slow", nil)
 
 	start := time.Now()
 	r.ServeHTTP(w, req)
@@ -75,7 +74,7 @@ func TestRequestTimeout_NormalRequestContextNotCanceled(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "/test", nil)
 	r.ServeHTTP(w, req)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -99,7 +98,7 @@ func TestRequestTimeout_TimeoutContextVisibleToOuterMiddleware(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "/slow", nil)
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "/slow", nil)
 	r.ServeHTTP(w, req)
 
 	require.ErrorIs(t, outerCause, ErrRequestTimeout,

--- a/packages/shared/pkg/storage/compress_upload_test.go
+++ b/packages/shared/pkg/storage/compress_upload_test.go
@@ -161,7 +161,7 @@ func TestCompressStreamRoundTrip(t *testing.T) {
 			cfg := defaultCfg(tc.codec, tc.workers, tc.frameSize)
 
 			ft, checksum, err := compressStream(
-				context.Background(),
+				t.Context(),
 				bytes.NewReader(original),
 				cfg,
 				up,
@@ -197,7 +197,7 @@ func TestCompressStreamContextCancel(t *testing.T) {
 
 	data := generateSemiRandomData(10 * megabyte)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	go func() {
 		time.Sleep(10 * time.Millisecond)
 		cancel()
@@ -237,7 +237,7 @@ func TestCompressStreamPartSizeMinimum(t *testing.T) {
 			cfg := defaultCfg(CompressionZstd, 4, tc.frameSize)
 			cfg.MinPartSizeMB = tc.minPartSizeMB
 
-			_, _, err := compressStream(context.Background(), bytes.NewReader(data), cfg, up, 4)
+			_, _, err := compressStream(t.Context(), bytes.NewReader(data), cfg, up, 4)
 			require.NoError(t, err)
 
 			// Verify: no non-final part is under 5 MiB.
@@ -278,7 +278,7 @@ func TestCompressStreamRace(t *testing.T) {
 	wantChecksum := sha256.Sum256(data)
 
 	// Use an errgroup to run all streams concurrently.
-	eg, ctx := errgroup.WithContext(context.Background())
+	eg, ctx := errgroup.WithContext(t.Context())
 	for i := range streams {
 		codec := CompressionZstd
 		if i%2 == 1 {
@@ -356,7 +356,7 @@ func BenchmarkCompress(b *testing.B) {
 				up := &ThrottledPartUploader{bandwidth: bcfg.bandwidth}
 
 				_, _, err := compressStream(
-					context.Background(),
+					b.Context(),
 					bytes.NewReader(data),
 					compCfg,
 					up, 4,

--- a/packages/shared/pkg/utils/promise_test.go
+++ b/packages/shared/pkg/utils/promise_test.go
@@ -18,7 +18,7 @@ func TestPromiseSuccess(t *testing.T) {
 		return 42, nil
 	})
 
-	value, err := p.Wait(context.Background())
+	value, err := p.Wait(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, 42, value)
 }
@@ -31,7 +31,7 @@ func TestPromiseError(t *testing.T) {
 		return 0, expectedErr
 	})
 
-	value, err := p.Wait(context.Background())
+	value, err := p.Wait(t.Context())
 	require.ErrorIs(t, err, expectedErr)
 	assert.Equal(t, 0, value)
 }
@@ -45,7 +45,7 @@ func TestPromiseDelayedResult(t *testing.T) {
 		return "delayed", nil
 	})
 
-	value, err := p.Wait(context.Background())
+	value, err := p.Wait(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, "delayed", value)
 }
@@ -59,7 +59,7 @@ func TestPromiseContextCancelled(t *testing.T) {
 		return 42, nil
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
 	defer cancel()
 
 	_, err := p.Wait(ctx)
@@ -83,7 +83,7 @@ func TestPromiseMultipleWaiters(t *testing.T) {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
-			results[idx], errs[idx] = p.Wait(context.Background())
+			results[idx], errs[idx] = p.Wait(t.Context())
 		}(i)
 	}
 


### PR DESCRIPTION
Tests now use the testing.T/B/F context binding introduced in Go 1.24 instead of context.Background(). The bound context is cancelled when the test finishes, so any goroutines or in-flight operations spawned by a test get stopped automatically when the test exits or times out — this avoids goroutine leaks and surfaces lifetime bugs that context.Background() silently masks.

Mechanical replacement across 31 test files:
- ctx := context.Background()                  -> ctx := t.Context()
- context.WithCancel(context.Background())     -> context.WithCancel(t.Context())
- context.WithTimeout(context.Background(), …) -> context.WithTimeout(t.Context(), …)
- Inside *testing.B benchmarks                 -> b.Context()
- Inside helpers taking testing.TB             -> tb.Context()
- ratelimit doRequest helper now takes *testing.T so it can use t.Context()
- Removed now-unused "context" imports where no other context.* usage remained

Intentionally left as context.Background():
- t.Cleanup(...) callbacks: t.Context() is cancelled BEFORE cleanups run, so passing it to Close()/Terminate() would abort the cleanup operation.
- Helpers without a *testing.T/B in scope (e.g. proxy_test.go newTestBackend, uffd/userfaultfd/rpc_services_test.go subprocess harness).
- Unreachable defensive fallbacks of the form `if parentCtx == nil { parentCtx = context.Background() }` in placement_benchmark_test.go after b.Context() (which never returns nil).

Verified with `go vet` and `go test -run=NONE` (compile-only) across all affected packages, including GOOS=linux for build-tagged orchestrator tests.