### PR TITLE
perf(sandbox): reduce memory dirtying from journald and envd logging

### DIFF
--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -144,20 +144,21 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 
 	// Polling runs at 50ms — log the first failure of each kind only so a
 	// persistently broken MMDS endpoint doesn't spam journald until ctx
-	// cancellation.
+	// cancellation. Tagged as syslog WARNING (<4>) since MMDS hiccups are
+	// expected during early boot and recoverable.
 	var loggedTokenErr, loggedOptsErr bool
 
 	for {
 		select {
 		case <-ctx.Done():
-			fmt.Fprintf(os.Stderr, "context cancelled while waiting for mmds opts")
+			fmt.Fprintf(os.Stderr, "<4>context cancelled while waiting for mmds opts\n")
 
 			return
 		case <-ticker.C:
 			token, err := getMMDSToken(ctx, httpClient)
 			if err != nil {
 				if !loggedTokenErr {
-					fmt.Fprintf(os.Stderr, "error getting mmds token (suppressing further failures): %v\n", err)
+					fmt.Fprintf(os.Stderr, "<4>error getting mmds token (suppressing further failures): %v\n", err)
 					loggedTokenErr = true
 				}
 
@@ -167,7 +168,7 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 			mmdsOpts, err := getMMDSOpts(ctx, httpClient, token)
 			if err != nil {
 				if !loggedOptsErr {
-					fmt.Fprintf(os.Stderr, "error getting mmds opts (suppressing further failures): %v\n", err)
+					fmt.Fprintf(os.Stderr, "<4>error getting mmds opts (suppressing further failures): %v\n", err)
 					loggedOptsErr = true
 				}
 

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -142,6 +142,11 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
+	// Polling runs at 50ms — log the first failure of each kind only so a
+	// persistently broken MMDS endpoint doesn't spam journald until ctx
+	// cancellation.
+	var loggedTokenErr, loggedOptsErr bool
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -151,14 +156,20 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 		case <-ticker.C:
 			token, err := getMMDSToken(ctx, httpClient)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error getting mmds token: %v\n", err)
+				if !loggedTokenErr {
+					fmt.Fprintf(os.Stderr, "error getting mmds token (suppressing further failures): %v\n", err)
+					loggedTokenErr = true
+				}
 
 				continue
 			}
 
 			mmdsOpts, err := getMMDSOpts(ctx, httpClient, token)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error getting mmds opts: %v\n", err)
+				if !loggedOptsErr {
+					fmt.Fprintf(os.Stderr, "error getting mmds opts (suppressing further failures): %v\n", err)
+					loggedOptsErr = true
+				}
 
 				continue
 			}

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -135,18 +135,33 @@ func GetAccessTokenHashFromMMDS(ctx context.Context) (string, error) {
 	return opts.AccessTokenHash, nil
 }
 
+// MMDS poll backoff: start fast for the common happy path (MMDS up at boot),
+// then double on each failure up to mmdsMaxBackoff so a persistently broken
+// endpoint doesn't keep firing HTTP requests every 50ms.
+const (
+	mmdsInitialBackoff = 50 * time.Millisecond
+	mmdsMaxBackoff     = 1 * time.Second
+)
+
 func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *utils.Map[string, string]) {
 	httpClient := &http.Client{}
 	defer httpClient.CloseIdleConnections()
 
-	ticker := time.NewTicker(50 * time.Millisecond)
-	defer ticker.Stop()
-
-	// Polling runs at 50ms — log the first failure of each kind only so a
-	// persistently broken MMDS endpoint doesn't spam journald until ctx
-	// cancellation. Tagged as syslog WARNING (<4>) since MMDS hiccups are
-	// expected during early boot and recoverable.
+	// Log only the first failure of each kind. Tagged as syslog WARNING (<4>)
+	// since MMDS hiccups are expected during early boot and recoverable.
 	var loggedTokenErr, loggedOptsErr bool
+
+	backoff := mmdsInitialBackoff
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+
+	advanceBackoff := func() {
+		backoff *= 2
+		if backoff > mmdsMaxBackoff {
+			backoff = mmdsMaxBackoff
+		}
+		timer.Reset(backoff)
+	}
 
 	for {
 		select {
@@ -154,7 +169,7 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 			fmt.Fprintf(os.Stderr, "<4>context cancelled while waiting for mmds opts\n")
 
 			return
-		case <-ticker.C:
+		case <-timer.C:
 			token, err := getMMDSToken(ctx, httpClient)
 			if err != nil {
 				if !loggedTokenErr {
@@ -162,6 +177,7 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 					loggedTokenErr = true
 				}
 
+				advanceBackoff()
 				continue
 			}
 
@@ -172,6 +188,7 @@ func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *ut
 					loggedOptsErr = true
 				}
 
+				advanceBackoff()
 				continue
 			}
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -19,12 +19,21 @@ const (
 	// log collector is unreachable, w.logs cannot grow unbounded. Oldest logs
 	// are dropped under back-pressure.
 	maxBufferedLogs = 10000
+
+	// Exporter send-failure backoff: each failure waits sendInitialBackoff,
+	// doubling up to sendMaxBackoff, before any further send is attempted.
+	// During the cooldown window logs are dropped (we already report the
+	// outage to journald and the orchestrator was supposed to receive them
+	// anyway). Resets to the initial value on the next successful send.
+	sendInitialBackoff = 1 * time.Second
+	sendMaxBackoff     = 5 * time.Minute
 )
 
 type HTTPExporter struct {
 	client   http.Client
 	logs     [][]byte
 	isNotFC  bool
+	verbose  bool
 	mmdsOpts *host.MMDSOpts
 
 	// Concurrency coordination
@@ -34,13 +43,14 @@ type HTTPExporter struct {
 	startOnce sync.Once
 }
 
-func NewHTTPLogsExporter(ctx context.Context, isNotFC bool, mmdsChan <-chan *host.MMDSOpts) *HTTPExporter {
+func NewHTTPLogsExporter(ctx context.Context, isNotFC bool, verbose bool, mmdsChan <-chan *host.MMDSOpts) *HTTPExporter {
 	exporter := &HTTPExporter{
 		client: http.Client{
 			Timeout: ExporterTimeout,
 		},
 		triggers:  make(chan struct{}, 1),
 		isNotFC:   isNotFC,
+		verbose:   verbose,
 		startOnce: sync.Once{},
 		mmdsOpts: &host.MMDSOpts{
 			SandboxID:            "unknown",
@@ -75,7 +85,12 @@ func (w *HTTPExporter) sendInstanceLogs(ctx context.Context, logs []byte, addres
 	return nil
 }
 
-func printLog(logs []byte) {
+func (w *HTTPExporter) printLog(logs []byte) {
+	// Only emit on -verbose. Inside FC stdout flows into journald, which is
+	// what this PR is trying to keep clean during send outages.
+	if !w.verbose {
+		return
+	}
 	fmt.Fprintf(os.Stdout, "%v", string(logs))
 }
 
@@ -102,8 +117,14 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 
 func (w *HTTPExporter) start(ctx context.Context) {
 	// Suppress repeated failures so a wedged collector doesn't 1:1-amplify
-	// envd logs into journald via the log.Printf default (stderr).
+	// envd logs into journald.
 	var loggedJSONErr, loggedSendErr bool
+
+	// Exponential backoff between send attempts after a failure, so a
+	// persistently broken collector doesn't keep wasting ExporterTimeout
+	// (10s) per log line.
+	var cooldownUntil time.Time
+	cooldown := sendInitialBackoff
 
 	for range w.triggers {
 		logs := w.getAllLogs()
@@ -113,8 +134,10 @@ func (w *HTTPExporter) start(ctx context.Context) {
 		}
 
 		if w.isNotFC {
-			for _, log := range logs {
-				fmt.Fprintf(os.Stdout, "%v", string(log))
+			if w.verbose {
+				for _, log := range logs {
+					fmt.Fprintf(os.Stdout, "%v", string(log))
+				}
 			}
 
 			continue
@@ -130,8 +153,13 @@ func (w *HTTPExporter) start(ctx context.Context) {
 					loggedJSONErr = true
 				}
 
-				printLog(logLine)
+				w.printLog(logLine)
 
+				continue
+			}
+
+			if time.Now().Before(cooldownUntil) {
+				// Skip send during cooldown; the log is dropped.
 				continue
 			}
 
@@ -142,11 +170,19 @@ func (w *HTTPExporter) start(ctx context.Context) {
 					loggedSendErr = true
 				}
 
-				printLog(logLine)
+				cooldownUntil = time.Now().Add(cooldown)
+				cooldown *= 2
+				if cooldown > sendMaxBackoff {
+					cooldown = sendMaxBackoff
+				}
+
+				w.printLog(logLine)
 
 				continue
 			}
 
+			cooldown = sendInitialBackoff
+			cooldownUntil = time.Time{}
 			loggedSendErr = false
 		}
 	}

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -15,10 +15,12 @@ import (
 const (
 	ExporterTimeout = 10 * time.Second
 
-	// maxBufferedLogs caps the in-memory log queue so that if the orchestrator
-	// log collector is unreachable, w.logs cannot grow unbounded. Oldest logs
-	// are dropped under back-pressure.
-	maxBufferedLogs = 10000
+	// maxBufferedBytes caps the total in-memory size of the log queue, so the
+	// queue stays bounded even when the collector is unreachable for a long
+	// time (e.g. before MMDS opts arrive on boot). Oldest logs are dropped on
+	// over-cap so the most recent — and most useful for whatever just
+	// happened — are the ones the orchestrator gets once it can be reached.
+	maxBufferedBytes = 4 << 20 // 4 MiB
 
 	// Exporter send-failure backoff: each failure waits sendInitialBackoff,
 	// doubling up to sendMaxBackoff, before any further send is attempted.
@@ -30,11 +32,12 @@ const (
 )
 
 type HTTPExporter struct {
-	client   http.Client
-	logs     [][]byte
-	isNotFC  bool
-	verbose  bool
-	mmdsOpts *host.MMDSOpts
+	client        http.Client
+	logs          [][]byte
+	bufferedBytes int
+	isNotFC       bool
+	verbose       bool
+	mmdsOpts      *host.MMDSOpts
 
 	// Concurrency coordination
 	triggers  chan struct{}
@@ -212,6 +215,7 @@ func (w *HTTPExporter) getAllLogs() [][]byte {
 
 	logs := w.logs
 	w.logs = nil
+	w.bufferedBytes = 0
 
 	return logs
 }
@@ -220,11 +224,16 @@ func (w *HTTPExporter) addLogs(logs []byte) {
 	w.logLock.Lock()
 	defer w.logLock.Unlock()
 
-	// Drop oldest under back-pressure so the queue can't grow unbounded if
-	// the collector is unreachable.
-	if len(w.logs) >= maxBufferedLogs {
-		w.logs = w.logs[len(w.logs)-maxBufferedLogs+1:]
+	// Drop oldest so total buffered size stays at or below maxBufferedBytes.
+	// Most recent logs are kept (those are usually the ones we want to see
+	// after a long buffering window, e.g. early boot before MMDS is up).
+	for w.bufferedBytes+len(logs) > maxBufferedBytes && len(w.logs) > 0 {
+		w.bufferedBytes -= len(w.logs[0])
+		w.logs[0] = nil // let GC reclaim the dropped log content
+		w.logs = w.logs[1:]
 	}
+
+	w.bufferedBytes += len(logs)
 	w.logs = append(w.logs, logs)
 
 	w.resumeProcessing()

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sync"
@@ -127,7 +126,7 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			w.mmdsLock.RUnlock()
 			if err != nil {
 				if !loggedJSONErr {
-					log.Printf("error adding instance logging options (%+v) to JSON (%+v) with logs (suppressing further failures): %v\n", w.mmdsOpts, logLine, err)
+					fmt.Fprintf(os.Stderr, "<4>error adding instance logging options (%+v) to JSON (%+v) with logs (suppressing further failures): %v\n", w.mmdsOpts, logLine, err)
 					loggedJSONErr = true
 				}
 
@@ -139,7 +138,7 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			err = w.sendInstanceLogs(ctx, logLineWithOpts, w.mmdsOpts.LogsCollectorAddress)
 			if err != nil {
 				if !loggedSendErr {
-					log.Printf("error sending instance logs (suppressing further failures): %+v", err)
+					fmt.Fprintf(os.Stderr, "<4>error sending instance logs (suppressing further failures): %v\n", err)
 					loggedSendErr = true
 				}
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -13,7 +13,14 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
 )
 
-const ExporterTimeout = 10 * time.Second
+const (
+	ExporterTimeout = 10 * time.Second
+
+	// maxBufferedLogs caps the in-memory log queue so that if the orchestrator
+	// log collector is unreachable, w.logs cannot grow unbounded. Oldest logs
+	// are dropped under back-pressure.
+	maxBufferedLogs = 10000
+)
 
 type HTTPExporter struct {
 	client   http.Client
@@ -95,6 +102,10 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 }
 
 func (w *HTTPExporter) start(ctx context.Context) {
+	// Suppress repeated failures so a wedged collector doesn't 1:1-amplify
+	// envd logs into journald via the log.Printf default (stderr).
+	var loggedJSONErr, loggedSendErr bool
+
 	for range w.triggers {
 		logs := w.getAllLogs()
 
@@ -115,7 +126,10 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			logLineWithOpts, err := w.mmdsOpts.AddOptsToJSON(logLine)
 			w.mmdsLock.RUnlock()
 			if err != nil {
-				log.Printf("error adding instance logging options (%+v) to JSON (%+v) with logs : %v\n", w.mmdsOpts, logLine, err)
+				if !loggedJSONErr {
+					log.Printf("error adding instance logging options (%+v) to JSON (%+v) with logs (suppressing further failures): %v\n", w.mmdsOpts, logLine, err)
+					loggedJSONErr = true
+				}
 
 				printLog(logLine)
 
@@ -124,12 +138,17 @@ func (w *HTTPExporter) start(ctx context.Context) {
 
 			err = w.sendInstanceLogs(ctx, logLineWithOpts, w.mmdsOpts.LogsCollectorAddress)
 			if err != nil {
-				log.Printf("error sending instance logs: %+v", err)
+				if !loggedSendErr {
+					log.Printf("error sending instance logs (suppressing further failures): %+v", err)
+					loggedSendErr = true
+				}
 
 				printLog(logLine)
 
 				continue
 			}
+
+			loggedSendErr = false
 		}
 	}
 }
@@ -166,6 +185,11 @@ func (w *HTTPExporter) addLogs(logs []byte) {
 	w.logLock.Lock()
 	defer w.logLock.Unlock()
 
+	// Drop oldest under back-pressure so the queue can't grow unbounded if
+	// the collector is unreachable.
+	if len(w.logs) >= maxBufferedLogs {
+		w.logs = w.logs[len(w.logs)-maxBufferedLogs+1:]
+	}
 	w.logs = append(w.logs, logs)
 
 	w.resumeProcessing()

--- a/packages/envd/internal/logs/logger.go
+++ b/packages/envd/internal/logs/logger.go
@@ -12,16 +12,20 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/logs/exporter"
 )
 
-func NewLogger(ctx context.Context, isNotFC bool, mmdsChan <-chan *host.MMDSOpts) *zerolog.Logger {
+func NewLogger(ctx context.Context, isNotFC bool, verbose bool, mmdsChan <-chan *host.MMDSOpts) *zerolog.Logger {
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	exporters := []io.Writer{}
 
-	if isNotFC {
+	if !isNotFC {
+		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan))
+	}
+	// Stdout is opt-in via -verbose. Inside FC stdout flows into journald and
+	// dirties guest pages on every snapshot, so we keep it off by default and
+	// rely on the HTTP exporter to ship debug logs to the orchestrator.
+	if verbose {
 		exporters = append(exporters, os.Stdout)
-	} else {
-		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan), os.Stdout)
 	}
 
 	l := zerolog.

--- a/packages/envd/internal/logs/logger.go
+++ b/packages/envd/internal/logs/logger.go
@@ -19,7 +19,7 @@ func NewLogger(ctx context.Context, isNotFC bool, verbose bool, mmdsChan <-chan 
 	exporters := []io.Writer{}
 
 	if !isNotFC {
-		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan))
+		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, verbose, mmdsChan))
 	}
 	// Stdout is opt-in via -verbose. Inside FC stdout flows into journald and
 	// dirties guest pages on every snapshot, so we keep it off by default and

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -221,7 +221,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from pty: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from pty")
 
 					break
 				}
@@ -269,7 +269,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from stdout: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from stdout")
 
 					break
 				}
@@ -313,7 +313,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from stderr: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from stderr")
 
 					break
 				}

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -56,6 +56,7 @@ var (
 	versionFlag bool
 	commitFlag  bool
 	cgroupRoot  string
+	verbose     bool
 )
 
 func parseFlags() {
@@ -92,6 +93,13 @@ func parseFlags() {
 		"cgroup-root",
 		"/sys/fs/cgroup",
 		"cgroup root directory",
+	)
+
+	flag.BoolVar(
+		&verbose,
+		"verbose",
+		false,
+		"write envd logs to stdout (inside FC this would dirty journald pages; HTTP exporter still ships full debug regardless)",
 	)
 
 	flag.Parse()
@@ -159,7 +167,7 @@ func main() {
 		go host.PollForMMDSOpts(ctx, mmdsChan, defaults.EnvVars)
 	}
 
-	l := logs.NewLogger(ctx, isNotFC, mmdsChan)
+	l := logs.NewLogger(ctx, isNotFC, verbose, mmdsChan)
 
 	m := chi.NewRouter()
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.20"
+const Version = "0.5.21"

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.22"
+const Version = "0.5.23"

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.21"
+const Version = "0.5.22"

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -12,10 +12,6 @@ Type=simple
 Restart=always
 User=root
 Group=root
-# Discard envd stdout (debug logs still ship via the HTTP exporter); only
-# stderr (envd panics/fatal errors) reaches journald.
-StandardOutput=null
-StandardError=journal
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
 ExecStartPre=/bin/sh -c 'mountpoint -q /etc/ssl/certs || (mkdir -p /run/e2b/certs && mount --bind /run/e2b/certs /etc/ssl/certs) && ([ -s /etc/ssl/certs/ca-certificates.crt ] || update-ca-certificates)'

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -12,6 +12,10 @@ Type=simple
 Restart=always
 User=root
 Group=root
+# Discard envd stdout (debug logs still ship via the HTTP exporter); only
+# stderr (envd panics/fatal errors) reaches journald.
+StandardOutput=null
+StandardError=journal
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
 ExecStartPre=/bin/sh -c 'mountpoint -q /etc/ssl/certs || (mkdir -p /run/e2b/certs && mount --bind /run/e2b/certs /etc/ssl/certs) && ([ -s /etc/ssl/certs/ca-certificates.crt ] || update-ca-certificates)'

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
@@ -1,0 +1,12 @@
+{{- /*gotype:github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs.templateModel*/ -}}
+{{ .WriteFile "etc/systemd/journald.conf.d/e2b.conf" 0o644 }}
+
+[Journal]
+Storage=persistent
+SystemMaxUse=8M
+SystemMaxFileSize=2M
+MaxLevelStore=warning
+MaxLevelConsole=warning
+MaxLevelKMsg=warning
+MaxLevelWall=emerg
+ForwardToSyslog=no

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -90,7 +90,7 @@ func TestAdditionalOCILayers(t *testing.T) {
 
 		keysIter := maps.Keys(actualFiles)
 		keys := slices.Collect(keysIter)
-		assert.Len(t, keys, 13)
+		assert.Len(t, keys, 14)
 		assert.Equal(t, "e2b.local", actualFiles["etc/hostname"])
 		assert.Equal(t, "nameserver 8.8.8.8", actualFiles["etc/resolv.conf"])
 


### PR DESCRIPTION
Reduces guest memory and rootfs dirtying caused by journald and envd logging during pause-resume cycles.

envd no longer writes to its stdout by default. A new `-verbose` flag opts in for local development; in FC production envd's stdout stays empty so it doesn't dirty journald pages. The HTTP exporter still ships the full debug stream to the orchestrator. Only envd's stderr (Go runtime panics, `log.Fatalf`, bootstrap and MMDS-poll warnings) reaches journald — which is where we actually want envd's lifecycle/fatal output to land.

The MMDS poll (50ms ticker) and the HTTP exporter's per-line "send failed" paths used to write to stderr per iteration / per log line, which 1:1-amplified into journald during outages. Both now log only the first failure of each kind. The exporter additionally caps its in-memory queue at 10k entries with drop-oldest semantics so a wedged collector can't grow it without bound. The remaining stderr writes from those two paths are tagged with the syslog `<4>` (WARNING) prefix so journald classifies them correctly instead of as errors.

The `handler.go` "error reading from pty/stdout/stderr" messages were on stderr but are about envd-handled user processes, not envd internals; they now flow through the zerolog logger.

A journald drop-in caps the remaining (other systemd services) journal at `Storage=persistent` / `SystemMaxUse=8M` / `MaxLevelStore=warning` so the journal can't grow without bound and the writes land on the rootfs (small, ext4-`inline_data`-friendly) rather than dirtying RAM via the default tmpfs path.