### PR TITLE
chore(api): log terminal template build failures

### DIFF
--- a/packages/api/internal/template-manager/template_status.go
+++ b/packages/api/internal/template-manager/template_status.go
@@ -282,6 +282,11 @@ func (tm *TemplateManager) SetStatus(ctx context.Context, buildID uuid.UUID, sta
 
 	var err error
 	if statusGroup.IsTerminal() {
+		logger.L().Warn(ctx, "Setting template build status to terminal failure",
+			logger.WithBuildID(buildID.String()),
+			zap.String("reason", buildReason.Message),
+		)
+
 		err = tm.sqlcDB.FailTemplateBuildAndDeactivate(ctx, queries.FailTemplateBuildAndDeactivateParams{
 			Status:     buildStatus(statusGroup),
 			FinishedAt: &now,


### PR DESCRIPTION
Add build ID and failure reason context before deactivating failed template builds so terminal failures are easier to trace.