### PR TITLE
fix(envd): make /init lock ctx-aware to prevent retry pile-up

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -131,7 +131,6 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		select {
 		case a.initLock <- struct{}{}:
 		case <-ctx.Done():
-			logger.Warn().Err(ctx.Err()).Msg("Gave up waiting for initLock")
 			w.WriteHeader(http.StatusServiceUnavailable)
 
 			return

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -128,14 +128,12 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		// Safe because Destroy() is nil-safe and TakeFrom clears the source.
 		defer initRequest.AccessToken.Destroy()
 
-		select {
-		case a.initLock <- struct{}{}:
-		case <-ctx.Done():
+		if err := a.initLock.Acquire(ctx, 1); err != nil {
 			w.WriteHeader(http.StatusServiceUnavailable)
 
 			return
 		}
-		defer func() { <-a.initLock }()
+		defer a.initLock.Release(1)
 
 		// Update data only if the request is newer or if there's no timestamp at all
 		if initRequest.Timestamp == nil || a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano()) {

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -128,8 +128,15 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		// Safe because Destroy() is nil-safe and TakeFrom clears the source.
 		defer initRequest.AccessToken.Destroy()
 
-		a.initLock.Lock()
-		defer a.initLock.Unlock()
+		select {
+		case a.initLock <- struct{}{}:
+		case <-ctx.Done():
+			logger.Warn().Err(ctx.Err()).Msg("Gave up waiting for initLock")
+			w.WriteHeader(http.StatusServiceUnavailable)
+
+			return
+		}
+		defer func() { <-a.initLock }()
 
 		// Update data only if the request is newer or if there's no timestamp at all
 		if initRequest.Timestamp == nil || a.lastSetTime.SetToGreater(initRequest.Timestamp.UnixNano()) {

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -37,7 +37,9 @@ type API struct {
 	mmdsClient    MMDSClient
 
 	lastSetTime *utils.AtomicMax
-	initLock    sync.Mutex
+	// initLock serializes /init handlers but, unlike sync.Mutex, respects the
+	// caller's ctx so a stuck predecessor cannot pile up retry goroutines.
+	initLock chan struct{}
 
 	caCertInstaller *host.CACertInstaller
 	isMountingNFS   atomic.Bool
@@ -54,6 +56,7 @@ func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.
 		lastSetTime:     utils.NewAtomicMax(),
 		accessToken:     &SecureToken{},
 		caCertInstaller: host.NewCACertInstaller(l),
+		initLock:        make(chan struct{}, 1),
 	}
 }
 

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
 
 	"github.com/e2b-dev/infra/packages/envd/internal/execcontext"
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
@@ -39,7 +40,7 @@ type API struct {
 	lastSetTime *utils.AtomicMax
 	// initLock serializes /init handlers but, unlike sync.Mutex, respects the
 	// caller's ctx so a stuck predecessor cannot pile up retry goroutines.
-	initLock chan struct{}
+	initLock *semaphore.Weighted
 
 	caCertInstaller *host.CACertInstaller
 	isMountingNFS   atomic.Bool
@@ -56,7 +57,7 @@ func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.
 		lastSetTime:     utils.NewAtomicMax(),
 		accessToken:     &SecureToken{},
 		caCertInstaller: host.NewCACertInstaller(l),
-		initLock:        make(chan struct{}, 1),
+		initLock:        semaphore.NewWeighted(1),
 	}
 }
 

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -38,9 +38,7 @@ type API struct {
 	mmdsClient    MMDSClient
 
 	lastSetTime *utils.AtomicMax
-	// initLock serializes /init handlers but, unlike sync.Mutex, respects the
-	// caller's ctx so a stuck predecessor cannot pile up retry goroutines.
-	initLock *semaphore.Weighted
+	initLock    *semaphore.Weighted
 
 	caCertInstaller *host.CACertInstaller
 	isMountingNFS   atomic.Bool

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Replaces `initLock` (`sync.Mutex`) with `semaphore.Weighted(1)`. Contended /init returns 503 the moment the caller's ctx fires instead of accumulating goroutines + buffered bodies + memguarded token pages behind a non-ctx-aware mutex.