### PR TITLE
chore: remove duplicate Diff mock config from root .mockery.yaml

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -80,14 +80,6 @@ packages:
           filename: mocks_test.go
           pkgname: utils
 
-  github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build:
-    interfaces:
-      Diff:
-        config:
-          dir: packages/orchestrator/pkg/sandbox/build/mocks
-          filename: mockdiff.go
-          pkgname: buildmocks
-
   github.com/e2b-dev/infra/packages/api/internal/handlers:
     interfaces:
       featureFlagsClient:


### PR DESCRIPTION
The Diff mock for packages/orchestrator/pkg/sandbox/build is already defined in packages/orchestrator/.mockery.yaml.