### PR TITLE
chore(orch): remove unnecessary `ALLOW_SANDBOX_INTERNET`

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -70,7 +70,6 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         ENVD_TIMEOUT                 = "${envd_timeout}"
         TEMPLATE_BUCKET_NAME         = "${template_bucket_name}"
         OTEL_COLLECTOR_GRPC_ENDPOINT = "${otel_collector_grpc_endpoint}"
-        ALLOW_SANDBOX_INTERNET       = "${allow_sandbox_internet}"
         ALLOW_SANDBOX_INTERNAL_CIDRS = "${allow_sandbox_internal_cidrs}"
         CLICKHOUSE_CONNECTION_STRING = "${clickhouse_connection_string}"
         REDIS_POOL_SIZE              = "${redis_pool_size}"

--- a/iac/modules/job-orchestrator/main.tf
+++ b/iac/modules/job-orchestrator/main.tf
@@ -9,7 +9,6 @@ locals {
     otel_collector_grpc_endpoint = var.otel_collector_grpc_endpoint
     envd_timeout                 = var.envd_timeout
     template_bucket_name         = var.template_bucket_name
-    allow_sandbox_internet       = var.allow_sandbox_internet
     allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
     clickhouse_connection_string = var.clickhouse_connection_string
     redis_url                    = var.redis_url

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -73,10 +73,6 @@ variable "template_bucket_name" {
   type = string
 }
 
-variable "allow_sandbox_internet" {
-  type = string
-}
-
 variable "allow_sandbox_internal_cidrs" {
   type        = string
   description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -199,7 +199,6 @@ module "nomad" {
   client_proxy_repository_name = module.init.client_proxy_repository_name
 
   orchestrator_node_pool              = local.client_pool_name
-  allow_sandbox_internet              = var.allow_sandbox_internet
   allow_sandbox_internal_cidrs        = var.allow_sandbox_internal_cidrs
   orchestrator_port                   = var.orchestrator_port
   orchestrator_proxy_port             = var.orchestrator_proxy_port

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -184,7 +184,6 @@ module "orchestrator" {
   otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
   envd_timeout                 = var.envd_timeout
   template_bucket_name         = var.template_bucket_name
-  allow_sandbox_internet       = var.allow_sandbox_internet
   allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
   clickhouse_connection_string = local.clickhouse_connection_string
   redis_url                    = var.redis_url

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -218,11 +218,6 @@ variable "orchestrator_proxy_port" {
   default = 5007
 }
 
-variable "allow_sandbox_internet" {
-  type    = bool
-  default = true
-}
-
 variable "allow_sandbox_internal_cidrs" {
   type        = string
   description = "Comma-separated CIDRs to allow through the sandbox firewall deny list"

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -125,11 +125,6 @@ variable "orchestrator_proxy_port" {
   default = 5007
 }
 
-variable "allow_sandbox_internet" {
-  type    = bool
-  default = true
-}
-
 variable "allow_sandbox_internal_cidrs" {
   type        = string
   description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -42,7 +42,6 @@ tf_vars := \
 	$(call tfvar, PREFIX) \
 	$(call tfvar, SANDBOX_STORAGE_BACKEND) \
 	$(call tfvar, ORCHESTRATOR_ENABLED) \
-	$(call tfvar, ALLOW_SANDBOX_INTERNET) \
 	$(call tfvar, API_INTERNAL_GRPC_PORT) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNAL_CIDRS) \
 	$(call tfvar, API_SERVER_COUNT) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -303,7 +303,6 @@ module "nomad" {
 
   # Orchestrator
   orchestrator_node_pool         = var.orchestrator_node_pool
-  allow_sandbox_internet         = var.allow_sandbox_internet
   allow_sandbox_internal_cidrs   = var.allow_sandbox_internal_cidrs
   orchestrator_port              = var.orchestrator_port
   orchestrator_proxy_port        = var.orchestrator_proxy_port

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -463,7 +463,6 @@ module "orchestrator" {
   otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
   envd_timeout                 = var.envd_timeout
   template_bucket_name         = var.template_bucket_name
-  allow_sandbox_internet       = var.allow_sandbox_internet
   allow_sandbox_internal_cidrs = var.allow_sandbox_internal_cidrs
   clickhouse_connection_string = local.clickhouse_connection_string
   redis_url                    = local.redis_url

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -315,10 +315,6 @@ variable "fc_env_pipeline_bucket_name" {
   type = string
 }
 
-variable "allow_sandbox_internet" {
-  type = bool
-}
-
 variable "allow_sandbox_internal_cidrs" {
   type        = string
   description = "Comma-separated CIDRs to allow through the sandbox firewall deny list"

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -278,11 +278,6 @@ variable "nomad_port" {
   default = 4646
 }
 
-variable "allow_sandbox_internet" {
-  type    = bool
-  default = true
-}
-
 variable "allow_sandbox_internal_cidrs" {
   type        = string
   description = "Comma-separated CIDRs to allow through the sandbox firewall deny list (e.g. 10.0.0.1/32,10.0.0.2/32)"

--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -22,7 +22,6 @@ import (
 const DefaultBusyboxVersion = "1.36.1"
 
 type BuilderConfig struct {
-	AllowSandboxInternet   bool          `env:"ALLOW_SANDBOX_INTERNET"   envDefault:"true"`
 	DomainName             string        `env:"DOMAIN_NAME"              envDefault:""`
 	EnvdTimeout            time.Duration `env:"ENVD_TIMEOUT"             envDefault:"10s"`
 	FirecrackerVersionsDir string        `env:"FIRECRACKER_VERSIONS_DIR" envDefault:"/fc-versions"`

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -33,7 +33,6 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
-	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
@@ -142,23 +141,6 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 
 	// Clone the network config to avoid modifying the original request
 	network := proto.CloneOf(req.GetSandbox().GetNetwork())
-
-	// TODO: Temporarily set this based on global config, should be removed later
-	// https://linear.app/e2b/issue/ENG-3291
-	//  (it should be passed network config from API)
-	allowInternet := s.config.AllowSandboxInternet
-	if req.GetSandbox().AllowInternetAccess != nil {
-		allowInternet = req.GetSandbox().GetAllowInternetAccess()
-	}
-	if !allowInternet {
-		if network == nil {
-			network = &orchestrator.SandboxNetworkConfig{}
-		}
-		if network.GetEgress() == nil {
-			network.Egress = &orchestrator.SandboxNetworkEgressConfig{}
-		}
-		network.Egress.DeniedCidrs = []string{sandbox_network.AllInternetTrafficCIDR}
-	}
 
 	resolvedFCVersion := featureflags.ResolveFirecrackerVersion(ctx, s.featureFlags, req.GetSandbox().GetFirecrackerVersion())
 	volumeMounts, err := createVolumeMountModelsFromAPI(req.GetSandbox().GetVolumeMounts())


### PR DESCRIPTION
API is setting the network config based on that parameter already, so this isn't needed anymore