### PR TITLE
fix(envd): replace env vars in /init instead of merging

### DIFF
--- a/packages/envd/internal/api/compose_test.go
+++ b/packages/envd/internal/api/compose_test.go
@@ -28,7 +28,7 @@ func newComposeTestAPI(t *testing.T) (*API, *user.User) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 

--- a/packages/envd/internal/api/download_test.go
+++ b/packages/envd/internal/api/download_test.go
@@ -92,7 +92,7 @@ func TestGetFilesContentDisposition(t *testing.T) {
 			// Create test API
 			logger := zerolog.Nop()
 			defaults := &execcontext.Defaults{
-				EnvVars: utils.NewMap[string, string](),
+				EnvVars: utils.NewEnvVars(),
 				User:    currentUser.Username,
 			}
 			api := New(&logger, defaults, nil, false)
@@ -141,7 +141,7 @@ func TestGetFilesContentDispositionWithNestedPath(t *testing.T) {
 	// Create test API
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -184,7 +184,7 @@ func TestGetFiles_GzipEncoding_ExplicitIdentityOffWithRange(t *testing.T) {
 	// Create test API
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -225,7 +225,7 @@ func TestGetFiles_GzipDownload(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -290,7 +290,7 @@ func TestPostFiles_GzipUpload(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -330,7 +330,7 @@ func TestPostFiles_RawBodyUpload(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -368,7 +368,7 @@ func TestPostFiles_RawBodyUploadCreatesDirectories(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -401,7 +401,7 @@ func TestPostFiles_RawBodyUploadRequiresPath(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -436,7 +436,7 @@ func TestPostFiles_RawBodyUploadOverwritesExisting(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -482,7 +482,7 @@ func TestPostFiles_RawBodyGzipUpload(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -516,7 +516,7 @@ func TestPostFiles_UnsupportedContentType(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -562,7 +562,7 @@ func TestPostFiles_MultipartStillWorksWithoutContentType(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)
@@ -620,7 +620,7 @@ func TestGzipUploadThenGzipDownload(t *testing.T) {
 
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    currentUser.Username,
 	}
 	api := New(&logger, defaults, nil, false)

--- a/packages/envd/internal/api/envs.go
+++ b/packages/envd/internal/api/envs.go
@@ -12,12 +12,7 @@ func (a *API) GetEnvs(w http.ResponseWriter, _ *http.Request) {
 
 	a.logger.Debug().Str(string(logs.OperationIDKey), operationID).Msg("Getting env vars")
 
-	envs := make(EnvVars)
-	a.defaults.EnvVars.Range(func(key, value string) bool {
-		envs[key] = value
-
-		return true
-	})
+	envs := EnvVars(a.defaults.EnvVars.All())
 
 	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "application/json")

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -186,15 +186,7 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 		newVars := *data.EnvVars
 		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(newVars)))
 
-		// Replace, not merge: drop keys that are no longer present so a customer
-		// who removes a variable from their config sees it actually removed.
-		a.defaults.EnvVars.Range(func(key, _ string) bool {
-			if _, keep := newVars[key]; !keep {
-				a.defaults.EnvVars.Delete(key)
-			}
-
-			return true
-		})
+		a.defaults.EnvVars.Clear()
 		for key, value := range newVars {
 			a.defaults.EnvVars.Store(key, value)
 		}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/netip"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -183,10 +185,7 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.EnvVars != nil {
-		keys := make([]string, 0, len(*data.EnvVars))
-		for key := range *data.EnvVars {
-			keys = append(keys, key)
-		}
+		keys := slices.Collect(maps.Keys(*data.EnvVars))
 		logger.Debug().Msgf("Setting %d env vars: %s", len(keys), strings.Join(keys, ", "))
 		a.defaults.EnvVars.ReplaceUserVars(*data.EnvVars)
 	}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -183,10 +183,19 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.EnvVars != nil {
-		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(*data.EnvVars)))
+		newVars := *data.EnvVars
+		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(newVars)))
 
-		for key, value := range *data.EnvVars {
-			logger.Debug().Msgf("Setting env var for %s", key)
+		// Replace, not merge: drop keys that are no longer present so a customer
+		// who removes a variable from their config sees it actually removed.
+		a.defaults.EnvVars.Range(func(key, _ string) bool {
+			if _, keep := newVars[key]; !keep {
+				a.defaults.EnvVars.Delete(key)
+			}
+
+			return true
+		})
+		for key, value := range newVars {
 			a.defaults.EnvVars.Store(key, value)
 		}
 	}

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -183,13 +183,11 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.EnvVars != nil {
-		newVars := *data.EnvVars
-		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(newVars)))
-
-		a.defaults.EnvVars.Clear()
-		for key, value := range newVars {
-			a.defaults.EnvVars.Store(key, value)
+		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(*data.EnvVars)))
+		for key := range *data.EnvVars {
+			logger.Debug().Msgf("Setting env var for %s", key)
 		}
+		a.defaults.EnvVars.ReplaceUserVars(*data.EnvVars)
 	}
 
 	if data.AccessToken.IsSet() {

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -183,10 +183,11 @@ func (a *API) SetData(ctx context.Context, logger zerolog.Logger, data PostInitJ
 	}
 
 	if data.EnvVars != nil {
-		logger.Debug().Msg(fmt.Sprintf("Setting %d env vars", len(*data.EnvVars)))
+		keys := make([]string, 0, len(*data.EnvVars))
 		for key := range *data.EnvVars {
-			logger.Debug().Msgf("Setting env var for %s", key)
+			keys = append(keys, key)
 		}
+		logger.Debug().Msgf("Setting %d env vars: %s", len(keys), strings.Join(keys, ", "))
 		a.defaults.EnvVars.ReplaceUserVars(*data.EnvVars)
 	}
 

--- a/packages/envd/internal/api/init_test.go
+++ b/packages/envd/internal/api/init_test.go
@@ -140,7 +140,7 @@ func (m *mockMMDSClient) GetAccessTokenHash(_ context.Context) (string, error) {
 func newTestAPI(accessToken *SecureToken, mmdsClient MMDSClient) *API {
 	logger := zerolog.Nop()
 	defaults := &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 	}
 	api := New(&logger, defaults, nil, false)
 	if accessToken != nil {

--- a/packages/envd/internal/execcontext/context.go
+++ b/packages/envd/internal/execcontext/context.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Defaults struct {
-	EnvVars *utils.Map[string, string]
+	EnvVars *utils.EnvVars
 	User    string
 	Workdir *string
 }

--- a/packages/envd/internal/host/mmds.go
+++ b/packages/envd/internal/host/mmds.go
@@ -129,7 +129,7 @@ func GetAccessTokenHashFromMMDS(ctx context.Context) (string, error) {
 	return opts.AccessTokenHash, nil
 }
 
-func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *utils.Map[string, string]) {
+func PollForMMDSOpts(ctx context.Context, mmdsChan chan<- *MMDSOpts, envVars *utils.EnvVars) {
 	httpClient := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
 	defer httpClient.CloseIdleConnections()
 

--- a/packages/envd/internal/services/filesystem/service_test.go
+++ b/packages/envd/internal/services/filesystem/service_test.go
@@ -8,7 +8,7 @@ import (
 func mockService() Service {
 	return Service{
 		defaults: &execcontext.Defaults{
-			EnvVars: utils.NewMap[string, string](),
+			EnvVars: utils.NewEnvVars(),
 		},
 	}
 }

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -155,11 +155,9 @@ func New(
 
 	// Add the environment variables from the global environment
 	if defaults.EnvVars != nil {
-		defaults.EnvVars.Range(func(key string, value string) bool {
+		for key, value := range defaults.EnvVars.All() {
 			formattedVars = append(formattedVars, key+"="+value)
-
-			return true
-		})
+		}
 	}
 
 	// Only the last values of the env vars are used - this allows for overwriting defaults

--- a/packages/envd/internal/services/process/start_test.go
+++ b/packages/envd/internal/services/process/start_test.go
@@ -37,7 +37,7 @@ func newTestService(t *testing.T) (spec.ProcessClient, func()) {
 	logger := zerolog.Nop()
 
 	svc := newService(&logger, &execcontext.Defaults{
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 		User:    u.Username,
 		Workdir: &cwd,
 	}, cgroups.NewNoopManager())

--- a/packages/envd/internal/utils/envvars.go
+++ b/packages/envd/internal/utils/envvars.go
@@ -1,0 +1,77 @@
+package utils
+
+import "sync"
+
+// EnvVars distinguishes system-set ("internal") entries from user-provided
+// ones; internal entries cannot be touched by the user-facing methods.
+type EnvVars struct {
+	m sync.Map
+}
+
+type envVarEntry struct {
+	value    string
+	internal bool
+}
+
+func NewEnvVars() *EnvVars {
+	return &EnvVars{}
+}
+
+// Store sets an internal entry, overwriting any existing one.
+func (e *EnvVars) Store(key, value string) {
+	e.m.Store(key, envVarEntry{value: value, internal: true})
+}
+
+// StoreUser sets a user entry; returns false if an internal entry exists.
+func (e *EnvVars) StoreUser(key, value string) bool {
+	for {
+		existing, loaded := e.m.Load(key)
+		if loaded && existing.(envVarEntry).internal {
+			return false
+		}
+		newEntry := envVarEntry{value: value}
+		if !loaded {
+			if _, raced := e.m.LoadOrStore(key, newEntry); !raced {
+				return true
+			}
+
+			continue
+		}
+		if e.m.CompareAndSwap(key, existing, newEntry) {
+			return true
+		}
+	}
+}
+
+func (e *EnvVars) Load(key string) (string, bool) {
+	v, ok := e.m.Load(key)
+	if !ok {
+		return "", false
+	}
+
+	return v.(envVarEntry).value, true
+}
+
+func (e *EnvVars) Range(f func(key, value string) bool) {
+	e.m.Range(func(k, v any) bool {
+		return f(k.(string), v.(envVarEntry).value)
+	})
+}
+
+// ReplaceUserVars replaces all user entries with newVars; internal entries
+// are left untouched even if they appear in newVars.
+func (e *EnvVars) ReplaceUserVars(newVars map[string]string) {
+	e.m.Range(func(k, v any) bool {
+		if v.(envVarEntry).internal {
+			return true
+		}
+		if _, keep := newVars[k.(string)]; !keep {
+			e.m.CompareAndDelete(k, v)
+		}
+
+		return true
+	})
+	for k, v := range newVars {
+		e.StoreUser(k, v)
+	}
+}

--- a/packages/envd/internal/utils/envvars.go
+++ b/packages/envd/internal/utils/envvars.go
@@ -5,7 +5,8 @@ import "sync"
 // EnvVars distinguishes system-set ("internal") entries from user-provided
 // ones; internal entries cannot be touched by the user-facing methods.
 type EnvVars struct {
-	m sync.Map
+	mu sync.RWMutex
+	m  map[string]envVarEntry
 }
 
 type envVarEntry struct {
@@ -14,64 +15,66 @@ type envVarEntry struct {
 }
 
 func NewEnvVars() *EnvVars {
-	return &EnvVars{}
+	return &EnvVars{m: make(map[string]envVarEntry)}
 }
 
 // Store sets an internal entry, overwriting any existing one.
 func (e *EnvVars) Store(key, value string) {
-	e.m.Store(key, envVarEntry{value: value, internal: true})
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.m[key] = envVarEntry{value: value, internal: true}
 }
 
 // StoreUser sets a user entry; returns false if an internal entry exists.
 func (e *EnvVars) StoreUser(key, value string) bool {
-	for {
-		existing, loaded := e.m.Load(key)
-		if loaded && existing.(envVarEntry).internal {
-			return false
-		}
-		newEntry := envVarEntry{value: value}
-		if !loaded {
-			if _, raced := e.m.LoadOrStore(key, newEntry); !raced {
-				return true
-			}
-
-			continue
-		}
-		if e.m.CompareAndSwap(key, existing, newEntry) {
-			return true
-		}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if existing, ok := e.m[key]; ok && existing.internal {
+		return false
 	}
+	e.m[key] = envVarEntry{value: value}
+
+	return true
 }
 
 func (e *EnvVars) Load(key string) (string, bool) {
-	v, ok := e.m.Load(key)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	v, ok := e.m[key]
 	if !ok {
 		return "", false
 	}
 
-	return v.(envVarEntry).value, true
+	return v.value, true
 }
 
 func (e *EnvVars) Range(f func(key, value string) bool) {
-	e.m.Range(func(k, v any) bool {
-		return f(k.(string), v.(envVarEntry).value)
-	})
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	for k, v := range e.m {
+		if !f(k, v.value) {
+			return
+		}
+	}
 }
 
 // ReplaceUserVars replaces all user entries with newVars; internal entries
 // are left untouched even if they appear in newVars.
 func (e *EnvVars) ReplaceUserVars(newVars map[string]string) {
-	e.m.Range(func(k, v any) bool {
-		if v.(envVarEntry).internal {
-			return true
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for k, v := range e.m {
+		if v.internal {
+			continue
 		}
-		if _, keep := newVars[k.(string)]; !keep {
-			e.m.CompareAndDelete(k, v)
+		if _, keep := newVars[k]; !keep {
+			delete(e.m, k)
 		}
-
-		return true
-	})
+	}
 	for k, v := range newVars {
-		e.StoreUser(k, v)
+		if existing, ok := e.m[k]; ok && existing.internal {
+			continue
+		}
+		e.m[k] = envVarEntry{value: v}
 	}
 }

--- a/packages/envd/internal/utils/envvars.go
+++ b/packages/envd/internal/utils/envvars.go
@@ -48,14 +48,16 @@ func (e *EnvVars) Load(key string) (string, bool) {
 	return v.value, true
 }
 
-func (e *EnvVars) Range(f func(key, value string) bool) {
+// All returns a snapshot of all entries as a plain map.
+func (e *EnvVars) All() map[string]string {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+	out := make(map[string]string, len(e.m))
 	for k, v := range e.m {
-		if !f(k, v.value) {
-			return
-		}
+		out[k] = v.value
 	}
+
+	return out
 }
 
 // ReplaceUserVars replaces all user entries with newVars; internal entries

--- a/packages/envd/internal/utils/envvars_test.go
+++ b/packages/envd/internal/utils/envvars_test.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func collect(e *EnvVars) map[string]string {
+	out := map[string]string{}
+	e.Range(func(k, v string) bool {
+		out[k] = v
+
+		return true
+	})
+
+	return out
+}
+
+func TestEnvVars_StoreUserRejectsInternal(t *testing.T) {
+	t.Parallel()
+	e := NewEnvVars()
+
+	e.Store("E2B_SANDBOX_ID", "sbx-1")
+	assert.False(t, e.StoreUser("E2B_SANDBOX_ID", "spoofed"))
+
+	v, _ := e.Load("E2B_SANDBOX_ID")
+	assert.Equal(t, "sbx-1", v)
+}
+
+func TestEnvVars_StorePromotesUserToInternal(t *testing.T) {
+	t.Parallel()
+	e := NewEnvVars()
+
+	require.True(t, e.StoreUser("FOO", "user"))
+	e.Store("FOO", "internal")
+
+	assert.False(t, e.StoreUser("FOO", "user-again"))
+	v, _ := e.Load("FOO")
+	assert.Equal(t, "internal", v)
+}
+
+func TestEnvVars_ReplaceUserVars(t *testing.T) {
+	t.Parallel()
+	e := NewEnvVars()
+
+	e.Store("E2B_SANDBOX", "true")
+	e.Store("E2B_SANDBOX_ID", "sbx-1")
+	require.True(t, e.StoreUser("FOO", "1"))
+	require.True(t, e.StoreUser("BAR", "2"))
+
+	e.ReplaceUserVars(map[string]string{
+		"BAR":            "two",
+		"BAZ":            "three",
+		"E2B_SANDBOX_ID": "spoofed",
+	})
+
+	assert.Equal(t, map[string]string{
+		"E2B_SANDBOX":    "true",
+		"E2B_SANDBOX_ID": "sbx-1",
+		"BAR":            "two",
+		"BAZ":            "three",
+	}, collect(e))
+
+	assert.True(t, e.StoreUser("BAZ", "four"))
+	v, _ := e.Load("BAZ")
+	assert.Equal(t, "four", v)
+
+	assert.False(t, e.StoreUser("E2B_SANDBOX_ID", "spoofed-again"))
+}
+
+func TestEnvVars_ReplaceUserVarsClearsOmittedKeys(t *testing.T) {
+	t.Parallel()
+	e := NewEnvVars()
+
+	e.Store("E2B_SANDBOX", "true")
+	require.True(t, e.StoreUser("FOO", "1"))
+	require.True(t, e.StoreUser("BAR", "2"))
+
+	e.ReplaceUserVars(map[string]string{"FOO": "1"})
+
+	assert.Equal(t, map[string]string{
+		"E2B_SANDBOX": "true",
+		"FOO":         "1",
+	}, collect(e))
+}

--- a/packages/envd/internal/utils/envvars_test.go
+++ b/packages/envd/internal/utils/envvars_test.go
@@ -7,17 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func collect(e *EnvVars) map[string]string {
-	out := map[string]string{}
-	e.Range(func(k, v string) bool {
-		out[k] = v
-
-		return true
-	})
-
-	return out
-}
-
 func TestEnvVars_StoreUserRejectsInternal(t *testing.T) {
 	t.Parallel()
 	e := NewEnvVars()
@@ -61,7 +50,7 @@ func TestEnvVars_ReplaceUserVars(t *testing.T) {
 		"E2B_SANDBOX_ID": "sbx-1",
 		"BAR":            "two",
 		"BAZ":            "three",
-	}, collect(e))
+	}, e.All())
 
 	assert.True(t, e.StoreUser("BAZ", "four"))
 	v, _ := e.Load("BAZ")
@@ -83,5 +72,5 @@ func TestEnvVars_ReplaceUserVarsClearsOmittedKeys(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"E2B_SANDBOX": "true",
 		"FOO":         "1",
-	}, collect(e))
+	}, e.All())
 }

--- a/packages/envd/internal/utils/map.go
+++ b/packages/envd/internal/utils/map.go
@@ -49,3 +49,7 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 func (m *Map[K, V]) Store(key K, value V) {
 	m.m.Store(key, value)
 }
+
+func (m *Map[K, V]) Clear() {
+	m.m.Clear()
+}

--- a/packages/envd/internal/utils/map.go
+++ b/packages/envd/internal/utils/map.go
@@ -49,7 +49,3 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 func (m *Map[K, V]) Store(key K, value V) {
 	m.m.Store(key, value)
 }
-
-func (m *Map[K, V]) Clear() {
-	m.m.Clear()
-}

--- a/packages/envd/main.go
+++ b/packages/envd/main.go
@@ -153,7 +153,7 @@ func main() {
 
 	defaults := &execcontext.Defaults{
 		User:    defaultUser,
-		EnvVars: utils.NewMap[string, string](),
+		EnvVars: utils.NewEnvVars(),
 	}
 	isFCBoolStr := strconv.FormatBool(!isNotFC)
 	defaults.EnvVars.Store("E2B_SANDBOX", isFCBoolStr)

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.23"
+const Version = "0.5.24"


### PR DESCRIPTION
Replaces the env-var dict on each /init that carries a non-nil `EnvVars` payload, so removing a variable from sandbox config takes effect on the next /init instead of persisting forever.