### PR TITLE
fix(db): enforce one default team per user via unique partial index

### DIFF
--- a/packages/db/migrations/20260511120000_users_teams_unique_default.sql
+++ b/packages/db/migrations/20260511120000_users_teams_unique_default.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS users_teams_user_id_is_default_idx
+    ON public.users_teams (user_id)
+    WHERE is_default = true;
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+DROP INDEX CONCURRENTLY IF EXISTS users_teams_user_id_is_default_idx;


### PR DESCRIPTION
Add unique index on `users_teams` on `used_id` for `is_default=TRUE`