### PR TITLE
feat(prefetch): cap memory prefetch at MemoryPrefetchMaxBytes per resume

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
@@ -91,6 +91,23 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 	maxCopyWorkers := p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxCopyWorkers)
 
 	blockSize := p.mapping.BlockSize
+
+	// Cap the total bytes we'll prefetch. Prefetch is access-order so this keeps the
+	// most useful pages and drops the long tail — under high concurrency a 10 GiB
+	// prefetch list would burn the per-region GCS egress budget for no marginal
+	// benefit (the guest only re-touches a small working set on resume).
+	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxBytes)); maxBytes > 0 && blockSize > 0 {
+		maxBlocks := maxBytes / blockSize
+		if maxBlocks > 0 && int64(len(indices)) > maxBlocks {
+			p.logger.Info(ctx, "prefetch: capping mapping to byte budget",
+				zap.Int64("max_bytes", maxBytes),
+				zap.Int("original_pages", len(indices)),
+				zap.Int64("capped_pages", maxBlocks),
+			)
+			indices = indices[:maxBlocks]
+		}
+	}
+
 	totalPages := len(indices)
 
 	span.SetAttributes(

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
@@ -92,13 +92,9 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 
 	blockSize := p.mapping.BlockSize
 
-	// Cap the total bytes we'll prefetch. Prefetch is access-order so this keeps the
-	// most useful pages and drops the long tail — under high concurrency a 10 GiB
-	// prefetch list would burn the per-region GCS egress budget for no marginal
-	// benefit (the guest only re-touches a small working set on resume).
+	// Cap total bytes prefetched (mapping is access-ordered, so we keep the prefix).
 	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxBytes)); maxBytes > 0 && blockSize > 0 {
-		maxBlocks := maxBytes / blockSize
-		if maxBlocks > 0 && int64(len(indices)) > maxBlocks {
+		if maxBlocks := maxBytes / blockSize; maxBlocks > 0 && int64(len(indices)) > maxBlocks {
 			p.logger.Info(ctx, "prefetch: capping mapping to byte budget",
 				zap.Int64("max_bytes", maxBytes),
 				zap.Int("original_pages", len(indices)),

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -183,6 +183,12 @@ var (
 	// Copy uses uffd syscalls, so we limit parallelism to avoid overwhelming the system.
 	MemoryPrefetchMaxCopyWorkers = NewIntFlag("memory-prefetch-max-copy-workers", 8)
 
+	// MemoryPrefetchMaxBytes caps the total memory bytes prefetched per sandbox resume.
+	// Mostly a guardrail against snapshots whose prefetch mappings grew larger than the
+	// per-resume GCS bandwidth budget can absorb (e.g. a build that walked 10 GiB of pages
+	// during optimize). 0 disables the cap.
+	MemoryPrefetchMaxBytes = NewIntFlag("memory-prefetch-max-bytes", 1024*1024*1024)
+
 	// TCPFirewallMaxConnectionsPerSandbox is the maximum number of concurrent TCP firewall
 	// connections allowed per sandbox. Negative means no limit.
 	TCPFirewallMaxConnectionsPerSandbox = NewIntFlag("tcpfirewall-max-connections-per-sandbox", -1)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -183,10 +183,7 @@ var (
 	// Copy uses uffd syscalls, so we limit parallelism to avoid overwhelming the system.
 	MemoryPrefetchMaxCopyWorkers = NewIntFlag("memory-prefetch-max-copy-workers", 8)
 
-	// MemoryPrefetchMaxBytes caps the total memory bytes prefetched per sandbox resume.
-	// Mostly a guardrail against snapshots whose prefetch mappings grew larger than the
-	// per-resume GCS bandwidth budget can absorb (e.g. a build that walked 10 GiB of pages
-	// during optimize). 0 disables the cap.
+	// MemoryPrefetchMaxBytes caps total bytes per memory prefetch run. 0 disables.
 	MemoryPrefetchMaxBytes = NewIntFlag("memory-prefetch-max-bytes", 1024*1024*1024)
 
 	// TCPFirewallMaxConnectionsPerSandbox is the maximum number of concurrent TCP firewall


### PR DESCRIPTION
Cap memory prefetch at `memory-prefetch-max-bytes` (default 1 GiB). Truncates the access-ordered mapping.