### PR TITLE
perf(envd): set ReadHeaderTimeout on HTTP server

### DIFF
--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -197,10 +197,16 @@ func main() {
 			),
 		),
 		Addr: fmt.Sprintf("0.0.0.0:%d", port),
-		// We remove the timeouts as the connection is terminated by closing of the sandbox and keepalive close.
-		ReadTimeout:  0,
-		WriteTimeout: 0,
-		IdleTimeout:  idleTimeout,
+		// ReadTimeout / WriteTimeout stay 0: connection is terminated by
+		// closing of the sandbox and keepalive close, and we have
+		// long-lived requests we must not cut off.
+		// ReadHeaderTimeout is safe to set and cheap insurance against
+		// slowloris-style header reads that would otherwise hold a goroutine
+		// + (eventually) initLock forever.
+		ReadTimeout:       0,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      0,
+		IdleTimeout:       idleTimeout,
 	}
 	httpserver.ConfigureH2C(s)
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Sets `ReadHeaderTimeout: 10s` on the envd http.Server. Read/WriteTimeout intentionally stay 0 (long-lived requests must not be cut), but ReadHeaderTimeout is independent and bounds slow-loris-style attacks against the request header phase only.