### PR TITLE
fix(auth): skip expected missing-header telemetry

### DIFF
--- a/packages/auth/pkg/auth/middleware.go
+++ b/packages/auth/pkg/auth/middleware.go
@@ -74,11 +74,13 @@ func (a *CommonAuthenticator[T]) GetHeaderKeysFromRequest(req *http.Request) (st
 func (a *CommonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.Context, input *openapi3filter.AuthenticationInput) error {
 	headerKey, err := a.GetHeaderKeysFromRequest(input.RequestValidationInput.Request)
 	if err != nil {
-		telemetry.ReportError(ctx,
-			"authorization header is missing",
-			err,
-			attribute.String("error.message", a.ErrorMessage),
-		)
+		if !errors.Is(err, ErrNoAuthHeader) {
+			telemetry.ReportError(ctx,
+				"authorization header is missing",
+				err,
+				attribute.String("error.message", a.ErrorMessage),
+			)
+		}
 
 		ginCtx.Status(http.StatusUnauthorized)
 


### PR DESCRIPTION
Missing auth headers are a normal unauthorized path, so avoid reporting ErrNoAuthHeader as an error while preserving telemetry for unexpected header parsing failures.