### PR TITLE
feat(memfd): async pause/copy (in-flight reads)

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/device.go
+++ b/packages/orchestrator/pkg/sandbox/block/device.go
@@ -41,6 +41,19 @@ type ReadonlyDevice interface {
 	SwapHeader(h *header.Header)
 }
 
+// DiffSource is the set of methods build.localDiff needs from its backing
+// store. Both *Cache (sync) and *MemfdCache (async, in-flight reads) satisfy
+// it, so the diff layer doesn't need to know which one it has.
+type DiffSource interface {
+	io.Closer
+	io.ReaderAt
+	Slice(off, length int64) ([]byte, error)
+	Size() (int64, error)
+	FileSize() (int64, error)
+	BlockSize() int64
+	Path() string
+}
+
 type Device interface {
 	ReadonlyDevice
 	io.WriterAt

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"golang.org/x/sys/unix"
@@ -95,4 +96,229 @@ func NewCacheFromMemfd(
 	}
 
 	return cache, nil
+}
+
+// MemfdCache wraps a Cache being populated from a memfd on a background
+// goroutine. Reads route to the cache file: if the requested range is
+// already populated (by runCopy or a prior demand-page), they're served
+// zero-copy; otherwise the read demand-pages from memfd → cache + marks
+// the range cached, so runCopy can skip it later. The memfd is closed and
+// its hugetlb pages released as soon as the full copy is done. Slices
+// returned have the same ownership as *Cache.Slice (valid until Close).
+//
+// Designed for the resume-from-just-paused-snapshot case: another sandbox
+// can resume and read this diff without waiting for the upload to finish.
+type MemfdCache struct {
+	*Cache
+
+	// mu guards src + cache writes by runCopy/demand-page paths.
+	mu  sync.Mutex
+	src *memfdSource // nil after the background copy completes
+
+	cancel context.CancelFunc
+	done   chan struct{} // closed by runCopy; serves as happens-before for err
+	err    error
+}
+
+// NewCacheFromMemfdAsync starts the memfd → cache copy on a goroutine so
+// Pause can return as soon as snapshot file + diff metadata are written.
+// The returned wrapper takes ownership of memfd; Close cancels the copy.
+func NewCacheFromMemfdAsync(
+	ctx context.Context,
+	blockSize int64,
+	filePath string,
+	memfd *Memfd,
+	dirty *roaring.Bitmap,
+) (*MemfdCache, error) {
+	cache, err := NewCache(int64(dirty.GetCardinality())*blockSize, blockSize, filePath, false)
+	if err != nil {
+		return nil, errors.Join(err, memfd.Close())
+	}
+	if dirty.IsEmpty() {
+		if closeErr := memfd.Close(); closeErr != nil {
+			return nil, errors.Join(fmt.Errorf("close memfd: %w", closeErr), cache.Close())
+		}
+
+		return &MemfdCache{Cache: cache}, nil
+	}
+
+	copyCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	m := &MemfdCache{
+		Cache:  cache,
+		src:    newMemfdSource(memfd, dirty, blockSize),
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+
+	go m.runCopy(copyCtx, dirty, blockSize)
+
+	return m, nil
+}
+
+func (m *MemfdCache) runCopy(ctx context.Context, dirty *roaring.Bitmap, blockSize int64) {
+	var err error
+	var cacheOff int64
+	for r := range BitsetRanges(dirty, blockSize) {
+		if err = ctx.Err(); err != nil {
+			break
+		}
+		if err = m.copyRange(cacheOff, r); err != nil {
+			break
+		}
+		cacheOff += r.Size
+	}
+
+	m.mu.Lock()
+	memfd := m.src.memfd
+	m.src = nil
+	m.mu.Unlock()
+
+	if closeErr := memfd.Close(); closeErr != nil {
+		err = errors.Join(err, fmt.Errorf("close memfd: %w", closeErr))
+	}
+	m.err = err
+	close(m.done)
+}
+
+// copyRange copies a single source range memfd → cache under the lock,
+// skipping it if a concurrent demand-page already populated those bytes.
+func (m *MemfdCache) copyRange(cacheOff int64, r Range) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.Cache.isCached(cacheOff, r.Size) {
+		return nil
+	}
+
+	src, err := m.src.memfd.Slice(r.Start, r.Size)
+	if err != nil {
+		return fmt.Errorf("memfd slice [%d,%d): %w", r.Start, r.Start+r.Size, err)
+	}
+	copy((*m.Cache.mmap)[cacheOff:cacheOff+r.Size], src)
+	m.Cache.setIsCached(cacheOff, r.Size)
+
+	return nil
+}
+
+// Wait blocks until the background copy completes. Only needed by callers
+// reading the cache file directly (e.g. via CachePath); ReadAt and Slice
+// work without waiting.
+func (m *MemfdCache) Wait(ctx context.Context) error {
+	if m.done == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.done:
+	}
+
+	return m.err
+}
+
+func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
+	if err := m.ensureCached(off, int64(len(b))); err != nil {
+		return 0, err
+	}
+
+	return m.Cache.ReadAt(b, off)
+}
+
+// Slice returns the embedded Cache's zero-copy slice — demand-paging the
+// range from memfd if runCopy hasn't reached it yet. Ownership matches
+// *Cache.Slice: valid until Close.
+func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
+	if err := m.ensureCached(off, length); err != nil {
+		return nil, err
+	}
+
+	return m.Cache.Slice(off, length)
+}
+
+// ensureCached makes sure [off, off+length) is in the cache file, copying
+// from memfd if necessary. After it returns, Cache.ReadAt/Slice operate on
+// populated bytes.
+func (m *MemfdCache) ensureCached(off, length int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.src == nil || m.Cache.isCached(off, length) {
+		return nil
+	}
+
+	return m.src.fill(m.Cache, off, length)
+}
+
+func (m *MemfdCache) Close() error {
+	if m.cancel != nil {
+		m.cancel()
+		<-m.done
+	}
+
+	return m.Cache.Close()
+}
+
+// memfdSource indexes memfd-backed ranges by cache offset so reads can
+// resolve a (cacheOff, length) into the corresponding memfd bytes.
+type memfdSource struct {
+	memfd   *Memfd
+	entries []memfdRange
+}
+
+type memfdRange struct{ cacheStart, srcStart, size int64 }
+
+func newMemfdSource(memfd *Memfd, dirty *roaring.Bitmap, blockSize int64) *memfdSource {
+	var entries []memfdRange
+	var cacheOff int64
+	for r := range BitsetRanges(dirty, blockSize) {
+		entries = append(entries, memfdRange{cacheStart: cacheOff, srcStart: r.Start, size: r.Size})
+		cacheOff += r.Size
+	}
+
+	return &memfdSource{memfd: memfd, entries: entries}
+}
+
+// fill copies [cacheOff, cacheOff+length) from memfd into cache.mmap and
+// marks the range cached. Caller must hold the cache lock.
+func (s *memfdSource) fill(cache *Cache, cacheOff, length int64) error {
+	end := cacheOff + length
+	for cacheOff < end {
+		i := s.find(cacheOff)
+		if i < 0 {
+			return BytesNotAvailableError{}
+		}
+		e := s.entries[i]
+		offsetInEntry := cacheOff - e.cacheStart
+		toCopy := min(end-cacheOff, e.size-offsetInEntry)
+
+		src, err := s.memfd.Slice(e.srcStart+offsetInEntry, toCopy)
+		if err != nil {
+			return fmt.Errorf("memfd slice: %w", err)
+		}
+		copy((*cache.mmap)[cacheOff:cacheOff+toCopy], src)
+		cache.setIsCached(cacheOff, toCopy)
+
+		cacheOff += toCopy
+	}
+
+	return nil
+}
+
+// find returns the index of the entry containing cacheOff, or -1.
+func (s *memfdSource) find(cacheOff int64) int {
+	lo, hi := 0, len(s.entries)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		if s.entries[mid].cacheStart > cacheOff {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+	i := lo - 1
+	if i < 0 || cacheOff >= s.entries[i].cacheStart+s.entries[i].size {
+		return -1
+	}
+
+	return i
 }

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -3,8 +3,10 @@
 package block
 
 import (
+	"context"
 	"crypto/rand"
 	"testing"
+	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/stretchr/testify/require"
@@ -75,4 +77,79 @@ func TestNewCacheFromMemfd_NonZeroRangeStart(t *testing.T) {
 	_, err = cache.ReadAt(got, 0)
 	require.NoError(t, err)
 	require.Equal(t, expected[pageSize*3:pageSize*5], got)
+}
+
+// In-flight reads must return memfd data even before runCopy reaches the
+// range, so a sandbox can resume from a just-paused snapshot without waiting.
+func TestNewCacheFromMemfdAsync_InFlightReadAt(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	memfd, expected := newTestMemfd(t, pageSize*8)
+	dirty := roaring.New()
+	dirty.AddMany([]uint32{1, 3, 5})
+
+	cache, err := NewCacheFromMemfdAsync(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	for i, srcBlock := range []int64{1, 3, 5} {
+		got := make([]byte, pageSize)
+		_, err := cache.ReadAt(got, int64(i)*pageSize)
+		require.NoError(t, err)
+		require.Equal(t, expected[srcBlock*pageSize:(srcBlock+1)*pageSize], got)
+	}
+
+	require.NoError(t, cache.Wait(t.Context()))
+}
+
+// Slice returned during a copy must outlive the memfd: runCopy demand-pages
+// any not-yet-copied range into the cache file, then closes memfd. The slice
+// points at the cache mmap, so it remains valid until Cache.Close.
+func TestNewCacheFromMemfdAsync_SliceOutlivesMemfd(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	memfd, expected := newTestMemfd(t, pageSize*4)
+	dirty := roaring.New()
+	dirty.AddMany([]uint32{0, 1, 2, 3})
+
+	cache, err := NewCacheFromMemfdAsync(t.Context(), pageSize, t.TempDir()+"/cache", memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	s, err := cache.Slice(pageSize, pageSize*2)
+	require.NoError(t, err)
+	want := make([]byte, pageSize*2)
+	copy(want, expected[pageSize:pageSize*3])
+
+	require.NoError(t, cache.Wait(t.Context()))
+	require.Equal(t, want, s)
+}
+
+// Detached background copy: cancelling the parent context must not abort
+// the goroutine since the caller (sandbox.go) hands ownership to MemfdCache.
+func TestNewCacheFromMemfdAsync_DetachesFromParent(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	memfd, expected := newTestMemfd(t, pageSize)
+	dirty := roaring.New()
+	dirty.Add(0)
+
+	parent, cancel := context.WithCancel(t.Context())
+	cache, err := NewCacheFromMemfdAsync(parent, pageSize, t.TempDir()+"/cache", memfd, dirty)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	cancel()
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancelWait()
+	require.NoError(t, cache.Wait(waitCtx))
+
+	got := make([]byte, pageSize)
+	_, err = cache.ReadAt(got, 0)
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
 }

--- a/packages/orchestrator/pkg/sandbox/build/local_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/local_diff.go
@@ -80,14 +80,14 @@ func (f *LocalDiffFile) CloseToDiff(
 
 type localDiff struct {
 	cacheKey DiffStoreKey
-	cache    *block.Cache
+	cache    block.DiffSource
 }
 
 var _ Diff = (*localDiff)(nil)
 
 func NewLocalDiffFromCache(
 	cacheKey DiffStoreKey,
-	cache *block.Cache,
+	cache block.DiffSource,
 ) (Diff, error) {
 	return &localDiff{
 		cache:    cache,
@@ -109,7 +109,21 @@ func newLocalDiff(
 	return NewLocalDiffFromCache(cacheKey, cache)
 }
 
+// waiter is implemented by async caches that must finish background copy
+// before the underlying file is read directly (e.g. for header parsing).
+type waiter interface {
+	Wait(ctx context.Context) error
+}
+
+// CachePath returns the path to the diff file on disk. For async caches
+// the background copy must finish before the file is safe to read directly.
 func (b *localDiff) CachePath() (string, error) {
+	if w, ok := b.cache.(waiter); ok {
+		if err := w.Wait(context.Background()); err != nil {
+			return "", fmt.Errorf("wait for cache: %w", err)
+		}
+	}
+
 	return b.cache.Path(), nil
 }
 
@@ -125,7 +139,7 @@ func (b *localDiff) Slice(_ context.Context, off, length int64, _ *storage.Frame
 	return b.cache.Slice(off, length)
 }
 
-func (b *localDiff) Size(_ context.Context) (int64, error) {
+func (b *localDiff) Size(context.Context) (int64, error) {
 	return b.cache.Size()
 }
 

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -28,7 +28,7 @@ func (p *Process) exportMemoryFromFc(
 	include *roaring.Bitmap,
 	cachePath string,
 	blockSize int64,
-) (*block.Cache, error) {
+) (block.DiffSource, error) {
 	m, err := p.client.memoryMapping(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memory mappings: %w", err)
@@ -64,9 +64,13 @@ func (p *Process) ExportMemory(
 	cachePath string,
 	blockSize int64,
 	memfd *block.Memfd,
-) (*block.Cache, error) {
+	bgCopy bool,
+) (block.DiffSource, error) {
 	if memfd == nil {
 		return p.exportMemoryFromFc(ctx, include, cachePath, blockSize)
+	}
+	if bgCopy {
+		return block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
 	}
 
 	return block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1129,6 +1129,9 @@ func (s *Sandbox) Pause(
 	}
 	recordSnapshotDiff(ctx, "memfile", memfileDiffMetadata, originalMemfile.Header(), useCase)
 
+	memfd := s.memory.Memfd(ctx)
+	bgCopy := memfd != nil && s.featureFlags.BoolFlag(ctx, featureflags.MemfdBackgroundCopyFlag, sandboxLDContext(s.Runtime, s.Config))
+
 	// Start POSTPROCESSING
 	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
 		ctx,
@@ -1137,7 +1140,8 @@ func (s *Sandbox) Pause(
 		memfileDiffMetadata,
 		s.config.DefaultCacheDir,
 		s.process,
-		s.memory.Memfd(ctx),
+		memfd,
+		bgCopy,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1206,13 +1210,14 @@ func pauseProcessMemory(
 	cacheDir string,
 	fc *fc.Process,
 	memfd *block.Memfd,
+	bgCopy bool,
 ) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
 	// ExportMemory owns memfd and closes it on all paths.
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
-	cache, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd)
+	cache, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd, bgCopy)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
 	}

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -127,6 +127,13 @@ var (
 	// directly instead of using process_vm_readv on pause.
 	UseMemFdFlag = NewBoolFlag("use-memfd", false)
 
+	// MemfdBackgroundCopyFlag asks pauseProcessMemory to copy memfd → diff
+	// cache on a background goroutine, letting Pause return as soon as
+	// snapfile + diff metadata are written. Reads of in-flight diff bytes
+	// demand-page from memfd; readers of the on-disk file (snapshot upload)
+	// wait. Requires UseMemFdFlag.
+	MemfdBackgroundCopyFlag = NewBoolFlag("memfd-background-copy", false)
+
 	// PeerToPeerChunkTransferFlag enables peer-to-peer chunk routing.
 	PeerToPeerChunkTransferFlag = NewBoolFlag("peer-to-peer-chunk-transfer", false)
 	// PeerToPeerAsyncCheckpointFlag makes Checkpoint upload fire-and-forget instead


### PR DESCRIPTION
Alternative to #2626 with the same async pause but in-flight reads — no
Wait on the read path.

ReadAt/Slice demand-page the requested range from memfd into the cache
file if runCopy hasn't reached it yet, then return the cache mmap slice.
runCopy skips already-cached ranges. The memfd is closed at end of copy;
returned slices stay valid (they point at the cache file mmap, not the
memfd).

Only direct readers of the on-disk file (CachePath, e.g. snapshot
upload) still Wait. Lets a follow-up sandbox resume from a just-paused
snapshot without blocking on the upload.

Gated by MemfdBackgroundCopyFlag; requires UseMemFdFlag (#2522).