### PR TITLE
fix(gcp): support keyless self-hosted deploys

### DIFF
--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -40,6 +40,8 @@ tf_vars := \
 	$(call tfvar, GCP_ZONE) \
 	$(call tfvar, DOMAIN_NAME) \
 	$(call tfvar, PREFIX) \
+	$(call tfvar, NETWORK_NAME) \
+	$(call tfvar, SUBNETWORK_NAME) \
 	$(call tfvar, SANDBOX_STORAGE_BACKEND) \
 	$(call tfvar, ORCHESTRATOR_ENABLED) \
 	$(call tfvar, ALLOW_SANDBOX_INTERNET) \
@@ -94,6 +96,7 @@ tf_vars := \
 	$(call tfvar, DB_MIN_IDLE_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MAX_OPEN_CONNECTIONS) \
 	$(call tfvar, AUTH_DB_MIN_IDLE_CONNECTIONS) \
+	$(call tfvar, CLOUDFLARE_API_TOKEN_SECRET_NAME) \
 	$(call tfvar, CLIENT_PROXY_OIDC_ISSUER_URL) \
 	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE) \
 	$(call tfvar, ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS) \

--- a/iac/provider-gcp/api.tf
+++ b/iac/provider-gcp/api.tf
@@ -10,21 +10,12 @@ resource "google_artifact_registry_repository_iam_member" "custom_environments_r
   member     = "serviceAccount:${module.init.service_account_email}"
 }
 
-resource "google_secret_manager_secret" "postgres_read_replica_connection_string" {
+data "google_secret_manager_secret" "postgres_read_replica_connection_string" {
   secret_id = "${var.prefix}postgres-read-replica-connection-string"
-
-  replication {
-    auto {}
-  }
 }
 
-resource "google_secret_manager_secret_version" "postgres_read_replica_connection_string" {
-  secret      = google_secret_manager_secret.postgres_read_replica_connection_string.name
-  secret_data = " "
-
-  lifecycle {
-    ignore_changes = [secret_data]
-  }
+data "google_secret_manager_secret_version" "postgres_read_replica_connection_string" {
+  secret = data.google_secret_manager_secret.postgres_read_replica_connection_string.name
 }
 
 resource "random_password" "api_secret" {

--- a/iac/provider-gcp/docker-reverse-proxy.tf
+++ b/iac/provider-gcp/docker-reverse-proxy.tf
@@ -1,14 +1,9 @@
-resource "google_service_account" "docker_registry_service_account" {
-  account_id   = "${var.prefix}docker-reverse-proxy-sa"
-  display_name = "Docker Reverse Proxy Service Account"
+data "google_service_account" "docker_registry_service_account" {
+  account_id = "${var.prefix}docker-proxy-sa"
 }
 
 resource "google_artifact_registry_repository_iam_member" "orchestration_repository_member" {
   repository = google_artifact_registry_repository.custom_environments_repository.name
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${google_service_account.docker_registry_service_account.email}"
-}
-
-resource "google_service_account_key" "google_service_key" {
-  service_account_id = google_service_account.docker_registry_service_account.id
+  member     = "serviceAccount:${data.google_service_account.docker_registry_service_account.email}"
 }

--- a/iac/provider-gcp/init/main.tf
+++ b/iac/provider-gcp/init/main.tf
@@ -73,8 +73,16 @@ resource "google_service_account" "infra_instances_service_account" {
   display_name = "Infra Instances Service Account"
 }
 
-resource "google_service_account_key" "google_service_key" {
+resource "google_service_account_iam_member" "infra_instances_service_account_token_creator" {
   service_account_id = google_service_account.infra_instances_service_account.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.infra_instances_service_account.email}"
+}
+
+resource "google_project_iam_member" "infra_instances_project_token_creator" {
+  project = var.gcp_project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.infra_instances_service_account.email}"
 }
 
 // todo: delete after migration period

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -3,7 +3,7 @@ output "service_account_email" {
 }
 
 output "google_service_account_key" {
-  value = google_service_account_key.google_service_key.private_key
+  value = ""
 }
 
 output "consul_acl_token_secret" {

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -126,12 +126,13 @@ module "cluster" {
 
   environment = var.environment
 
-  cloudflare_api_token_secret_name = module.init.cloudflare_api_token_secret_name
+  cloudflare_api_token_secret_name = coalesce(var.cloudflare_api_token_secret_name, module.init.cloudflare_api_token_secret_name)
   gcp_project_id                   = var.gcp_project_id
   gcp_region                       = var.gcp_region
   gcp_zone                         = var.gcp_zone
   google_service_account_key       = module.init.google_service_account_key
   network_name                     = var.network_name
+  subnetwork_name                  = var.subnetwork_name
 
   build_clusters_config  = var.build_clusters_config
   client_clusters_config = var.client_clusters_config
@@ -247,7 +248,7 @@ module "nomad" {
   api_secret                                             = random_password.api_secret.result
   custom_envs_repository_name                            = google_artifact_registry_repository.custom_environments_repository.name
   postgres_connection_string_secret_name                 = module.init.postgres_connection_string_secret_name
-  postgres_read_replica_connection_string_secret_version = google_secret_manager_secret_version.postgres_read_replica_connection_string
+  postgres_read_replica_connection_string_secret_version = data.google_secret_manager_secret_version.postgres_read_replica_connection_string
   supabase_jwt_secrets_secret_name                       = module.init.supabase_jwt_secret_name
   posthog_api_key_secret_name                            = module.init.posthog_api_key_secret_name
   analytics_collector_host_secret_name                   = module.init.analytics_collector_host_secret_name
@@ -299,7 +300,7 @@ module "nomad" {
 
   # Docker reverse proxy
   docker_reverse_proxy_port                = var.docker_reverse_proxy_port
-  docker_reverse_proxy_service_account_key = google_service_account_key.google_service_key.private_key
+  docker_reverse_proxy_service_account_key = ""
 
   # Orchestrator
   orchestrator_node_pool         = var.orchestrator_node_pool

--- a/iac/provider-gcp/modules/nodepool-api/main.tf
+++ b/iac/provider-gcp/modules/nodepool-api/main.tf
@@ -137,7 +137,8 @@ resource "google_compute_instance_template" "template" {
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
 
     dynamic "access_config" {
       for_each = var.api_use_nat ? [] : ["public_ip"]

--- a/iac/provider-gcp/modules/nodepool-api/scripts/start-api.sh
+++ b/iac/provider-gcp/modules/nodepool-api/scripts/start-api.sh
@@ -37,18 +37,14 @@ gsutil cp "gs://${SCRIPTS_BUCKET}/run-nomad-${RUN_NOMAD_FILE_HASH}.sh" /opt/noma
 chmod +x /opt/consul/bin/run-consul.sh /opt/nomad/bin/run-nomad.sh
 
 mkdir -p /root/docker
-touch /root/docker/config.json
 cat <<EOF >/root/docker/config.json
 {
-    "auths": {
-        "${GCP_REGION}-docker.pkg.dev": {
-            "username": "_json_key_base64",
-            "password": "${GOOGLE_SERVICE_ACCOUNT_KEY}",
-            "server_address": "https://${GCP_REGION}-docker.pkg.dev"
-        }
-    }
+  "credHelpers": {
+    "${GCP_REGION}-docker.pkg.dev": "gcloud"
+  }
 }
 EOF
+gcloud auth configure-docker --quiet "${GCP_REGION}-docker.pkg.dev" || true
 
 
 mkdir -p /etc/systemd/resolved.conf.d/

--- a/iac/provider-gcp/modules/nodepool-api/variables.tf
+++ b/iac/provider-gcp/modules/nodepool-api/variables.tf
@@ -11,6 +11,11 @@ variable "network_name" {
   type = string
 }
 
+variable "subnetwork_name" {
+  type    = string
+  default = ""
+}
+
 variable "cluster_tag_name" {
   description = "Network tag applied to cluster instances for firewall rules and Consul auto-discovery."
   type        = string

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -31,12 +31,8 @@ locals {
   }
 }
 
-resource "google_secret_manager_secret" "consul_gossip_encryption_key" {
+data "google_secret_manager_secret" "consul_gossip_encryption_key" {
   secret_id = "${var.prefix}consul-gossip-key"
-
-  replication {
-    auto {}
-  }
 }
 
 resource "random_id" "consul_gossip_encryption_key" {
@@ -44,23 +40,19 @@ resource "random_id" "consul_gossip_encryption_key" {
 }
 
 resource "google_secret_manager_secret_version" "consul_gossip_encryption_key" {
-  secret      = google_secret_manager_secret.consul_gossip_encryption_key.name
+  secret      = data.google_secret_manager_secret.consul_gossip_encryption_key.name
   secret_data = random_id.consul_gossip_encryption_key.b64_std
 }
 
-resource "google_secret_manager_secret" "consul_dns_request_token" {
+data "google_secret_manager_secret" "consul_dns_request_token" {
   secret_id = "${var.prefix}consul-dns-request-token"
-
-  replication {
-    auto {}
-  }
 }
 
 resource "random_uuid" "consul_dns_request_token" {
 }
 
 resource "google_secret_manager_secret_version" "consul_dns_request_token" {
-  secret      = google_secret_manager_secret.consul_dns_request_token.name
+  secret      = data.google_secret_manager_secret.consul_dns_request_token.name
   secret_data = random_uuid.consul_dns_request_token.result
 }
 
@@ -166,6 +158,7 @@ module "build_cluster" {
   cluster_name              = "${var.prefix}${var.build_cluster_name}-${each.key}"
   image_family              = var.build_image_family
   network_name              = var.network_name
+  subnetwork_name           = var.subnetwork_name
   base_hugepages_percentage = coalesce((each.value.hugepages_percentage), local.build_base_hugepages_percentage)
   network_interface_type    = each.value.network_interface_type
   node_labels               = each.value.node_labels
@@ -225,6 +218,7 @@ module "client_cluster" {
   cluster_name              = each.key == "default" ? "${var.prefix}${var.client_cluster_name}" : "${var.prefix}${var.client_cluster_name}-${each.key}"
   image_family              = var.client_image_family
   network_name              = var.network_name
+  subnetwork_name           = var.subnetwork_name
   base_hugepages_percentage = coalesce((each.value.hugepages_percentage), local.client_base_hugepages_percentage)
   network_interface_type    = each.value.network_interface_type
   node_labels               = each.value.node_labels

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -526,6 +526,20 @@ resource "google_compute_firewall" "client_proxy_firewall_ingress" {
   source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
 }
 
+resource "google_compute_firewall" "cluster_internal_allow_all" {
+  name    = "${var.prefix}${var.cluster_tag_name}-internal-allow-all"
+  network = var.network_name
+
+  allow {
+    protocol = "all"
+  }
+
+  direction   = "INGRESS"
+  priority    = 900
+  source_tags = [var.cluster_tag_name]
+  target_tags = [var.cluster_tag_name]
+}
+
 resource "google_compute_firewall" "internal_remote_connection_firewall_ingress" {
   name    = "${var.prefix}${var.cluster_tag_name}-internal-remote-connection-firewall-ingress"
   network = var.network_name

--- a/iac/provider-gcp/nomad-cluster/nodepool-api.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-api.tf
@@ -134,7 +134,8 @@ resource "google_compute_instance_template" "api" {
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
 
     dynamic "access_config" {
       for_each = var.api_use_nat ? [] : ["public_ip"]

--- a/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-clickhouse.tf
@@ -139,7 +139,8 @@ resource "google_compute_instance_template" "clickhouse" {
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
 
     access_config {}
   }

--- a/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-control-server.tf
@@ -121,7 +121,8 @@ resource "google_compute_instance_template" "server" {
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
 
     # Create access config dynamically. If a public ip is requested, we just need the empty `access_config` block
     # to automatically assign an external IP address.

--- a/iac/provider-gcp/nomad-cluster/nodepool-loki.tf
+++ b/iac/provider-gcp/nomad-cluster/nodepool-loki.tf
@@ -110,7 +110,8 @@ resource "google_compute_instance_template" "loki" {
   }
 
   network_interface {
-    network = var.network_name
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
 
     dynamic "access_config" {
       for_each = ["public_ip"]

--- a/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
@@ -262,6 +262,7 @@ EOF
     "default_policy": "deny",
     "enable_token_persistence": true,
     "tokens": {
+      "agent": "$consul_token",
       "default": "$consul_token"
     }
   },

--- a/iac/provider-gcp/nomad-cluster/scripts/start-clickhouse.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-clickhouse.sh
@@ -55,18 +55,14 @@ gsutil cp "gs://${SCRIPTS_BUCKET}/run-nomad-${RUN_NOMAD_FILE_HASH}.sh" /opt/noma
 chmod +x /opt/consul/bin/run-consul.sh /opt/nomad/bin/run-nomad.sh
 
 mkdir -p /root/docker
-touch /root/docker/config.json
 cat <<EOF >/root/docker/config.json
 {
-    "auths": {
-        "${GCP_REGION}-docker.pkg.dev": {
-            "username": "_json_key_base64",
-            "password": "${GOOGLE_SERVICE_ACCOUNT_KEY}",
-            "server_address": "https://${GCP_REGION}-docker.pkg.dev"
-        }
-    }
+  "credHelpers": {
+    "${GCP_REGION}-docker.pkg.dev": "gcloud"
+  }
 }
 EOF
+gcloud auth configure-docker --quiet "${GCP_REGION}-docker.pkg.dev" || true
 
 
 mkdir -p /etc/systemd/resolved.conf.d/

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -190,18 +190,14 @@ gsutil cp "gs://${SCRIPTS_BUCKET}/run-nomad-${RUN_NOMAD_FILE_HASH}.sh" /opt/noma
 chmod +x /opt/consul/bin/run-consul.sh /opt/nomad/bin/run-nomad.sh
 
 mkdir -p /root/docker
-touch /root/docker/config.json
 cat <<EOF >/root/docker/config.json
 {
-    "auths": {
-        "${GCP_REGION}-docker.pkg.dev": {
-            "username": "_json_key_base64",
-            "password": "${GOOGLE_SERVICE_ACCOUNT_KEY}",
-            "server_address": "https://${GCP_REGION}-docker.pkg.dev"
-        }
-    }
+  "credHelpers": {
+    "${GCP_REGION}-docker.pkg.dev": "gcloud"
+  }
 }
 EOF
+gcloud auth configure-docker --quiet "${GCP_REGION}-docker.pkg.dev" || true
 
 mkdir -p /etc/systemd/resolved.conf.d/
 touch /etc/systemd/resolved.conf.d/consul.conf

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -183,6 +183,11 @@ variable "network_name" {
   type = string
 }
 
+variable "subnetwork_name" {
+  type    = string
+  default = ""
+}
+
 variable "google_service_account_email" {
   type = string
 }

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
@@ -208,8 +208,9 @@ resource "google_compute_instance_template" "template" {
   }
 
   network_interface {
-    network  = var.network_name
-    nic_type = var.network_interface_type
+    network    = var.network_name
+    subnetwork = coalesce(var.subnetwork_name, var.network_name)
+    nic_type   = var.network_interface_type
 
     dynamic "access_config" {
       for_each = ["public_ip"]

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
@@ -86,6 +86,12 @@ variable "network_name" {
   type        = string
 }
 
+variable "subnetwork_name" {
+  description = "Name of the VPC subnet for the cluster"
+  type        = string
+  default     = ""
+}
+
 variable "cluster_tag_name" {
   description = "Network tag applied to cluster instances for firewall rules"
   type        = string

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -599,7 +599,7 @@ resource "google_secret_manager_secret_version" "clickhouse_server_secret_value"
 }
 
 resource "google_service_account" "clickhouse_service_account" {
-  account_id   = "${var.prefix}clickhouse-service-account"
+  account_id   = "${var.prefix}clickhouse-sa"
   display_name = "${var.prefix}clickhouse-service-account"
 }
 
@@ -607,14 +607,6 @@ resource "google_storage_bucket_iam_member" "clickhouse_service_account_iam" {
   bucket = var.clickhouse_backups_bucket_name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.clickhouse_service_account.email}"
-}
-
-resource "google_storage_hmac_key" "clickhouse_hmac_key" {
-  service_account_email = google_service_account.clickhouse_service_account.email
-}
-
-resource "google_service_account_key" "clickhouse_service_account_key" {
-  service_account_id = google_service_account.clickhouse_service_account.id
 }
 
 module "clickhouse" {
@@ -641,7 +633,7 @@ module "clickhouse" {
 
   # Backup
   backup_bucket                = var.clickhouse_backups_bucket_name
-  gcs_credentials_json_encoded = google_service_account_key.clickhouse_service_account_key.private_key
+  gcs_credentials_json_encoded = ""
 
   # Migrator
   clickhouse_migrator_image = data.google_artifact_registry_docker_image.clickhouse_migrator_image.self_link

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -368,6 +368,12 @@ variable "domain_name" {
   description = "The domain name where e2b will run"
 }
 
+variable "cloudflare_api_token_secret_name" {
+  type        = string
+  description = "Secret Manager secret name containing the Cloudflare API token. Defaults to the token secret created by module.init."
+  default     = ""
+}
+
 variable "prefix" {
   type        = string
   description = "The prefix to use for all resources in this module"
@@ -743,6 +749,11 @@ variable "default_persistent_volume_type" {
 variable "network_name" {
   type    = string
   default = "default"
+}
+
+variable "subnetwork_name" {
+  type    = string
+  default = ""
 }
 
 variable "volume_token_issuer" {

--- a/packages/docker-reverse-proxy/go.mod
+++ b/packages/docker-reverse-proxy/go.mod
@@ -12,9 +12,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/oauth2 v0.36.0
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/packages/docker-reverse-proxy/go.sum
+++ b/packages/docker-reverse-proxy/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
+cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
 dario.cat/mergo v1.0.2/go.mod h1:E/hbnu0NxMFBjpMIE34DRGLWqDy0g5FuKDhCb31ngxA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -178,6 +180,8 @@ golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/packages/docker-reverse-proxy/internal/constants/main.go
+++ b/packages/docker-reverse-proxy/internal/constants/main.go
@@ -22,10 +22,6 @@ func CheckRequired() error {
 		missing = append(missing, "GCP_DOCKER_REPOSITORY_NAME")
 	}
 
-	if consts.GoogleServiceAccountSecret == "" {
-		missing = append(missing, "GOOGLE_SERVICE_ACCOUNT_BASE64")
-	}
-
 	if consts.GCPRegion == "" {
 		missing = append(missing, "GCP_REGION")
 	}

--- a/packages/docker-reverse-proxy/internal/handlers/token.go
+++ b/packages/docker-reverse-proxy/internal/handlers/token.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/docker-reverse-proxy/internal/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"golang.org/x/oauth2/google"
 )
 
 type DockerToken struct {
@@ -129,8 +131,11 @@ func getToken(ctx context.Context, templateID string) (*DockerToken, error) {
 		return nil, fmt.Errorf("failed to create request for scope - %s: %w", templateID, err)
 	}
 
-	// Use the service account credentials for the request
-	r.Header.Set("Authorization", fmt.Sprintf("Basic %s", consts.EncodedDockerCredentials))
+	authHeader, err := dockerRegistryAuthorization(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve docker registry auth: %w", err)
+	}
+	r.Header.Set("Authorization", authHeader)
 
 	resp, err := http.DefaultClient.Do(r)
 	if err != nil {
@@ -161,4 +166,25 @@ func getToken(ctx context.Context, templateID string) (*DockerToken, error) {
 	}
 
 	return parsedBody, nil
+}
+
+func dockerRegistryAuthorization(ctx context.Context) (string, error) {
+	if consts.GoogleServiceAccountSecret != "" {
+		encoded := base64.StdEncoding.EncodeToString(
+			fmt.Appendf(nil, "_json_key_base64:%s", consts.GoogleServiceAccountSecret),
+		)
+		return fmt.Sprintf("Basic %s", encoded), nil
+	}
+
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return "", fmt.Errorf("failed to find default credentials: %w", err)
+	}
+
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("failed to get default credential token: %w", err)
+	}
+
+	return fmt.Sprintf("Bearer %s", token.AccessToken), nil
 }

--- a/packages/shared/pkg/artifacts-registry/registry_gcp.go
+++ b/packages/shared/pkg/artifacts-registry/registry_gcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"golang.org/x/oauth2/google"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -78,9 +79,32 @@ func (g *GCPArtifactsRegistry) GetImage(ctx context.Context, templateId string, 
 	return img, nil
 }
 
-func (g *GCPArtifactsRegistry) getAuthToken(_ context.Context) (*authn.Basic, error) {
+type gcpADCAuthenticator struct {
+	ctx context.Context
+}
+
+func (a gcpADCAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	creds, err := google.FindDefaultCredentials(a.ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+	}
+
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default credential token: %w", err)
+	}
+
+	return &authn.AuthConfig{
+		RegistryToken: token.AccessToken,
+	}, nil
+}
+
+func (g *GCPArtifactsRegistry) getAuthToken(ctx context.Context) (authn.Authenticator, error) {
 	authCfg := consts.DockerAuthConfig
 	if authCfg == "" {
+		if consts.GoogleServiceAccountSecret == "" {
+			return gcpADCAuthenticator{ctx: ctx}, nil
+		}
 		return &gcpAuthConfig, nil
 	}
 

--- a/packages/shared/pkg/dockerhub/repository_gcp.go
+++ b/packages/shared/pkg/dockerhub/repository_gcp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistry "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"golang.org/x/oauth2/google"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
@@ -59,9 +60,32 @@ func (g *GCPRemoteRepository) GetImage(_ context.Context, tag string, platform c
 	return img, nil
 }
 
-func getAuthToken(_ context.Context) (authn.Authenticator, error) {
+type gcpADCAuthenticator struct {
+	ctx context.Context
+}
+
+func (a gcpADCAuthenticator) Authorization() (*authn.AuthConfig, error) {
+	creds, err := google.FindDefaultCredentials(a.ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find default credentials: %w", err)
+	}
+
+	token, err := creds.TokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default credential token: %w", err)
+	}
+
+	return &authn.AuthConfig{
+		RegistryToken: token.AccessToken,
+	}, nil
+}
+
+func getAuthToken(ctx context.Context) (authn.Authenticator, error) {
 	authCfg := consts.DockerAuthConfig
 	if authCfg == "" {
+		if consts.GoogleServiceAccountSecret == "" {
+			return gcpADCAuthenticator{ctx: ctx}, nil
+		}
 		return &gcpAuthConfig, nil
 	}
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -18,6 +18,8 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2/google"
+	iamcredentials "google.golang.org/api/iamcredentials/v1"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
@@ -144,7 +146,11 @@ func (s *gcpStorage) GetDetails() string {
 	return fmt.Sprintf("[GCP Storage, bucket set to %s]", s.bucket.BucketName())
 }
 
-func (s *gcpStorage) UploadSignedURL(_ context.Context, path string, ttl time.Duration) (string, error) {
+func (s *gcpStorage) UploadSignedURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	if consts.GoogleServiceAccountSecret == "" {
+		return s.uploadSignedURLWithADC(ctx, path, ttl)
+	}
+
 	token, err := parseServiceAccountBase64(consts.GoogleServiceAccountSecret)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse GCP service account: %w", err)
@@ -158,6 +164,55 @@ func (s *gcpStorage) UploadSignedURL(_ context.Context, path string, ttl time.Du
 	}
 
 	url, err := storage.SignedURL(s.bucket.BucketName(), path, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signed URL for GCS object (%s): %w", path, err)
+	}
+
+	return url, nil
+}
+
+func (s *gcpStorage) uploadSignedURLWithADC(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return "", fmt.Errorf("failed to find default credentials: %w", err)
+	}
+
+	serviceAccountEmail, err := googleCredentialsServiceAccountEmail(creds.JSON)
+	if err != nil {
+		serviceAccountEmail, err = metadataServiceAccountEmail(ctx)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve service account email: %w", err)
+		}
+	}
+
+	iamService, err := iamcredentials.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return "", fmt.Errorf("failed to create IAM credentials service: %w", err)
+	}
+
+	signBytes := func(b []byte) ([]byte, error) {
+		name := fmt.Sprintf("projects/-/serviceAccounts/%s", serviceAccountEmail)
+		resp, err := iamService.Projects.ServiceAccounts.SignBlob(name, &iamcredentials.SignBlobRequest{
+			Payload: base64.StdEncoding.EncodeToString(b),
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign blob with IAM Credentials: %w", err)
+		}
+
+		decoded, err := base64.StdEncoding.DecodeString(resp.SignedBlob)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode signed blob: %w", err)
+		}
+
+		return decoded, nil
+	}
+
+	url, err := storage.SignedURL(s.bucket.BucketName(), path, &storage.SignedURLOptions{
+		GoogleAccessID: serviceAccountEmail,
+		Method:         http.MethodPut,
+		Expires:        time.Now().Add(ttl),
+		SignBytes:      signBytes,
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create signed URL for GCS object (%s): %w", path, err)
 	}
@@ -532,6 +587,58 @@ func (o *gcpObject) storeFileCompressed(ctx context.Context, localPath string, c
 type gcpServiceToken struct {
 	ClientEmail string `json:"client_email"`
 	PrivateKey  string `json:"private_key"`
+}
+
+func googleCredentialsServiceAccountEmail(rawJSON []byte) (string, error) {
+	if len(rawJSON) == 0 {
+		return "", errors.New("credentials JSON is empty")
+	}
+
+	var token gcpServiceToken
+	if err := json.Unmarshal(rawJSON, &token); err != nil {
+		return "", fmt.Errorf("failed to parse credentials JSON: %w", err)
+	}
+
+	if token.ClientEmail == "" {
+		return "", errors.New("credentials JSON does not include client_email")
+	}
+
+	return token.ClientEmail, nil
+}
+
+func metadataServiceAccountEmail(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email",
+		nil,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create metadata request: %w", err)
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to query metadata service account email: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata service returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read metadata service account email: %w", err)
+	}
+
+	email := string(bytes.TrimSpace(body))
+	if email == "" {
+		return "", errors.New("metadata service returned empty service account email")
+	}
+
+	return email, nil
 }
 
 func parseServiceAccountBase64(serviceAccount string) (*gcpServiceToken, error) {


### PR DESCRIPTION
Allow GCP self-hosted clusters to run without service account JSON keys by using ADC for registry and storage operations. Add the network and secret configuration needed to reuse existing project resources safely.