### PR TITLE
fix: resolve correct creator ip on oauth sign up

### DIFF
--- a/packages/dashboard-api/internal/teamprovision/creator_context.go
+++ b/packages/dashboard-api/internal/teamprovision/creator_context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	supabasedb "github.com/e2b-dev/infra/packages/db/pkg/supabase"
 	sharedteamprovision "github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const (
@@ -23,7 +24,8 @@ const (
 )
 
 // resolveCreatorContext reads signup IP/UA and auth provider from
-// auth.users.raw_app_meta_data, which Supabase populates for every signup flow.
+// auth.users.raw_app_meta_data and falls back to auth.sessions for social
+// providers when metadata is missing.
 // Returns nil when the user cannot be found so callers can keep going without
 // the optional context.
 func resolveCreatorContext(ctx context.Context, supabaseDB *supabasedb.Client, userID uuid.UUID) (*sharedteamprovision.CreatorContextV1, error) {
@@ -44,13 +46,31 @@ func resolveCreatorContext(ctx context.Context, supabaseDB *supabasedb.Client, u
 	}
 
 	authMethod := sharedteamprovision.AuthMethodPassword
+	ipAddress := stringFromMetadata(metadata, signupIPMetadataKey)
+	userAgent := stringFromMetadata(metadata, signupUserAgentMetadataKey)
+
 	if hasOAuthProvider(metadata) {
 		authMethod = sharedteamprovision.AuthMethodSocial
+
+		if ipAddress == "" || userAgent == "" {
+			session, sessionErr := supabaseDB.Write.GetLatestAuthSessionByUserID(ctx, userID)
+			if sessionErr != nil && !dberrors.IsNotFoundError(sessionErr) {
+				return nil, fmt.Errorf("get latest auth session: %w", sessionErr)
+			}
+			if sessionErr == nil {
+				if ipAddress == "" {
+					ipAddress = utils.DerefOrDefault(session.Ip, "")
+				}
+				if userAgent == "" {
+					userAgent = utils.DerefOrDefault(session.UserAgent, "")
+				}
+			}
+		}
 	}
 
 	return &sharedteamprovision.CreatorContextV1{
-		IPAddress:  stringFromMetadata(metadata, signupIPMetadataKey),
-		UserAgent:  stringFromMetadata(metadata, signupUserAgentMetadataKey),
+		IPAddress:  ipAddress,
+		UserAgent:  userAgent,
 		AuthMethod: authMethod,
 	}, nil
 }

--- a/packages/dashboard-api/internal/teamprovision/creator_context.go
+++ b/packages/dashboard-api/internal/teamprovision/creator_context.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	supabasedb "github.com/e2b-dev/infra/packages/db/pkg/supabase"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sharedteamprovision "github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -54,10 +56,15 @@ func resolveCreatorContext(ctx context.Context, supabaseDB *supabasedb.Client, u
 
 		if ipAddress == "" || userAgent == "" {
 			session, sessionErr := supabaseDB.Write.GetLatestAuthSessionByUserID(ctx, userID)
-			if sessionErr != nil && !dberrors.IsNotFoundError(sessionErr) {
-				return nil, fmt.Errorf("get latest auth session: %w", sessionErr)
-			}
-			if sessionErr == nil {
+
+			if sessionErr != nil {
+				if !dberrors.IsNotFoundError(sessionErr) {
+					logger.L().Warn(ctx, "failed to resolve latest auth session for creator context, falling back to metadata",
+						zap.String("user_id", userID.String()),
+						zap.Error(sessionErr),
+					)
+				}
+			} else {
 				if ipAddress == "" {
 					ipAddress = utils.DerefOrDefault(session.Ip, "")
 				}

--- a/packages/db/pkg/supabase/queries/get_auth_user.sql.go
+++ b/packages/db/pkg/supabase/queries/get_auth_user.sql.go
@@ -28,3 +28,23 @@ func (q *Queries) GetAuthUserByID(ctx context.Context, dollar_1 uuid.UUID) (Auth
 	)
 	return i, err
 }
+
+const getLatestAuthSessionByUserID = `-- name: GetLatestAuthSessionByUserID :one
+SELECT user_agent, ip
+FROM auth.sessions
+WHERE user_id = $1::uuid
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+type GetLatestAuthSessionByUserIDRow struct {
+	UserAgent *string
+	Ip        *string
+}
+
+func (q *Queries) GetLatestAuthSessionByUserID(ctx context.Context, dollar_1 uuid.UUID) (GetLatestAuthSessionByUserIDRow, error) {
+	row := q.db.QueryRow(ctx, getLatestAuthSessionByUserID, dollar_1)
+	var i GetLatestAuthSessionByUserIDRow
+	err := row.Scan(&i.UserAgent, &i.Ip)
+	return i, err
+}

--- a/packages/db/pkg/supabase/queries/models.go
+++ b/packages/db/pkg/supabase/queries/models.go
@@ -10,6 +10,13 @@ import (
 	"github.com/google/uuid"
 )
 
+type AuthSession struct {
+	UserID    uuid.UUID
+	CreatedAt time.Time
+	UserAgent *string
+	Ip        *string
+}
+
 type AuthUser struct {
 	ID             uuid.UUID
 	Email          string

--- a/packages/db/pkg/supabase/schema/auth_users_override.sql
+++ b/packages/db/pkg/supabase/schema/auth_users_override.sql
@@ -18,3 +18,10 @@ CREATE TABLE auth.users (
     raw_app_meta_data jsonb,
     PRIMARY KEY (id)
 );
+
+CREATE TABLE auth.sessions (
+    user_id uuid NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    user_agent text,
+    ip text
+);

--- a/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
+++ b/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
@@ -2,3 +2,10 @@
 SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
 FROM auth.users
 WHERE id = $1::uuid;
+
+-- name: GetLatestAuthSessionByUserID :one
+SELECT user_agent, ip
+FROM auth.sessions
+WHERE user_id = $1::uuid
+ORDER BY created_at DESC
+LIMIT 1;


### PR DESCRIPTION
## Summary
- Add OAuth creator-context fallback to latest `auth.sessions` IP/user agent when signup metadata is missing.