### PR TITLE
fix(envd): make CA install lock ctx-aware

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -30,6 +30,13 @@ var (
 const (
 	maxTimeInPast   = 50 * time.Millisecond
 	maxTimeInFuture = 5 * time.Second
+
+	// caBundleInstallTimeout caps how long the CA bundle install can block
+	// the /init handler. The foreground append is on tmpfs and finishes in
+	// sub-ms; the cap covers the case where a background cleanup goroutine
+	// from a previous install (NBD write to the persistent extra-certs dir)
+	// is still holding CACertInstaller's mutex.
+	caBundleInstallTimeout = 5 * time.Second
 )
 
 // validateInitAccessToken validates the access token for /init requests.
@@ -214,7 +221,14 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.CaBundle != nil && *data.CaBundle != "" {
-		err := a.caCertInstaller.Install(context.WithoutCancel(ctx), *data.CaBundle)
+		// WithoutCancel(ctx) so a 50 ms orchestrator-side client cancel doesn't
+		// abort a half-written bundle update. Bound the work with a hard deadline
+		// so the installer cannot hold initLock indefinitely if the underlying
+		// mutex (held by the background cleanup goroutine doing NBD writes) is
+		// slow to release — see CACertInstaller in packages/envd/internal/host.
+		installCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), caBundleInstallTimeout)
+		err := a.caCertInstaller.Install(installCtx, *data.CaBundle)
+		cancel()
 		if err != nil {
 			return fmt.Errorf("failed to install CA bundle: %w", err)
 		}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -30,9 +30,6 @@ var (
 const (
 	maxTimeInPast   = 50 * time.Millisecond
 	maxTimeInFuture = 5 * time.Second
-
-	// caBundleInstallTimeout caps how long /init waits for the CA install lock.
-	caBundleInstallTimeout = 5 * time.Second
 )
 
 // validateInitAccessToken validates the access token for /init requests.
@@ -217,10 +214,7 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.CaBundle != nil && *data.CaBundle != "" {
-		installCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), caBundleInstallTimeout)
-		err := a.caCertInstaller.Install(installCtx, *data.CaBundle)
-		cancel()
-		if err != nil {
+		if err := a.caCertInstaller.Install(ctx, *data.CaBundle); err != nil {
 			return fmt.Errorf("failed to install CA bundle: %w", err)
 		}
 	}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -31,11 +31,7 @@ const (
 	maxTimeInPast   = 50 * time.Millisecond
 	maxTimeInFuture = 5 * time.Second
 
-	// caBundleInstallTimeout caps how long the CA bundle install can block
-	// the /init handler. The foreground append is on tmpfs and finishes in
-	// sub-ms; the cap covers the case where a background cleanup goroutine
-	// from a previous install (NBD write to the persistent extra-certs dir)
-	// is still holding CACertInstaller's mutex.
+	// caBundleInstallTimeout caps how long /init waits for the CA install lock.
 	caBundleInstallTimeout = 5 * time.Second
 )
 
@@ -221,11 +217,6 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.CaBundle != nil && *data.CaBundle != "" {
-		// WithoutCancel(ctx) so a 50 ms orchestrator-side client cancel doesn't
-		// abort a half-written bundle update. Bound the work with a hard deadline
-		// so the installer cannot hold initLock indefinitely if the underlying
-		// mutex (held by the background cleanup goroutine doing NBD writes) is
-		// slow to release — see CACertInstaller in packages/envd/internal/host.
 		installCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), caBundleInstallTimeout)
 		err := a.caCertInstaller.Install(installCtx, *data.CaBundle)
 		cancel()

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -112,7 +112,7 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 		Dur("append_duration", time.Since(start)).
 		Msg("CA cert appended to bundle")
 
-	go func() {
+	go func() { //nolint:contextcheck // background cleanup must outlive the caller's ctx
 		cleanStart := time.Now()
 
 		_ = c.mu.Acquire(context.Background(), 1)

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -64,7 +64,7 @@ func (c *CACertInstaller) Install(ctx context.Context, certPEM string) error {
 //
 // All goroutine work runs under mu to keep the bundle and extra-certs file
 // consistent with concurrent foreground appends.
-func (c *CACertInstaller) install(_ context.Context, certPEM, bundlePath, extraPath string) error {
+func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extraPath string) error {
 	if certPEM == "" {
 		return nil
 	}
@@ -75,7 +75,9 @@ func (c *CACertInstaller) install(_ context.Context, certPEM, bundlePath, extraP
 	// consistent regardless of how the caller formatted the PEM.
 	normalized := strings.TrimRight(certPEM, "\n") + "\n"
 
-	c.mu.Lock()
+	if err := lockMutexCtx(ctx, &c.mu); err != nil {
+		return fmt.Errorf("acquire CA install lock: %w", err)
+	}
 	defer c.mu.Unlock()
 
 	if c.lastCACert == normalized {
@@ -145,6 +147,30 @@ func (c *CACertInstaller) install(_ context.Context, certPEM, bundlePath, extraP
 	}()
 
 	return nil
+}
+
+// lockMutexCtx acquires mu but bails out if ctx is cancelled first. Lets a
+// caller bound how long /init holds initLock waiting on a slow background
+// goroutine still holding mu (typically a previous install's NBD write).
+func lockMutexCtx(ctx context.Context, mu *sync.Mutex) error {
+	acquired := make(chan struct{})
+	go func() {
+		mu.Lock()
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+		return nil
+	case <-ctx.Done():
+		// The lock will be acquired by the goroutine above eventually; release
+		// it as soon as it gets the lock so we don't leak ownership.
+		go func() {
+			<-acquired
+			mu.Unlock()
+		}()
+
+		return ctx.Err()
+	}
 }
 
 // removeCertFromBundle rewrites bundlePath removing all occurrences of certPEM.

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -28,7 +27,10 @@ const (
 // ExecStartPre), so all reads and writes bypass the NBD-backed filesystem and
 // atomic cert rotation via os.Rename works within the same device.
 type CACertInstaller struct {
-	mu     sync.Mutex
+	// mu is a buffered-1 channel acting as a ctx-aware mutex. Lock acquisition
+	// respects the caller's ctx; the actual install work always runs to
+	// completion once the lock is held.
+	mu     chan struct{}
 	logger *zerolog.Logger
 
 	// lastCACert caches the most recently installed PEM so that resume (same
@@ -40,7 +42,10 @@ type CACertInstaller struct {
 }
 
 func NewCACertInstaller(logger *zerolog.Logger) *CACertInstaller {
-	return &CACertInstaller{logger: logger}
+	return &CACertInstaller{
+		logger: logger,
+		mu:     make(chan struct{}, 1),
+	}
 }
 
 // Install injects certPEM into the system CA bundle. Returns an error if the
@@ -75,10 +80,12 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	// consistent regardless of how the caller formatted the PEM.
 	normalized := strings.TrimRight(certPEM, "\n") + "\n"
 
-	if err := lockMutexCtx(ctx, &c.mu); err != nil {
-		return fmt.Errorf("acquire CA install lock: %w", err)
+	select {
+	case c.mu <- struct{}{}:
+	case <-ctx.Done():
+		return fmt.Errorf("acquire CA install lock: %w", ctx.Err())
 	}
-	defer c.mu.Unlock()
+	defer func() { <-c.mu }()
 
 	if c.lastCACert == normalized {
 		c.logger.Debug().
@@ -112,8 +119,8 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	go func() {
 		cleanStart := time.Now()
 
-		c.mu.Lock()
-		defer c.mu.Unlock()
+		c.mu <- struct{}{}
+		defer func() { <-c.mu }()
 
 		// A newer install has taken over; let that goroutine handle cleanup.
 		if c.lastCACert != normalized {
@@ -147,25 +154,6 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	}()
 
 	return nil
-}
-
-// lockMutexCtx acquires mu or returns ctx.Err() if ctx is cancelled first.
-// On cancellation, releases the lock when the background goroutine eventually
-// acquires it so ownership is never leaked.
-func lockMutexCtx(ctx context.Context, mu *sync.Mutex) error {
-	acquired := make(chan struct{})
-	go func() {
-		mu.Lock()
-		close(acquired)
-	}()
-	select {
-	case <-acquired:
-		return nil
-	case <-ctx.Done():
-		go func() { <-acquired; mu.Unlock() }()
-
-		return ctx.Err()
-	}
 }
 
 // removeCertFromBundle rewrites bundlePath removing all occurrences of certPEM.

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -149,9 +149,9 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	return nil
 }
 
-// lockMutexCtx acquires mu but bails out if ctx is cancelled first. Lets a
-// caller bound how long /init holds initLock waiting on a slow background
-// goroutine still holding mu (typically a previous install's NBD write).
+// lockMutexCtx acquires mu or returns ctx.Err() if ctx is cancelled first.
+// On cancellation, releases the lock when the background goroutine eventually
+// acquires it so ownership is never leaked.
 func lockMutexCtx(ctx context.Context, mu *sync.Mutex) error {
 	acquired := make(chan struct{})
 	go func() {
@@ -162,13 +162,7 @@ func lockMutexCtx(ctx context.Context, mu *sync.Mutex) error {
 	case <-acquired:
 		return nil
 	case <-ctx.Done():
-		// The lock will be acquired by the goroutine above eventually; release
-		// it as soon as it gets the lock so we don't leak ownership.
-		go func() {
-			<-acquired
-			mu.Unlock()
-		}()
-
+		go func() { <-acquired; mu.Unlock() }()
 		return ctx.Err()
 	}
 }

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -28,8 +28,6 @@ const (
 // ExecStartPre), so all reads and writes bypass the NBD-backed filesystem and
 // atomic cert rotation via os.Rename works within the same device.
 type CACertInstaller struct {
-	// mu is a ctx-aware mutex; Acquire respects the caller's ctx so a stuck
-	// background cleanup can't permanently wedge a foreground /init.
 	mu     *semaphore.Weighted
 	logger *zerolog.Logger
 

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -163,6 +163,7 @@ func lockMutexCtx(ctx context.Context, mu *sync.Mutex) error {
 		return nil
 	case <-ctx.Done():
 		go func() { <-acquired; mu.Unlock() }()
+
 		return ctx.Err()
 	}
 }

--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -27,10 +28,9 @@ const (
 // ExecStartPre), so all reads and writes bypass the NBD-backed filesystem and
 // atomic cert rotation via os.Rename works within the same device.
 type CACertInstaller struct {
-	// mu is a buffered-1 channel acting as a ctx-aware mutex. Lock acquisition
-	// respects the caller's ctx; the actual install work always runs to
-	// completion once the lock is held.
-	mu     chan struct{}
+	// mu is a ctx-aware mutex; Acquire respects the caller's ctx so a stuck
+	// background cleanup can't permanently wedge a foreground /init.
+	mu     *semaphore.Weighted
 	logger *zerolog.Logger
 
 	// lastCACert caches the most recently installed PEM so that resume (same
@@ -44,7 +44,7 @@ type CACertInstaller struct {
 func NewCACertInstaller(logger *zerolog.Logger) *CACertInstaller {
 	return &CACertInstaller{
 		logger: logger,
-		mu:     make(chan struct{}, 1),
+		mu:     semaphore.NewWeighted(1),
 	}
 }
 
@@ -80,12 +80,10 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	// consistent regardless of how the caller formatted the PEM.
 	normalized := strings.TrimRight(certPEM, "\n") + "\n"
 
-	select {
-	case c.mu <- struct{}{}:
-	case <-ctx.Done():
-		return fmt.Errorf("acquire CA install lock: %w", ctx.Err())
+	if err := c.mu.Acquire(ctx, 1); err != nil {
+		return fmt.Errorf("acquire CA install lock: %w", err)
 	}
-	defer func() { <-c.mu }()
+	defer c.mu.Release(1)
 
 	if c.lastCACert == normalized {
 		c.logger.Debug().
@@ -119,8 +117,8 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 	go func() {
 		cleanStart := time.Now()
 
-		c.mu <- struct{}{}
-		defer func() { <-c.mu }()
+		_ = c.mu.Acquire(context.Background(), 1)
+		defer c.mu.Release(1)
 
 		// A newer install has taken over; let that goroutine handle cleanup.
 		if c.lastCACert != normalized {

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Replaces `sync.Mutex` on `CACertInstaller` with `semaphore.Weighted(1)`. Foreground /init's lock acquisition now respects the caller's ctx; the actual file I/O has no ctx checks so it runs to completion once acquired. Background cleanup goroutine uses `context.Background` so it outlives the caller.