### PR TITLE
feat(orchestrator): add v4HeaderForUncompressed FF bit

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -113,10 +113,11 @@ func (u *Upload) publish(ctx context.Context, t build.DiffType, h *headers.Heade
 }
 
 // resolveCompressConfig returns the effective compression config for a given
-// file type and use case, plus the v4HeaderForUncompressed bit. Feature flags
-// override the base config when active. Returns zero-value CompressConfig when
-// compression is disabled. fileType, useCase are added to the LD evaluation
-// context; blockSize constrains legal frame sizes — see validateCompressConfig.
+// file type and use case, plus whether the V4 header layout should be used for
+// an uncompressed upload. Feature flags override the base config when active.
+// Returns zero-value CompressConfig when compression is disabled. fileType,
+// useCase are added to the LD evaluation context; blockSize constrains legal
+// frame sizes — see validateCompressConfig.
 func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff *featureflags.Client, fileType string, blockSize uint64, useCase string) (storage.CompressConfig, bool, error) {
 	resolved := base
 	var useV4 bool
@@ -131,9 +132,9 @@ func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff 
 		}
 		ctx = featureflags.AddToContext(ctx, extra...)
 
-		v := ff.JSONFlag(ctx, featureflags.CompressConfigFlag).AsValueMap()
-		useV4 = v.Get("v4HeaderForUncompressed").BoolValue()
+		useV4 = ff.BoolFlag(ctx, featureflags.V4HeaderForUncompressedFlag)
 
+		v := ff.JSONFlag(ctx, featureflags.CompressConfigFlag).AsValueMap()
 		if v.Get("compressBuilds").BoolValue() {
 			ct := v.Get("compressionType").StringValue()
 			ldCfg := storage.CompressConfig{

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -27,6 +27,7 @@ type Upload struct {
 	root           storage.CompressConfig
 	objectMetadata storage.ObjectMetadata
 	future         *utils.ErrorOnce
+	useV4          bool
 }
 
 func NewUpload(
@@ -39,11 +40,11 @@ func NewUpload(
 	useCase string,
 	objectMetadata storage.ObjectMetadata,
 ) (*Upload, error) {
-	mem, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, snap.MemfileDiffHeader.Metadata.BlockSize, useCase)
+	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, snap.MemfileDiffHeader.Metadata.BlockSize, useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve memfile compress config: %w", err)
 	}
-	root, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, snap.RootfsDiffHeader.Metadata.BlockSize, useCase)
+	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, snap.RootfsDiffHeader.Metadata.BlockSize, useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}
@@ -57,6 +58,7 @@ func NewUpload(
 		mem:            mem,
 		root:           root,
 		objectMetadata: objectMetadata,
+		useV4:          memV4 || rootV4,
 	}
 
 	if uploads != nil {
@@ -71,7 +73,7 @@ func NewUpload(
 }
 
 func (u *Upload) Run(ctx context.Context) error {
-	if !u.mem.IsCompressionEnabled() && !u.root.IsCompressionEnabled() {
+	if !u.mem.IsCompressionEnabled() && !u.root.IsCompressionEnabled() && !u.useV4 {
 		return u.runV3(ctx)
 	}
 
@@ -111,20 +113,13 @@ func (u *Upload) publish(ctx context.Context, t build.DiffType, h *headers.Heade
 }
 
 // resolveCompressConfig returns the effective compression config for a given
-// file type and use case. Feature flags override the base config when active.
-// Returns zero-value CompressConfig when compression is disabled.
-//
-// fileType and useCase are added to the LD evaluation context so that
-// LaunchDarkly targeting rules can differentiate (e.g. compress memfile
-// but not rootfs, or compress builds but not pauses). blockSize is the
-// in-VM read granularity for this fileType (from the diff header) and
-// constrains the legal frame sizes — see validateCompressConfig.
-//
-// The resolved config is validated; an invalid env or LD-derived config
-// surfaces as an error so the upload fails fast rather than streaming with
-// a misconfigured frame size.
-func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff *featureflags.Client, fileType string, blockSize uint64, useCase string) (storage.CompressConfig, error) {
+// file type and use case, plus the v4HeaderForUncompressed bit. Feature flags
+// override the base config when active. Returns zero-value CompressConfig when
+// compression is disabled. fileType, useCase are added to the LD evaluation
+// context; blockSize constrains legal frame sizes — see validateCompressConfig.
+func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff *featureflags.Client, fileType string, blockSize uint64, useCase string) (storage.CompressConfig, bool, error) {
 	resolved := base
+	var useV4 bool
 
 	if ff != nil {
 		var extra []ldcontext.Context
@@ -137,6 +132,7 @@ func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff 
 		ctx = featureflags.AddToContext(ctx, extra...)
 
 		v := ff.JSONFlag(ctx, featureflags.CompressConfigFlag).AsValueMap()
+		useV4 = v.Get("v4HeaderForUncompressed").BoolValue()
 
 		if v.Get("compressBuilds").BoolValue() {
 			ct := v.Get("compressionType").StringValue()
@@ -156,14 +152,14 @@ func resolveCompressConfig(ctx context.Context, base storage.CompressConfig, ff 
 	}
 
 	if !resolved.IsCompressionEnabled() {
-		return storage.CompressConfig{}, nil
+		return storage.CompressConfig{}, useV4, nil
 	}
 
 	if err := validateCompressConfig(resolved, blockSize); err != nil {
-		return storage.CompressConfig{}, err
+		return storage.CompressConfig{}, false, err
 	}
 
-	return resolved, nil
+	return resolved, useV4, nil
 }
 
 // validateCompressConfig checks that the resolved config is internally

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+func newCompressConfigFF(t *testing.T, cfg map[string]any) *featureflags.Client {
+	t.Helper()
+
+	td := ldtestdata.DataSource()
+	td.Update(td.Flag(featureflags.CompressConfigFlag.Key()).ValueForAll(ldvalue.CopyArbitraryValue(cfg)))
+
+	ff, err := featureflags.NewClientWithDatasource(td)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = ff.Close(t.Context())
+	})
+
+	return ff
+}
+
+func resolveV4(t *testing.T, ff *featureflags.Client) bool {
+	t.Helper()
+	_, useV4, err := resolveCompressConfig(t.Context(), storage.CompressConfig{}, ff, storage.MemfileName, 4096, storage.UseCaseBuild)
+	require.NoError(t, err)
+	return useV4
+}
+
+func TestResolveCompressConfig_V4_NilClient(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, resolveV4(t, nil))
+}
+
+func TestResolveCompressConfig_V4_FlagOff(t *testing.T) {
+	t.Parallel()
+
+	ff := newCompressConfigFF(t, map[string]any{"v4HeaderForUncompressed": false})
+	require.False(t, resolveV4(t, ff))
+}
+
+func TestResolveCompressConfig_V4_FlagOn(t *testing.T) {
+	t.Parallel()
+
+	ff := newCompressConfigFF(t, map[string]any{"v4HeaderForUncompressed": true})
+	require.True(t, resolveV4(t, ff))
+}

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -33,6 +33,7 @@ func resolveV4(t *testing.T, ff *featureflags.Client) bool {
 	t.Helper()
 	_, useV4, err := resolveCompressConfig(t.Context(), storage.CompressConfig{}, ff, storage.MemfileName, 4096, storage.UseCaseBuild)
 	require.NoError(t, err)
+
 	return useV4
 }
 

--- a/packages/orchestrator/pkg/sandbox/build_upload_test.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_test.go
@@ -5,7 +5,6 @@ package sandbox
 import (
 	"testing"
 
-	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
 	"github.com/stretchr/testify/require"
 
@@ -13,11 +12,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
-func newCompressConfigFF(t *testing.T, cfg map[string]any) *featureflags.Client {
+func newV4HeaderFF(t *testing.T, on bool) *featureflags.Client {
 	t.Helper()
 
 	td := ldtestdata.DataSource()
-	td.Update(td.Flag(featureflags.CompressConfigFlag.Key()).ValueForAll(ldvalue.CopyArbitraryValue(cfg)))
+	td.Update(td.Flag(featureflags.V4HeaderForUncompressedFlag.Key()).VariationForAll(on))
 
 	ff, err := featureflags.NewClientWithDatasource(td)
 	require.NoError(t, err)
@@ -46,13 +45,13 @@ func TestResolveCompressConfig_V4_NilClient(t *testing.T) {
 func TestResolveCompressConfig_V4_FlagOff(t *testing.T) {
 	t.Parallel()
 
-	ff := newCompressConfigFF(t, map[string]any{"v4HeaderForUncompressed": false})
+	ff := newV4HeaderFF(t, false)
 	require.False(t, resolveV4(t, ff))
 }
 
 func TestResolveCompressConfig_V4_FlagOn(t *testing.T) {
 	t.Parallel()
 
-	ff := newCompressConfigFF(t, map[string]any{"v4HeaderForUncompressed": true})
+	ff := newV4HeaderFF(t, true)
 	require.True(t, resolveV4(t, ff))
 }

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -5,6 +5,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
@@ -62,17 +63,23 @@ func (u *Upload) uploadFramed(
 	var selfBuild headers.BuildData
 
 	if srcPath != "" {
-		ft, checksum, err := storage.UploadFramed(ctx, u.store, u.paths.DataFile(string(fileType), cfg.CompressionType()), seekableTypeFor(fileType), srcPath, storage.WithCompressConfig(cfg), storage.WithMetadata(u.objectMetadata))
+		ft, checksum, err := storage.UploadFramed(ctx, u.store, u.paths.DataFile(string(fileType), cfg.CompressionType()), seekableTypeFor(fileType), srcPath, storage.WithCompressConfig(cfg), storage.WithMetadata(u.objectMetadata), storage.WithChecksumSHA256())
 		if err != nil {
 			return fmt.Errorf("%s upload: %w", fileType, err)
 		}
 
-		// FrameTable count, not os.Stat: sparse memfile diffs stream less than
-		// they appear on disk.
-		selfBuild = headers.BuildData{Size: ft.UncompressedSize(), Checksum: checksum}
-		if ft.IsCompressed() {
-			selfBuild.FrameData = ft
+		// Compressed: frame-table byte count, since sparse memfile diffs stream
+		// fewer bytes than they occupy on disk. Uncompressed has no table.
+		size := ft.UncompressedSize()
+		if !ft.IsCompressed() {
+			info, statErr := os.Stat(srcPath)
+			if statErr != nil {
+				return fmt.Errorf("%s stat: %w", fileType, statErr)
+			}
+			size = info.Size()
 		}
+
+		selfBuild = headers.BuildData{Size: size, Checksum: checksum, FrameData: ft}
 	}
 
 	h := srcHeader.CloneForUpload(headers.MetadataVersionV4)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -356,15 +356,17 @@ func GetTrackedTemplatesSet(ctx context.Context, ff *Client) map[string]struct{}
 
 // CompressConfigFlag controls compression during template builds.
 // When compressBuilds is true, builds upload exclusively compressed data
-// (no uncompressed fallback). When false, exclusively uncompressed with V3 headers.
+// (no uncompressed fallback). When false, exclusively uncompressed.
+// v4HeaderForUncompressed forces the V4 header layout on uncompressed uploads.
 var CompressConfigFlag = NewJSONFlag("compress-config", ldvalue.FromJSONMarshal(map[string]any{
-	"compressBuilds":     false,
-	"compressionType":    "",
-	"compressionLevel":   0,
-	"frameSizeKB":        0,
-	"minPartSizeMB":      0,
-	"frameEncodeWorkers": 0,
-	"encoderConcurrency": 0,
+	"compressBuilds":          false,
+	"compressionType":         "",
+	"compressionLevel":        0,
+	"frameSizeKB":             0,
+	"minPartSizeMB":           0,
+	"frameEncodeWorkers":      0,
+	"encoderConcurrency":      0,
+	"v4HeaderForUncompressed": false,
 }))
 
 // TCPFirewallEgressThrottleConfig controls per-sandbox egress throttling via Firecracker's

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -126,6 +126,11 @@ var (
 	FreePageReportingFlag            = NewBoolFlag("free-page-reporting", false)
 
 	NetworkTransformRulesFlag = NewBoolFlag("network-transform-rules", env.IsDevelopment())
+
+	// V4HeaderForUncompressedFlag forces the V4 header layout on uncompressed
+	// uploads. Independent of compress-config: it changes the header format,
+	// not whether data is compressed.
+	V4HeaderForUncompressedFlag = NewBoolFlag("v4-header-for-uncompressed", false)
 )
 
 type IntFlag struct {
@@ -356,17 +361,16 @@ func GetTrackedTemplatesSet(ctx context.Context, ff *Client) map[string]struct{}
 
 // CompressConfigFlag controls compression during template builds.
 // When compressBuilds is true, builds upload exclusively compressed data
-// (no uncompressed fallback). When false, exclusively uncompressed.
-// v4HeaderForUncompressed forces the V4 header layout on uncompressed uploads.
+// (no uncompressed fallback). When false, exclusively uncompressed with V3
+// headers (unless V4HeaderForUncompressedFlag is set).
 var CompressConfigFlag = NewJSONFlag("compress-config", ldvalue.FromJSONMarshal(map[string]any{
-	"compressBuilds":          false,
-	"compressionType":         "",
-	"compressionLevel":        0,
-	"frameSizeKB":             0,
-	"minPartSizeMB":           0,
-	"frameEncodeWorkers":      0,
-	"encoderConcurrency":      0,
-	"v4HeaderForUncompressed": false,
+	"compressBuilds":     false,
+	"compressionType":    "",
+	"compressionLevel":   0,
+	"frameSizeKB":        0,
+	"minPartSizeMB":      0,
+	"frameEncodeWorkers": 0,
+	"encoderConcurrency": 0,
 }))
 
 // TCPFirewallEgressThrottleConfig controls per-sandbox egress throttling via Firecracker's

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -167,11 +167,9 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 		return nil, [32]byte{}, fmt.Errorf("complete upload: %w", err)
 	}
 
-	var checksum [32]byte
-	copy(checksum[:], hasher.Sum(nil))
 	ft := NewFrameTable(cfg.CompressionType(), frameSizes)
 
-	return ft, checksum, nil
+	return ft, sum256(hasher), nil
 }
 
 func readLoop(ctx context.Context, in io.Reader, cfg CompressConfig, hasher io.Writer, q chan<- *part) error {

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -410,17 +410,21 @@ func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath s
 		return 0, fmt.Errorf("failed to initiate upload: %w", err)
 	}
 
-	eg, egCtx := errgroup.WithContext(ctx)
-	var parts []Part
+	// Hash on a sibling goroutine while parts upload — the read overlaps the
+	// upload, adding no wall-clock latency. Own file handle (separate from the
+	// part uploaders' ReadAt); opened here so a failed upload can close it.
+	var hashFile *os.File
 	if hasher != nil {
-		eg.Go(func() error {
-			// Own file handle so it doesn't race the part uploaders' ReadAt.
-			hashFile, err := os.Open(filePath)
-			if err != nil {
-				return fmt.Errorf("failed to open file for checksum: %w", err)
-			}
-			defer hashFile.Close()
+		hashFile, err = os.Open(filePath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to open file for checksum: %w", err)
+		}
+		defer hashFile.Close()
+	}
 
+	var eg errgroup.Group
+	if hashFile != nil {
+		eg.Go(func() error {
 			if _, err := io.Copy(hasher, hashFile); err != nil {
 				return fmt.Errorf("failed to checksum file: %w", err)
 			}
@@ -428,12 +432,16 @@ func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath s
 			return nil
 		})
 	}
-	parts, err = m.uploadParts(egCtx, maxConcurrency, numParts, fileSize, file, uploadID)
-	if waitErr := eg.Wait(); err == nil {
-		err = waitErr
+
+	parts, err := m.uploadParts(ctx, maxConcurrency, numParts, fileSize, file, uploadID)
+	if hashFile != nil && err != nil {
+		hashFile.Close() // cancel the now-pointless io.Copy
+	}
+	if hashErr := eg.Wait(); err == nil {
+		err = hashErr
 	}
 	if err != nil {
-		return 0, fmt.Errorf("failed to upload parts: %w", err)
+		return 0, fmt.Errorf("failed to upload file: %w", err)
 	}
 
 	if err := m.completeUpload(ctx, uploadID, parts); err != nil {

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
+	"hash"
 	"io"
 	"math"
 	"math/rand"
@@ -382,7 +383,7 @@ func (m *MultipartUploader) completeUpload(ctx context.Context, uploadID string,
 	return nil
 }
 
-func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath string, maxConcurrency int) (int64, error) {
+func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath string, maxConcurrency int, hasher hash.Hash) (int64, error) {
 	// Open file
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -409,7 +410,28 @@ func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath s
 		return 0, fmt.Errorf("failed to initiate upload: %w", err)
 	}
 
-	parts, err := m.uploadParts(ctx, maxConcurrency, numParts, fileSize, file, uploadID)
+	eg, egCtx := errgroup.WithContext(ctx)
+	var parts []Part
+	if hasher != nil {
+		eg.Go(func() error {
+			// Own file handle so it doesn't race the part uploaders' ReadAt.
+			hashFile, err := os.Open(filePath)
+			if err != nil {
+				return fmt.Errorf("failed to open file for checksum: %w", err)
+			}
+			defer hashFile.Close()
+
+			if _, err := io.Copy(hasher, hashFile); err != nil {
+				return fmt.Errorf("failed to checksum file: %w", err)
+			}
+
+			return nil
+		})
+	}
+	parts, err = m.uploadParts(egCtx, maxConcurrency, numParts, fileSize, file, uploadID)
+	if waitErr := eg.Wait(); err == nil {
+		err = waitErr
+	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to upload parts: %w", err)
 	}

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -243,7 +244,7 @@ func TestMultipartUploader_UploadFileInParallel_Success(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 2)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 2, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&initiateCount))
@@ -258,6 +259,42 @@ func TestMultipartUploader_UploadFileInParallel_Success(t *testing.T) {
 		}
 	}
 	require.Equal(t, testContent, reconstructed.String())
+}
+
+func TestMultipartUploader_UploadFileInParallel_Checksum(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.txt")
+	testContent := strings.Repeat("checksummed payload ", 5000) // multiple chunks
+	require.NoError(t, os.WriteFile(testFile, []byte(testContent), 0o644))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.RawQuery == uploadsPath:
+			response := InitiateMultipartUploadResult{
+				Bucket:   testBucketName,
+				Key:      testObjectName,
+				UploadID: "checksum-upload-id",
+			}
+			xmlData, _ := xml.Marshal(response)
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusOK)
+			w.Write(xmlData)
+		case strings.Contains(r.URL.RawQuery, "partNumber"):
+			w.Header().Set("ETag", `"etag"`)
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.RawQuery, "uploadId"):
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+
+	uploader := createTestMultipartUploader(t, handler)
+	hasher := sha256.New()
+	_, err := uploader.UploadFileInParallel(t.Context(), testFile, 4, hasher)
+	require.NoError(t, err)
+
+	require.Equal(t, sha256.Sum256([]byte(testContent)), sum256(hasher))
 }
 
 func TestMultipartUploader_InitiateUpload_WithRetries(t *testing.T) {
@@ -359,7 +396,7 @@ func TestMultipartUploader_HighConcurrency_StressTest(t *testing.T) {
 	uploader := createTestMultipartUploader(t, handler)
 
 	// Use high concurrency to stress test
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 50)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 50, nil)
 	require.NoError(t, err)
 
 	// Verify all calls were made
@@ -430,7 +467,7 @@ func TestMultipartUploader_RandomFailures_ChaosTest(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 10)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 10, nil)
 	require.NoError(t, err)
 
 	t.Logf("Chaos test: %d total attempts, %d successes",
@@ -495,7 +532,7 @@ func TestMultipartUploader_PartialFailures_Recovery(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5, nil)
 	require.NoError(t, err)
 
 	// Verify that all parts eventually succeeded after retries
@@ -544,7 +581,7 @@ func TestMultipartUploader_EdgeCases_EmptyFile(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), emptyFile, 5)
+	_, err = uploader.UploadFileInParallel(t.Context(), emptyFile, 5, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&initiateCalls))
@@ -588,7 +625,7 @@ func TestMultipartUploader_EdgeCases_VerySmallFile(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), smallFile, 10) // High concurrency for small file
+	_, err = uploader.UploadFileInParallel(t.Context(), smallFile, 10, nil) // High concurrency for small file
 	require.NoError(t, err)
 
 	// Small file should produce exactly one part
@@ -686,7 +723,7 @@ func TestMultipartUploader_ResourceExhaustion_TooManyConcurrentUploads(t *testin
 	uploader := createTestMultipartUploader(t, handler)
 
 	// Try with extremely high concurrency
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 1000)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 1000, nil)
 	require.NoError(t, err)
 
 	// Should have observed significant concurrency but not necessarily 1000
@@ -735,7 +772,7 @@ func TestMultipartUploader_BoundaryConditions_ExactChunkSize(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5, nil)
 	require.NoError(t, err)
 
 	// Should have exactly 2 parts, each of ChunkSize
@@ -751,7 +788,7 @@ func TestMultipartUploader_FileNotFound_Error(t *testing.T) {
 		t.Error("Should not make any HTTP requests for missing file")
 	})
 
-	_, err := uploader.UploadFileInParallel(t.Context(), "/nonexistent/file.txt", 5)
+	_, err := uploader.UploadFileInParallel(t.Context(), "/nonexistent/file.txt", 5, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to open file")
 }
@@ -814,7 +851,7 @@ func TestMultipartUploader_ConcurrentRetries_RaceCondition(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 20) // High concurrency
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 20, nil) // High concurrency
 	require.NoError(t, err)
 
 	t.Logf("Total HTTP requests made: %d", atomic.LoadInt32(&totalRequests))

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -728,7 +728,6 @@ func TestSerializeDeserialize_V4_Uncompressed_SelfEntry(t *testing.T) {
 	require.Len(t, got.Builds, 1)
 	require.Contains(t, got.Builds, buildID)
 	require.Nil(t, got.GetBuildFrameData(buildID))
-	require.Equal(t, storage.CompressionNone, got.GetBuildFrameData(buildID).CompressionType())
 }
 
 // Layered chain V4-uncompressed (self) → V4-compressed (mid) → V4-uncompressed

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -694,3 +694,228 @@ func TestSerializeDeserialize_V4_SparseTrimming(t *testing.T) {
 	_, err = gotFT.LocateCompressed(4096)
 	require.Error(t, err)
 }
+
+func TestSerializeDeserialize_V4_Uncompressed_SelfEntry(t *testing.T) {
+	t.Parallel()
+
+	buildID := uuid.New()
+	metadata := &Metadata{
+		Version:     MetadataVersionV4,
+		BlockSize:   4096,
+		Size:        8192,
+		Generation:  0,
+		BuildId:     buildID,
+		BaseBuildId: buildID,
+	}
+
+	mappings := []BuildMap{
+		{Offset: 0, Length: 8192, BuildId: buildID, BuildStorageOffset: 0},
+	}
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		buildID: {},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
+	require.Len(t, got.Builds, 1)
+	require.Contains(t, got.Builds, buildID)
+	require.Nil(t, got.GetBuildFrameData(buildID))
+	require.Equal(t, storage.CompressionNone, got.GetBuildFrameData(buildID).CompressionType())
+}
+
+// Layered chain V4-uncompressed (self) → V4-compressed (mid) → V4-uncompressed
+// (older) → V3 ancestor → V3 ancestor: V4 ancestors round-trip via Builds, V3
+// ancestors stay absent.
+func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
+	t.Parallel()
+
+	selfID := uuid.New()
+	midID := uuid.New()
+	olderID := uuid.New()
+	v3aID := uuid.New()
+	v3bID := uuid.New()
+
+	midFT := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 4096, C: 1234},
+	})
+
+	metadata := &Metadata{
+		Version:     MetadataVersionV4,
+		BlockSize:   4096,
+		Size:        4096 * 5,
+		Generation:  4,
+		BuildId:     selfID,
+		BaseBuildId: v3bID,
+	}
+
+	mappings := []BuildMap{
+		{Offset: 0, Length: 4096, BuildId: selfID, BuildStorageOffset: 0},
+		{Offset: 4096, Length: 4096, BuildId: midID, BuildStorageOffset: 0},
+		{Offset: 8192, Length: 4096, BuildId: olderID, BuildStorageOffset: 0},
+		{Offset: 12288, Length: 4096, BuildId: v3aID, BuildStorageOffset: 0},
+		{Offset: 16384, Length: 4096, BuildId: v3bID, BuildStorageOffset: 0},
+	}
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		selfID:  {},
+		midID:   {Size: 4096, FrameData: midFT},
+		olderID: {Size: 4096},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
+	require.Len(t, got.Mapping, 5)
+	require.Len(t, got.Builds, 3)
+
+	require.Nil(t, got.GetBuildFrameData(selfID))
+	require.Nil(t, got.GetBuildFrameData(olderID))
+
+	gotMidFT := got.GetBuildFrameData(midID)
+	require.NotNil(t, gotMidFT)
+	require.Equal(t, storage.CompressionZstd, gotMidFT.CompressionType())
+	require.Equal(t, 1, gotMidFT.NumFrames())
+
+	_, hasV3a := got.Builds[v3aID]
+	require.False(t, hasV3a)
+	_, hasV3b := got.Builds[v3bID]
+	require.False(t, hasV3b)
+
+	require.Equal(t, selfID, got.Mapping[0].BuildId)
+	require.Equal(t, midID, got.Mapping[1].BuildId)
+	require.Equal(t, olderID, got.Mapping[2].BuildId)
+	require.Equal(t, v3aID, got.Mapping[3].BuildId)
+	require.Equal(t, v3bID, got.Mapping[4].BuildId)
+}
+
+// Layered chain with a compressed self entry:
+// C-v4 (self) → U-v4 (mid) → C-v4 (older) → V3 → V3. After a serialize round
+// trip, every virtual offset resolves to the right build via GetShiftedMapping
+// and carries the expected compression (FrameData present iff compressed).
+func TestSerializeDeserialize_V4_CompressedSelfChain(t *testing.T) {
+	t.Parallel()
+
+	selfID := uuid.New()
+	midID := uuid.New()
+	olderID := uuid.New()
+	v3aID := uuid.New()
+	v3bID := uuid.New()
+
+	selfFT := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 4096, C: 1100},
+		{U: 4096, C: 1200},
+	})
+	olderFT := storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{
+		{U: 4096, C: 1300},
+	})
+
+	metadata := &Metadata{
+		Version:     MetadataVersionV4,
+		BlockSize:   4096,
+		Size:        4096 * 6,
+		Generation:  4,
+		BuildId:     selfID,
+		BaseBuildId: v3bID,
+	}
+
+	// self spans two blocks to exercise the intra-build shift.
+	mappings := []BuildMap{
+		{Offset: 0, Length: 8192, BuildId: selfID, BuildStorageOffset: 0},
+		{Offset: 8192, Length: 4096, BuildId: midID, BuildStorageOffset: 0},
+		{Offset: 12288, Length: 4096, BuildId: olderID, BuildStorageOffset: 0},
+		{Offset: 16384, Length: 4096, BuildId: v3aID, BuildStorageOffset: 0},
+		{Offset: 20480, Length: 4096, BuildId: v3bID, BuildStorageOffset: 0},
+	}
+
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{
+		selfID:  {Size: 8192, FrameData: selfFT},
+		midID:   {Size: 4096},
+		olderID: {Size: 4096, FrameData: olderFT},
+	}
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
+	require.Len(t, got.Builds, 3)
+
+	// Walk every virtual block offset and check it resolves to the owning
+	// build with the expected compression.
+	cases := []struct {
+		offset     int64
+		wantBuild  uuid.UUID
+		wantOffset uint64
+		compressed bool
+	}{
+		{0, selfID, 0, true},
+		{4096, selfID, 4096, true}, // shifted read inside self
+		{8192, midID, 0, false},    // uncompressed V4
+		{12288, olderID, 0, true},  // compressed ancestor
+		{16384, v3aID, 0, false},   // V3 ancestor, no Builds entry
+		{20480, v3bID, 0, false},   // V3 ancestor, no Builds entry
+	}
+	for _, tc := range cases {
+		m, err := got.GetShiftedMapping(t.Context(), tc.offset)
+		require.NoError(t, err, "offset %d", tc.offset)
+		require.Equal(t, tc.wantBuild, m.BuildId, "offset %d build", tc.offset)
+		require.Equal(t, tc.wantOffset, m.Offset, "offset %d storage offset", tc.offset)
+
+		ft := got.GetBuildFrameData(m.BuildId)
+		if tc.compressed {
+			require.NotNil(t, ft, "offset %d expected FrameData", tc.offset)
+			require.Equal(t, storage.CompressionZstd, ft.CompressionType(), "offset %d", tc.offset)
+		} else {
+			require.Nil(t, ft, "offset %d expected no FrameData", tc.offset)
+		}
+	}
+
+	// V3 ancestors must not have leaked into Builds.
+	_, hasV3a := got.Builds[v3aID]
+	require.False(t, hasV3a)
+	_, hasV3b := got.Builds[v3bID]
+	require.False(t, hasV3b)
+}
+
+func TestDeserialize_V3_StaysV3(t *testing.T) {
+	t.Parallel()
+
+	buildID := uuid.New()
+	metadata := &Metadata{
+		Version:     3,
+		BlockSize:   4096,
+		Size:        4096,
+		Generation:  0,
+		BuildId:     buildID,
+		BaseBuildId: buildID,
+	}
+	mappings := []BuildMap{{Offset: 0, Length: 4096, BuildId: buildID}}
+
+	data, err := serializeV3(metadata, mappings)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(3), got.Metadata.Version)
+	require.Nil(t, got.Builds)
+	require.Nil(t, got.GetBuildFrameData(buildID))
+}

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"time"
@@ -103,6 +104,20 @@ func WithMetadata(metadata ObjectMetadata) PutOption { return storageopts.WithMe
 // stored as `any` in storageopts to avoid importing storage from there;
 // backends use CompressConfigFromOpts to pull it back out.
 func WithCompressConfig(cfg CompressConfig) PutOption { return storageopts.WithCompression(cfg) }
+
+func WithChecksumSHA256() PutOption {
+	return func(o *PutOptions) { o.Checksum = true }
+}
+
+// sum256 finalizes h into a SHA-256 digest, or the zero digest when h is nil.
+func sum256(h hash.Hash) [32]byte {
+	var sum [32]byte
+	if h != nil {
+		copy(sum[:], h.Sum(nil))
+	}
+
+	return sum
+}
 
 func ApplyPutOptions(opts []PutOption) PutOptions { return storageopts.Apply(opts) }
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -3,10 +3,12 @@ package storage
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"maps"
 	"net/http"
@@ -431,6 +433,12 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 		return ft, checksum, err
 	}
 
+	// Uncompressed uploads only hash when the caller asked for a checksum.
+	var hasher hash.Hash
+	if putOpts.Checksum {
+		hasher = sha256.New()
+	}
+
 	// If the file is too small, the overhead of writing in parallel isn't worth the effort.
 	// Write it in one shot instead.
 	if fileInfo.Size() < gcpMultipartUploadChunkSize {
@@ -458,7 +466,11 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 			zap.String("compression", "none"),
 		)
 
-		return nil, [32]byte{}, e
+		if hasher != nil {
+			hasher.Write(data)
+		}
+
+		return nil, sum256(hasher), e
 	}
 
 	uploader, err := NewMultipartUploaderWithRetryConfig(
@@ -475,7 +487,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 	}
 
 	start := time.Now()
-	count, err := uploader.UploadFileInParallel(ctx, path, maxConcurrency)
+	count, err := uploader.UploadFileInParallel(ctx, path, maxConcurrency, hasher)
 	if err != nil {
 		timer.Failure(ctx, count)
 
@@ -494,7 +506,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 
 	timer.Success(ctx, count)
 
-	return nil, [32]byte{}, e
+	return nil, sum256(hasher), e
 }
 
 func (o *gcpObject) storeFileCompressed(ctx context.Context, localPath string, cfg CompressConfig, maxConcurrency int, putOpts PutOptions) (*FrameTable, [32]byte, error) {

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -14,6 +14,7 @@ const ObjectMetadataTeamID = "team_id"
 type PutOptions struct {
 	Metadata    ObjectMetadata
 	Compression any
+	Checksum    bool
 }
 
 type PutOption func(*PutOptions)


### PR DESCRIPTION
Lets uncompressed uploads use the V4 header layout via the compress-config flag. Adds round-trip coverage for mixed compressed/uncompressed V4 chains.

Tested on my cluster, running integ tests in UncompressedV4 mode over a compressed base template, plus the new units tests for the more complex chains.