### PR TITLE
feat(memfd): async pause/copy (wait-on-read)

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"golang.org/x/sys/unix"
@@ -104,34 +103,22 @@ func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roari
 	return nil
 }
 
-// MemfdCache wraps a Cache that is populated from a memfd on a background
-// goroutine. While the copy is in flight reads route to the memfd directly
-// (zero-copy via the mmap), so in-flight consumers — e.g. a follow-up
-// sandbox that resumes from a just-paused snapshot before its upload
-// finishes — see correct bytes without blocking. Once the copy completes,
-// runCopy closes the memfd (releasing the hugetlb pages — potentially
-// tens of GB) and subsequent reads delegate to the embedded Cache.
-//
-// The cache file is the side-effect runCopy writes; use Wait (or
-// CachePath's Wait type-assertion) only if you need the file path.
+// MemfdCache wraps a Cache populated from a memfd on a background
+// goroutine. Reads block on the copy via Wait. Once it finishes, runCopy
+// closes the memfd (releasing the hugetlb pages — potentially tens of GB)
+// and reads delegate to the embedded Cache.
 type MemfdCache struct {
 	*Cache
 
-	// mu guards src across the runCopy → reader transition: runCopy nils
-	// src and closes memfd under Lock; readers check src under RLock so
-	// they never read from a closed/munmap'd memfd.
-	mu  sync.RWMutex
-	src *memfdSource // non-nil while the background copy is in flight
-
 	cancel context.CancelFunc
-	done   chan struct{} // closed by runCopy; serves as the happens-before for err
+	done   chan struct{} // closed by runCopy; happens-before for err
 	err    error
 }
 
-// NewCacheFromMemfdAsync starts the memfd→cache copy on a goroutine so gRPC
-// Pause can return as soon as the snapshot file and diff metadata are
-// written. The returned wrapper takes ownership of memfd; runCopy closes it
-// when the copy completes (or is cancelled via Close).
+// NewCacheFromMemfdAsync starts the memfd→cache copy on a goroutine so
+// Pause can return as soon as the snapshot file + diff metadata are
+// written. The returned wrapper takes ownership of memfd; runCopy closes
+// it when the copy completes (or is cancelled via Close).
 func NewCacheFromMemfdAsync(
 	ctx context.Context,
 	blockSize int64,
@@ -151,32 +138,21 @@ func NewCacheFromMemfdAsync(
 		return &MemfdCache{Cache: cache}, nil
 	}
 
-	// Detach from the request context so the copy can outlive Pause; Close
-	// drives cancellation.
+	// Detach from the request context so the copy outlives Pause.
 	copyCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	m := &MemfdCache{
 		Cache:  cache,
-		src:    newMemfdSource(memfd, dirty, blockSize),
 		cancel: cancel,
 		done:   make(chan struct{}),
 	}
 
-	go m.runCopy(copyCtx, dirty, blockSize)
+	go m.runCopy(copyCtx, memfd, dirty, blockSize)
 
 	return m, nil
 }
 
-func (m *MemfdCache) runCopy(ctx context.Context, dirty *roaring.Bitmap, blockSize int64) {
-	err := copyFromMemfd(ctx, m.Cache, m.src.memfd, dirty, blockSize)
-
-	// Park src=nil under the lock so any concurrent reader has either
-	// finished its memfd access (we waited for their RLock) or will take
-	// the cache path on its next call.
-	m.mu.Lock()
-	memfd := m.src.memfd
-	m.src = nil
-	m.mu.Unlock()
-
+func (m *MemfdCache) runCopy(ctx context.Context, memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) {
+	err := copyFromMemfd(ctx, m.Cache, memfd, dirty, blockSize)
 	if closeErr := memfd.Close(); closeErr != nil {
 		err = errors.Join(err, fmt.Errorf("close memfd: %w", closeErr))
 	}
@@ -185,8 +161,6 @@ func (m *MemfdCache) runCopy(ctx context.Context, dirty *roaring.Bitmap, blockSi
 }
 
 // Wait blocks until the background copy completes (or ctx is cancelled).
-// Only needed if the caller will read the cache file directly (e.g. via
-// CachePath); ReadAt and Slice work without waiting.
 func (m *MemfdCache) Wait(ctx context.Context) error {
 	if m.done == nil {
 		return nil
@@ -201,32 +175,16 @@ func (m *MemfdCache) Wait(ctx context.Context) error {
 }
 
 func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if m.src != nil {
-		return m.src.readAt(b, off)
+	if err := m.Wait(context.Background()); err != nil {
+		return 0, err
 	}
 
 	return m.Cache.ReadAt(b, off)
 }
 
-// Slice copies bytes into a fresh buffer while the copy is in flight
-// (a zero-copy memfd view would dangle once runCopy munmaps), and
-// returns the embedded Cache's zero-copy slice afterwards.
 func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	if m.src != nil {
-		b := make([]byte, length)
-		n, err := m.src.readAt(b, off)
-		if err != nil {
-			return nil, err
-		}
-		if int64(n) < length {
-			return nil, BytesNotAvailableError{}
-		}
-
-		return b, nil
+	if err := m.Wait(context.Background()); err != nil {
+		return nil, err
 	}
 
 	return m.Cache.Slice(off, length)
@@ -239,64 +197,4 @@ func (m *MemfdCache) Close() error {
 	}
 
 	return m.Cache.Close()
-}
-
-// memfdSource indexes the memfd-backed ranges by cache offset so reads can
-// be served from the memfd directly without touching the in-flight cache.
-type memfdSource struct {
-	memfd   *Memfd
-	entries []memfdRange
-}
-
-type memfdRange struct{ cacheStart, srcStart, size int64 }
-
-func newMemfdSource(memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) *memfdSource {
-	var entries []memfdRange
-	var cacheOff int64
-	for r := range BitsetRanges(dirty, blockSize) {
-		entries = append(entries, memfdRange{cacheStart: cacheOff, srcStart: r.Start, size: r.Size})
-		cacheOff += r.Size
-	}
-
-	return &memfdSource{memfd: memfd, entries: entries}
-}
-
-// findEntry returns the index of the entry containing cacheOff, or -1.
-func (s *memfdSource) findEntry(cacheOff int64) int {
-	lo, hi := 0, len(s.entries)
-	for lo < hi {
-		mid := (lo + hi) / 2
-		if s.entries[mid].cacheStart > cacheOff {
-			hi = mid
-		} else {
-			lo = mid + 1
-		}
-	}
-	i := lo - 1
-	if i < 0 || cacheOff >= s.entries[i].cacheStart+s.entries[i].size {
-		return -1
-	}
-
-	return i
-}
-
-func (s *memfdSource) readAt(b []byte, cacheOff int64) (int, error) {
-	n := 0
-	for n < len(b) {
-		i := s.findEntry(cacheOff + int64(n))
-		if i < 0 {
-			return n, nil
-		}
-		e := s.entries[i]
-		offsetInEntry := cacheOff + int64(n) - e.cacheStart
-		toCopy := min(int64(len(b)-n), e.size-offsetInEntry)
-		src, err := s.memfd.Slice(e.srcStart+offsetInEntry, toCopy)
-		if err != nil {
-			return n, fmt.Errorf("memfd slice: %w", err)
-		}
-		copy(b[n:n+int(toCopy)], src)
-		n += int(toCopy)
-	}
-
-	return n, nil
 }

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -104,38 +104,3 @@ func TestNewCacheFromMemfdAsync_DetachesAndFlushes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, fromFile)
 }
-
-// Reads (both in-flight and post-copy) must return correct bytes: in
-// flight they come from the memfd, post-copy from the cache file mmap.
-// Exercises the runCopy → reader transition under -race.
-func TestNewCacheFromMemfdAsync_ReadsBeforeAndAfterCopy(t *testing.T) {
-	t.Parallel()
-
-	pageSize := int64(header.PageSize)
-	memfd, expected := newTestMemfd(t, pageSize*6)
-
-	// Non-adjacent blocks so the memfdSource indexes more than one entry.
-	dirty := roaring.New()
-	dirty.AddMany([]uint32{0, 2, 5})
-
-	cache, err := NewCacheFromMemfdAsync(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = cache.Close() })
-
-	checkBlocks := func(label string) {
-		for i, srcBlock := range []int64{0, 2, 5} {
-			got := make([]byte, pageSize)
-			_, err := cache.ReadAt(got, int64(i)*pageSize)
-			require.NoError(t, err, "%s ReadAt block %d", label, i)
-			require.Equal(t, expected[srcBlock*pageSize:(srcBlock+1)*pageSize], got, "%s ReadAt block %d", label, i)
-
-			slice, err := cache.Slice(int64(i)*pageSize, pageSize)
-			require.NoError(t, err, "%s Slice block %d", label, i)
-			require.Equal(t, expected[srcBlock*pageSize:(srcBlock+1)*pageSize], slice, "%s Slice block %d", label, i)
-		}
-	}
-
-	checkBlocks("in-flight")
-	require.NoError(t, cache.Wait(t.Context()))
-	checkBlocks("post-copy")
-}


### PR DESCRIPTION
Background goroutine copies memfd → diff cache after Pause returns. The
snapshot file + diff metadata are written synchronously; the byte copy
runs detached so Pause returns sooner. Memfd is closed (hugetlb pages
released) at the end of the copy.

Reads (ReadAt/Slice/CachePath) Wait for the copy before serving.

Gated by MemfdBackgroundCopyFlag; requires UseMemFdFlag (#2522).