### PR TITLE
feat(rootfs): blanket IPv4 PREROUTING DNAT to 127.0.0.1

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/e2b-ipv4-forward.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/e2b-ipv4-forward.service.tpl
@@ -1,0 +1,16 @@
+{{- /*gotype:github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs.templateModel*/ -}}
+{{ .WriteFile "/etc/systemd/system/e2b-ipv4-forward.service" 0o644 }}
+
+[Unit]
+Description=E2B IPv4 PREROUTING DNAT to 127.0.0.1
+After=network-pre.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c 'echo 1 > /proc/sys/net/ipv4/conf/all/route_localnet'
+ExecStart=/bin/sh -c 'iptables -t nat -C PREROUTING -i eth0 -p tcp -j DNAT --to-destination 127.0.0.1 2>/dev/null || iptables -t nat -A PREROUTING -i eth0 -p tcp -j DNAT --to-destination 127.0.0.1'
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -249,6 +249,8 @@ func additionalOCILayers(
 			"etc/systemd/system/multi-user.target.wants/envd.service": "etc/systemd/system/envd.service",
 			// Enable chrony service autostart
 			"etc/systemd/system/multi-user.target.wants/chrony.service": "etc/systemd/system/chrony.service",
+			// Enable blanket IPv4 PREROUTING DNAT to 127.0.0.1
+			"etc/systemd/system/multi-user.target.wants/e2b-ipv4-forward.service": "etc/systemd/system/e2b-ipv4-forward.service",
 		},
 	)
 	if err != nil {

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -90,7 +90,7 @@ func TestAdditionalOCILayers(t *testing.T) {
 
 		keysIter := maps.Keys(actualFiles)
 		keys := slices.Collect(keysIter)
-		assert.Len(t, keys, 14)
+		assert.Len(t, keys, 15)
 		assert.Equal(t, "e2b.local", actualFiles["etc/hostname"])
 		assert.Equal(t, "nameserver 8.8.8.8", actualFiles["etc/resolv.conf"])
 


### PR DESCRIPTION
Replaces the per-port socat path for IPv4 listeners with one provision-time iptables rule + sysctl:

\`\`\`
net.ipv4.conf.all.route_localnet=1
iptables -t nat -A PREROUTING -i eth0 -p tcp -j DNAT --to-destination 127.0.0.1
\`\`\`

Applied at boot by \`e2b-ipv4-forward.service\`. envd's scanner still tracks IPv6 listeners and keeps socat for those (no \`route_localnet\` for v6). Idempotent: \`iptables -C\` check before \`-A\`.

Supersedes #2697.