### PR TITLE
fix(envd): bound NFS mount kernel-side retries

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -243,14 +243,12 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
-	// Bound the mount against an unreachable proxy to ~10s total:
-	//   - timeo=20 (2s per NFS RPC) with retrans=2 → kernel gives up
-	//     after ~6s of exponential backoff (2+4) and returns ETIMEDOUT.
-	//   - retry=0 stops mount(8) from looping further on RPC failure.
-	//   - nfsMountTimeout (10s) is the userspace SIGKILL backstop.
+	// Bound the kernel-side NFS RPC retry budget. timeo is in deciseconds;
+	// timeo=20 + retrans=2 gives 3 attempts ~2s apart (~6s total) before
+	// the kernel returns ETIMEDOUT instead of sitting in D-state. The
+	// 10s nfsMountTimeout SIGKILL is the userspace backstop.
 	"timeo=20",
 	"retrans=2",
-	"retry=0",
 
 	// disable caching so that pause/resume works correctly
 	"noac",

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -243,6 +243,14 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
+	// Bound kernel-side retries against an unreachable NFS proxy.
+	// timeo is in deciseconds; 20 = 2s. With retrans=2 the in-kernel mount
+	// gives up after ~6s of exponential backoff and returns ETIMEDOUT,
+	// instead of leaving the mount syscall in D-state for SIGKILL to
+	// (eventually) interrupt.
+	"timeo=20",
+	"retrans=2",
+
 	// disable caching so that pause/resume works correctly
 	"noac",
 	"lookupcache=none",

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -243,13 +243,14 @@ var nfsOptions = strings.Join([]string{
 	"nfsvers=3",      // nfs proxy is nfs version 3
 	"noacl",          // no reason for acl in the sandbox
 
-	// Bound kernel-side retries against an unreachable NFS proxy.
-	// timeo is in deciseconds; 20 = 2s. With retrans=2 the in-kernel mount
-	// gives up after ~6s of exponential backoff and returns ETIMEDOUT,
-	// instead of leaving the mount syscall in D-state for SIGKILL to
-	// (eventually) interrupt.
+	// Bound the mount against an unreachable proxy to ~10s total:
+	//   - timeo=20 (2s per NFS RPC) with retrans=2 → kernel gives up
+	//     after ~6s of exponential backoff (2+4) and returns ETIMEDOUT.
+	//   - retry=0 stops mount(8) from looping further on RPC failure.
+	//   - nfsMountTimeout (10s) is the userspace SIGKILL backstop.
 	"timeo=20",
 	"retrans=2",
+	"retry=0",
 
 	// disable caching so that pause/resume works correctly
 	"noac",

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Adds `timeo=20,retrans=2` to the NFS mount options so that an unreachable proxy makes the in-kernel mount give up after ~6s instead of sitting in D-state past the userspace 10s timeout.