### PR TITLE
fix(envd): set OOMScoreAdjust to -999 so kernel can reclaim a leaky envd

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -18,7 +18,12 @@ ExecStartPre=/bin/sh -c 'mountpoint -q /etc/ssl/certs || (mkdir -p /run/e2b/cert
 ExecStart=/bin/bash -l -c "/usr/bin/envd"
 Nice=-20
 OOMPolicy=continue
-OOMScoreAdjust=-1000
+# -999 (not -1000): envd is still extremely low priority for the OOM killer but
+# not fully immune. If envd ever leaks past memory.max for its cgroup, the
+# kernel can recover by killing it; combined with Restart=always +
+# StartLimitIntervalSec=0 below this self-heals into a fresh envd instead of
+# requiring a manual `pkill envd` recipe.
+OOMScoreAdjust=-999
 Environment="GOMEMLIMIT={{ .MemoryLimit }}MiB"
 
 Delegate=yes


### PR DESCRIPTION
\`OOMScoreAdjust=-1000\` makes envd fully immune to the OOM killer. If envd ever leaks past \`memory.max\` for its cgroup (historical snapshots can still carry the pre-0.5.16 fan-out leak), the kernel kills *some other process* in the cgroup and envd keeps growing.

\`-999\` is still extremely low priority but not fully immune. Combined with the existing \`Restart=always\` + \`StartLimitIntervalSec=0\`, a leaky envd self-heals into a fresh instance instead of needing a manual \`pkill envd ; sleep 5\` recipe (Petr Vaněk's Apr-30 finding).

## Test plan
- [ ] On a freshly built sandbox, \`cat /proc/\$(pidof envd)/oom_score_adj\` returns \`-999\`.
- [ ] Inject memory pressure inside the sandbox until the cgroup hits memory.max; verify the kernel eventually kills envd (instead of another process) and systemd restarts it.