### PR TITLE
fix(api): re-register api-grpc Consul service as alias of api-internal-grpc

### DIFF
--- a/iac/modules/job-api/jobs/api.hcl
+++ b/iac/modules/job-api/jobs/api.hcl
@@ -99,6 +99,23 @@ job "api" {
       }
     }
 
+    # Compatibility alias for service name `api-grpc`, which was renamed to `api-internal-grpc` in #2470.
+    # Old client-proxy allocations were rendered with API_GRPC_ADDRESS=api-grpc.service.consul:<port> and still expect that name.
+    # Drop this block once all old client-proxy allocations have been replaced.
+    service {
+      name = "api-grpc"
+      port = "api_internal_grpc"
+      task = "start"
+
+      check {
+        type     = "tcp"
+        name     = "api-grpc"
+        interval = "3s"
+        timeout  = "3s"
+        port     = "api_internal_grpc"
+      }
+    }
+
 %{ if update_stanza }
     # An update stanza to enable rolling updates of the service
     update {


### PR DESCRIPTION
#2470 renamed the API internal gRPC Consul service from api-grpc to api-internal-grpc. Old client-proxy allocations still have API_GRPC_ADDRESS=api-grpc.service.consul:<port> baked in and break when the old name disappears. Re-register api-grpc on the same internal port so legacy client proxies keep working during the migration. Remove once no pre-#2470 client-proxy allocations remain.