### PR TITLE
chore: pin gopls in mise tools

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@ buf 1.28.1
 bun 1.3.2
 gcloud 534.0.0
 golang 1.25.9
+go:golang.org/x/tools/gopls 0.21.1
 golangci-lint 2.7.2
 packer 1.13.1
 protoc 29.3


### PR DESCRIPTION
## Summary
- Pin gopls in .tool-versions so mise shims resolve the Go language server for editors.
- Keeps Zed and other editor integrations on the repo-managed Go tooling path.

## Verification
- mise which gopls
- gopls version