### PR TITLE
(fix)compression: increase storage gRPC connections to 8

### DIFF
--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -41,7 +41,7 @@ const (
 	googleMaxBackoff               = 10 * time.Second
 	googleBackoffMultiplier        = 2
 	googleMaxAttempts              = 10
-	defaultGRPCConnectionPoolSize  = 4
+	defaultGRPCConnectionPoolSize  = 8
 	defaultGCSEnableDirectPath     = false
 	gcloudDefaultUploadConcurrency = 16
 


### PR DESCRIPTION
Fetching in compressed mode, we make more GCS requests (2MbU at a time, not 4). Increasing the number of gRPC connection to 8 appears to have improved the performance - better fetch P9x and fewer health check failures.