### PR TITLE
feat(orchestrator): team-target free-page-hinting at template create

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -378,6 +378,7 @@ func doBuild(
 		KernelVersion:      kernel,
 		FirecrackerVersion: fc,
 		FreePageReporting:  fcInfo.HasFreePageReporting(),
+		FreePageHinting:    fcInfo.HasFreePageHinting(),
 		TeamID:             "local",
 		Steps:              steps,
 	}

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -161,27 +161,29 @@ type RuntimeMetadata struct {
 	TemplateID  string
 	SandboxID   string
 	ExecutionID string
-	TeamID      string
+
+	// TeamID is best-effort metadata for logging/telemetry only; it is not
+	// always populated (e.g. some build paths) so do not use it for control
+	// flow or feature-flag targeting. For team targeting rely on the team
+	// context embedded in ctx by the caller (e.g. the build entrypoint or the
+	// orchestrator gRPC handler).
+	TeamID string
 
 	// BuildID is the ID of the associated template build.
 	BuildID     string
 	SandboxType SandboxType
 }
 
-// sandboxLDContexts builds LD contexts (sandbox + team + template) for
-// per-sandbox flag targeting. Empty IDs produce invalid contexts that are
-// filtered out during context merging in the flag client.
-func sandboxLDContexts(runtime RuntimeMetadata, config *Config) []ldcontext.Context {
-	return []ldcontext.Context{
-		ldcontext.NewBuilder(runtime.SandboxID).
-			Kind(featureflags.SandboxKind).
-			SetString(featureflags.SandboxTemplateAttribute, runtime.TemplateID).
-			SetString(featureflags.SandboxKernelVersionAttribute, config.FirecrackerConfig.KernelVersion).
-			SetString(featureflags.SandboxFirecrackerVersionAttribute, config.FirecrackerConfig.FirecrackerVersion).
-			Build(),
-		featureflags.TeamContext(runtime.TeamID),
-		featureflags.TemplateContext(runtime.TemplateID),
-	}
+// sandboxLDContext builds an LD context with kernel/FC-version attributes for
+// per-sandbox flag targeting. Team/template targeting comes from the team and
+// template contexts the caller embeds in ctx.
+func sandboxLDContext(runtime RuntimeMetadata, config *Config) ldcontext.Context {
+	return ldcontext.NewBuilder(runtime.SandboxID).
+		Kind(featureflags.SandboxKind).
+		SetString(featureflags.SandboxTemplateAttribute, runtime.TemplateID).
+		SetString(featureflags.SandboxKernelVersionAttribute, config.FirecrackerConfig.KernelVersion).
+		SetString(featureflags.SandboxFirecrackerVersionAttribute, config.FirecrackerConfig.FirecrackerVersion).
+		Build()
 }
 
 type Resources struct {
@@ -507,7 +509,7 @@ func (f *Factory) CreateSandbox(
 	})
 
 	freePageHinting := fc.FCSupportsFreePageHinting(config.FirecrackerConfig.FirecrackerVersion) &&
-		featureflags.IsFreePageHintingEnabled(ctx, f.featureFlags, sandboxLDContexts(runtime, config)...)
+		featureflags.IsFreePageHintingEnabled(ctx, f.featureFlags, sandboxLDContext(runtime, config))
 
 	err = fcHandle.Create(
 		ctx,
@@ -1086,7 +1088,7 @@ func (s *Sandbox) Pause(
 
 	// Drain free-page-hinting before pause so the snapshot doesn't capture
 	// pages the guest already considers free. Timeout per use case; 0 disables.
-	if t := featureflags.GetFreePageHintingTimeout(ctx, s.featureFlags, string(useCase), sandboxLDContexts(s.Runtime, s.Config)...); t > 0 {
+	if t := featureflags.GetFreePageHintingTimeout(ctx, s.featureFlags, string(useCase), sandboxLDContext(s.Runtime, s.Config)); t > 0 {
 		drainCtx, cancel := context.WithTimeout(ctx, t)
 		if err := s.process.DrainBalloon(drainCtx); err != nil {
 			telemetry.ReportError(ctx, "balloon hinting drain failed (continuing pause)", err)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -161,24 +161,27 @@ type RuntimeMetadata struct {
 	TemplateID  string
 	SandboxID   string
 	ExecutionID string
-
-	// TeamID optional, used only for logging
-	TeamID string
+	TeamID      string
 
 	// BuildID is the ID of the associated template build.
 	BuildID     string
 	SandboxType SandboxType
 }
 
-// sandboxLDContext builds an LD context with kernel/FC-version attributes for
-// per-sandbox flag targeting.
-func sandboxLDContext(runtime RuntimeMetadata, config *Config) ldcontext.Context {
-	return ldcontext.NewBuilder(runtime.SandboxID).
-		Kind(featureflags.SandboxKind).
-		SetString(featureflags.SandboxTemplateAttribute, runtime.TemplateID).
-		SetString(featureflags.SandboxKernelVersionAttribute, config.FirecrackerConfig.KernelVersion).
-		SetString(featureflags.SandboxFirecrackerVersionAttribute, config.FirecrackerConfig.FirecrackerVersion).
-		Build()
+// sandboxLDContexts builds LD contexts (sandbox + team + template) for
+// per-sandbox flag targeting. Empty IDs produce undefined contexts that are
+// filtered out by the flag client.
+func sandboxLDContexts(runtime RuntimeMetadata, config *Config) []ldcontext.Context {
+	return []ldcontext.Context{
+		ldcontext.NewBuilder(runtime.SandboxID).
+			Kind(featureflags.SandboxKind).
+			SetString(featureflags.SandboxTemplateAttribute, runtime.TemplateID).
+			SetString(featureflags.SandboxKernelVersionAttribute, config.FirecrackerConfig.KernelVersion).
+			SetString(featureflags.SandboxFirecrackerVersionAttribute, config.FirecrackerConfig.FirecrackerVersion).
+			Build(),
+		featureflags.TeamContext(runtime.TeamID),
+		featureflags.TemplateContext(runtime.TemplateID),
+	}
 }
 
 type Resources struct {
@@ -504,7 +507,7 @@ func (f *Factory) CreateSandbox(
 	})
 
 	freePageHinting := fc.FCSupportsFreePageHinting(config.FirecrackerConfig.FirecrackerVersion) &&
-		featureflags.IsFreePageHintingEnabled(ctx, f.featureFlags, sandboxLDContext(runtime, config))
+		featureflags.IsFreePageHintingEnabled(ctx, f.featureFlags, sandboxLDContexts(runtime, config)...)
 
 	err = fcHandle.Create(
 		ctx,
@@ -1083,7 +1086,7 @@ func (s *Sandbox) Pause(
 
 	// Drain free-page-hinting before pause so the snapshot doesn't capture
 	// pages the guest already considers free. Timeout per use case; 0 disables.
-	if t := featureflags.GetFreePageHintingTimeout(ctx, s.featureFlags, string(useCase), sandboxLDContext(s.Runtime, s.Config)); t > 0 {
+	if t := featureflags.GetFreePageHintingTimeout(ctx, s.featureFlags, string(useCase), sandboxLDContexts(s.Runtime, s.Config)...); t > 0 {
 		drainCtx, cancel := context.WithTimeout(ctx, t)
 		if err := s.process.DrainBalloon(drainCtx); err != nil {
 			telemetry.ReportError(ctx, "balloon hinting drain failed (continuing pause)", err)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -74,6 +74,10 @@ type Config struct {
 	TotalDiskSizeMB   int64
 	HugePages         bool
 	FreePageReporting bool
+	// FreePageHinting is the build-time install decision for virtio-balloon
+	// FPH. Set only by the build pipeline; runtime resumes inherit the
+	// balloon configuration from the snapshot.
+	FreePageHinting bool
 
 	Envd EnvdMetadata
 
@@ -508,8 +512,10 @@ func (f *Factory) CreateSandbox(
 		return nil
 	})
 
-	freePageHinting := fc.FCSupportsFreePageHinting(config.FirecrackerConfig.FirecrackerVersion) &&
-		featureflags.IsFreePageHintingEnabled(ctx, f.featureFlags, sandboxLDContext(runtime, config))
+	// Build-time install decision (see TemplateConfig.FreePageHinting).
+	// Runtime resumes inherit the balloon config from the snapshot and never
+	// reach this branch.
+	freePageHinting := fc.FCSupportsFreePageHinting(config.FirecrackerConfig.FirecrackerVersion) && config.FreePageHinting
 
 	err = fcHandle.Create(
 		ctx,

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -169,8 +169,8 @@ type RuntimeMetadata struct {
 }
 
 // sandboxLDContexts builds LD contexts (sandbox + team + template) for
-// per-sandbox flag targeting. Empty IDs produce undefined contexts that are
-// filtered out by the flag client.
+// per-sandbox flag targeting. Empty IDs produce invalid contexts that are
+// filtered out during context merging in the flag client.
 func sandboxLDContexts(runtime RuntimeMetadata, config *Config) []ldcontext.Context {
 	return []ldcontext.Context{
 		ldcontext.NewBuilder(runtime.SandboxID).

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -74,10 +74,7 @@ type Config struct {
 	TotalDiskSizeMB   int64
 	HugePages         bool
 	FreePageReporting bool
-	// FreePageHinting is the build-time install decision for virtio-balloon
-	// FPH. Set only by the build pipeline; runtime resumes inherit the
-	// balloon configuration from the snapshot.
-	FreePageHinting bool
+	FreePageHinting   bool
 
 	Envd EnvdMetadata
 
@@ -166,14 +163,10 @@ type RuntimeMetadata struct {
 	SandboxID   string
 	ExecutionID string
 
-	// TeamID is best-effort metadata for logging/telemetry only; it is not
-	// always populated (e.g. some build paths) so do not use it for control
-	// flow or feature-flag targeting. For team targeting rely on the team
-	// context embedded in ctx by the caller (e.g. the build entrypoint or the
-	// orchestrator gRPC handler).
+	// TeamID is best-effort metadata; not always populated so do not use for
+	// decisions or feature-flag targeting.
 	TeamID string
 
-	// BuildID is the ID of the associated template build.
 	BuildID     string
 	SandboxType SandboxType
 }
@@ -512,9 +505,6 @@ func (f *Factory) CreateSandbox(
 		return nil
 	})
 
-	// Build-time install decision (see TemplateConfig.FreePageHinting).
-	// Runtime resumes inherit the balloon config from the snapshot and never
-	// reach this branch.
 	freePageHinting := fc.FCSupportsFreePageHinting(config.FirecrackerConfig.FirecrackerVersion) && config.FreePageHinting
 
 	err = fcHandle.Create(

--- a/packages/orchestrator/pkg/template/build/config/config.go
+++ b/packages/orchestrator/pkg/template/build/config/config.go
@@ -44,6 +44,13 @@ type TemplateConfig struct {
 	// FreePageReporting enables Firecracker's balloon free-page-reporting.
 	FreePageReporting bool
 
+	// FreePageHinting enables Firecracker's balloon free-page-hinting at
+	// install time. Decided at template create with team context available
+	// (see create_template.go) and propagated through the build phases so the
+	// decision applies to every install+run sandbox the build creates, even
+	// when team context is not present further down the call chain.
+	FreePageHinting bool
+
 	// Command to run to check if the template is ready.
 	ReadyCmd string
 

--- a/packages/orchestrator/pkg/template/build/config/config.go
+++ b/packages/orchestrator/pkg/template/build/config/config.go
@@ -44,11 +44,7 @@ type TemplateConfig struct {
 	// FreePageReporting enables Firecracker's balloon free-page-reporting.
 	FreePageReporting bool
 
-	// FreePageHinting enables Firecracker's balloon free-page-hinting at
-	// install time. Decided at template create with team context available
-	// (see create_template.go) and propagated through the build phases so the
-	// decision applies to every install+run sandbox the build creates, even
-	// when team context is not present further down the call chain.
+	// FreePageHinting enables Firecracker's balloon free-page-hinting.
 	FreePageHinting bool
 
 	// Command to run to check if the template is ready.

--- a/packages/orchestrator/pkg/template/build/phases/base/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/builder.go
@@ -206,6 +206,7 @@ func (bb *BaseBuilder) buildLayerFromOCI(
 		RamMB:             bb.Config.MemoryMB,
 		HugePages:         bb.Config.HugePages,
 		FreePageReporting: bb.Config.FreePageReporting,
+		FreePageHinting:   bb.Config.FreePageHinting,
 
 		Envd: sandbox.EnvdMetadata{
 			Version: bb.EnvdVersion,

--- a/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
@@ -155,6 +155,7 @@ func (ppb *PostProcessingBuilder) Build(
 		RamMB:             ppb.Config.MemoryMB,
 		HugePages:         ppb.Config.HugePages,
 		FreePageReporting: ppb.Config.FreePageReporting,
+		FreePageHinting:   ppb.Config.FreePageHinting,
 
 		Envd: sandbox.EnvdMetadata{
 			Version:        ppb.EnvdVersion,

--- a/packages/orchestrator/pkg/template/build/phases/steps/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/steps/builder.go
@@ -169,6 +169,7 @@ func (sb *StepBuilder) Build(
 		RamMB:             sb.Config.MemoryMB,
 		HugePages:         sb.Config.HugePages,
 		FreePageReporting: sb.Config.FreePageReporting,
+		FreePageHinting:   sb.Config.FreePageHinting,
 
 		Envd: sandbox.EnvdMetadata{
 			Version: sb.EnvdVersion,

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -68,10 +68,6 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 	}
 	hugePages := fcInfo.HasHugePages()
 	freePageReporting := fcInfo.HasFreePageReporting() && s.featureFlags.BoolFlag(ctx, featureflags.FreePageReportingFlag)
-	// Decide FPH at template create with team context, then propagate the
-	// decision through the build via TemplateConfig so the team targeting
-	// applies to every install+run sandbox the build creates regardless of
-	// downstream ctx state.
 	freePageHinting := fcInfo.HasFreePageHinting() && featureflags.IsFreePageHintingEnabled(ctx, s.featureFlags)
 
 	childSpan.SetAttributes(

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -68,6 +68,11 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 	}
 	hugePages := fcInfo.HasHugePages()
 	freePageReporting := fcInfo.HasFreePageReporting() && s.featureFlags.BoolFlag(ctx, featureflags.FreePageReportingFlag)
+	// Decide FPH at template create with team context, then propagate the
+	// decision through the build via TemplateConfig so the team targeting
+	// applies to every install+run sandbox the build creates regardless of
+	// downstream ctx state.
+	freePageHinting := fcInfo.HasFreePageHinting() && featureflags.IsFreePageHintingEnabled(ctx, s.featureFlags)
 
 	childSpan.SetAttributes(
 		telemetry.WithTemplateID(cfg.GetTemplateID()),
@@ -79,6 +84,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 		attribute.Int64("env.vcpu_count", int64(cfg.GetVCpuCount())),
 		attribute.Bool("env.huge_pages", hugePages),
 		attribute.Bool("env.free_page_reporting", freePageReporting),
+		attribute.Bool("env.free_page_hinting", freePageHinting),
 	)
 
 	template := config.TemplateConfig{
@@ -93,6 +99,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 		DiskSizeMB:           int64(cfg.GetDiskSizeMB()),
 		HugePages:            hugePages,
 		FreePageReporting:    freePageReporting,
+		FreePageHinting:      freePageHinting,
 		FromImage:            cfg.GetFromImage(),
 		FromTemplate:         cfg.GetFromTemplate(),
 		RegistryAuthProvider: authProvider,

--- a/packages/shared/pkg/featureflags/context.go
+++ b/packages/shared/pkg/featureflags/context.go
@@ -81,11 +81,14 @@ func mergeSameKind(first ldcontext.Context, second ldcontext.Context) ldcontext.
 	return builder.Build()
 }
 
-func removeUndefined(contexts []ldcontext.Context) []ldcontext.Context {
+// removeInvalid drops contexts that are undefined or invalid (e.g. empty key).
+// Invalid contexts would otherwise poison the multi-context built by
+// ldcontext.NewMulti and silently force all flag reads to fallback.
+func removeInvalid(contexts []ldcontext.Context) []ldcontext.Context {
 	var result []ldcontext.Context
 
 	for _, item := range contexts {
-		if !item.IsDefined() {
+		if !item.IsDefined() || item.Err() != nil {
 			continue
 		}
 
@@ -103,7 +106,7 @@ func mergeContexts(ctx context.Context, contexts []ldcontext.Context) ldcontext.
 
 	contexts = flattenContexts(contexts)
 
-	contexts = removeUndefined(contexts)
+	contexts = removeInvalid(contexts)
 
 	if len(contexts) == 0 {
 		return ldcontext.NewWithKind("none", "none")

--- a/packages/shared/pkg/featureflags/context.go
+++ b/packages/shared/pkg/featureflags/context.go
@@ -81,9 +81,8 @@ func mergeSameKind(first ldcontext.Context, second ldcontext.Context) ldcontext.
 	return builder.Build()
 }
 
-// removeInvalid drops contexts that are undefined or invalid (e.g. empty key).
-// Invalid contexts would otherwise poison the multi-context built by
-// ldcontext.NewMulti and silently force all flag reads to fallback.
+// removeInvalid drops undefined or invalid (e.g. empty key) contexts that
+// would otherwise poison the resulting multi-context.
 func removeInvalid(contexts []ldcontext.Context) []ldcontext.Context {
 	var result []ldcontext.Context
 

--- a/packages/shared/pkg/featureflags/context_test.go
+++ b/packages/shared/pkg/featureflags/context_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFlattenContexts(t *testing.T) {
@@ -248,7 +249,7 @@ func TestSetContext(t *testing.T) {
 
 		invalidTeam := TeamContext("")
 		assert.True(t, invalidTeam.IsDefined())
-		assert.NotNil(t, invalidTeam.Err())
+		require.Error(t, invalidTeam.Err())
 
 		ctx := AddToContext(t.Context(), invalidTeam, UserContext(""), SandboxContext("sandbox-123"))
 
@@ -257,6 +258,6 @@ func TestSetContext(t *testing.T) {
 		assert.False(t, embedded.Multiple())
 		assert.Equal(t, "sandbox-123", embedded.Key())
 		assert.Equal(t, SandboxKind, embedded.Kind())
-		assert.Nil(t, embedded.Err())
+		require.NoError(t, embedded.Err())
 	})
 }

--- a/packages/shared/pkg/featureflags/context_test.go
+++ b/packages/shared/pkg/featureflags/context_test.go
@@ -240,4 +240,23 @@ func TestSetContext(t *testing.T) {
 		assert.Equal(t, "team-456", embedded.Key())
 		assert.Equal(t, "Second Team", embedded.Name().String())
 	})
+
+	// Empty-key contexts are IsDefined()==true but Err()!=nil; without
+	// filtering they would poison the resulting multi-context.
+	t.Run("invalid_contexts_filtered_out", func(t *testing.T) {
+		t.Parallel()
+
+		invalidTeam := TeamContext("")
+		assert.True(t, invalidTeam.IsDefined())
+		assert.NotNil(t, invalidTeam.Err())
+
+		ctx := AddToContext(t.Context(), invalidTeam, UserContext(""), SandboxContext("sandbox-123"))
+
+		embedded, ok := getContext(ctx)
+		assert.True(t, ok)
+		assert.False(t, embedded.Multiple())
+		assert.Equal(t, "sandbox-123", embedded.Key())
+		assert.Equal(t, SandboxKind, embedded.Kind())
+		assert.Nil(t, embedded.Err())
+	})
 }


### PR DESCRIPTION
## Summary

Evaluate the team-targeted `free-page-hinting-config` flag once at template create (where `featureflags.AddToContext` reliably injects the team context) and persist the decision in `TemplateConfig` / `sandbox.Config`. The install-time check in `CreateSandbox` now reads `config.FreePageHinting` instead of re-evaluating the flag against whatever ctx happens to be in flight further down the build chain. Runtime sandboxes are always resumes and inherit the balloon config from the snapshot.

Mirrors the existing `FreePageReporting` plumbing through the build phases. Also adds a small defensive fix to `featureflags.mergeContexts` to drop invalid (empty-key) contexts so they cannot poison the resulting multi-context.
