### PR TITLE
chore(api): clean up stale Redis indexes while on memory backend

### DIFF
--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -166,6 +166,8 @@ func New(
 		reservationStorage = reservations.NewReservationStorage()
 		sandboxStorage = populate_redis.NewStorage(memory.NewStorage(), redisStorage)
 		logger.L().Info(ctx, "Using populate_redis sandbox storage backend")
+
+		go redisbackend.NewCleaner(redisStorage).Start(ctx)
 	case cfg.SandboxStorageBackendRedis:
 		reservationStorage = redisreservations.NewReservationStorage(redisClient)
 		sandboxStorage = redisStorage

--- a/packages/api/internal/sandbox/storage/redis/cleaner.go
+++ b/packages/api/internal/sandbox/storage/redis/cleaner.go
@@ -1,0 +1,79 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+const cleanerInterval = time.Minute
+
+// TODO: Remove once fully migrated to Redis
+//
+// Cleaner prunes stale entries from the two Redis sandbox indexes
+// (`globalExpirationSet` and `globalTeamsSet`).
+//
+// Multi-pod safety: every operation the Cleaner triggers (ZREM/SREM of
+// possibly-absent members) is idempotent. Concurrent Cleaners across pods
+// produce duplicate Redis traffic, not incorrect state, so we do not take
+// a distributed lock.
+type Cleaner struct {
+	storage *Storage
+	tick    time.Duration
+}
+
+func NewCleaner(storage *Storage) *Cleaner {
+	return &Cleaner{
+		storage: storage,
+		tick:    cleanerInterval,
+	}
+}
+
+// Start blocks until ctx is cancelled
+func (c *Cleaner) Start(ctx context.Context) {
+	t := time.NewTicker(c.tick)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := c.RunOnce(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				logger.L().Warn(ctx, "redis storage cleanup cycle failed", zap.Error(err))
+			}
+		}
+	}
+}
+
+// RunOnce performs one cleanup pass. Each sub-step is independent; a failure
+// in one is logged but does not abort the other.
+//
+// Per-cycle work is bounded:
+//   - ExpiredItems caps internally at expiredItemsBatchSize (256) members.
+//   - TeamsWithSandboxCount is one ZRANGE + one pipelined SCARD batch.
+func (c *Cleaner) RunOnce(ctx context.Context) error {
+	var errs []error
+
+	// 1. globalExpirationSet: ExpiredItems internally ZREMs members whose
+	//    sandbox JSON is gone (items.go:131-135). Discard the returned
+	//    sandbox list — actually evicting still-running sandboxes is the
+	//    evictor's job, which in memory mode reads the memory backend.
+	if _, err := c.storage.ExpiredItems(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("expiration index sweep: %w", err))
+	}
+
+	// 2. globalTeamsSet: TeamsWithSandboxCount internally ZREMs teams whose
+	//    per-team SCARD is 0 AND whose score is older than StaleCutoff
+	//    (operations.go:268-288). Discard the returned counts.
+	if _, err := c.storage.TeamsWithSandboxCount(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("teams index sweep: %w", err))
+	}
+
+	return errors.Join(errs...)
+}

--- a/packages/api/internal/sandbox/storage/redis/cleaner_test.go
+++ b/packages/api/internal/sandbox/storage/redis/cleaner_test.go
@@ -1,0 +1,230 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+)
+
+// TestCleaner_PrunesOrphanedExpirationEntry is the smoke test for the whole
+// feature: if a member sits in globalExpirationSet without a matching sandbox
+// JSON key, the cleaner must ZREM it. This is the dominant leak source —
+// an Add that wrote globalExpirationSet (step 1) but failed before the
+// atomic SET+SADD (step 2 via addSandboxScript).
+func TestCleaner_PrunesOrphanedExpirationEntry(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	teamID := uuid.New().String()
+	sandboxID := "ghost-" + uuid.NewString()
+	member := expirationMember(teamID, sandboxID)
+
+	// Plant an orphan: ZSET entry with old score, no sandbox JSON key.
+	require.NoError(t, client.ZAdd(ctx, globalExpirationSet, redis.Z{
+		Score:  float64(time.Now().Add(-time.Hour).UnixMilli()),
+		Member: member,
+	}).Err())
+
+	cleaner := NewCleaner(storage)
+	require.NoError(t, cleaner.RunOnce(ctx))
+
+	_, err := client.ZScore(ctx, globalExpirationSet, member).Result()
+	require.ErrorIs(t, err, redis.Nil, "orphan should have been ZREM'd from globalExpirationSet")
+}
+
+// TestCleaner_PreservesLiveEntries is the negative regression guard: a real
+// sandbox added through Storage.Add must survive a RunOnce in all indexes
+// plus its JSON key.
+func TestCleaner_PreservesLiveEntries(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	sbx := createTestSandbox("live-" + uuid.NewString())
+	require.NoError(t, storage.Add(ctx, sbx))
+
+	cleaner := NewCleaner(storage)
+	require.NoError(t, cleaner.RunOnce(ctx))
+
+	// globalExpirationSet still has it.
+	_, err := client.ZScore(ctx, globalExpirationSet,
+		expirationMember(sbx.TeamID.String(), sbx.SandboxID)).Result()
+	require.NoError(t, err, "live entry should remain in globalExpirationSet")
+
+	// globalTeamsSet still has the team.
+	_, err = client.ZScore(ctx, globalTeamsSet, sbx.TeamID.String()).Result()
+	require.NoError(t, err, "live team should remain in globalTeamsSet")
+
+	// Per-team SET still has the sandbox ID.
+	isMember, err := client.SIsMember(ctx,
+		GetSandboxStorageTeamIndexKey(sbx.TeamID.String()), sbx.SandboxID).Result()
+	require.NoError(t, err)
+	require.True(t, isMember, "live sandbox should remain in per-team index")
+
+	// Sandbox JSON itself is untouched.
+	got, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
+	require.NoError(t, err)
+	require.Equal(t, sbx.SandboxID, got.SandboxID)
+}
+
+// TestCleaner_PrunesEmptyOldTeam plants a stale entry in globalTeamsSet whose
+// per-team SET is empty; TeamsWithSandboxCount must ZREM it.
+func TestCleaner_PrunesEmptyOldTeam(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	staleTeamID := uuid.New().String()
+	oldScore := float64(time.Now().Add(-time.Hour).Unix())
+
+	require.NoError(t, client.ZAdd(ctx, globalTeamsSet, redis.Z{
+		Score:  oldScore,
+		Member: staleTeamID,
+	}).Err())
+
+	cleaner := NewCleaner(storage)
+	require.NoError(t, cleaner.RunOnce(ctx))
+
+	_, err := client.ZScore(ctx, globalTeamsSet, staleTeamID).Result()
+	require.ErrorIs(t, err, redis.Nil, "stale empty team should have been ZREM'd")
+}
+
+// TestCleaner_PreservesYoungEmptyTeam validates the StaleCutoff race guard:
+// an empty team that was added recently must NOT be pruned, because Add
+// writes the team entry before the per-team SET SADD (operations.go:33-47)
+// so an empty SET on a fresh team can be a transient in-flight Add.
+func TestCleaner_PreservesYoungEmptyTeam(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	youngTeamID := uuid.New().String()
+
+	require.NoError(t, client.ZAdd(ctx, globalTeamsSet, redis.Z{
+		Score:  float64(time.Now().Unix()),
+		Member: youngTeamID,
+	}).Err())
+
+	cleaner := NewCleaner(storage)
+	require.NoError(t, cleaner.RunOnce(ctx))
+
+	_, err := client.ZScore(ctx, globalTeamsSet, youngTeamID).Result()
+	require.NoError(t, err, "young empty team should be preserved (race guard)")
+}
+
+// TestCleaner_ConcurrentRunsConverge proves the multi-pod safety contract:
+// running RunOnce from N goroutines against the same Redis must produce
+// the same final state as one run, with no errors.
+func TestCleaner_ConcurrentRunsConverge(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	const n = 50
+	for i := range n {
+		teamID := uuid.New().String()
+		sandboxID := fmt.Sprintf("ghost-%d", i)
+		require.NoError(t, client.ZAdd(ctx, globalExpirationSet, redis.Z{
+			Score:  float64(time.Now().Add(-time.Hour).UnixMilli()),
+			Member: expirationMember(teamID, sandboxID),
+		}).Err())
+	}
+
+	initial, err := client.ZCard(ctx, globalExpirationSet).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, n, initial)
+
+	cleaner := NewCleaner(storage)
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Go(func() {
+			assert.NoError(t, cleaner.RunOnce(ctx))
+		})
+	}
+	wg.Wait()
+
+	final, err := client.ZCard(ctx, globalExpirationSet).Result()
+	require.NoError(t, err)
+	require.Zero(t, final, "all orphans should be pruned despite concurrent runs")
+}
+
+// TestCleaner_StartExitsOnContextCancel guards against a goroutine leak —
+// the Start loop must return promptly when its context is cancelled.
+func TestCleaner_StartExitsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	storage, _ := setupTestStorage(t)
+	cleaner := NewCleaner(storage)
+	cleaner.tick = 10 * time.Millisecond // tighten so a tick happens during the test
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		cleaner.Start(ctx)
+		close(done)
+	}()
+
+	// Let at least one tick fire, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cleaner.Start did not exit on ctx.Done()")
+	}
+}
+
+// TestCleaner_PreservesFutureScoredExpirationEntry guards the score-based
+// filter inside ExpiredItems: a member whose score is in the future
+// (sandbox still running) but whose JSON is briefly missing must not be
+// touched, because ExpiredItems' ZRangeByScore filters by score <= now.
+func TestCleaner_PreservesFutureScoredExpirationEntry(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+	ctx := t.Context()
+
+	teamID := uuid.New().String()
+	sandboxID := "future-" + uuid.NewString()
+	member := expirationMember(teamID, sandboxID)
+
+	// Score in the future — outside the ZRangeByScore window in ExpiredItems.
+	require.NoError(t, client.ZAdd(ctx, globalExpirationSet, redis.Z{
+		Score:  float64(time.Now().Add(time.Hour).UnixMilli()),
+		Member: member,
+	}).Err())
+
+	cleaner := NewCleaner(storage)
+	require.NoError(t, cleaner.RunOnce(ctx))
+
+	_, err := client.ZScore(ctx, globalExpirationSet, member).Result()
+	require.NoError(t, err, "future-scored entry must not be pruned")
+}
+
+// Compile-time guard so future refactors of sandbox.StaleCutoff get noticed
+// here: the cleaner's correctness depends on it being > 0.
+var _ = func() bool {
+	if sandbox.StaleCutoff <= 0 {
+		panic("sandbox.StaleCutoff must be positive for cleaner race guards to hold")
+	}
+
+	return true
+}()


### PR DESCRIPTION
When SANDBOX_STORAGE_BACKEND=memory, Redis may accumulate stale data forever in `globalExpirationSet` and `globalTeamsSet`.

Add a 1-minute cleanup goroutine, wired only in the `populate_redis` branch, that invokes the existing read-path janitors:
  - `ExpiredItems` ZREMs orphaned `globalExpirationSet` entries
  - `TeamsWithSandboxCount` ZREMs empty-and-stale `globalTeamsSet` entries

All operations are idempotent ZREMs, so concurrent pods are safe without a distributed lock.