### PR TITLE
fix(api): downgrade team-limit build errors to warnings and dedupe logs

### DIFF
--- a/packages/api/internal/handlers/deprecated_template_request_build.go
+++ b/packages/api/internal/handlers/deprecated_template_request_build.go
@@ -51,7 +51,7 @@ func (a *APIStore) PostTemplates(c *gin.Context) {
 
 	template, apiErr := a.buildTemplate(ctx, userID, team, templateID, body)
 	if apiErr != nil {
-		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
+		telemetry.ReportErrorByCode(ctx, apiErr.Code, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 
 		return
@@ -130,7 +130,7 @@ func (a *APIStore) PostTemplatesTemplateID(c *gin.Context, rawTemplateID api.Tem
 
 	template, apiErr := a.buildTemplate(ctx, userID, team, templateID, body)
 	if apiErr != nil {
-		telemetry.ReportCriticalError(ctx, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
+		telemetry.ReportErrorByCode(ctx, apiErr.Code, "error when requesting template build", apiErr.Err, telemetry.WithTemplateID(templateID))
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 
 		return

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -137,7 +137,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	template, apiError := template.RegisterBuild(ctx, a.templateCache, a.sqlcDB, buildReq)
 	if apiError != nil {
 		a.sendAPIStoreError(c, apiError.Code, apiError.ClientMsg)
-		telemetry.ReportCriticalError(ctx, "build template register failed", apiError.Err)
+		telemetry.ReportErrorByCode(ctx, apiError.Code, "build template register failed", apiError.Err)
 
 		return nil
 	}

--- a/packages/api/internal/handlers/template_request_build_v3.go
+++ b/packages/api/internal/handlers/template_request_build_v3.go
@@ -137,7 +137,7 @@ func requestTemplateBuild(ctx context.Context, c *gin.Context, a *APIStore, body
 	template, apiError := template.RegisterBuild(ctx, a.templateCache, a.sqlcDB, buildReq)
 	if apiError != nil {
 		a.sendAPIStoreError(c, apiError.Code, apiError.ClientMsg)
-		telemetry.ReportErrorByCode(ctx, apiError.Code, "build template register failed", apiError.Err)
+		telemetry.ReportErrorByCode(ctx, apiError.Code, "error when requesting template build", apiError.Err, telemetry.WithTemplateID(templateID))
 
 		return nil
 	}

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -145,8 +145,6 @@ func RegisterBuild(
 
 	cpuCount, ramMB, apiError := team.LimitResources(data.Team.Limits, data.CpuCount, data.MemoryMB)
 	if apiError != nil {
-		telemetry.ReportCriticalError(ctx, "error when getting CPU and RAM", apiError.Err)
-
 		return nil, apiError
 	}
 

--- a/packages/api/internal/template/register_build.go
+++ b/packages/api/internal/template/register_build.go
@@ -255,7 +255,6 @@ func RegisterBuild(
 
 		if exists {
 			err := fmt.Errorf("alias '%s' is already used", alias)
-			telemetry.ReportCriticalError(ctx, "conflict of alias", err, attribute.String("alias", alias))
 
 			return nil, &api.APIError{
 				Err:       err,
@@ -317,7 +316,6 @@ func RegisterBuild(
 			telemetry.ReportEvent(ctx, "created new alias", attribute.String("env.alias", alias))
 		} else if aliasDB.EnvID != data.TemplateID {
 			err := fmt.Errorf("alias '%s' already used", alias)
-			telemetry.ReportCriticalError(ctx, "alias already used", err, attribute.String("alias", alias))
 
 			return nil, &api.APIError{
 				Err:       err,


### PR DESCRIPTION
Client-side validation failures (e.g. memory exceeds team limits) were logged twice as errors: once inside RegisterBuild and again in the handlers. Drop the inner log and route the outer log through ReportErrorByCode so 4xx responses emit a single Warn while 5xx responses still emit an Error.