### PR TITLE
fix(envd): fall back to lazy unmount when forced NFS umount fails

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -325,24 +325,16 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 
 	logger.Debug().Msgf("Unmounting stale NFS mount at %q (was: %s)", path, source)
 
-	// First try a forced unmount. For NFS specifically MNT_FORCE only aborts
-	// in-flight RPCs (see fs/nfs/super.c::nfs_umount_begin); when the server is
-	// reachable and the customer's resumed processes still hold open file
-	// descriptors into the mount, this fails with EBUSY ("target is busy").
+	// Forced umount; for NFS MNT_FORCE only aborts in-flight RPCs and fails
+	// EBUSY when customer FDs still hold the mount.
 	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
 	if err == nil {
 		a.mountedPaths.Delete(path)
-
 		return nil
 	}
 
-	// Fall back to lazy unmount (MNT_DETACH). This detaches the mount from the
-	// namespace immediately and lets the kernel clean up when the surviving
-	// FDs close. The path becomes available for a fresh mount right away —
-	// which is the goal — and the old FDs keep reading from the previous mount
-	// (correct when the NFS source IP is unchanged across resume; otherwise
-	// they'll see ESTALE on next access, same outcome the customer would get
-	// from a successful forced unmount).
+	// Lazy fallback (MNT_DETACH): detach from namespace now, kernel cleans up
+	// when surviving FDs close.
 	logger.Warn().
 		Err(err).
 		Str("path", path).
@@ -356,7 +348,6 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 	}
 
 	a.mountedPaths.Delete(path)
-
 	return nil
 }
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -325,13 +325,36 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 
 	logger.Debug().Msgf("Unmounting stale NFS mount at %q (was: %s)", path, source)
 
-	// Force unmount since the handles are stale anyway
+	// First try a forced unmount. For NFS specifically MNT_FORCE only aborts
+	// in-flight RPCs (see fs/nfs/super.c::nfs_umount_begin); when the server is
+	// reachable and the customer's resumed processes still hold open file
+	// descriptors into the mount, this fails with EBUSY ("target is busy").
 	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to unmount stale NFS mount at %q: %w\n%s", path, err, string(data))
+	if err == nil {
+		a.mountedPaths.Delete(path)
+
+		return nil
 	}
 
-	// Clear our tracking state for this path
+	// Fall back to lazy unmount (MNT_DETACH). This detaches the mount from the
+	// namespace immediately and lets the kernel clean up when the surviving
+	// FDs close. The path becomes available for a fresh mount right away —
+	// which is the goal — and the old FDs keep reading from the previous mount
+	// (correct when the NFS source IP is unchanged across resume; otherwise
+	// they'll see ESTALE on next access, same outcome the customer would get
+	// from a successful forced unmount).
+	logger.Warn().
+		Err(err).
+		Str("path", path).
+		Str("umount_output", string(data)).
+		Msg("Forced NFS unmount failed, falling back to lazy detach")
+
+	lazyData, lazyErr := exec.CommandContext(ctx, "umount", "--lazy", path).CombinedOutput()
+	if lazyErr != nil {
+		return fmt.Errorf("failed to unmount stale NFS mount at %q: forced umount: %w (%s); lazy umount: %w (%s)",
+			path, err, strings.TrimSpace(string(data)), lazyErr, strings.TrimSpace(string(lazyData)))
+	}
+
 	a.mountedPaths.Delete(path)
 
 	return nil

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -330,24 +330,28 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
 	if err == nil {
 		a.mountedPaths.Delete(path)
+
 		return nil
 	}
 
-	// Lazy fallback (MNT_DETACH): detach from namespace now, kernel cleans up
-	// when surviving FDs close.
+	// Lazy fallback (MNT_DETACH) on a fresh, short-lived context so the
+	// forced umount running out of ctx budget doesn't also kill the fallback.
 	logger.Warn().
 		Err(err).
 		Str("path", path).
 		Str("umount_output", string(data)).
 		Msg("Forced NFS unmount failed, falling back to lazy detach")
 
-	lazyData, lazyErr := exec.CommandContext(ctx, "umount", "--lazy", path).CombinedOutput()
+	lazyCtx, lazyCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+	defer lazyCancel()
+	lazyData, lazyErr := exec.CommandContext(lazyCtx, "umount", "--lazy", path).CombinedOutput()
 	if lazyErr != nil {
 		return fmt.Errorf("failed to unmount stale NFS mount at %q: forced umount: %w (%s); lazy umount: %w (%s)",
 			path, err, strings.TrimSpace(string(data)), lazyErr, strings.TrimSpace(string(lazyData)))
 	}
 
 	a.mountedPaths.Delete(path)
+
 	return nil
 }
 

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -325,29 +325,14 @@ func (a *API) unmountNFS(ctx context.Context, logger zerolog.Logger, path string
 
 	logger.Debug().Msgf("Unmounting stale NFS mount at %q (was: %s)", path, source)
 
-	// Forced umount; for NFS MNT_FORCE only aborts in-flight RPCs and fails
-	// EBUSY when customer FDs still hold the mount.
-	data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput()
-	if err == nil {
-		a.mountedPaths.Delete(path)
-
-		return nil
-	}
-
-	// Lazy fallback (MNT_DETACH) on a fresh, short-lived context so the
-	// forced umount running out of ctx budget doesn't also kill the fallback.
-	logger.Warn().
-		Err(err).
-		Str("path", path).
-		Str("umount_output", string(data)).
-		Msg("Forced NFS unmount failed, falling back to lazy detach")
-
-	lazyCtx, lazyCancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
-	defer lazyCancel()
-	lazyData, lazyErr := exec.CommandContext(lazyCtx, "umount", "--lazy", path).CombinedOutput()
-	if lazyErr != nil {
-		return fmt.Errorf("failed to unmount stale NFS mount at %q: forced umount: %w (%s); lazy umount: %w (%s)",
-			path, err, strings.TrimSpace(string(data)), lazyErr, strings.TrimSpace(string(lazyData)))
+	if data, err = exec.CommandContext(ctx, "umount", "--force", path).CombinedOutput(); err != nil {
+		logger.Warn().Err(err).Str("path", path).Str("output", string(data)).Msg("Forced NFS umount failed, falling back to lazy")
+		// Fresh ctx so the forced umount running out of budget doesn't kill the fallback.
+		lazyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Second)
+		defer cancel()
+		if data, err = exec.CommandContext(lazyCtx, "umount", "--lazy", path).CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to unmount stale NFS mount at %q: %w\n%s", path, err, string(data))
+		}
 	}
 
 	a.mountedPaths.Delete(path)

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Falls back to `umount --lazy` when forced unmount on resume fails with EBUSY (customer FDs hold the mount).