### PR TITLE
chore(envd): remove unused -cmd flag and InitializeStartProcess

### DIFF
--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os/user"
 	"strconv"
 	"time"
 
@@ -16,41 +15,6 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/services/process/handler"
 	rpc "github.com/e2b-dev/infra/packages/envd/internal/services/spec/process"
 )
-
-func (s *Service) InitializeStartProcess(ctx context.Context, user *user.User, req *rpc.StartRequest) error {
-	var err error
-
-	ctx = logs.AddRequestIDToContext(ctx)
-
-	defer s.logger.
-		Err(err).
-		Interface("request", req).
-		Str(string(logs.OperationIDKey), ctx.Value(logs.OperationIDKey).(string)).
-		Msg("Initialized startCmd")
-
-	handlerL := s.logger.With().Str(string(logs.OperationIDKey), ctx.Value(logs.OperationIDKey).(string)).Logger()
-
-	startProcCtx, startProcCancel := context.WithCancel(ctx)
-	proc, err := handler.New(startProcCtx, user, req, &handlerL, s.defaults, s.cgroupManager, startProcCancel)
-	if err != nil {
-		return err
-	}
-
-	pid, err := proc.Start(0)
-	if err != nil {
-		return err
-	}
-
-	s.processes.Store(pid, proc)
-
-	go func() {
-		defer s.processes.Delete(pid)
-
-		proc.Wait()
-	}()
-
-	return nil
-}
 
 func (s *Service) Start(ctx context.Context, req *connect.Request[rpc.StartRequest], stream *connect.ServerStream[rpc.StartResponse]) error {
 	return logs.LogServerStreamWithoutEvents(ctx, s.logger, req, stream, s.handleStart)

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -25,7 +25,6 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/services/cgroups"
 	filesystemRpc "github.com/e2b-dev/infra/packages/envd/internal/services/filesystem"
 	processRpc "github.com/e2b-dev/infra/packages/envd/internal/services/process"
-	processSpec "github.com/e2b-dev/infra/packages/envd/internal/services/spec/process"
 	"github.com/e2b-dev/infra/packages/envd/internal/utils"
 	"github.com/e2b-dev/infra/packages/envd/pkg"
 	"github.com/e2b-dev/infra/packages/shared/pkg/httpserver"
@@ -54,10 +53,9 @@ var (
 	isNotFC bool
 	port    int64
 
-	versionFlag  bool
-	commitFlag   bool
-	startCmdFlag string
-	cgroupRoot   string
+	versionFlag bool
+	commitFlag  bool
+	cgroupRoot  string
 )
 
 func parseFlags() {
@@ -87,13 +85,6 @@ func parseFlags() {
 		"port",
 		defaultPort,
 		"a port on which the daemon should run",
-	)
-
-	flag.StringVar(
-		&startCmdFlag,
-		"cmd",
-		"",
-		"a command to run on the daemon start",
 	)
 
 	flag.StringVar(
@@ -185,7 +176,7 @@ func main() {
 	}()
 
 	processLogger := l.With().Str("logger", "process").Logger()
-	processService := processRpc.Handle(m, &processLogger, defaults, cgroupManager)
+	processRpc.Handle(m, &processLogger, defaults, cgroupManager)
 
 	service := api.New(&envLogger, defaults, mmdsChan, isNotFC)
 	handler := api.HandlerFromMux(service, m)
@@ -204,28 +195,6 @@ func main() {
 		IdleTimeout:  idleTimeout,
 	}
 	httpserver.ConfigureH2C(s)
-
-	// TODO: Not used anymore in template build, replaced by direct envd command call.
-	if startCmdFlag != "" {
-		tag := "startCmd"
-		cwd := "/home/user"
-		user, err := permissions.GetUser("root")
-		if err != nil {
-			log.Fatalf("error getting user: %v", err) //nolint:gocritic // probably fine to bail if we're done?
-		}
-
-		if err = processService.InitializeStartProcess(ctx, user, &processSpec.StartRequest{
-			Tag: &tag,
-			Process: &processSpec.ProcessConfig{
-				Envs: make(map[string]string),
-				Cmd:  "/bin/bash",
-				Args: []string{"-l", "-c", startCmdFlag},
-				Cwd:  &cwd,
-			},
-		}); err != nil {
-			log.Fatalf("error starting process: %v", err)
-		}
-	}
 
 	// Bind all open ports on 127.0.0.1 and localhost to the eth0 interface
 	portScanner := publicport.NewScanner(portScannerInterval)

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -208,7 +208,7 @@ func main() {
 
 	err := s.ListenAndServe()
 	if err != nil {
-		log.Fatalf("error starting server: %v", err)
+		log.Fatalf("error starting server: %v", err) //nolint:gocritic // last line of main; process exits anyway
 	}
 }
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.19"
+const Version = "0.5.20"


### PR DESCRIPTION
The -cmd flag and InitializeStartProcess() have been unused for over   
a year, since 47b5f00d18fa ("Get logs for start command (#637)", May   
2025) moved start command execution to the orchestrator via RPC.       

The nolint directive was moved to the last line of main() as it was
previously suppressed on log.Fatalf() inside the -cmd block it was just
removed.