### PR TITLE
chore(envd): minimize binary size with build-flag tweaks

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -2,7 +2,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 BUILD := $(shell git rev-parse --short HEAD)
-LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
+LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
@@ -27,7 +27,7 @@ else
 endif
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -a -o bin/envd ${LDFLAGS}
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -trimpath -buildvcs=false -a -o bin/envd ${LDFLAGS}
 
 build-debug:
 	CGO_ENABLED=1 go build -race -gcflags=all="-N -l" -o bin/debug/envd ${LDFLAGS}

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -2,7 +2,8 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
 BUILD := $(shell git rev-parse --short HEAD)
-LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
+LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
+PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
@@ -27,7 +28,7 @@ else
 endif
 
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -trimpath -buildvcs=false -a -o bin/envd ${LDFLAGS}
+	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -trimpath -buildvcs=false -a -o bin/envd ${PROD_LDFLAGS}
 
 build-debug:
 	CGO_ENABLED=1 go build -race -gcflags=all="-N -l" -o bin/debug/envd ${LDFLAGS}


### PR DESCRIPTION
Adds `-trimpath`, `-buildvcs=false`, `-buildid=` and `-s -w` to the prod `envd` build.

Effect: drops debug paths, VCS metadata, and the linker build ID from the binary. No runtime cost (Go's pclntab is untouched, so panics/pprof/stack traces still resolve names + lines), smaller mmap'd footprint, and reproducible builds across machines. `build-debug` is intentionally unaffected.