### PR TITLE
feat(prefetch): collect & replay rootfs prefetch alongside memory prefetch

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/tracking_device.go
+++ b/packages/orchestrator/pkg/sandbox/block/tracking_device.go
@@ -21,11 +21,13 @@ func NewTrackingReadonlyDevice(inner ReadonlyDevice, tracker *PrefetchTracker) *
 
 func (t *TrackingReadonlyDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	t.tracker.Add(off, Read)
+
 	return t.inner.ReadAt(ctx, p, off)
 }
 
 func (t *TrackingReadonlyDevice) Slice(ctx context.Context, off, length int64) ([]byte, error) {
 	t.tracker.Add(off, Read)
+
 	return t.inner.Slice(ctx, off, length)
 }
 

--- a/packages/orchestrator/pkg/sandbox/block/tracking_device.go
+++ b/packages/orchestrator/pkg/sandbox/block/tracking_device.go
@@ -8,13 +8,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
-// TrackingReadonlyDevice wraps a ReadonlyDevice and records each read offset
-// into a PrefetchTracker. Used on the rootfs source during build's optimize
-// phase (and during Checkpoint) to capture the workload-derived read pattern
-// that the prefetcher then warms on subsequent resumes.
-//
-// The tracker is shared with the surrounding code; this wrapper only adds
-// observation.
+// TrackingReadonlyDevice records each read offset into a PrefetchTracker
+// and forwards calls to the underlying ReadonlyDevice.
 type TrackingReadonlyDevice struct {
 	inner   ReadonlyDevice
 	tracker *PrefetchTracker
@@ -26,38 +21,17 @@ func NewTrackingReadonlyDevice(inner ReadonlyDevice, tracker *PrefetchTracker) *
 
 func (t *TrackingReadonlyDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	t.tracker.Add(off, Read)
-
 	return t.inner.ReadAt(ctx, p, off)
 }
 
 func (t *TrackingReadonlyDevice) Slice(ctx context.Context, off, length int64) ([]byte, error) {
 	t.tracker.Add(off, Read)
-
 	return t.inner.Slice(ctx, off, length)
 }
 
-func (t *TrackingReadonlyDevice) Size(ctx context.Context) (int64, error) {
-	return t.inner.Size(ctx)
-}
-
-func (t *TrackingReadonlyDevice) BlockSize() int64 {
-	return t.inner.BlockSize()
-}
-
-func (t *TrackingReadonlyDevice) Header() *header.Header {
-	return t.inner.Header()
-}
-
-func (t *TrackingReadonlyDevice) SwapHeader(h *header.Header) {
-	t.inner.SwapHeader(h)
-}
-
-func (t *TrackingReadonlyDevice) Close() error {
-	return t.inner.Close()
-}
-
-// PrefetchData returns the collected access pattern, suitable for
-// metadata.PrefetchEntriesToMapping.
-func (t *TrackingReadonlyDevice) PrefetchData() PrefetchData {
-	return t.tracker.PrefetchData()
-}
+func (t *TrackingReadonlyDevice) Size(ctx context.Context) (int64, error) { return t.inner.Size(ctx) }
+func (t *TrackingReadonlyDevice) BlockSize() int64                        { return t.inner.BlockSize() }
+func (t *TrackingReadonlyDevice) Header() *header.Header                  { return t.inner.Header() }
+func (t *TrackingReadonlyDevice) SwapHeader(h *header.Header)             { t.inner.SwapHeader(h) }
+func (t *TrackingReadonlyDevice) Close() error                            { return t.inner.Close() }
+func (t *TrackingReadonlyDevice) PrefetchData() PrefetchData              { return t.tracker.PrefetchData() }

--- a/packages/orchestrator/pkg/sandbox/block/tracking_device.go
+++ b/packages/orchestrator/pkg/sandbox/block/tracking_device.go
@@ -1,0 +1,63 @@
+//go:build linux
+
+package block
+
+import (
+	"context"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// TrackingReadonlyDevice wraps a ReadonlyDevice and records each read offset
+// into a PrefetchTracker. Used on the rootfs source during build's optimize
+// phase (and during Checkpoint) to capture the workload-derived read pattern
+// that the prefetcher then warms on subsequent resumes.
+//
+// The tracker is shared with the surrounding code; this wrapper only adds
+// observation.
+type TrackingReadonlyDevice struct {
+	inner   ReadonlyDevice
+	tracker *PrefetchTracker
+}
+
+func NewTrackingReadonlyDevice(inner ReadonlyDevice, tracker *PrefetchTracker) *TrackingReadonlyDevice {
+	return &TrackingReadonlyDevice{inner: inner, tracker: tracker}
+}
+
+func (t *TrackingReadonlyDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	t.tracker.Add(off, Read)
+
+	return t.inner.ReadAt(ctx, p, off)
+}
+
+func (t *TrackingReadonlyDevice) Slice(ctx context.Context, off, length int64) ([]byte, error) {
+	t.tracker.Add(off, Read)
+
+	return t.inner.Slice(ctx, off, length)
+}
+
+func (t *TrackingReadonlyDevice) Size(ctx context.Context) (int64, error) {
+	return t.inner.Size(ctx)
+}
+
+func (t *TrackingReadonlyDevice) BlockSize() int64 {
+	return t.inner.BlockSize()
+}
+
+func (t *TrackingReadonlyDevice) Header() *header.Header {
+	return t.inner.Header()
+}
+
+func (t *TrackingReadonlyDevice) SwapHeader(h *header.Header) {
+	t.inner.SwapHeader(h)
+}
+
+func (t *TrackingReadonlyDevice) Close() error {
+	return t.inner.Close()
+}
+
+// PrefetchData returns the collected access pattern, suitable for
+// metadata.PrefetchEntriesToMapping.
+func (t *TrackingReadonlyDevice) PrefetchData() PrefetchData {
+	return t.tracker.PrefetchData()
+}

--- a/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
@@ -49,7 +49,7 @@ func (p *Prefetcher) Start(ctx context.Context) {
 	indices := p.mapping.Indices
 	blockSize := p.mapping.BlockSize
 
-	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxBytes)); maxBytes > 0 {
+	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.RootfsPrefetchMaxBytes)); maxBytes > 0 {
 		if maxBlocks := maxBytes / blockSize; maxBlocks > 0 && int64(len(indices)) > maxBlocks {
 			indices = indices[:maxBlocks]
 		}

--- a/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
@@ -75,6 +75,7 @@ func (p *Prefetcher) Start(ctx context.Context) {
 			for off := range jobs {
 				if _, err := p.source.Slice(ctx, off, blockSize); err != nil {
 					failed.Add(1)
+
 					continue
 				}
 				fetched.Add(1)
@@ -82,9 +83,11 @@ func (p *Prefetcher) Start(ctx context.Context) {
 		})
 	}
 
+producer:
 	for _, idx := range indices {
 		select {
 		case <-ctx.Done():
+			break producer
 		case jobs <- header.BlockOffset(int64(idx), blockSize):
 		}
 	}

--- a/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
@@ -1,0 +1,113 @@
+//go:build linux
+
+package rootfs
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/metadata"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// Prefetcher walks a workload-derived prefetch mapping for the rootfs source
+// and issues Slice calls so the chunker cache is warm before the guest
+// demands the same blocks via NBD. Unlike the memory prefetcher there is no
+// copy / prefault phase — populating the source's cache is enough; NBD
+// reads on those blocks hit the warm cache directly.
+type Prefetcher struct {
+	logger       logger.Logger
+	source       block.Slicer
+	mapping      *metadata.MemoryPrefetchMapping
+	featureFlags *featureflags.Client
+}
+
+func NewPrefetcher(
+	log logger.Logger,
+	source block.Slicer,
+	mapping *metadata.MemoryPrefetchMapping,
+	flags *featureflags.Client,
+) *Prefetcher {
+	return &Prefetcher{logger: log, source: source, mapping: mapping, featureFlags: flags}
+}
+
+// Start runs the prefetcher to completion or until ctx is cancelled.
+// Fire-and-forget — errors are logged at debug.
+func (p *Prefetcher) Start(ctx context.Context) {
+	if p.mapping == nil {
+		return
+	}
+	indices := p.mapping.Indices
+	if len(indices) == 0 {
+		return
+	}
+
+	ctx = storage.WithSkipCacheWriteback(ctx)
+	ctx, span := tracer.Start(ctx, "rootfs-prefetch")
+	defer span.End()
+
+	blockSize := p.mapping.BlockSize
+	if blockSize <= 0 {
+		return
+	}
+
+	// Apply the same byte cap the memory prefetcher uses so a runaway
+	// mapping cannot blow the per-resume bandwidth budget.
+	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxBytes)); maxBytes > 0 {
+		maxBlocks := maxBytes / blockSize
+		if maxBlocks > 0 && int64(len(indices)) > maxBlocks {
+			indices = indices[:maxBlocks]
+		}
+	}
+
+	maxWorkers := p.featureFlags.IntFlag(ctx, featureflags.RootfsPrefetchMaxWorkers)
+	if maxWorkers <= 0 {
+		return
+	}
+
+	span.SetAttributes(
+		attribute.Int("rootfs.prefetch.total_blocks", len(indices)),
+		attribute.Int("rootfs.prefetch.workers", maxWorkers),
+		attribute.Int64("rootfs.prefetch.block_size", blockSize),
+	)
+
+	jobs := make(chan int64, maxWorkers)
+	var fetched, failed atomic.Int64
+
+	var wg sync.WaitGroup
+	for range maxWorkers {
+		wg.Go(func() {
+			for off := range jobs {
+				if _, err := p.source.Slice(ctx, off, blockSize); err != nil {
+					failed.Add(1)
+
+					continue
+				}
+				fetched.Add(1)
+			}
+		})
+	}
+
+	for _, idx := range indices {
+		select {
+		case <-ctx.Done():
+		case jobs <- header.BlockOffset(int64(idx), blockSize):
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	p.logger.Debug(ctx, "rootfs prefetch completed",
+		zap.Int64("fetched", fetched.Load()),
+		zap.Int64("failed", failed.Load()),
+		zap.Int("total", len(indices)),
+	)
+}

--- a/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/prefetch.go
@@ -18,11 +18,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
-// Prefetcher walks a workload-derived prefetch mapping for the rootfs source
-// and issues Slice calls so the chunker cache is warm before the guest
-// demands the same blocks via NBD. Unlike the memory prefetcher there is no
-// copy / prefault phase — populating the source's cache is enough; NBD
-// reads on those blocks hit the warm cache directly.
+// Prefetcher warms the rootfs chunker cache by issuing Slice calls against
+// the prefetch mapping. No copy phase: populating the chunker cache is
+// enough; subsequent NBD reads hit it.
 type Prefetcher struct {
 	logger       logger.Logger
 	source       block.Slicer
@@ -39,14 +37,8 @@ func NewPrefetcher(
 	return &Prefetcher{logger: log, source: source, mapping: mapping, featureFlags: flags}
 }
 
-// Start runs the prefetcher to completion or until ctx is cancelled.
-// Fire-and-forget — errors are logged at debug.
 func (p *Prefetcher) Start(ctx context.Context) {
-	if p.mapping == nil {
-		return
-	}
-	indices := p.mapping.Indices
-	if len(indices) == 0 {
+	if p.mapping == nil || len(p.mapping.Indices) == 0 || p.mapping.BlockSize <= 0 {
 		return
 	}
 
@@ -54,16 +46,11 @@ func (p *Prefetcher) Start(ctx context.Context) {
 	ctx, span := tracer.Start(ctx, "rootfs-prefetch")
 	defer span.End()
 
+	indices := p.mapping.Indices
 	blockSize := p.mapping.BlockSize
-	if blockSize <= 0 {
-		return
-	}
 
-	// Apply the same byte cap the memory prefetcher uses so a runaway
-	// mapping cannot blow the per-resume bandwidth budget.
 	if maxBytes := int64(p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxBytes)); maxBytes > 0 {
-		maxBlocks := maxBytes / blockSize
-		if maxBlocks > 0 && int64(len(indices)) > maxBlocks {
+		if maxBlocks := maxBytes / blockSize; maxBlocks > 0 && int64(len(indices)) > maxBlocks {
 			indices = indices[:maxBlocks]
 		}
 	}
@@ -88,7 +75,6 @@ func (p *Prefetcher) Start(ctx context.Context) {
 			for off := range jobs {
 				if _, err := p.source.Slice(ctx, off, blockSize); err != nil {
 					failed.Add(1)
-
 					continue
 				}
 				fetched.Add(1)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -625,11 +625,6 @@ func (f *Factory) ResumeSandbox(
 
 	// Prefetching
 	go func() {
-		memfile, err := t.Memfile(ctx)
-		if err != nil {
-			return
-		}
-
 		meta, err := t.Metadata()
 		if err != nil {
 			return
@@ -637,37 +632,29 @@ func (f *Factory) ResumeSandbox(
 
 		telemetry.ReportEvent(ctx, "got metadata")
 
-		// Start background prefetcher as early as possible if prefetch mapping exists
-		// Fetching from source starts immediately; copying waits for uffd to be ready
+		l := logger.L().With(logger.WithSandboxID(runtime.SandboxID), logger.WithTemplateID(runtime.TemplateID), logger.WithTeamID(runtime.TeamID))
+
+		// Memory prefetcher: must wait for uffd before copying pages in.
 		if meta.Prefetch != nil && meta.Prefetch.Memory != nil {
-			fcUffd, err := uffdPromise.Wait(ctx)
-			if err != nil {
-				return
+			memfile, err := t.Memfile(ctx)
+			if err == nil {
+				go func() {
+					fcUffd, err := uffdPromise.Wait(ctx)
+					if err != nil {
+						return
+					}
+					telemetry.ReportEvent(ctx, "starting prefetcher")
+					p := prefetch.New(l, memfile, fcUffd, meta.Prefetch.Memory, f.featureFlags)
+					if err := p.Start(execCtx); err != nil {
+						l.Error(ctx, "failed to start prefetcher", zap.Error(err))
+					}
+				}()
 			}
-
-			telemetry.ReportEvent(ctx, "starting prefetcher")
-			l := logger.L().With(logger.WithSandboxID(runtime.SandboxID), logger.WithTemplateID(runtime.TemplateID), logger.WithTeamID(runtime.TeamID))
-
-			go func() {
-				p := prefetch.New(
-					l,
-					memfile,
-					fcUffd,
-					meta.Prefetch.Memory,
-					f.featureFlags,
-				)
-				err := p.Start(execCtx)
-				if err != nil {
-					l.Error(ctx, "failed to start prefetcher", zap.Error(err))
-				}
-			}()
 		}
 
-		// Background rootfs prefetcher; fetches only (no UFFD copy).
+		// Rootfs prefetcher: independent of uffd; warms the chunker cache only.
 		if meta.Prefetch != nil && meta.Prefetch.Rootfs != nil {
-			rootfsDev, err := t.Rootfs()
-			if err == nil {
-				l := logger.L().With(logger.WithSandboxID(runtime.SandboxID), logger.WithTemplateID(runtime.TemplateID), logger.WithTeamID(runtime.TeamID))
+			if rootfsDev, err := t.Rootfs(); err == nil {
 				go rootfs.NewPrefetcher(l, rootfsDev, meta.Prefetch.Rootfs, f.featureFlags).Start(execCtx)
 			}
 		}
@@ -1209,6 +1196,7 @@ func (s *Sandbox) RootfsPrefetchData() block.PrefetchData {
 	if s.Resources == nil || s.Resources.rootfsTracker == nil {
 		return block.PrefetchData{}
 	}
+
 	return s.Resources.rootfsTracker.PrefetchData()
 }
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -188,10 +188,7 @@ type Resources struct {
 	rootfs rootfs.Provider
 	memory uffd.MemoryBackend
 
-	// rootfsTracker observes reads against the rootfs source so that build
-	// optimize / Checkpoint can collect a workload-derived rootfs prefetch
-	// mapping (parallel to the UFFD-side memory prefetch tracker). Always
-	// allocated; ignored by code paths that don't query it.
+	// rootfsTracker collects reads against the rootfs source for prefetch capture.
 	rootfsTracker *block.PrefetchTracker
 }
 
@@ -666,9 +663,7 @@ func (f *Factory) ResumeSandbox(
 			}()
 		}
 
-		// Background rootfs prefetcher — fetches blocks the build/optimize phase
-		// observed the guest reading, so the chunker cache is warm by the time
-		// the guest demands them via NBD. Fetch-only; no UFFD copy phase.
+		// Background rootfs prefetcher; fetches only (no UFFD copy).
 		if meta.Prefetch != nil && meta.Prefetch.Rootfs != nil {
 			rootfsDev, err := t.Rootfs()
 			if err == nil {
@@ -681,10 +676,6 @@ func (f *Factory) ResumeSandbox(
 	// Slot initialization
 	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased)
 
-	// rootfsTracker observes reads against the rootfs source so a subsequent
-	// Checkpoint can collect a workload-derived rootfs prefetch mapping. We
-	// always create the tracker — it's cheap — but PrefetchData is only
-	// queried when needed.
 	var rootfsTracker *block.PrefetchTracker
 
 	// Rootfs initialization
@@ -1213,14 +1204,11 @@ func (s *Sandbox) FlushAndReadBalloonMetrics(ctx context.Context) (fc.BalloonMet
 	return s.process.FlushAndReadBalloonMetrics(ctx)
 }
 
-// RootfsPrefetchData returns the ordered rootfs read access data for prefetch
-// mapping. Empty if the rootfs source wasn't wrapped in a tracking shim
-// (e.g. paths that don't run the optimize phase).
+// RootfsPrefetchData returns the rootfs read access data collected during this run.
 func (s *Sandbox) RootfsPrefetchData() block.PrefetchData {
 	if s.Resources == nil || s.Resources.rootfsTracker == nil {
 		return block.PrefetchData{}
 	}
-
 	return s.Resources.rootfsTracker.PrefetchData()
 }
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -187,6 +187,12 @@ type Resources struct {
 	Slot   *network.Slot
 	rootfs rootfs.Provider
 	memory uffd.MemoryBackend
+
+	// rootfsTracker observes reads against the rootfs source so that build
+	// optimize / Checkpoint can collect a workload-derived rootfs prefetch
+	// mapping (parallel to the UFFD-side memory prefetch tracker). Always
+	// allocated; ignored by code paths that don't query it.
+	rootfsTracker *block.PrefetchTracker
 }
 
 type internalConfig struct {
@@ -361,6 +367,8 @@ func (f *Factory) CreateSandbox(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rootfs: %w", err)
 	}
+	rootfsTracker := block.NewPrefetchTracker(rootFS.BlockSize())
+	rootFS = block.NewTrackingReadonlyDevice(rootFS, rootfsTracker)
 
 	var rootfsProvider rootfs.Provider
 	if rootfsCachePath == "" {
@@ -447,9 +455,10 @@ func (f *Factory) CreateSandbox(
 	telemetry.ReportEvent(ctx, "created fc client")
 
 	resources := &Resources{
-		Slot:   ips,
-		rootfs: rootfsProvider,
-		memory: uffd.NewNoopMemory(memfileSize, memfile.BlockSize()),
+		Slot:          ips,
+		rootfs:        rootfsProvider,
+		rootfsTracker: rootfsTracker,
+		memory:        uffd.NewNoopMemory(memfileSize, memfile.BlockSize()),
 	}
 
 	metadata := &Metadata{
@@ -656,10 +665,27 @@ func (f *Factory) ResumeSandbox(
 				}
 			}()
 		}
+
+		// Background rootfs prefetcher — fetches blocks the build/optimize phase
+		// observed the guest reading, so the chunker cache is warm by the time
+		// the guest demands them via NBD. Fetch-only; no UFFD copy phase.
+		if meta.Prefetch != nil && meta.Prefetch.Rootfs != nil {
+			rootfsDev, err := t.Rootfs()
+			if err == nil {
+				l := logger.L().With(logger.WithSandboxID(runtime.SandboxID), logger.WithTemplateID(runtime.TemplateID), logger.WithTeamID(runtime.TeamID))
+				go rootfs.NewPrefetcher(l, rootfsDev, meta.Prefetch.Rootfs, f.featureFlags).Start(execCtx)
+			}
+		}
 	}()
 
 	// Slot initialization
 	ipsPromise := getNetworkSlot(ctx, f.networkPool, cleanup, config.Network, f.Sandboxes.NetworkReleased)
+
+	// rootfsTracker observes reads against the rootfs source so a subsequent
+	// Checkpoint can collect a workload-derived rootfs prefetch mapping. We
+	// always create the tracker — it's cheap — but PrefetchData is only
+	// queried when needed.
+	var rootfsTracker *block.PrefetchTracker
 
 	// Rootfs initialization
 	overlayPromise := utils.NewPromise(func() (rootfs.Provider, error) {
@@ -667,6 +693,8 @@ func (f *Factory) ResumeSandbox(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get rootfs: %w", err)
 		}
+		rootfsTracker = block.NewPrefetchTracker(readonlyRootfs.BlockSize())
+		readonlyRootfs = block.NewTrackingReadonlyDevice(readonlyRootfs, rootfsTracker)
 
 		telemetry.ReportEvent(ctx, "got template rootfs")
 
@@ -792,9 +820,10 @@ func (f *Factory) ResumeSandbox(
 	}
 
 	resources := &Resources{
-		Slot:   ips,
-		rootfs: overlay,
-		memory: fcUffd,
+		Slot:          ips,
+		rootfs:        overlay,
+		rootfsTracker: rootfsTracker,
+		memory:        fcUffd,
 	}
 
 	metadata := &Metadata{
@@ -1182,6 +1211,17 @@ func (s *Sandbox) Pause(
 // updated cumulative virtio-balloon counters. Used by the FPH bench.
 func (s *Sandbox) FlushAndReadBalloonMetrics(ctx context.Context) (fc.BalloonMetricsSnapshot, error) {
 	return s.process.FlushAndReadBalloonMetrics(ctx)
+}
+
+// RootfsPrefetchData returns the ordered rootfs read access data for prefetch
+// mapping. Empty if the rootfs source wasn't wrapped in a tracking shim
+// (e.g. paths that don't run the optimize phase).
+func (s *Sandbox) RootfsPrefetchData() block.PrefetchData {
+	if s.Resources == nil || s.Resources.rootfsTracker == nil {
+		return block.PrefetchData{}
+	}
+
+	return s.Resources.rootfsTracker.PrefetchData()
 }
 
 // MemoryPrefetchData returns the ordered page fault data for prefetch mapping.

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -640,21 +640,30 @@ func (s *Server) Checkpoint(ctx context.Context, in *orchestrator.SandboxCheckpo
 	if prefetchErr != nil {
 		sbxlogger.I(resumedSbx).Warn(ctx, "failed to get prefetch data for checkpoint", zap.Error(prefetchErr))
 	}
+	rootfsPrefetchData := resumedSbx.RootfsPrefetchData()
 
 	// Setup lifecycle for the resumed sandbox
 	s.setupSandboxLifecycle(ctx, resumedSbx)
 
 	// Embed prefetch data into the metadata so it's uploaded with the snapshot files in a single pass.
+	var (
+		memoryMapping *metadata.MemoryPrefetchMapping
+		rootfsMapping *metadata.MemoryPrefetchMapping
+	)
 	if prefetchErr == nil {
-		prefetchMapping := metadata.PrefetchEntriesToMapping(slices.Collect(maps.Values(prefetchData.BlockEntries)), prefetchData.BlockSize)
-		if prefetchMapping != nil {
-			res.meta = res.meta.WithPrefetch(&metadata.Prefetch{
-				Memory: prefetchMapping,
-			})
+		memoryMapping = metadata.PrefetchEntriesToMapping(slices.Collect(maps.Values(prefetchData.BlockEntries)), prefetchData.BlockSize)
+	}
+	if len(rootfsPrefetchData.BlockEntries) > 0 {
+		rootfsMapping = metadata.PrefetchEntriesToMapping(slices.Collect(maps.Values(rootfsPrefetchData.BlockEntries)), rootfsPrefetchData.BlockSize)
+	}
+	if memoryMapping != nil || rootfsMapping != nil {
+		res.meta = res.meta.WithPrefetch(&metadata.Prefetch{
+			Memory: memoryMapping,
+			Rootfs: rootfsMapping,
+		})
 
-			if err := s.templateCache.UpdateMetadata(in.GetBuildId(), res.meta); err != nil {
-				sbxlogger.I(resumedSbx).Warn(ctx, "failed to update local metadata with prefetch", zap.Error(err))
-			}
+		if err := s.templateCache.UpdateMetadata(in.GetBuildId(), res.meta); err != nil {
+			sbxlogger.I(resumedSbx).Warn(ctx, "failed to update local metadata with prefetch", zap.Error(err))
 		}
 	}
 

--- a/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
@@ -134,7 +134,7 @@ func (pb *OptimizeBuilder) Build(
 	}
 
 	// Resume the sandbox from the finalize snapshot
-	memoryPrefetchMapping, err := pb.collectMemoryPrefetchMapping(ctx, localTemplate)
+	memoryPrefetchMapping, rootfsPrefetchMapping, err := pb.collectPrefetchMappings(ctx, localTemplate)
 	if err != nil {
 		// Log but don't fail the build - prefetch is an optimization
 		pb.logger.Warn(ctx, "failed to collect prefetch mapping, continuing without prefetch",
@@ -148,9 +148,10 @@ func (pb *OptimizeBuilder) Build(
 		}, nil
 	}
 
-	// Update metadata with prefetch mapping
+	// Update metadata with prefetch mappings (memory + rootfs).
 	updatedMetadata := sourceLayer.Metadata.WithPrefetch(&metadata.Prefetch{
 		Memory: memoryPrefetchMapping,
+		Rootfs: rootfsPrefetchMapping,
 	})
 
 	// Upload the updated metadata
@@ -181,10 +182,10 @@ func (pb *OptimizeBuilder) Build(
 	}, nil
 }
 
-func (pb *OptimizeBuilder) collectMemoryPrefetchMapping(
+func (pb *OptimizeBuilder) collectPrefetchMappings(
 	ctx context.Context,
 	localTemplate sbxtemplate.Template,
-) (*metadata.MemoryPrefetchMapping, error) {
+) (*metadata.MemoryPrefetchMapping, *metadata.MemoryPrefetchMapping, error) {
 	ctx, span := tracer.Start(ctx, "collect prefetch-mapping")
 	defer span.End()
 
@@ -207,53 +208,71 @@ func (pb *OptimizeBuilder) collectMemoryPrefetchMapping(
 	// Create sandbox creator for resuming
 	sandboxCreator := layer.NewResumeSandbox(sbxConfig, pb.sandboxFactory, prefetchTimeout)
 
-	// Run sandbox multiple times and collect prefetch data
-	var allPrefetchData []block.PrefetchData
+	// Run sandbox multiple times and collect prefetch data for both surfaces
+	var allMemory, allRootfs []block.PrefetchData
 	for i := range prefetchIterations {
 		pb.logger.Debug(ctx, fmt.Sprintf("starting sandbox run %d/%d for prefetch collection", i+1, prefetchIterations))
-		prefetchData, err := pb.runSandboxAndCollectPrefetch(ctx, sandboxCreator, localTemplate)
+		memData, rootfsData, err := pb.runSandboxAndCollectPrefetch(ctx, sandboxCreator, localTemplate)
 		if err != nil {
-			return nil, fmt.Errorf("failed to collect prefetch data from run %d: %w", i+1, err)
+			return nil, nil, fmt.Errorf("failed to collect prefetch data from run %d: %w", i+1, err)
 		}
-		allPrefetchData = append(allPrefetchData, prefetchData)
+		allMemory = append(allMemory, memData)
+		allRootfs = append(allRootfs, rootfsData)
 	}
 
-	// Compute intersection with average order across all runs
-	commonEntries := computeCommonPrefetchEntries(allPrefetchData)
-
-	if len(commonEntries) == 0 {
-		pb.logger.Debug(ctx, "no common blocks found for prefetch mapping")
-
-		return nil, nil
-	}
+	memoryMapping := mappingFromRuns(allMemory)
+	rootfsMapping := mappingFromRuns(allRootfs)
 
 	span.SetAttributes(
 		attribute.Int64("prefetch_iterations", int64(prefetchIterations)),
-		attribute.Int64("prefetch_blocks_common", int64(len(commonEntries))),
-		attribute.Int64("block_size", allPrefetchData[0].BlockSize),
+		attribute.Int("prefetch_memory_blocks", lenIndices(memoryMapping)),
+		attribute.Int("prefetch_rootfs_blocks", lenIndices(rootfsMapping)),
 	)
 
-	return metadata.PrefetchEntriesToMapping(commonEntries, allPrefetchData[0].BlockSize), nil
+	return memoryMapping, rootfsMapping, nil
 }
 
-// runSandboxAndCollectPrefetch runs a sandbox and collects the prefetch data.
+// mappingFromRuns intersects PrefetchData across N runs and returns the
+// derived mapping. Returns nil when nothing common was seen.
+func mappingFromRuns(runs []block.PrefetchData) *metadata.MemoryPrefetchMapping {
+	if len(runs) == 0 || runs[0].BlockSize == 0 {
+		return nil
+	}
+	common := computeCommonPrefetchEntries(runs)
+	if len(common) == 0 {
+		return nil
+	}
+
+	return metadata.PrefetchEntriesToMapping(common, runs[0].BlockSize)
+}
+
+func lenIndices(m *metadata.MemoryPrefetchMapping) int {
+	if m == nil {
+		return 0
+	}
+
+	return len(m.Indices)
+}
+
+// runSandboxAndCollectPrefetch runs a sandbox and collects both memory and
+// rootfs prefetch data observed during the run.
 func (pb *OptimizeBuilder) runSandboxAndCollectPrefetch(
 	ctx context.Context,
 	sandboxCreator *layer.ResumeSandbox,
 	localTemplate sbxtemplate.Template,
-) (block.PrefetchData, error) {
+) (block.PrefetchData, block.PrefetchData, error) {
 	sbx, err := sandboxCreator.Sandbox(ctx, pb.layerExecutor, localTemplate)
 	if err != nil {
-		return block.PrefetchData{}, fmt.Errorf("failed to resume sandbox: %w", err)
+		return block.PrefetchData{}, block.PrefetchData{}, fmt.Errorf("failed to resume sandbox: %w", err)
 	}
 	defer sbx.Close(ctx)
 
-	prefetchData, err := sbx.MemoryPrefetchData(ctx)
+	memData, err := sbx.MemoryPrefetchData(ctx)
 	if err != nil {
-		return block.PrefetchData{}, fmt.Errorf("failed to get prefetch data: %w", err)
+		return block.PrefetchData{}, block.PrefetchData{}, fmt.Errorf("failed to get memory prefetch data: %w", err)
 	}
 
-	return prefetchData, nil
+	return memData, sbx.RootfsPrefetchData(), nil
 }
 
 // updateMetadata updates the template metadata in storages.

--- a/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/optimize/builder.go
@@ -232,8 +232,7 @@ func (pb *OptimizeBuilder) collectPrefetchMappings(
 	return memoryMapping, rootfsMapping, nil
 }
 
-// mappingFromRuns intersects PrefetchData across N runs and returns the
-// derived mapping. Returns nil when nothing common was seen.
+// mappingFromRuns intersects PrefetchData across N runs.
 func mappingFromRuns(runs []block.PrefetchData) *metadata.MemoryPrefetchMapping {
 	if len(runs) == 0 || runs[0].BlockSize == 0 {
 		return nil
@@ -254,8 +253,7 @@ func lenIndices(m *metadata.MemoryPrefetchMapping) int {
 	return len(m.Indices)
 }
 
-// runSandboxAndCollectPrefetch runs a sandbox and collects both memory and
-// rootfs prefetch data observed during the run.
+// runSandboxAndCollectPrefetch runs a sandbox and returns memory + rootfs prefetch data.
 func (pb *OptimizeBuilder) runSandboxAndCollectPrefetch(
 	ctx context.Context,
 	sandboxCreator *layer.ResumeSandbox,

--- a/packages/orchestrator/pkg/template/metadata/template_metadata.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata.go
@@ -177,6 +177,7 @@ func (t Template) WithRootfsPrefetch(rootfs *MemoryPrefetchMapping) Template {
 	pf.Rootfs = rootfs
 	out := t
 	out.Prefetch = &pf
+
 	return out
 }
 
@@ -189,6 +190,7 @@ func (t Template) WithMemoryPrefetch(memory *MemoryPrefetchMapping) Template {
 	pf.Memory = memory
 	out := t
 	out.Prefetch = &pf
+
 	return out
 }
 

--- a/packages/orchestrator/pkg/template/metadata/template_metadata.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata.go
@@ -101,9 +101,6 @@ func (p *MemoryPrefetchMapping) Count() int {
 
 type Prefetch struct {
 	Memory *MemoryPrefetchMapping `json:"memory"`
-	// Rootfs reuses MemoryPrefetchMapping's shape (offset / access type / block size)
-	// for the rootfs source. The prefetcher just warms the chunker cache — no UFFD
-	// copy phase — so the access-type field is informational only there.
 	Rootfs *MemoryPrefetchMapping `json:"rootfs,omitempty"`
 }
 
@@ -171,8 +168,7 @@ func (t Template) WithPrefetch(prefetch *Prefetch) Template {
 	}
 }
 
-// WithRootfsPrefetch returns a copy of the template with the rootfs prefetch
-// mapping replaced. Preserves the existing Memory mapping if any.
+// WithRootfsPrefetch replaces the rootfs prefetch mapping, preserving Memory.
 func (t Template) WithRootfsPrefetch(rootfs *MemoryPrefetchMapping) Template {
 	var pf Prefetch
 	if t.Prefetch != nil {
@@ -181,12 +177,10 @@ func (t Template) WithRootfsPrefetch(rootfs *MemoryPrefetchMapping) Template {
 	pf.Rootfs = rootfs
 	out := t
 	out.Prefetch = &pf
-
 	return out
 }
 
-// WithMemoryPrefetch returns a copy of the template with the memory prefetch
-// mapping replaced. Preserves the existing Rootfs mapping if any.
+// WithMemoryPrefetch replaces the memory prefetch mapping, preserving Rootfs.
 func (t Template) WithMemoryPrefetch(memory *MemoryPrefetchMapping) Template {
 	var pf Prefetch
 	if t.Prefetch != nil {
@@ -195,7 +189,6 @@ func (t Template) WithMemoryPrefetch(memory *MemoryPrefetchMapping) Template {
 	pf.Memory = memory
 	out := t
 	out.Prefetch = &pf
-
 	return out
 }
 

--- a/packages/orchestrator/pkg/template/metadata/template_metadata.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata.go
@@ -101,6 +101,10 @@ func (p *MemoryPrefetchMapping) Count() int {
 
 type Prefetch struct {
 	Memory *MemoryPrefetchMapping `json:"memory"`
+	// Rootfs reuses MemoryPrefetchMapping's shape (offset / access type / block size)
+	// for the rootfs source. The prefetcher just warms the chunker cache — no UFFD
+	// copy phase — so the access-type field is informational only there.
+	Rootfs *MemoryPrefetchMapping `json:"rootfs,omitempty"`
 }
 
 type Template struct {
@@ -165,6 +169,34 @@ func (t Template) WithPrefetch(prefetch *Prefetch) Template {
 		FromImage:    t.FromImage,
 		Prefetch:     prefetch,
 	}
+}
+
+// WithRootfsPrefetch returns a copy of the template with the rootfs prefetch
+// mapping replaced. Preserves the existing Memory mapping if any.
+func (t Template) WithRootfsPrefetch(rootfs *MemoryPrefetchMapping) Template {
+	var pf Prefetch
+	if t.Prefetch != nil {
+		pf = *t.Prefetch
+	}
+	pf.Rootfs = rootfs
+	out := t
+	out.Prefetch = &pf
+
+	return out
+}
+
+// WithMemoryPrefetch returns a copy of the template with the memory prefetch
+// mapping replaced. Preserves the existing Rootfs mapping if any.
+func (t Template) WithMemoryPrefetch(memory *MemoryPrefetchMapping) Template {
+	var pf Prefetch
+	if t.Prefetch != nil {
+		pf = *t.Prefetch
+	}
+	pf.Memory = memory
+	out := t
+	out.Prefetch = &pf
+
+	return out
 }
 
 func (t Template) ToFile(path string) error {

--- a/packages/orchestrator/pkg/template/metadata/template_metadata.go
+++ b/packages/orchestrator/pkg/template/metadata/template_metadata.go
@@ -168,32 +168,6 @@ func (t Template) WithPrefetch(prefetch *Prefetch) Template {
 	}
 }
 
-// WithRootfsPrefetch replaces the rootfs prefetch mapping, preserving Memory.
-func (t Template) WithRootfsPrefetch(rootfs *MemoryPrefetchMapping) Template {
-	var pf Prefetch
-	if t.Prefetch != nil {
-		pf = *t.Prefetch
-	}
-	pf.Rootfs = rootfs
-	out := t
-	out.Prefetch = &pf
-
-	return out
-}
-
-// WithMemoryPrefetch replaces the memory prefetch mapping, preserving Rootfs.
-func (t Template) WithMemoryPrefetch(memory *MemoryPrefetchMapping) Template {
-	var pf Prefetch
-	if t.Prefetch != nil {
-		pf = *t.Prefetch
-	}
-	pf.Memory = memory
-	out := t
-	out.Prefetch = &pf
-
-	return out
-}
-
 func (t Template) ToFile(path string) error {
 	mr, err := serialize(t)
 	if err != nil {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -183,14 +183,10 @@ var (
 	// Copy uses uffd syscalls, so we limit parallelism to avoid overwhelming the system.
 	MemoryPrefetchMaxCopyWorkers = NewIntFlag("memory-prefetch-max-copy-workers", 8)
 
-	// MemoryPrefetchMaxBytes caps total bytes a single prefetch run will fetch.
-	// Shared between the memory and rootfs prefetchers (each enforces it on its
-	// own mapping). 0 disables. Defaults to 1 GiB.
+	// MemoryPrefetchMaxBytes caps total bytes per prefetch run (memory + rootfs). 0 disables.
 	MemoryPrefetchMaxBytes = NewIntFlag("memory-prefetch-max-bytes", 1024*1024*1024)
 
 	// RootfsPrefetchMaxWorkers bounds parallelism of the rootfs prefetcher.
-	// Reads populate the chunker cache; we keep the default lower so the
-	// rootfs warm-up doesn't compete with the memory prefetcher.
 	RootfsPrefetchMaxWorkers = NewIntFlag("rootfs-prefetch-max-workers", 8)
 
 	// TCPFirewallMaxConnectionsPerSandbox is the maximum number of concurrent TCP firewall

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -183,6 +183,16 @@ var (
 	// Copy uses uffd syscalls, so we limit parallelism to avoid overwhelming the system.
 	MemoryPrefetchMaxCopyWorkers = NewIntFlag("memory-prefetch-max-copy-workers", 8)
 
+	// MemoryPrefetchMaxBytes caps total bytes a single prefetch run will fetch.
+	// Shared between the memory and rootfs prefetchers (each enforces it on its
+	// own mapping). 0 disables. Defaults to 1 GiB.
+	MemoryPrefetchMaxBytes = NewIntFlag("memory-prefetch-max-bytes", 1024*1024*1024)
+
+	// RootfsPrefetchMaxWorkers bounds parallelism of the rootfs prefetcher.
+	// Reads populate the chunker cache; we keep the default lower so the
+	// rootfs warm-up doesn't compete with the memory prefetcher.
+	RootfsPrefetchMaxWorkers = NewIntFlag("rootfs-prefetch-max-workers", 8)
+
 	// TCPFirewallMaxConnectionsPerSandbox is the maximum number of concurrent TCP firewall
 	// connections allowed per sandbox. Negative means no limit.
 	TCPFirewallMaxConnectionsPerSandbox = NewIntFlag("tcpfirewall-max-connections-per-sandbox", -1)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -183,8 +183,8 @@ var (
 	// Copy uses uffd syscalls, so we limit parallelism to avoid overwhelming the system.
 	MemoryPrefetchMaxCopyWorkers = NewIntFlag("memory-prefetch-max-copy-workers", 8)
 
-	// MemoryPrefetchMaxBytes caps total bytes per prefetch run (memory + rootfs). 0 disables.
-	MemoryPrefetchMaxBytes = NewIntFlag("memory-prefetch-max-bytes", 1024*1024*1024)
+	// RootfsPrefetchMaxBytes caps total bytes fetched per rootfs prefetch run. 0 disables.
+	RootfsPrefetchMaxBytes = NewIntFlag("rootfs-prefetch-max-bytes", 1024*1024*1024)
 
 	// RootfsPrefetchMaxWorkers bounds parallelism of the rootfs prefetcher.
 	RootfsPrefetchMaxWorkers = NewIntFlag("rootfs-prefetch-max-workers", 8)


### PR DESCRIPTION
Extend the workload-derived prefetch pipeline from memory to rootfs: tracker on the rootfs source records reads, build/optimize + Checkpoint persist a `Prefetch.Rootfs` mapping, resume replays it via `source.Slice` (no UFFD copy phase — the chunker is the cache).