### PR TITLE
fix(orch): keep PostInit Timestamp stable across retries to break envd livelock

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -131,8 +131,12 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		a.initLock.Lock()
 		defer a.initLock.Unlock()
 
-		// Update data only if the request is newer or if there's no timestamp at all
-		if initRequest.Timestamp == nil || a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano()) {
+		// Update data only if the request is newer or if there's no timestamp at all.
+		// We check without mutating so that a failed SetData doesn't permanently
+		// raise lastSetTime — retries with the same pinned Timestamp must be able
+		// to re-run SetData until it succeeds.
+		shouldRun := initRequest.Timestamp == nil || initRequest.Timestamp.UnixNano() > a.lastSetTime.Load()
+		if shouldRun {
 			err = a.SetData(ctx, logger, initRequest)
 			if err != nil {
 				switch {
@@ -145,6 +149,9 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(err.Error()))
 
 				return
+			}
+			if initRequest.Timestamp != nil {
+				a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano())
 			}
 		}
 	}

--- a/packages/envd/internal/utils/atomic.go
+++ b/packages/envd/internal/utils/atomic.go
@@ -25,3 +25,11 @@ func (a *AtomicMax) SetToGreater(newValue int64) bool {
 
 	return true
 }
+
+// Load returns the current value.
+func (a *AtomicMax) Load() int64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.val
+}

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -37,6 +37,14 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 ) (*http.Response, int64, error) {
 	requestCount := int64(0)
 
+	// Pin Timestamp for the whole retry loop so envd's lastSetTime.SetToGreater
+	// idempotency guard can actually fire on a re-delivered request. With a
+	// fresh time.Now() per retry every queued PostInit looked newer than the
+	// previous one, and envd ran SetData end-to-end on every queued retry —
+	// writing the eventual 204 to a dead socket each time and never letting
+	// the orchestrator observe a success (the livelock described in the
+	// bitfrost / Mode-B investigation).
+	now := time.Now()
 	jsonBody := &envd.PostInitJSONBody{
 		LifecycleID:    s.LifecycleID,
 		EnvVars:        s.Config.Envd.Vars,
@@ -46,16 +54,15 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 		DefaultWorkdir: utils.DerefOrDefault(s.Config.Envd.DefaultWorkdir, ""),
 		VolumeMounts:   s.convertMounts(s.Config.VolumeMounts),
 		CaBundle:       s.CABundle,
+		Timestamp:      now,
+	}
+
+	body, err := json.Marshal(jsonBody)
+	if err != nil {
+		return nil, requestCount, err
 	}
 
 	for {
-		jsonBody.Timestamp = time.Now()
-
-		body, err := json.Marshal(jsonBody)
-		if err != nil {
-			return nil, requestCount, err
-		}
-
 		requestCount++
 		reqCtx, cancel := context.WithTimeout(ctx, s.internalConfig.EnvdInitRequestTimeout)
 		request, err := http.NewRequestWithContext(reqCtx, method, address, bytes.NewReader(body))

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -37,13 +37,8 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 ) (*http.Response, int64, error) {
 	requestCount := int64(0)
 
-	// Pin Timestamp for the whole retry loop so envd's lastSetTime.SetToGreater
-	// idempotency guard can actually fire on a re-delivered request. With a
-	// fresh time.Now() per retry every queued PostInit looked newer than the
-	// previous one, and envd ran SetData end-to-end on every queued retry —
-	// writing the eventual 204 to a dead socket each time and never letting
-	// the orchestrator observe a success (the livelock described in the
-	// bitfrost / Mode-B investigation).
+	// Pin Timestamp once so envd's lastSetTime.SetToGreater guard can skip
+	// re-delivered retries instead of re-running SetData against dead sockets.
 	now := time.Now()
 	jsonBody := &envd.PostInitJSONBody{
 		LifecycleID:    s.LifecycleID,


### PR DESCRIPTION
Pin `Timestamp` once before the retry loop so envd `lastSetTime.SetToGreater` can skip replays; marshal body once.