### PR TITLE
Ingress safe rollout support

### DIFF
--- a/iac/modules/job-ingress/jobs/traefik.toml
+++ b/iac/modules/job-ingress/jobs/traefik.toml
@@ -10,6 +10,7 @@
 
     [entryPoints.web.transport.lifecycle]
       # Keep accepting requests (and /ping) until LB detects health failure and stops routing
+      # /ping returns 503 while in graceful shutdown
       requestAcceptGraceTimeout = "30s"
       # After the grace window, give active connections up to 24h to finish before forcefully closing them
       graceTimeOut = "24h"

--- a/iac/modules/job-ingress/jobs/traefik.toml
+++ b/iac/modules/job-ingress/jobs/traefik.toml
@@ -7,6 +7,13 @@
 [entryPoints]
   [entryPoints.web]
     address = ":${ingress_port}"
+
+    [entryPoints.web.transport.lifecycle]
+      # Keep accepting requests (and /ping) until LB detects health failure and stops routing
+      requestAcceptGraceTimeout = "30s"
+      # After the grace window, give active connections up to 24h to finish before forcefully closing them
+      graceTimeOut = "24h"
+
   [entryPoints.traefik]
     address = ":${control_port}"
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -165,7 +165,6 @@ module "cluster" {
   nomad_port                   = var.nomad_port
   google_service_account_email = module.init.service_account_email
   domain_name                  = var.domain_name
-  ingress_timeout_seconds      = var.ingress_timeout_seconds
 
   additional_domains                      = local.additional_domains
   additional_api_paths_handled_by_ingress = local.normalized_api_paths_handled_by_ingress

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -117,7 +117,6 @@ module "network" {
   domain_name                             = var.domain_name
   additional_domains                      = var.additional_domains
   additional_api_paths_handled_by_ingress = var.additional_api_paths_handled_by_ingress
-  ingress_timeout_seconds                 = var.ingress_timeout_seconds
 
   client_proxy_port        = var.client_proxy_port
   client_proxy_health_port = var.client_proxy_health_port

--- a/iac/provider-gcp/nomad-cluster/network/ingress.tf
+++ b/iac/provider-gcp/nomad-cluster/network/ingress.tf
@@ -43,7 +43,8 @@ resource "google_compute_backend_service" "ingress" {
   session_affinity = null
   health_checks    = [google_compute_health_check.ingress.id]
 
-  timeout_sec = var.ingress_timeout_seconds
+  timeout_sec                     = 86400
+  connection_draining_timeout_sec = 1
 
   load_balancing_scheme = "EXTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"
@@ -64,7 +65,8 @@ resource "google_compute_backend_service" "h2c_ingress" {
   session_affinity = null
   health_checks    = [google_compute_health_check.ingress.id]
 
-  timeout_sec = var.ingress_timeout_seconds
+  timeout_sec                     = 86400
+  connection_draining_timeout_sec = 1
 
   load_balancing_scheme = "EXTERNAL_MANAGED"
   locality_lb_policy    = "ROUND_ROBIN"

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -303,8 +303,19 @@ resource "google_compute_url_map" "orch_map" {
   }
 
   path_matcher {
-    name            = "session-paths"
-    default_service = google_compute_backend_service.default["session"].self_link
+    name = "session-paths"
+
+    default_route_action {
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.default["session"].self_link
+        weight          = 99
+      }
+
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.ingress.self_link
+        weight          = 1
+      }
+    }
   }
 
   path_matcher {

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -303,19 +303,8 @@ resource "google_compute_url_map" "orch_map" {
   }
 
   path_matcher {
-    name = "session-paths"
-
-    default_route_action {
-      weighted_backend_services {
-        backend_service = google_compute_backend_service.default["session"].self_link
-        weight          = 99
-      }
-
-      weighted_backend_services {
-        backend_service = google_compute_backend_service.ingress.self_link
-        weight          = 1
-      }
-    }
+    name            = "session-paths"
+    default_service = google_compute_backend_service.default["session"].self_link
   }
 
   path_matcher {

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -109,7 +109,3 @@ variable "additional_api_paths_handled_by_ingress" {
     timeout_sec = optional(number)
   }))
 }
-
-variable "ingress_timeout_seconds" {
-  type = number
-}

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -388,7 +388,3 @@ variable "additional_api_paths_handled_by_ingress" {
     timeout_sec = optional(number)
   }))
 }
-
-variable "ingress_timeout_seconds" {
-  type = number
-}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -820,8 +820,3 @@ variable "traefik_config_files" {
   description = "Map of filename => content for additional Traefik dynamic configuration files"
   default     = {}
 }
-
-variable "ingress_timeout_seconds" {
-  type    = number
-  default = 80
-}

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -139,7 +139,7 @@ variable "additional_api_paths_handled_by_ingress" {
     - Legacy: list(string) - e.g. ["/path1/*", "/path2/*"]
     - New: list(object({paths = list(string), timeout_sec = optional(number)}))
       e.g. [{paths = ["/path1/*", "/path2/*"], timeout_sec = 120}]
-    Per-route timeout_sec overrides the ingress backend default (see ingress_timeout_seconds).
+    Per-route timeout_sec overrides the ingress backend default.
   EOT
   default     = []
 }


### PR DESCRIPTION
- Support Traefik draining until opened connections are closed gracefully
- PoC for routing 1% of sandbox traffic over ingress instead directly to client proxy