### PR TITLE
fix(envd): include suppressed count in exporter error logs

### DIFF
--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -148,6 +148,7 @@ func (w *HTTPExporter) Write(logs []byte) (int, error) {
 	// Drop oversized lines: Loki would reject them anyway.
 	if len(logs) > maxLogLineBytes {
 		w.oversizedLog.log(maxLogLineBytes)
+
 		return len(logs), nil
 	}
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -21,10 +21,11 @@ const (
 )
 
 type HTTPExporter struct {
-	client        http.Client
-	logs          [][]byte
-	bufferedBytes int
-	mmdsOpts      atomic.Pointer[host.MMDSOpts]
+	client           http.Client
+	logs             [][]byte
+	bufferedBytes    int
+	mmdsOpts         atomic.Pointer[host.MMDSOpts]
+	droppedOversized atomic.Int64
 
 	// Concurrency coordination
 	triggers  chan struct{}
@@ -91,10 +92,16 @@ func (w *HTTPExporter) start(ctx context.Context) {
 	// fast-failing collector (e.g. TCP RST) can't flood journald. The
 	// suppressed count is included on the next emitted line.
 	const logFloor = time.Minute
-	var lastLoggedJSONErr, lastLoggedSendErr time.Time
+	var lastLoggedJSONErr, lastLoggedSendErr, lastLoggedOversized time.Time
 	var suppressedJSONErrs, suppressedSendErrs int
 
 	for range w.triggers {
+		if dropped := w.droppedOversized.Load(); dropped > 0 && time.Since(lastLoggedOversized) > logFloor {
+			log.Printf("dropped %d log lines exceeding %d bytes", dropped, maxLogLineBytes)
+			w.droppedOversized.Add(-dropped)
+			lastLoggedOversized = time.Now()
+		}
+
 		logs := w.getAllLogs()
 
 		if len(logs) == 0 {
@@ -147,6 +154,8 @@ func (w *HTTPExporter) resumeProcessing() {
 func (w *HTTPExporter) Write(logs []byte) (int, error) {
 	// Drop oversized lines: Loki would reject them anyway.
 	if len(logs) > maxLogLineBytes {
+		w.droppedOversized.Add(1)
+		w.resumeProcessing()
 		return len(logs), nil
 	}
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -88,9 +88,11 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 
 func (w *HTTPExporter) start(ctx context.Context) {
 	// Cap stderr noise: log each error kind at most once per logFloor so a
-	// fast-failing collector (e.g. TCP RST) can't flood journald.
+	// fast-failing collector (e.g. TCP RST) can't flood journald. The
+	// suppressed count is included on the next emitted line.
 	const logFloor = time.Minute
 	var lastLoggedJSONErr, lastLoggedSendErr time.Time
+	var suppressedJSONErrs, suppressedSendErrs int
 
 	for range w.triggers {
 		logs := w.getAllLogs()
@@ -108,8 +110,11 @@ func (w *HTTPExporter) start(ctx context.Context) {
 			logLineWithOpts, err := opts.AddOptsToJSON(logLine)
 			if err != nil {
 				if time.Since(lastLoggedJSONErr) > logFloor {
-					log.Printf("error adding instance logging options to JSON: %v", err)
+					log.Printf("error adding instance logging options to JSON (%d suppressed since last log): %v", suppressedJSONErrs, err)
 					lastLoggedJSONErr = time.Now()
+					suppressedJSONErrs = 0
+				} else {
+					suppressedJSONErrs++
 				}
 
 				continue
@@ -117,8 +122,11 @@ func (w *HTTPExporter) start(ctx context.Context) {
 
 			if err := w.sendInstanceLogs(ctx, logLineWithOpts, opts.LogsCollectorAddress); err != nil {
 				if time.Since(lastLoggedSendErr) > logFloor {
-					log.Printf("error sending instance logs: %+v", err)
+					log.Printf("error sending instance logs (%d suppressed since last log): %+v", suppressedSendErrs, err)
 					lastLoggedSendErr = time.Now()
+					suppressedSendErrs = 0
+				} else {
+					suppressedSendErrs++
 				}
 
 				continue

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -19,8 +19,6 @@ const (
 	maxLogLineBytes  = 192 << 10
 	maxBufferedBytes = 8 << 20
 
-	// logFloor caps stderr noise so a fast-failing collector or a stream
-	// of oversized lines can't flood journald.
 	logFloor = time.Minute
 )
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -3,7 +3,6 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"log"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -18,14 +17,21 @@ const (
 	// Under Loki's 256 KiB max_line_size default.
 	maxLogLineBytes  = 192 << 10
 	maxBufferedBytes = 8 << 20
+
+	// logFloor caps stderr noise so a fast-failing collector or a stream
+	// of oversized lines can't flood journald.
+	logFloor = time.Minute
 )
 
 type HTTPExporter struct {
-	client           http.Client
-	logs             [][]byte
-	bufferedBytes    int
-	mmdsOpts         atomic.Pointer[host.MMDSOpts]
-	droppedOversized atomic.Int64
+	client        http.Client
+	logs          [][]byte
+	bufferedBytes int
+	mmdsOpts      atomic.Pointer[host.MMDSOpts]
+
+	jsonErrLog   *rateLimitedLogger
+	sendErrLog   *rateLimitedLogger
+	oversizedLog *rateLimitedLogger
 
 	// Concurrency coordination
 	triggers  chan struct{}
@@ -39,7 +45,10 @@ func NewHTTPLogsExporter(ctx context.Context, mmdsChan <-chan *host.MMDSOpts) *H
 			Timeout:   ExporterTimeout,
 			Transport: &http.Transport{DisableKeepAlives: true},
 		},
-		triggers: make(chan struct{}, 1),
+		triggers:     make(chan struct{}, 1),
+		jsonErrLog:   newRateLimitedLogger(logFloor, "error adding instance logging options to JSON: %v"),
+		sendErrLog:   newRateLimitedLogger(logFloor, "error sending instance logs: %+v"),
+		oversizedLog: newRateLimitedLogger(logFloor, "dropped log line exceeding %d bytes"),
 	}
 
 	go exporter.listenForMMDSOptsAndStart(ctx, mmdsChan)
@@ -88,20 +97,7 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 }
 
 func (w *HTTPExporter) start(ctx context.Context) {
-	// Cap stderr noise: log each error kind at most once per logFloor so a
-	// fast-failing collector (e.g. TCP RST) can't flood journald. The
-	// suppressed count is included on the next emitted line.
-	const logFloor = time.Minute
-	var lastLoggedJSONErr, lastLoggedSendErr, lastLoggedOversized time.Time
-	var suppressedJSONErrs, suppressedSendErrs int
-
 	for range w.triggers {
-		if dropped := w.droppedOversized.Load(); dropped > 0 && time.Since(lastLoggedOversized) > logFloor {
-			log.Printf("dropped %d log lines exceeding %d bytes", dropped, maxLogLineBytes)
-			w.droppedOversized.Add(-dropped)
-			lastLoggedOversized = time.Now()
-		}
-
 		logs := w.getAllLogs()
 
 		if len(logs) == 0 {
@@ -116,25 +112,13 @@ func (w *HTTPExporter) start(ctx context.Context) {
 		for _, logLine := range logs {
 			logLineWithOpts, err := opts.AddOptsToJSON(logLine)
 			if err != nil {
-				if time.Since(lastLoggedJSONErr) > logFloor {
-					log.Printf("error adding instance logging options to JSON (%d suppressed since last log): %v", suppressedJSONErrs, err)
-					lastLoggedJSONErr = time.Now()
-					suppressedJSONErrs = 0
-				} else {
-					suppressedJSONErrs++
-				}
+				w.jsonErrLog.log(err)
 
 				continue
 			}
 
 			if err := w.sendInstanceLogs(ctx, logLineWithOpts, opts.LogsCollectorAddress); err != nil {
-				if time.Since(lastLoggedSendErr) > logFloor {
-					log.Printf("error sending instance logs (%d suppressed since last log): %+v", suppressedSendErrs, err)
-					lastLoggedSendErr = time.Now()
-					suppressedSendErrs = 0
-				} else {
-					suppressedSendErrs++
-				}
+				w.sendErrLog.log(err)
 
 				continue
 			}
@@ -154,8 +138,7 @@ func (w *HTTPExporter) resumeProcessing() {
 func (w *HTTPExporter) Write(logs []byte) (int, error) {
 	// Drop oversized lines: Loki would reject them anyway.
 	if len(logs) > maxLogLineBytes {
-		w.droppedOversized.Add(1)
-		w.resumeProcessing()
+		w.oversizedLog.log(maxLogLineBytes)
 		return len(logs), nil
 	}
 

--- a/packages/envd/internal/logs/exporter/exporter.go
+++ b/packages/envd/internal/logs/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -74,6 +75,10 @@ func (w *HTTPExporter) sendInstanceLogs(ctx context.Context, logs []byte, addres
 	}
 	defer response.Body.Close()
 
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("collector returned %s", response.Status)
+	}
+
 	return nil
 }
 
@@ -97,7 +102,13 @@ func (w *HTTPExporter) listenForMMDSOptsAndStart(ctx context.Context, mmdsChan <
 }
 
 func (w *HTTPExporter) start(ctx context.Context) {
-	for range w.triggers {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.triggers:
+		}
+
 		logs := w.getAllLogs()
 
 		if len(logs) == 0 {

--- a/packages/envd/internal/logs/exporter/rate_limited_logger.go
+++ b/packages/envd/internal/logs/exporter/rate_limited_logger.go
@@ -1,0 +1,32 @@
+package exporter
+
+import (
+	"log"
+	"sync/atomic"
+	"time"
+)
+
+// rateLimitedLogger emits log.Printf at most once per floor, appending a
+// count of suppressed calls since the last emitted line. It is lock-free
+// and may slightly miscount under contention (acceptable for noise caps).
+type rateLimitedLogger struct {
+	floor      time.Duration
+	format     string
+	lastLogged atomic.Int64 // unix nano
+	suppressed atomic.Int64
+}
+
+func newRateLimitedLogger(floor time.Duration, format string) *rateLimitedLogger {
+	return &rateLimitedLogger{floor: floor, format: format}
+}
+
+func (r *rateLimitedLogger) log(args ...any) {
+	last := r.lastLogged.Load()
+	now := time.Now().UnixNano()
+	if now-last <= int64(r.floor) || !r.lastLogged.CompareAndSwap(last, now) {
+		r.suppressed.Add(1)
+		return
+	}
+	suppressed := r.suppressed.Swap(0)
+	log.Printf(r.format+" (%d suppressed since last log)", append(args, suppressed)...)
+}

--- a/packages/envd/internal/logs/exporter/rate_limited_logger.go
+++ b/packages/envd/internal/logs/exporter/rate_limited_logger.go
@@ -21,11 +21,13 @@ func (r *rateLimitedLogger) log(args ...any) {
 	last := r.lastLogged.Load()
 	if last != nil && time.Since(*last) <= r.floor {
 		r.suppressed.Add(1)
+
 		return
 	}
 	now := time.Now()
 	if !r.lastLogged.CompareAndSwap(last, &now) {
 		r.suppressed.Add(1)
+
 		return
 	}
 	suppressed := r.suppressed.Swap(0)

--- a/packages/envd/internal/logs/exporter/rate_limited_logger.go
+++ b/packages/envd/internal/logs/exporter/rate_limited_logger.go
@@ -2,17 +2,15 @@ package exporter
 
 import (
 	"log"
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
 type rateLimitedLogger struct {
-	floor  time.Duration
-	format string
-
-	mu         sync.Mutex
-	lastLogged time.Time
-	suppressed int
+	floor      time.Duration
+	format     string
+	lastLogged atomic.Pointer[time.Time]
+	suppressed atomic.Int64
 }
 
 func newRateLimitedLogger(floor time.Duration, format string) *rateLimitedLogger {
@@ -20,14 +18,16 @@ func newRateLimitedLogger(floor time.Duration, format string) *rateLimitedLogger
 }
 
 func (r *rateLimitedLogger) log(args ...any) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if time.Since(r.lastLogged) <= r.floor {
-		r.suppressed++
+	last := r.lastLogged.Load()
+	if last != nil && time.Since(*last) <= r.floor {
+		r.suppressed.Add(1)
 		return
 	}
-	log.Printf(r.format+" (%d suppressed since last log)", append(args, r.suppressed)...)
-	r.lastLogged = time.Now()
-	r.suppressed = 0
+	now := time.Now()
+	if !r.lastLogged.CompareAndSwap(last, &now) {
+		r.suppressed.Add(1)
+		return
+	}
+	suppressed := r.suppressed.Swap(0)
+	log.Printf(r.format+" (%d suppressed since last log)", append(args, suppressed)...)
 }

--- a/packages/envd/internal/logs/exporter/rate_limited_logger.go
+++ b/packages/envd/internal/logs/exporter/rate_limited_logger.go
@@ -2,18 +2,17 @@ package exporter
 
 import (
 	"log"
-	"sync/atomic"
+	"sync"
 	"time"
 )
 
-// rateLimitedLogger emits log.Printf at most once per floor, appending a
-// count of suppressed calls since the last emitted line. It is lock-free
-// and may slightly miscount under contention (acceptable for noise caps).
 type rateLimitedLogger struct {
-	floor      time.Duration
-	format     string
-	lastLogged atomic.Int64 // unix nano
-	suppressed atomic.Int64
+	floor  time.Duration
+	format string
+
+	mu         sync.Mutex
+	lastLogged time.Time
+	suppressed int
 }
 
 func newRateLimitedLogger(floor time.Duration, format string) *rateLimitedLogger {
@@ -21,12 +20,14 @@ func newRateLimitedLogger(floor time.Duration, format string) *rateLimitedLogger
 }
 
 func (r *rateLimitedLogger) log(args ...any) {
-	last := r.lastLogged.Load()
-	now := time.Now().UnixNano()
-	if now-last <= int64(r.floor) || !r.lastLogged.CompareAndSwap(last, now) {
-		r.suppressed.Add(1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if time.Since(r.lastLogged) <= r.floor {
+		r.suppressed++
 		return
 	}
-	suppressed := r.suppressed.Swap(0)
-	log.Printf(r.format+" (%d suppressed since last log)", append(args, suppressed)...)
+	log.Printf(r.format+" (%d suppressed since last log)", append(args, r.suppressed)...)
+	r.lastLogged = time.Now()
+	r.suppressed = 0
 }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.22"
+const Version = "0.5.23"


### PR DESCRIPTION
Follow-up to #2676 addressing @djeebus' review: when the exporter rate-limits a repeated error kind, also report how many similar errors were swallowed since the last emitted log line.

Bumps envd to 0.5.23.