### PR TITLE
feat(metrics): record per-snapshot dirty/empty/total bytes at creation

### DIFF
--- a/packages/orchestrator/benchmarks/benchmark_test.go
+++ b/packages/orchestrator/benchmarks/benchmark_test.go
@@ -386,7 +386,7 @@ func (tc *testContainer) testOneItem(b *testing.B, buildID, kernelVersion, fcVer
 		KernelVersion:      kernelVersion,
 		FirecrackerVersion: fcVersion,
 	})
-	snap, err := sbx.Pause(ctx, templateMetadata)
+	snap, err := sbx.Pause(ctx, templateMetadata, sandbox.SnapshotUseCasePause)
 	require.NoError(b, err)
 	require.NotNil(b, snap)
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -640,7 +640,7 @@ func (r *runner) pauseOnce(ctx context.Context, opts pauseOptions, verbose bool)
 
 	// Pause and create snapshot
 	pauseStart := time.Now()
-	snapshot, err := sbx.Pause(ctx, newMeta)
+	snapshot, err := sbx.Pause(ctx, newMeta, sandbox.SnapshotUseCasePause)
 	pauseDur := time.Since(pauseStart)
 	totalDur := time.Since(t0)
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1032,6 +1032,7 @@ func (s *Sandbox) Shutdown(ctx context.Context) error {
 func (s *Sandbox) Pause(
 	ctx context.Context,
 	m metadata.Template,
+	useCase SnapshotUseCase,
 ) (st *Snapshot, e error) {
 	ctx, span := tracer.Start(ctx, "sandbox-snapshot")
 	defer span.End()
@@ -1092,9 +1093,10 @@ func (s *Sandbox) Pause(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memfile metadata: %w", err)
 	}
+	recordSnapshotDiff(ctx, "memfile", memfileDiffMetadata, originalMemfile.Header(), useCase)
 
 	// Start POSTPROCESSING
-	memfileDiff, memfileDiffHeader, memfileDiffStats, err := pauseProcessMemory(
+	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
 		ctx,
 		buildID,
 		originalMemfile.Header(),
@@ -1107,7 +1109,7 @@ func (s *Sandbox) Pause(
 	}
 	cleanup.AddNoContext(ctx, memfileDiff.Close)
 
-	rootfsDiff, rootfsDiffHeader, rootfsDiffStats, err := pauseProcessRootfs(
+	rootfsDiff, rootfsDiffHeader, err := pauseProcessRootfs(
 		ctx,
 		buildID,
 		originalRootfs.Header(),
@@ -1116,6 +1118,7 @@ func (s *Sandbox) Pause(
 			closeHook: s.Close,
 		},
 		s.config.DefaultCacheDir,
+		useCase,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1135,10 +1138,8 @@ func (s *Sandbox) Pause(
 		Metafile:          metadataFileLink,
 		MemfileDiff:       memfileDiff,
 		MemfileDiffHeader: memfileDiffHeader,
-		MemfileDiffStats:  memfileDiffStats,
 		RootfsDiff:        rootfsDiff,
 		RootfsDiffHeader:  rootfsDiffHeader,
-		RootfsDiffStats:   rootfsDiffStats,
 
 		BuildID: buildID,
 
@@ -1163,20 +1164,13 @@ func pauseProcessMemory(
 	diffMetadata *header.DiffMetadata,
 	cacheDir string,
 	fc *fc.Process,
-) (d build.Diff, h *header.Header, s SnapshotDiffStats, e error) {
+) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
 	header, err := diffMetadata.ToDiffHeader(ctx, originalHeader, buildID)
 	if err != nil {
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create memfile header: %w", err)
-	}
-
-	bs := int64(originalHeader.Metadata.BlockSize)
-	stats := SnapshotDiffStats{
-		DirtyBytes: int64(diffMetadata.Dirty.GetCardinality()) * bs,
-		EmptyBytes: int64(diffMetadata.Empty.GetCardinality()) * bs,
-		TotalBytes: int64(originalHeader.Metadata.Size),
+		return nil, nil, fmt.Errorf("failed to create memfile header: %w", err)
 	}
 
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
@@ -1188,7 +1182,7 @@ func pauseProcessMemory(
 		diffMetadata.BlockSize,
 	)
 	if err != nil {
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to export memory: %w", err)
+		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
 	}
 
 	diff, err := build.NewLocalDiffFromCache(
@@ -1197,10 +1191,10 @@ func pauseProcessMemory(
 	)
 	if err != nil {
 		// Close the cache even if the diff creation fails.
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
+		return nil, nil, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
 	}
 
-	return diff, header, stats, nil
+	return diff, header, nil
 }
 
 func pauseProcessRootfs(
@@ -1209,26 +1203,28 @@ func pauseProcessRootfs(
 	originalHeader *header.Header,
 	diffCreator DiffCreator,
 	cacheDir string,
-) (d build.Diff, h *header.Header, s SnapshotDiffStats, e error) {
+	useCase SnapshotUseCase,
+) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-rootfs")
 	defer span.End()
 
 	rootfsDiffFile, err := build.NewLocalDiffFile(cacheDir, buildId.String(), build.Rootfs)
 	if err != nil {
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create rootfs diff: %w", err)
+		return nil, nil, fmt.Errorf("failed to create rootfs diff: %w", err)
 	}
 
 	rootfsDiffMetadata, err := diffCreator.process(ctx, rootfsDiffFile.File)
 	if err != nil {
 		err = errors.Join(err, rootfsDiffFile.Close())
 
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("error creating diff: %w", err)
+		return nil, nil, fmt.Errorf("error creating diff: %w", err)
 	}
 	telemetry.ReportEvent(ctx, "exported rootfs")
+	recordSnapshotDiff(ctx, "rootfs", rootfsDiffMetadata, originalHeader, useCase)
 
 	rootfsDiff, err := rootfsDiffFile.CloseToDiff(int64(originalHeader.Metadata.BlockSize))
 	if err != nil {
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to convert rootfs diff file to local diff: %w", err)
+		return nil, nil, fmt.Errorf("failed to convert rootfs diff file to local diff: %w", err)
 	}
 	telemetry.ReportEvent(ctx, "converted rootfs diff file to local diff")
 
@@ -1236,17 +1232,10 @@ func pauseProcessRootfs(
 	if err != nil {
 		err = errors.Join(err, rootfsDiff.Close())
 
-		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create rootfs header: %w", err)
+		return nil, nil, fmt.Errorf("failed to create rootfs header: %w", err)
 	}
 
-	bs := int64(originalHeader.Metadata.BlockSize)
-	stats := SnapshotDiffStats{
-		DirtyBytes: int64(rootfsDiffMetadata.Dirty.GetCardinality()) * bs,
-		EmptyBytes: int64(rootfsDiffMetadata.Empty.GetCardinality()) * bs,
-		TotalBytes: int64(originalHeader.Metadata.Size),
-	}
-
-	return rootfsDiff, rootfsHeader, stats, nil
+	return rootfsDiff, rootfsHeader, nil
 }
 
 // createCgroup creates a cgroup for sandbox resource accounting.

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1094,7 +1094,7 @@ func (s *Sandbox) Pause(
 	}
 
 	// Start POSTPROCESSING
-	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
+	memfileDiff, memfileDiffHeader, memfileDiffStats, err := pauseProcessMemory(
 		ctx,
 		buildID,
 		originalMemfile.Header(),
@@ -1107,7 +1107,7 @@ func (s *Sandbox) Pause(
 	}
 	cleanup.AddNoContext(ctx, memfileDiff.Close)
 
-	rootfsDiff, rootfsDiffHeader, err := pauseProcessRootfs(
+	rootfsDiff, rootfsDiffHeader, rootfsDiffStats, err := pauseProcessRootfs(
 		ctx,
 		buildID,
 		originalRootfs.Header(),
@@ -1135,8 +1135,10 @@ func (s *Sandbox) Pause(
 		Metafile:          metadataFileLink,
 		MemfileDiff:       memfileDiff,
 		MemfileDiffHeader: memfileDiffHeader,
+		MemfileDiffStats:  memfileDiffStats,
 		RootfsDiff:        rootfsDiff,
 		RootfsDiffHeader:  rootfsDiffHeader,
+		RootfsDiffStats:   rootfsDiffStats,
 
 		BuildID: buildID,
 
@@ -1161,14 +1163,16 @@ func pauseProcessMemory(
 	diffMetadata *header.DiffMetadata,
 	cacheDir string,
 	fc *fc.Process,
-) (d build.Diff, h *header.Header, e error) {
+) (d build.Diff, h *header.Header, s SnapshotDiffStats, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
 	header, err := diffMetadata.ToDiffHeader(ctx, originalHeader, buildID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create memfile header: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create memfile header: %w", err)
 	}
+
+	stats := diffStatsFromMetadata(diffMetadata, originalHeader)
 
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
 
@@ -1179,7 +1183,7 @@ func pauseProcessMemory(
 		diffMetadata.BlockSize,
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to export memory: %w", err)
 	}
 
 	diff, err := build.NewLocalDiffFromCache(
@@ -1188,10 +1192,10 @@ func pauseProcessMemory(
 	)
 	if err != nil {
 		// Close the cache even if the diff creation fails.
-		return nil, nil, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
 	}
 
-	return diff, header, nil
+	return diff, header, stats, nil
 }
 
 func pauseProcessRootfs(
@@ -1200,26 +1204,26 @@ func pauseProcessRootfs(
 	originalHeader *header.Header,
 	diffCreator DiffCreator,
 	cacheDir string,
-) (d build.Diff, h *header.Header, e error) {
+) (d build.Diff, h *header.Header, s SnapshotDiffStats, e error) {
 	ctx, span := tracer.Start(ctx, "process-rootfs")
 	defer span.End()
 
 	rootfsDiffFile, err := build.NewLocalDiffFile(cacheDir, buildId.String(), build.Rootfs)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create rootfs diff: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create rootfs diff: %w", err)
 	}
 
 	rootfsDiffMetadata, err := diffCreator.process(ctx, rootfsDiffFile.File)
 	if err != nil {
 		err = errors.Join(err, rootfsDiffFile.Close())
 
-		return nil, nil, fmt.Errorf("error creating diff: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("error creating diff: %w", err)
 	}
 	telemetry.ReportEvent(ctx, "exported rootfs")
 
 	rootfsDiff, err := rootfsDiffFile.CloseToDiff(int64(originalHeader.Metadata.BlockSize))
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to convert rootfs diff file to local diff: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to convert rootfs diff file to local diff: %w", err)
 	}
 	telemetry.ReportEvent(ctx, "converted rootfs diff file to local diff")
 
@@ -1227,10 +1231,25 @@ func pauseProcessRootfs(
 	if err != nil {
 		err = errors.Join(err, rootfsDiff.Close())
 
-		return nil, nil, fmt.Errorf("failed to create rootfs header: %w", err)
+		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create rootfs header: %w", err)
 	}
 
-	return rootfsDiff, rootfsHeader, nil
+	stats := diffStatsFromMetadata(rootfsDiffMetadata, originalHeader)
+
+	return rootfsDiff, rootfsHeader, stats, nil
+}
+
+func diffStatsFromMetadata(d *header.DiffMetadata, original *header.Header) SnapshotDiffStats {
+	if d == nil || original == nil {
+		return SnapshotDiffStats{}
+	}
+	bs := int64(original.Metadata.BlockSize)
+
+	return SnapshotDiffStats{
+		DirtyBytes: int64(d.Dirty.GetCardinality()) * bs,
+		EmptyBytes: int64(d.Empty.GetCardinality()) * bs,
+		TotalBytes: int64(original.Metadata.Size),
+	}
 }
 
 // createCgroup creates a cgroup for sandbox resource accounting.

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1172,7 +1172,12 @@ func pauseProcessMemory(
 		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create memfile header: %w", err)
 	}
 
-	stats := diffStatsFromMetadata(diffMetadata, originalHeader)
+	bs := int64(originalHeader.Metadata.BlockSize)
+	stats := SnapshotDiffStats{
+		DirtyBytes: int64(diffMetadata.Dirty.GetCardinality()) * bs,
+		EmptyBytes: int64(diffMetadata.Empty.GetCardinality()) * bs,
+		TotalBytes: int64(originalHeader.Metadata.Size),
+	}
 
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
 
@@ -1234,22 +1239,14 @@ func pauseProcessRootfs(
 		return nil, nil, SnapshotDiffStats{}, fmt.Errorf("failed to create rootfs header: %w", err)
 	}
 
-	stats := diffStatsFromMetadata(rootfsDiffMetadata, originalHeader)
+	bs := int64(originalHeader.Metadata.BlockSize)
+	stats := SnapshotDiffStats{
+		DirtyBytes: int64(rootfsDiffMetadata.Dirty.GetCardinality()) * bs,
+		EmptyBytes: int64(rootfsDiffMetadata.Empty.GetCardinality()) * bs,
+		TotalBytes: int64(originalHeader.Metadata.Size),
+	}
 
 	return rootfsDiff, rootfsHeader, stats, nil
-}
-
-func diffStatsFromMetadata(d *header.DiffMetadata, original *header.Header) SnapshotDiffStats {
-	if d == nil || original == nil {
-		return SnapshotDiffStats{}
-	}
-	bs := int64(original.Metadata.BlockSize)
-
-	return SnapshotDiffStats{
-		DirtyBytes: int64(d.Dirty.GetCardinality()) * bs,
-		EmptyBytes: int64(d.Empty.GetCardinality()) * bs,
-		TotalBytes: int64(original.Metadata.Size),
-	}
 }
 
 // createCgroup creates a cgroup for sandbox resource accounting.

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -13,19 +13,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
-type SnapshotDiffStats struct {
-	DirtyBytes int64
-	EmptyBytes int64
-	TotalBytes int64
-}
-
 type Snapshot struct {
 	MemfileDiff       build.Diff
 	MemfileDiffHeader *header.Header
-	MemfileDiffStats  SnapshotDiffStats
 	RootfsDiff        build.Diff
 	RootfsDiffHeader  *header.Header
-	RootfsDiffStats   SnapshotDiffStats
 	Snapfile          template.File
 	Metafile          template.File
 	BuildID           uuid.UUID

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -13,11 +13,19 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
+type SnapshotDiffStats struct {
+	DirtyBytes int64
+	EmptyBytes int64
+	TotalBytes int64
+}
+
 type Snapshot struct {
 	MemfileDiff       build.Diff
 	MemfileDiffHeader *header.Header
+	MemfileDiffStats  SnapshotDiffStats
 	RootfsDiff        build.Diff
 	RootfsDiffHeader  *header.Header
+	RootfsDiffStats   SnapshotDiffStats
 	Snapfile          template.File
 	Metafile          template.File
 	BuildID           uuid.UUID

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -47,9 +47,16 @@ func recordSnapshotDiff(
 
 	snapshotTotalBytes.Record(ctx, total, metric.WithAttributes(ft, uc))
 
+	var fullBytes, emptyBytes int64
+	if dm.Dirty != nil {
+		fullBytes = int64(dm.Dirty.GetCardinality()) * bs
+	}
+	if dm.Empty != nil {
+		emptyBytes = int64(dm.Empty.GetCardinality()) * bs
+	}
 	for kind, b := range map[string]int64{
-		"full":  int64(dm.Dirty.GetCardinality()) * bs,
-		"empty": int64(dm.Empty.GetCardinality()) * bs,
+		"full":  fullBytes,
+		"empty": emptyBytes,
 	} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
 		snapshotDiffBytes.Record(ctx, b, attrs)

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -11,9 +11,9 @@ import (
 )
 
 var (
-	snapshotDiffBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
-	snapshotDiffRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioBp))
-	snapshotTotalBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
+	snapshotDiffBytes    = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
+	snapshotDiffRatioPct = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioPct))
+	snapshotTotalBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
 )
 
 type SnapshotUseCase string
@@ -40,21 +40,21 @@ func emitSnapshotDiff(ctx context.Context, fileType string, s SnapshotDiffStats,
 	for kind, b := range map[string]int64{"full": s.DirtyBytes, "empty": s.EmptyBytes} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
 		snapshotDiffBytes.Record(ctx, b, attrs)
-		snapshotDiffRatioBp.Record(ctx, ratioBp(b, s.TotalBytes), attrs)
+		snapshotDiffRatioPct.Record(ctx, ratioPct(b, s.TotalBytes), attrs)
 	}
 }
 
-func ratioBp(num, denom int64) int64 {
+func ratioPct(num, denom int64) int64 {
 	if denom <= 0 {
 		return 0
 	}
-	bp := num * 10000 / denom
-	if bp < 0 {
+	pct := num * 100 / denom
+	if pct < 0 {
 		return 0
 	}
-	if bp > 10000 {
-		return 10000
+	if pct > 100 {
+		return 100
 	}
 
-	return bp
+	return pct
 }

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -35,7 +35,9 @@ func RecordSnapshotDiffMetrics(ctx context.Context, snap *Snapshot, useCase Snap
 func emitSnapshotDiff(ctx context.Context, fileType string, s SnapshotDiffStats, uc attribute.KeyValue) {
 	ft := attribute.String("file_type", fileType)
 	snapshotTotalBytes.Record(ctx, s.TotalBytes, metric.WithAttributes(ft, uc))
-	for kind, b := range map[string]int64{"dirty": s.DirtyBytes, "empty": s.EmptyBytes} {
+	// "full" = blocks that carry data in this snapshot (DiffMetadata.Dirty);
+	// "empty" = zero/Empty-mapped blocks (DiffMetadata.Empty).
+	for kind, b := range map[string]int64{"full": s.DirtyBytes, "empty": s.EmptyBytes} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
 		snapshotDiffBytes.Record(ctx, b, attrs)
 		snapshotDiffRatioBp.Record(ctx, ratioBp(b, s.TotalBytes), attrs)

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -1,0 +1,58 @@
+package sandbox
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+var (
+	snapshotDiffBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
+	snapshotDiffRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioBp))
+	snapshotTotalBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
+)
+
+type SnapshotUseCase string
+
+const (
+	SnapshotUseCasePause SnapshotUseCase = "pause"
+	SnapshotUseCaseBuild SnapshotUseCase = "build"
+)
+
+func RecordSnapshotDiffMetrics(ctx context.Context, snap *Snapshot, useCase SnapshotUseCase) {
+	if snap == nil {
+		return
+	}
+	uc := attribute.String("use_case", string(useCase))
+	emitSnapshotDiff(ctx, "memfile", snap.MemfileDiffStats, uc)
+	emitSnapshotDiff(ctx, "rootfs", snap.RootfsDiffStats, uc)
+}
+
+func emitSnapshotDiff(ctx context.Context, fileType string, s SnapshotDiffStats, uc attribute.KeyValue) {
+	ft := attribute.String("file_type", fileType)
+	snapshotTotalBytes.Record(ctx, s.TotalBytes, metric.WithAttributes(ft, uc))
+	for kind, b := range map[string]int64{"dirty": s.DirtyBytes, "empty": s.EmptyBytes} {
+		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
+		snapshotDiffBytes.Record(ctx, b, attrs)
+		snapshotDiffRatioBp.Record(ctx, ratioBp(b, s.TotalBytes), attrs)
+	}
+}
+
+func ratioBp(num, denom int64) int64 {
+	if denom <= 0 {
+		return 0
+	}
+	bp := num * 10000 / denom
+	if bp < 0 {
+		return 0
+	}
+	if bp > 10000 {
+		return 10000
+	}
+
+	return bp
+}

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -24,11 +24,6 @@ const (
 	SnapshotUseCaseBuild SnapshotUseCase = "build"
 )
 
-// recordSnapshotDiff emits per-snapshot full/empty/total bytes for one file.
-// Call right after the per-pause DiffMetadata for that file is produced.
-// "full" = blocks carrying data (DiffMetadata.Dirty); "empty" = zero-mapped
-// blocks (DiffMetadata.Empty). Total comes from the original (pre-merge)
-// header so the denominator is the file's full mapped size.
 func recordSnapshotDiff(
 	ctx context.Context,
 	fileType string,
@@ -47,15 +42,15 @@ func recordSnapshotDiff(
 
 	snapshotTotalBytes.Record(ctx, total, metric.WithAttributes(ft, uc))
 
-	var fullBytes, emptyBytes int64
+	var dirtyBytes, emptyBytes int64
 	if dm.Dirty != nil {
-		fullBytes = int64(dm.Dirty.GetCardinality()) * bs
+		dirtyBytes = int64(dm.Dirty.GetCardinality()) * bs
 	}
 	if dm.Empty != nil {
 		emptyBytes = int64(dm.Empty.GetCardinality()) * bs
 	}
 	for kind, b := range map[string]int64{
-		"full":  fullBytes,
+		"dirty": dirtyBytes,
 		"empty": emptyBytes,
 	} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	snapshotDiffBytes    = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
-	snapshotDiffRatioPct = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioPct))
-	snapshotTotalBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
+	snapshotDiffBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
+	snapshotDiffRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioBp))
+	snapshotTotalBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
 )
 
 type SnapshotUseCase string
@@ -55,21 +55,23 @@ func recordSnapshotDiff(
 	} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
 		snapshotDiffBytes.Record(ctx, b, attrs)
-		snapshotDiffRatioPct.Record(ctx, ratioPct(b, total), attrs)
+		snapshotDiffRatioBp.Record(ctx, ratioBp(b, total), attrs)
 	}
 }
 
-func ratioPct(num, denom int64) int64 {
+// ratioBp returns num/denom in basis points (10000 = 100.00%) so we keep
+// sub-percent resolution. Grafana panels divide by 100 to display percent.
+func ratioBp(num, denom int64) int64 {
 	if denom <= 0 {
 		return 0
 	}
-	pct := num * 100 / denom
-	if pct < 0 {
+	bp := num * 10000 / denom
+	if bp < 0 {
 		return 0
 	}
-	if pct > 100 {
-		return 100
+	if bp > 10000 {
+		return 10000
 	}
 
-	return pct
+	return bp
 }

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -6,6 +6,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -23,24 +24,36 @@ const (
 	SnapshotUseCaseBuild SnapshotUseCase = "build"
 )
 
-func RecordSnapshotDiffMetrics(ctx context.Context, snap *Snapshot, useCase SnapshotUseCase) {
-	if snap == nil {
+// recordSnapshotDiff emits per-snapshot full/empty/total bytes for one file.
+// Call right after the per-pause DiffMetadata for that file is produced.
+// "full" = blocks carrying data (DiffMetadata.Dirty); "empty" = zero-mapped
+// blocks (DiffMetadata.Empty). Total comes from the original (pre-merge)
+// header so the denominator is the file's full mapped size.
+func recordSnapshotDiff(
+	ctx context.Context,
+	fileType string,
+	dm *header.DiffMetadata,
+	original *header.Header,
+	useCase SnapshotUseCase,
+) {
+	if dm == nil || original == nil || original.Metadata == nil {
 		return
 	}
-	uc := attribute.String("use_case", string(useCase))
-	emitSnapshotDiff(ctx, "memfile", snap.MemfileDiffStats, uc)
-	emitSnapshotDiff(ctx, "rootfs", snap.RootfsDiffStats, uc)
-}
+	bs := int64(original.Metadata.BlockSize)
+	total := int64(original.Metadata.Size)
 
-func emitSnapshotDiff(ctx context.Context, fileType string, s SnapshotDiffStats, uc attribute.KeyValue) {
 	ft := attribute.String("file_type", fileType)
-	snapshotTotalBytes.Record(ctx, s.TotalBytes, metric.WithAttributes(ft, uc))
-	// "full" = blocks that carry data in this snapshot (DiffMetadata.Dirty);
-	// "empty" = zero/Empty-mapped blocks (DiffMetadata.Empty).
-	for kind, b := range map[string]int64{"full": s.DirtyBytes, "empty": s.EmptyBytes} {
+	uc := attribute.String("use_case", string(useCase))
+
+	snapshotTotalBytes.Record(ctx, total, metric.WithAttributes(ft, uc))
+
+	for kind, b := range map[string]int64{
+		"full":  int64(dm.Dirty.GetCardinality()) * bs,
+		"empty": int64(dm.Empty.GetCardinality()) * bs,
+	} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
 		snapshotDiffBytes.Record(ctx, b, attrs)
-		snapshotDiffRatioPct.Record(ctx, ratioPct(b, s.TotalBytes), attrs)
+		snapshotDiffRatioPct.Record(ctx, ratioPct(b, total), attrs)
 	}
 }
 

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -746,11 +746,10 @@ func (s *Server) snapshotAndCacheSandbox(
 		FirecrackerVersion: sbx.Config.FirecrackerConfig.FirecrackerVersion,
 	})
 
-	snapshot, err := sbx.Pause(ctx, meta)
+	snapshot, err := sbx.Pause(ctx, meta, sandbox.SnapshotUseCasePause)
 	if err != nil {
 		return nil, fmt.Errorf("error snapshotting sandbox: %w", err)
 	}
-	sandbox.RecordSnapshotDiffMetrics(ctx, snapshot, sandbox.SnapshotUseCasePause)
 
 	err = s.templateCache.AddSnapshot(
 		ctx,

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -750,6 +750,7 @@ func (s *Server) snapshotAndCacheSandbox(
 	if err != nil {
 		return nil, fmt.Errorf("error snapshotting sandbox: %w", err)
 	}
+	sandbox.RecordSnapshotDiffMetrics(ctx, snapshot, sandbox.SnapshotUseCasePause)
 
 	err = s.templateCache.AddSnapshot(
 		ctx,

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -264,6 +264,7 @@ func (lb *LayerExecutor) PauseAndUpload(
 	if err != nil {
 		return fmt.Errorf("error processing vm: %w", err)
 	}
+	sandbox.RecordSnapshotDiffMetrics(ctx, snapshot, sandbox.SnapshotUseCaseBuild)
 
 	// Add snapshot to template cache so it can be used immediately
 	err = lb.templateCache.AddSnapshot(

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -260,11 +260,11 @@ func (lb *LayerExecutor) PauseAndUpload(
 	snapshot, err := sbx.Pause(
 		ctx,
 		meta,
+		sandbox.SnapshotUseCaseBuild,
 	)
 	if err != nil {
 		return fmt.Errorf("error processing vm: %w", err)
 	}
-	sandbox.RecordSnapshotDiffMetrics(ctx, snapshot, sandbox.SnapshotUseCaseBuild)
 
 	// Add snapshot to template cache so it can be used immediately
 	err = lb.templateCache.AddSnapshot(

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -122,7 +122,7 @@ const (
 	SandboxFCBlockIOEngineThrottled     HistogramType = "orchestrator.sandbox.fc.block.io_engine_throttled"
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
 
-	// Snapshot diff histograms (file_type=memfile|rootfs, kind=dirty|empty, use_case=pause|build).
+	// Snapshot diff histograms (file_type=memfile|rootfs, kind=full|empty, use_case=pause|build).
 	SnapshotDiffBytes   HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
 	SnapshotDiffRatioBp HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_bp"
 	SnapshotTotalBytes  HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
@@ -358,8 +358,8 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
 
-	SnapshotDiffBytes:   "Per-snapshot dirty/empty bytes per file",
-	SnapshotDiffRatioBp: "Per-snapshot dirty/empty as fraction of total mapped size, in basis points (10000=100%)",
+	SnapshotDiffBytes:   "Per-snapshot full/empty bytes per file",
+	SnapshotDiffRatioBp: "Per-snapshot full/empty as fraction of total mapped size, in basis points (10000=100%)",
 	SnapshotTotalBytes:  "Per-snapshot total mapped size of the file",
 }
 

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -122,7 +122,6 @@ const (
 	SandboxFCBlockIOEngineThrottled     HistogramType = "orchestrator.sandbox.fc.block.io_engine_throttled"
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
 
-	// Snapshot diff histograms (file_type=memfile|rootfs, kind=full|empty, use_case=pause|build).
 	SnapshotDiffBytes    HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
 	SnapshotDiffRatioPct HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_pct"
 	SnapshotTotalBytes   HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
@@ -358,8 +357,8 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
 
-	SnapshotDiffBytes:    "Per-snapshot full/empty bytes per file",
-	SnapshotDiffRatioPct: "Per-snapshot full/empty as percentage of total mapped size",
+	SnapshotDiffBytes:    "Per-snapshot dirty/empty bytes per file",
+	SnapshotDiffRatioPct: "Per-snapshot dirty/empty as percentage of total mapped size",
 	SnapshotTotalBytes:   "Per-snapshot total mapped size of the file",
 }
 

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -123,9 +123,9 @@ const (
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
 
 	// Snapshot diff histograms (file_type=memfile|rootfs, kind=full|empty, use_case=pause|build).
-	SnapshotDiffBytes   HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
-	SnapshotDiffRatioBp HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_bp"
-	SnapshotTotalBytes  HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
+	SnapshotDiffBytes    HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
+	SnapshotDiffRatioPct HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_pct"
+	SnapshotTotalBytes   HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
 )
 
 const (
@@ -358,9 +358,9 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
 
-	SnapshotDiffBytes:   "Per-snapshot full/empty bytes per file",
-	SnapshotDiffRatioBp: "Per-snapshot full/empty as fraction of total mapped size, in basis points (10000=100%)",
-	SnapshotTotalBytes:  "Per-snapshot total mapped size of the file",
+	SnapshotDiffBytes:    "Per-snapshot full/empty bytes per file",
+	SnapshotDiffRatioPct: "Per-snapshot full/empty as percentage of total mapped size",
+	SnapshotTotalBytes:   "Per-snapshot total mapped size of the file",
 }
 
 var histogramUnits = map[HistogramType]string{
@@ -392,9 +392,9 @@ var histogramUnits = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "{op}",
 	SandboxFCBlockRemainingReqs:         "{event}",
 
-	SnapshotDiffBytes:   "{By}",
-	SnapshotDiffRatioBp: "{1}",
-	SnapshotTotalBytes:  "{By}",
+	SnapshotDiffBytes:    "{By}",
+	SnapshotDiffRatioPct: "%",
+	SnapshotTotalBytes:   "{By}",
 }
 
 func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram, error) {

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -122,9 +122,9 @@ const (
 	SandboxFCBlockIOEngineThrottled     HistogramType = "orchestrator.sandbox.fc.block.io_engine_throttled"
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
 
-	SnapshotDiffBytes    HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
-	SnapshotDiffRatioPct HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_pct"
-	SnapshotTotalBytes   HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
+	SnapshotDiffBytes   HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
+	SnapshotDiffRatioBp HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_bp"
+	SnapshotTotalBytes  HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
 )
 
 const (
@@ -357,9 +357,9 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
 
-	SnapshotDiffBytes:    "Per-snapshot dirty/empty bytes per file",
-	SnapshotDiffRatioPct: "Per-snapshot dirty/empty as percentage of total mapped size",
-	SnapshotTotalBytes:   "Per-snapshot total mapped size of the file",
+	SnapshotDiffBytes:   "Per-snapshot dirty/empty bytes per file",
+	SnapshotDiffRatioBp: "Per-snapshot dirty/empty as fraction of total mapped size, in basis points (10000=100%)",
+	SnapshotTotalBytes:  "Per-snapshot total mapped size of the file",
 }
 
 var histogramUnits = map[HistogramType]string{
@@ -391,9 +391,9 @@ var histogramUnits = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "{op}",
 	SandboxFCBlockRemainingReqs:         "{event}",
 
-	SnapshotDiffBytes:    "{By}",
-	SnapshotDiffRatioPct: "%",
-	SnapshotTotalBytes:   "{By}",
+	SnapshotDiffBytes:   "{By}",
+	SnapshotDiffRatioBp: "{1}",
+	SnapshotTotalBytes:  "{By}",
 }
 
 func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram, error) {

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -121,6 +121,11 @@ const (
 	SandboxFCBlockRateLimiterEventCount HistogramType = "orchestrator.sandbox.fc.block.rate_limiter_event_count"
 	SandboxFCBlockIOEngineThrottled     HistogramType = "orchestrator.sandbox.fc.block.io_engine_throttled"
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
+
+	// Snapshot diff histograms (file_type=memfile|rootfs, kind=dirty|empty, use_case=pause|build).
+	SnapshotDiffBytes   HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
+	SnapshotDiffRatioBp HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_bp"
+	SnapshotTotalBytes  HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
 )
 
 const (
@@ -352,6 +357,10 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockRateLimiterEventCount: "Distribution of Firecracker VMM block rate limiter events per metrics flush",
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
+
+	SnapshotDiffBytes:   "Per-snapshot dirty/empty bytes per file",
+	SnapshotDiffRatioBp: "Per-snapshot dirty/empty as fraction of total mapped size, in basis points (10000=100%)",
+	SnapshotTotalBytes:  "Per-snapshot total mapped size of the file",
 }
 
 var histogramUnits = map[HistogramType]string{
@@ -382,6 +391,10 @@ var histogramUnits = map[HistogramType]string{
 	SandboxFCBlockRateLimiterEventCount: "{event}",
 	SandboxFCBlockIOEngineThrottled:     "{op}",
 	SandboxFCBlockRemainingReqs:         "{event}",
+
+	SnapshotDiffBytes:   "{By}",
+	SnapshotDiffRatioBp: "{1}",
+	SnapshotTotalBytes:  "{By}",
 }
 
 func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram, error) {


### PR DESCRIPTION
Per-snapshot histograms (full/empty/total bytes + ratio %) recorded inside Sandbox.Pause, attributed by file_type (memfile/rootfs), kind (full/empty), and use_case (pause/build), so we can see how FPR/FPH/reclaim affect snapshot composition and tell pause-time samples from template-build samples apart.