### PR TITLE
perf(sandbox): keep envd logging out of journald

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -46,7 +46,7 @@ start-docker:
 	-p 8001:8001 \
 	--rm \
 	-i envd-debug \
-	/usr/bin/envd -isnotfc
+	/usr/bin/envd -isnotfc -verbose
 
 build-and-upload:
 	make build

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -3,10 +3,8 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"sync"
 	"time"
 
@@ -18,7 +16,6 @@ const ExporterTimeout = 10 * time.Second
 type HTTPExporter struct {
 	client   http.Client
 	logs     [][]byte
-	isNotFC  bool
 	mmdsOpts *host.MMDSOpts
 
 	// Concurrency coordination
@@ -28,13 +25,12 @@ type HTTPExporter struct {
 	startOnce sync.Once
 }
 
-func NewHTTPLogsExporter(ctx context.Context, isNotFC bool, mmdsChan <-chan *host.MMDSOpts) *HTTPExporter {
+func NewHTTPLogsExporter(ctx context.Context, mmdsChan <-chan *host.MMDSOpts) *HTTPExporter {
 	exporter := &HTTPExporter{
 		client: http.Client{
 			Timeout: ExporterTimeout,
 		},
 		triggers:  make(chan struct{}, 1),
-		isNotFC:   isNotFC,
 		startOnce: sync.Once{},
 		mmdsOpts: &host.MMDSOpts{
 			SandboxID:            "unknown",
@@ -69,10 +65,6 @@ func (w *HTTPExporter) sendInstanceLogs(ctx context.Context, logs []byte, addres
 	return nil
 }
 
-func printLog(logs []byte) {
-	fmt.Fprintf(os.Stdout, "%v", string(logs))
-}
-
 func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <-chan *host.MMDSOpts) {
 	for {
 		select {
@@ -102,14 +94,6 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			continue
 		}
 
-		if w.isNotFC {
-			for _, log := range logs {
-				fmt.Fprintf(os.Stdout, "%v", string(log))
-			}
-
-			continue
-		}
-
 		for _, logLine := range logs {
 			w.mmdsLock.RLock()
 			logLineWithOpts, err := w.mmdsOpts.AddOptsToJSON(logLine)
@@ -117,16 +101,12 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			if err != nil {
 				log.Printf("error adding instance logging options (%+v) to JSON (%+v) with logs : %v\n", w.mmdsOpts, logLine, err)
 
-				printLog(logLine)
-
 				continue
 			}
 
 			err = w.sendInstanceLogs(ctx, logLineWithOpts, w.mmdsOpts.LogsCollectorAddress)
 			if err != nil {
 				log.Printf("error sending instance logs: %+v", err)
-
-				printLog(logLine)
 
 				continue
 			}

--- a/packages/envd/internal/logs/logger.go
+++ b/packages/envd/internal/logs/logger.go
@@ -12,16 +12,17 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/logs/exporter"
 )
 
-func NewLogger(ctx context.Context, isNotFC bool, mmdsChan <-chan *host.MMDSOpts) *zerolog.Logger {
+func NewLogger(ctx context.Context, isFC bool, verbose bool, mmdsChan <-chan *host.MMDSOpts) *zerolog.Logger {
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
 	exporters := []io.Writer{}
 
-	if isNotFC {
+	if isFC {
+		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, mmdsChan))
+	}
+	if verbose {
 		exporters = append(exporters, os.Stdout)
-	} else {
-		exporters = append(exporters, exporter.NewHTTPLogsExporter(ctx, isNotFC, mmdsChan), os.Stdout)
 	}
 
 	l := zerolog.

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -221,7 +221,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from pty: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from pty")
 
 					break
 				}
@@ -269,7 +269,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from stdout: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from stdout")
 
 					break
 				}
@@ -313,7 +313,7 @@ func New(
 				}
 
 				if readErr != nil {
-					fmt.Fprintf(os.Stderr, "error reading from stderr: %s\n", readErr)
+					logger.Error().Err(readErr).Msg("error reading from stderr")
 
 					break
 				}

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -56,6 +56,7 @@ var (
 	versionFlag bool
 	commitFlag  bool
 	cgroupRoot  string
+	verbose     bool
 )
 
 func parseFlags() {
@@ -63,7 +64,7 @@ func parseFlags() {
 		&isNotFC,
 		"isnotfc",
 		false,
-		"isNotFCmode prints all logs to stdout",
+		"run outside of Firecracker (skips MMDS poll and HTTP log exporter)",
 	)
 
 	flag.BoolVar(
@@ -92,6 +93,13 @@ func parseFlags() {
 		"cgroup-root",
 		"/sys/fs/cgroup",
 		"cgroup root directory",
+	)
+
+	flag.BoolVar(
+		&verbose,
+		"verbose",
+		false,
+		"write envd logs to stdout",
 	)
 
 	flag.Parse()
@@ -159,7 +167,7 @@ func main() {
 		go host.PollForMMDSOpts(ctx, mmdsChan, defaults.EnvVars)
 	}
 
-	l := logs.NewLogger(ctx, isNotFC, mmdsChan)
+	l := logs.NewLogger(ctx, !isNotFC, verbose, mmdsChan)
 
 	m := chi.NewRouter()
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.20"
+const Version = "0.5.21"

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/journald.conf.tpl
@@ -1,0 +1,6 @@
+{{- /*gotype:github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs.templateModel*/ -}}
+{{ .WriteFile "etc/systemd/journald.conf.d/e2b.conf" 0o644 }}
+
+[Journal]
+Storage=persistent
+SystemMaxUse=8M

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -90,7 +90,7 @@ func TestAdditionalOCILayers(t *testing.T) {
 
 		keysIter := maps.Keys(actualFiles)
 		keys := slices.Collect(keysIter)
-		assert.Len(t, keys, 13)
+		assert.Len(t, keys, 14)
 		assert.Equal(t, "e2b.local", actualFiles["etc/hostname"])
 		assert.Equal(t, "nameserver 8.8.8.8", actualFiles["etc/resolv.conf"])
 


### PR DESCRIPTION
envd's zerolog stdout writer is now gated behind a new \`-verbose\` flag (default off), so production envd inside FC no longer writes anything to stdout — journald stays clean of per-request debug events. The HTTP exporter still ships full debug to the orchestrator regardless.

A journald drop-in caps the rest of the in-VM journal at \`Storage=persistent\` / \`SystemMaxUse=8M\` / \`MaxLevelStore=warning\` so other systemd services can't grow it without bound either.

\`handler.go\`'s "error reading from pty/stdout/stderr" messages were on raw stderr but are about envd-handled user processes, not envd internals; they now flow through the zerolog logger.

Split out of #2674 (journal-side half).