### PR TITLE
fix(orch): preserve Prefetch in template metadata transition helpers

### DIFF
--- a/packages/orchestrator/pkg/template/metadata/template_metadata.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata.go
@@ -129,6 +129,7 @@ func (t Template) BasedOn(
 		Start:        t.Start,
 		FromTemplate: &ft,
 		FromImage:    nil,
+		Prefetch:     t.Prefetch,
 	}
 }
 
@@ -140,6 +141,7 @@ func (t Template) NewVersionTemplate(metadata TemplateMetadata) Template {
 		Start:        t.Start,
 		FromTemplate: t.FromTemplate,
 		FromImage:    t.FromImage,
+		Prefetch:     t.Prefetch,
 	}
 }
 
@@ -151,6 +153,7 @@ func (t Template) SameVersionTemplate(metadata TemplateMetadata) Template {
 		Start:        t.Start,
 		FromTemplate: t.FromTemplate,
 		FromImage:    t.FromImage,
+		Prefetch:     t.Prefetch,
 	}
 }
 

--- a/packages/orchestrator/pkg/template/metadata/template_metadata_test.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata_test.go
@@ -217,3 +217,40 @@ type errorReader struct {
 func (er *errorReader) Read([]byte) (n int, err error) {
 	return 0, er.err
 }
+
+func TestPrefetchPreservedAcrossHelpers(t *testing.T) {
+	t.Parallel()
+
+	prefetch := &Prefetch{Memory: &MemoryPrefetchMapping{
+		Indices:     []uint64{1, 2, 3},
+		AccessTypes: []AccessType{AccessRead, AccessRead, AccessPrefetch},
+		BlockSize:   4096,
+	}}
+	original := Template{
+		Version:  CurrentVersion,
+		Template: TemplateMetadata{BuildID: "old"},
+		Prefetch: prefetch,
+	}
+
+	t.Run("SameVersionTemplate", func(t *testing.T) {
+		t.Parallel()
+		updated := original.SameVersionTemplate(TemplateMetadata{BuildID: "new"})
+		assert.Equal(t, "new", updated.Template.BuildID)
+		require.NotNil(t, updated.Prefetch)
+		assert.Equal(t, prefetch.Memory.Indices, updated.Prefetch.Memory.Indices)
+	})
+
+	t.Run("NewVersionTemplate", func(t *testing.T) {
+		t.Parallel()
+		updated := original.NewVersionTemplate(TemplateMetadata{BuildID: "new"})
+		require.NotNil(t, updated.Prefetch)
+		assert.Equal(t, prefetch.Memory.Indices, updated.Prefetch.Memory.Indices)
+	})
+
+	t.Run("BasedOn", func(t *testing.T) {
+		t.Parallel()
+		updated := original.BasedOn(FromTemplate{Alias: "parent", BuildID: "parent-build"})
+		require.NotNil(t, updated.Prefetch)
+		assert.Equal(t, prefetch.Memory.Indices, updated.Prefetch.Memory.Indices)
+	})
+}


### PR DESCRIPTION
Preserve `t.Prefetch` in `SameVersionTemplate`/`NewVersionTemplate`/`BasedOn`. Pause was the only caller without a `WithPrefetch` re-attachment, so paused snapshots silently lost the build-time prefetch list.