### PR TITLE
perf(envd): parse /proc/net/tcp directly for port scanner + socat hysteresis

### DIFF
--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -29,13 +29,23 @@ var defaultGatewayIP = net.IPv4(169, 254, 0, 21)
 
 type PortToForward struct {
 	socat *exec.Cmd
-	// Process ID of the process that's listening on port.
-	pid int32
 	// family version of the ip.
 	family uint32
 	state  PortState
 	port   uint32
+	// missedScans counts consecutive scans where the listener wasn't seen.
+	// We only stop the socat once it has gone missing for at least
+	// portDeleteThreshold scans so a short flicker (next.js dev HMR rebuild,
+	// docker compose restart, ...) doesn't drop the existing socat and the
+	// in-flight connections with it.
+	missedScans int
 }
+
+// portDeleteThreshold is the number of consecutive scans the listener has to
+// be missing before the corresponding socat is stopped. With the 1 Hz scan
+// interval this gives a ~3 s grace window which covers the common short-lived
+// restart cases without keeping orphaned socats around indefinitely.
+const portDeleteThreshold = 3
 
 type Forwarder struct {
 	logger        *zerolog.Logger
@@ -79,53 +89,63 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 
 	for {
 		// procs is an array of currently opened ports.
-		if procs, ok := <-f.scannerSubscriber.Messages; ok {
-			// Now we are going to refresh all ports that are being forwarded in the `ports` map. Maybe add new ones
-			// and maybe remove some.
+		procs, ok := <-f.scannerSubscriber.Messages
+		if !ok {
+			return
+		}
 
-			// Go through the ports that are currently being forwarded and set all of them
-			// to the `DELETE` state. We don't know yet if they will be there after refresh.
-			for _, v := range f.ports {
-				v.state = PortStateDelete
+		// Pre-mark every tracked port as "missed this scan"; the next loop
+		// flips back any port that's still listening. This is the
+		// scan-relative half of the hysteresis: a port that's gone for one
+		// scan increments missedScans, a port that returns within the
+		// portDeleteThreshold window resets it.
+		for _, v := range f.ports {
+			v.state = PortStateDelete
+		}
+
+		// Refresh: mark every listener we still see and start socat for
+		// listeners we haven't seen before. Keyed by (family, ip, port) —
+		// PID is no longer available from the scanner (we trade it for the
+		// /proc walk it would have required) and isn't needed either: if a
+		// new process binds the same (ip, port) the forwarded path is still
+		// correct.
+		for _, p := range procs {
+			key := fmt.Sprintf("%d-%s-%d", p.Family, p.Laddr.IP, p.Laddr.Port)
+
+			if val, portOk := f.ports[key]; portOk {
+				val.state = PortStateForward
+				val.missedScans = 0
+
+				continue
 			}
 
-			// Let's refresh our map of currently forwarded ports and mark the currently opened ones with the "FORWARD" state.
-			// This will make sure we won't delete them later.
-			for _, p := range procs {
-				key := fmt.Sprintf("%d-%d", p.Pid, p.Laddr.Port)
+			f.logger.Debug().
+				Str("ip", p.Laddr.IP).
+				Uint32("port", p.Laddr.Port).
+				Uint32("family", familyToIPVersion(p.Family)).
+				Str("state", p.Status).
+				Msg("Detected new opened port on localhost that is not forwarded")
 
-				// We check if the opened port is in our map of forwarded ports.
-				val, portOk := f.ports[key]
-				if portOk {
-					// Just mark the port as being forwarded so we don't delete it.
-					// The actual socat process that handles forwarding should be running from the last iteration.
-					val.state = PortStateForward
-				} else {
-					f.logger.Debug().
-						Str("ip", p.Laddr.IP).
-						Uint32("port", p.Laddr.Port).
-						Uint32("family", familyToIPVersion(p.Family)).
-						Str("state", p.Status).
-						Msg("Detected new opened port on localhost that is not forwarded")
-
-					// The opened port wasn't in the map so we create a new PortToForward and start forwarding.
-					ptf := &PortToForward{
-						pid:    p.Pid,
-						port:   p.Laddr.Port,
-						state:  PortStateForward,
-						family: familyToIPVersion(p.Family),
-					}
-					f.ports[key] = ptf
-					f.startPortForwarding(ctx, ptf)
-				}
+			ptf := &PortToForward{
+				port:   p.Laddr.Port,
+				state:  PortStateForward,
+				family: familyToIPVersion(p.Family),
 			}
+			f.ports[key] = ptf
+			f.startPortForwarding(ctx, ptf)
+		}
 
-			// We go through the ports map one more time and stop forwarding all ports
-			// that stayed marked as "DELETE".
-			for _, v := range f.ports {
-				if v.state == PortStateDelete {
-					f.stopPortForwarding(v)
-				}
+		// Tear down only ports that have been missing for several consecutive
+		// scans. Short flickers (Next.js HMR rebuild, docker compose restart)
+		// no longer thrash socat.
+		for key, v := range f.ports {
+			if v.state != PortStateDelete {
+				continue
+			}
+			v.missedScans++
+			if v.missedScans >= portDeleteThreshold {
+				f.stopPortForwarding(v)
+				delete(f.ports, key)
 			}
 		}
 	}
@@ -150,7 +170,6 @@ func (f *Forwarder) startPortForwarding(ctx context.Context, p *PortToForward) {
 
 	f.logger.Debug().
 		Str("socatCmd", cmd.String()).
-		Int32("pid", p.pid).
 		Uint32("family", p.family).
 		IPAddr("sourceIP", f.sourceIP.To4()).
 		Uint32("port", p.port).
@@ -188,7 +207,6 @@ func (f *Forwarder) stopPortForwarding(p *PortToForward) {
 
 	logger := f.logger.With().
 		Str("socatCmd", p.socat.String()).
-		Int32("pid", p.pid).
 		Uint32("family", p.family).
 		IPAddr("sourceIP", f.sourceIP.To4()).
 		Uint32("port", p.port).

--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -28,23 +28,15 @@ const (
 var defaultGatewayIP = net.IPv4(169, 254, 0, 21)
 
 type PortToForward struct {
-	socat *exec.Cmd
-	// family version of the ip.
-	family uint32
-	state  PortState
-	port   uint32
-	// missedScans counts consecutive scans where the listener wasn't seen.
-	// We only stop the socat once it has gone missing for at least
-	// portDeleteThreshold scans so a short flicker (next.js dev HMR rebuild,
-	// docker compose restart, ...) doesn't drop the existing socat and the
-	// in-flight connections with it.
+	socat       *exec.Cmd
+	family      uint32
+	state       PortState
+	port        uint32
 	missedScans int
 }
 
-// portDeleteThreshold is the number of consecutive scans the listener has to
-// be missing before the corresponding socat is stopped. With the 1 Hz scan
-// interval this gives a ~3 s grace window which covers the common short-lived
-// restart cases without keeping orphaned socats around indefinitely.
+// portDeleteThreshold is the number of consecutive scans without seeing the
+// listener before stopping its socat (~3 s at 1 Hz). Absorbs HMR/restart flicker.
 const portDeleteThreshold = 3
 
 type Forwarder struct {
@@ -94,21 +86,10 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 			return
 		}
 
-		// Pre-mark every tracked port as "missed this scan"; the next loop
-		// flips back any port that's still listening. This is the
-		// scan-relative half of the hysteresis: a port that's gone for one
-		// scan increments missedScans, a port that returns within the
-		// portDeleteThreshold window resets it.
 		for _, v := range f.ports {
 			v.state = PortStateDelete
 		}
 
-		// Refresh: mark every listener we still see and start socat for
-		// listeners we haven't seen before. Keyed by (family, ip, port) —
-		// PID is no longer available from the scanner (we trade it for the
-		// /proc walk it would have required) and isn't needed either: if a
-		// new process binds the same (ip, port) the forwarded path is still
-		// correct.
 		for _, p := range procs {
 			key := fmt.Sprintf("%d-%s-%d", p.Family, p.Laddr.IP, p.Laddr.Port)
 
@@ -135,9 +116,6 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 			f.startPortForwarding(ctx, ptf)
 		}
 
-		// Tear down only ports that have been missing for several consecutive
-		// scans. Short flickers (Next.js HMR rebuild, docker compose restart)
-		// no longer thrash socat.
 		for key, v := range f.ports {
 			if v.state != PortStateDelete {
 				continue

--- a/packages/envd/internal/port/forward.go
+++ b/packages/envd/internal/port/forward.go
@@ -91,7 +91,10 @@ func (f *Forwarder) StartForwarding(ctx context.Context) {
 		}
 
 		for _, p := range procs {
-			key := fmt.Sprintf("%d-%s-%d", p.Family, p.Laddr.IP, p.Laddr.Port)
+			// Key on port only so a dual-stack listener (127.0.0.1 + ::1 same
+			// port) maps to a single socat — socat always binds the v4 gateway
+			// regardless of family, so two entries would collide on bind.
+			key := fmt.Sprintf("%d", p.Laddr.Port)
 
 			if val, portOk := f.ports[key]; portOk {
 				val.state = PortStateForward

--- a/packages/envd/internal/port/proc_listeners_linux.go
+++ b/packages/envd/internal/port/proc_listeners_linux.go
@@ -15,15 +15,9 @@ import (
 	gnet "github.com/shirou/gopsutil/v4/net"
 )
 
-// listListeningSockets returns the TCP and TCP6 sockets in LISTEN state by
-// parsing /proc/net/tcp{,6} directly. It is dramatically cheaper than
-// gopsutil's net.Connections, which walks every /proc/<pid>/fd directory to
-// produce inode→PID mappings (O(processes × open fds) syscalls per scan). The
-// port forwarder only needs (family, local addr, local port, status) so the
-// PID lookup is pure overhead.
-//
-// The returned slice is shaped as []net.ConnectionStat for compatibility with
-// the existing subscriber/filter wiring; the Pid field is always 0.
+// listListeningSockets parses /proc/net/tcp{,6} and returns LISTEN sockets.
+// Skips the /proc/<pid>/fd walk that gopsutil.net.Connections does — the
+// forwarder doesn't use PID.
 func listListeningSockets() ([]gnet.ConnectionStat, error) {
 	var out []gnet.ConnectionStat
 
@@ -42,12 +36,10 @@ func listListeningSockets() ([]gnet.ConnectionStat, error) {
 	return out, nil
 }
 
-// tcpStateListen is the on-the-wire encoding of TCP_LISTEN in /proc/net/tcp.
-const tcpStateListen = "0A"
-
-// listenStatus is the human-readable status string the rest of the package
-// expects (matches gopsutil's net.Connections output).
-const listenStatus = "LISTEN"
+const (
+	tcpStateListen = "0A"
+	listenStatus   = "LISTEN"
+)
 
 func parseProcNetTCP(path string, family uint32) ([]gnet.ConnectionStat, error) {
 	f, err := os.Open(path)
@@ -58,18 +50,13 @@ func parseProcNetTCP(path string, family uint32) ([]gnet.ConnectionStat, error) 
 
 	var out []gnet.ConnectionStat
 	scanner := bufio.NewScanner(f)
-	// Skip header.
-	if scanner.Scan() {
+	if scanner.Scan() { // skip header
 		_ = scanner.Text()
 	}
 
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
-		// Need at least: sl, local, rem, st
-		if len(fields) < 4 {
-			continue
-		}
-		if fields[3] != tcpStateListen {
+		if len(fields) < 4 || fields[3] != tcpStateListen {
 			continue
 		}
 
@@ -89,28 +76,22 @@ func parseProcNetTCP(path string, family uint32) ([]gnet.ConnectionStat, error) 
 	return out, scanner.Err()
 }
 
-// decodeProcAddr parses one local_address / remote_address field from
-// /proc/net/tcp{,6}: an upper-case hex IP, ':', and a 4-hex-digit port.
-//
-// The IP bytes are written byte-by-byte but each 4-byte word is in CPU byte
-// order (little-endian on x86/arm64). For IPv4 we just reverse the four bytes;
-// for IPv6 each consecutive 4-byte group is little-endian within the group.
+// decodeProcAddr parses an IIIIIIII:PPPP (or 32-char-hex:PPPP for v6) field.
+// Each 4-byte word in the IP is in CPU byte order.
 func decodeProcAddr(s string, family uint32) (string, uint16, error) {
 	colon := strings.IndexByte(s, ':')
 	if colon < 0 {
 		return "", 0, fmt.Errorf("missing colon in %q", s)
 	}
-	ipHex := s[:colon]
-	portHex := s[colon+1:]
 
-	port64, err := strconv.ParseUint(portHex, 16, 16)
+	port64, err := strconv.ParseUint(s[colon+1:], 16, 16)
 	if err != nil {
-		return "", 0, fmt.Errorf("port %q: %w", portHex, err)
+		return "", 0, err
 	}
 
-	raw, err := hex.DecodeString(ipHex)
+	raw, err := hex.DecodeString(s[:colon])
 	if err != nil {
-		return "", 0, fmt.Errorf("ip %q: %w", ipHex, err)
+		return "", 0, err
 	}
 
 	switch family {
@@ -118,22 +99,18 @@ func decodeProcAddr(s string, family uint32) (string, uint16, error) {
 		if len(raw) != 4 {
 			return "", 0, fmt.Errorf("ipv4 expects 4 bytes, got %d", len(raw))
 		}
-		ip := net.IPv4(raw[3], raw[2], raw[1], raw[0])
-
-		return ip.String(), uint16(port64), nil
+		return net.IPv4(raw[3], raw[2], raw[1], raw[0]).String(), uint16(port64), nil
 	case syscall.AF_INET6:
 		if len(raw) != 16 {
 			return "", 0, fmt.Errorf("ipv6 expects 16 bytes, got %d", len(raw))
 		}
 		buf := make([]byte, 16)
-		// Reverse each 4-byte group.
 		for i := 0; i < 16; i += 4 {
 			buf[i+0] = raw[i+3]
 			buf[i+1] = raw[i+2]
 			buf[i+2] = raw[i+1]
 			buf[i+3] = raw[i+0]
 		}
-
 		return net.IP(buf).String(), uint16(port64), nil
 	default:
 		return "", 0, fmt.Errorf("unsupported family %d", family)

--- a/packages/envd/internal/port/proc_listeners_linux.go
+++ b/packages/envd/internal/port/proc_listeners_linux.go
@@ -79,17 +79,17 @@ func parseProcNetTCP(path string, family uint32) ([]gnet.ConnectionStat, error) 
 // decodeProcAddr parses an IIIIIIII:PPPP (or 32-char-hex:PPPP for v6) field.
 // Each 4-byte word in the IP is in CPU byte order.
 func decodeProcAddr(s string, family uint32) (string, uint16, error) {
-	colon := strings.IndexByte(s, ':')
-	if colon < 0 {
+	ipHex, portHex, ok := strings.Cut(s, ":")
+	if !ok {
 		return "", 0, fmt.Errorf("missing colon in %q", s)
 	}
 
-	port64, err := strconv.ParseUint(s[colon+1:], 16, 16)
+	port64, err := strconv.ParseUint(portHex, 16, 16)
 	if err != nil {
 		return "", 0, err
 	}
 
-	raw, err := hex.DecodeString(s[:colon])
+	raw, err := hex.DecodeString(ipHex)
 	if err != nil {
 		return "", 0, err
 	}
@@ -99,6 +99,7 @@ func decodeProcAddr(s string, family uint32) (string, uint16, error) {
 		if len(raw) != 4 {
 			return "", 0, fmt.Errorf("ipv4 expects 4 bytes, got %d", len(raw))
 		}
+
 		return net.IPv4(raw[3], raw[2], raw[1], raw[0]).String(), uint16(port64), nil
 	case syscall.AF_INET6:
 		if len(raw) != 16 {
@@ -111,6 +112,7 @@ func decodeProcAddr(s string, family uint32) (string, uint16, error) {
 			buf[i+2] = raw[i+1]
 			buf[i+3] = raw[i+0]
 		}
+
 		return net.IP(buf).String(), uint16(port64), nil
 	default:
 		return "", 0, fmt.Errorf("unsupported family %d", family)

--- a/packages/envd/internal/port/proc_listeners_linux.go
+++ b/packages/envd/internal/port/proc_listeners_linux.go
@@ -1,0 +1,141 @@
+//go:build linux
+
+package port
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	gnet "github.com/shirou/gopsutil/v4/net"
+)
+
+// listListeningSockets returns the TCP and TCP6 sockets in LISTEN state by
+// parsing /proc/net/tcp{,6} directly. It is dramatically cheaper than
+// gopsutil's net.Connections, which walks every /proc/<pid>/fd directory to
+// produce inode→PID mappings (O(processes × open fds) syscalls per scan). The
+// port forwarder only needs (family, local addr, local port, status) so the
+// PID lookup is pure overhead.
+//
+// The returned slice is shaped as []net.ConnectionStat for compatibility with
+// the existing subscriber/filter wiring; the Pid field is always 0.
+func listListeningSockets() ([]gnet.ConnectionStat, error) {
+	var out []gnet.ConnectionStat
+
+	if v4, err := parseProcNetTCP("/proc/net/tcp", syscall.AF_INET); err == nil {
+		out = append(out, v4...)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if v6, err := parseProcNetTCP("/proc/net/tcp6", syscall.AF_INET6); err == nil {
+		out = append(out, v6...)
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// tcpStateListen is the on-the-wire encoding of TCP_LISTEN in /proc/net/tcp.
+const tcpStateListen = "0A"
+
+// listenStatus is the human-readable status string the rest of the package
+// expects (matches gopsutil's net.Connections output).
+const listenStatus = "LISTEN"
+
+func parseProcNetTCP(path string, family uint32) ([]gnet.ConnectionStat, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var out []gnet.ConnectionStat
+	scanner := bufio.NewScanner(f)
+	// Skip header.
+	if scanner.Scan() {
+		_ = scanner.Text()
+	}
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		// Need at least: sl, local, rem, st
+		if len(fields) < 4 {
+			continue
+		}
+		if fields[3] != tcpStateListen {
+			continue
+		}
+
+		ip, port, err := decodeProcAddr(fields[1], family)
+		if err != nil {
+			continue
+		}
+
+		out = append(out, gnet.ConnectionStat{
+			Family: family,
+			Type:   syscall.SOCK_STREAM,
+			Laddr:  gnet.Addr{IP: ip, Port: uint32(port)},
+			Status: listenStatus,
+		})
+	}
+
+	return out, scanner.Err()
+}
+
+// decodeProcAddr parses one local_address / remote_address field from
+// /proc/net/tcp{,6}: an upper-case hex IP, ':', and a 4-hex-digit port.
+//
+// The IP bytes are written byte-by-byte but each 4-byte word is in CPU byte
+// order (little-endian on x86/arm64). For IPv4 we just reverse the four bytes;
+// for IPv6 each consecutive 4-byte group is little-endian within the group.
+func decodeProcAddr(s string, family uint32) (string, uint16, error) {
+	colon := strings.IndexByte(s, ':')
+	if colon < 0 {
+		return "", 0, fmt.Errorf("missing colon in %q", s)
+	}
+	ipHex := s[:colon]
+	portHex := s[colon+1:]
+
+	port64, err := strconv.ParseUint(portHex, 16, 16)
+	if err != nil {
+		return "", 0, fmt.Errorf("port %q: %w", portHex, err)
+	}
+
+	raw, err := hex.DecodeString(ipHex)
+	if err != nil {
+		return "", 0, fmt.Errorf("ip %q: %w", ipHex, err)
+	}
+
+	switch family {
+	case syscall.AF_INET:
+		if len(raw) != 4 {
+			return "", 0, fmt.Errorf("ipv4 expects 4 bytes, got %d", len(raw))
+		}
+		ip := net.IPv4(raw[3], raw[2], raw[1], raw[0])
+
+		return ip.String(), uint16(port64), nil
+	case syscall.AF_INET6:
+		if len(raw) != 16 {
+			return "", 0, fmt.Errorf("ipv6 expects 16 bytes, got %d", len(raw))
+		}
+		buf := make([]byte, 16)
+		// Reverse each 4-byte group.
+		for i := 0; i < 16; i += 4 {
+			buf[i+0] = raw[i+3]
+			buf[i+1] = raw[i+2]
+			buf[i+2] = raw[i+1]
+			buf[i+3] = raw[i+0]
+		}
+
+		return net.IP(buf).String(), uint16(port64), nil
+	default:
+		return "", 0, fmt.Errorf("unsupported family %d", family)
+	}
+}

--- a/packages/envd/internal/port/proc_listeners_linux_test.go
+++ b/packages/envd/internal/port/proc_listeners_linux_test.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package port
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeProcAddrV4(t *testing.T) {
+	t.Parallel()
+	ip, port, err := decodeProcAddr("0100007F:1F90", syscall.AF_INET)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", ip)
+	assert.Equal(t, uint16(8080), port)
+}
+
+func TestDecodeProcAddrV4_Wildcard(t *testing.T) {
+	t.Parallel()
+	ip, port, err := decodeProcAddr("00000000:0050", syscall.AF_INET)
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", ip)
+	assert.Equal(t, uint16(80), port)
+}
+
+func TestDecodeProcAddrV6_Loopback(t *testing.T) {
+	t.Parallel()
+	// IPv6 loopback ::1 expressed in /proc/net/tcp6 form (4-byte groups in CPU
+	// byte order — for little-endian that's the last group as 01000000).
+	ip, port, err := decodeProcAddr("00000000000000000000000001000000:1F90", syscall.AF_INET6)
+	require.NoError(t, err)
+	assert.Equal(t, "::1", ip)
+	assert.Equal(t, uint16(8080), port)
+}
+
+func TestDecodeProcAddr_InvalidFamily(t *testing.T) {
+	t.Parallel()
+	_, _, err := decodeProcAddr("00000000:0050", syscall.AF_UNIX)
+	assert.Error(t, err)
+}
+
+func TestDecodeProcAddr_MalformedPort(t *testing.T) {
+	t.Parallel()
+	_, _, err := decodeProcAddr("0100007F:ZZZZ", syscall.AF_INET)
+	assert.Error(t, err)
+}

--- a/packages/envd/internal/port/proc_listeners_other.go
+++ b/packages/envd/internal/port/proc_listeners_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+
+package port
+
+import gnet "github.com/shirou/gopsutil/v4/net"
+
+// listListeningSockets is only used on Linux; the rest of envd doesn't run
+// the port forwarder elsewhere. Returning empty keeps the build green on
+// developer macOS without pulling in a platform-specific fallback.
+func listListeningSockets() ([]gnet.ConnectionStat, error) {
+	return nil, nil
+}

--- a/packages/envd/internal/port/scan.go
+++ b/packages/envd/internal/port/scan.go
@@ -44,9 +44,13 @@ func (s *Scanner) Unsubscribe(sub *ScannerSubscriber) {
 // ScanAndBroadcast scans LISTEN sockets and broadcasts them to subscribers.
 func (s *Scanner) ScanAndBroadcast() {
 	for {
-		listeners, _ := listListeningSockets()
-		for _, sub := range s.subs.Items() {
-			sub.Signal(listeners)
+		listeners, err := listListeningSockets()
+		// Skip broadcast on transient parser errors so the empty list doesn't
+		// flip every active port into the DELETE path.
+		if err == nil {
+			for _, sub := range s.subs.Items() {
+				sub.Signal(listeners)
+			}
 		}
 		select {
 		case <-s.scanExit:

--- a/packages/envd/internal/port/scan.go
+++ b/packages/envd/internal/port/scan.go
@@ -41,10 +41,7 @@ func (s *Scanner) Unsubscribe(sub *ScannerSubscriber) {
 	sub.Destroy()
 }
 
-// ScanAndBroadcast starts scanning open TCP ports and broadcasts every open
-// port to all subscribers. Uses a direct /proc/net/tcp{,6} parser instead of
-// gopsutil's net.Connections so the scan does not walk /proc/<pid>/fd for
-// every process (the forwarder doesn't need PID information).
+// ScanAndBroadcast scans LISTEN sockets and broadcasts them to subscribers.
 func (s *Scanner) ScanAndBroadcast() {
 	for {
 		listeners, _ := listListeningSockets()

--- a/packages/envd/internal/port/scan.go
+++ b/packages/envd/internal/port/scan.go
@@ -41,13 +41,15 @@ func (s *Scanner) Unsubscribe(sub *ScannerSubscriber) {
 	sub.Destroy()
 }
 
-// ScanAndBroadcast starts scanning open TCP ports and broadcasts every open port to all subscribers.
+// ScanAndBroadcast starts scanning open TCP ports and broadcasts every open
+// port to all subscribers. Uses a direct /proc/net/tcp{,6} parser instead of
+// gopsutil's net.Connections so the scan does not walk /proc/<pid>/fd for
+// every process (the forwarder doesn't need PID information).
 func (s *Scanner) ScanAndBroadcast() {
 	for {
-		// tcp monitors both ipv4 and ipv6 connections.
-		processes, _ := net.Connections("tcp")
+		listeners, _ := listListeningSockets()
 		for _, sub := range s.subs.Items() {
-			sub.Signal(processes)
+			sub.Signal(listeners)
 		}
 		select {
 		case <-s.scanExit:

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Replace gopsutil `net.Connections` with a direct `/proc/net/tcp{,6}` LISTEN parser (skips the `/proc/<pid>/fd` walk). Drop PID from forwarder map key and add 3-scan delete hysteresis.