### PR TITLE
fix(orch): bump envd init response_body truncation to 1024 chars

### DIFF
--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -149,7 +149,7 @@ func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
 			logger.WithSandboxID(s.Runtime.SandboxID),
 			logger.WithEnvdVersion(s.Config.Envd.Version),
 			zap.Int("status_code", response.StatusCode),
-			zap.String("response_body", utils.Truncate(string(body), 100)),
+			zap.String("response_body", utils.Truncate(string(body), 1024)),
 		)
 
 		return fmt.Errorf("unexpected status code: %d", response.StatusCode)


### PR DESCRIPTION
Bump envd response_body truncation from 100 to 1024 chars.