### PR TITLE
fix(orchestrator): overwrite envID in sandbox logs too

### DIFF
--- a/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
+++ b/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
@@ -45,8 +45,9 @@ func (h *APIStore) Logs(c *gin.Context) {
 		return
 	}
 
-	// Overwrite instanceID and teamID to avoid spoofing
+	// Overwrite instanceID, envID, and teamID to avoid spoofing
 	payload["instanceID"] = sbxID
+	payload["envID"] = sbx.Runtime.TemplateID
 	payload["teamID"] = sbx.Runtime.TeamID
 
 	logs, err := json.Marshal(payload)


### PR DESCRIPTION
The \`/logs\` handler already overwrites \`instanceID\` and \`teamID\` from the authoritative sandbox map; \`envID\` was the only identity field still trusted from the envd payload. Take it from \`sbx.Runtime.TemplateID\` too so envd doesn't need to be trusted for any of them.

Minimal change; the wire format (single-JSON POST) and existing \`validatePayloadSandboxID\` are unchanged.