### PR TITLE
feat(auth): allow unconfigured AUTH_PROVIDER_CONFIG

### DIFF
--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -133,7 +133,20 @@ func (s *AuthService[T]) ValidateAccessToken(ctx context.Context, ginCtx *gin.Co
 }
 
 // ValidateAuthProviderToken verifies a JWT against the configured auth provider and resolves an internal user ID.
+//
+// When no auth provider verifier is configured (AUTH_PROVIDER_CONFIG is unset),
+// every token is denied with 401. This makes "no auth provider" a valid
+// configuration: API key / access token flows keep working, but JWT-based
+// flows are universally rejected.
 func (s *AuthService[T]) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError) {
+	if s.authProviderVerifier == nil {
+		return uuid.UUID{}, &APIError{
+			Err:       errors.New("auth provider is not configured"),
+			ClientMsg: "Backend authentication failed",
+			Code:      http.StatusUnauthorized,
+		}
+	}
+
 	return s.validateJWTWithProvider(ctx, ginCtx, s.authProviderVerifier, token, "auth provider")
 }
 

--- a/packages/auth/pkg/auth/service_test.go
+++ b/packages/auth/pkg/auth/service_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthService_ValidateAuthProviderTokenNilVerifier ensures that when
+// AUTH_PROVIDER_CONFIG is unset (verifier is nil), ValidateAuthProviderToken
+// denies the request with 401 instead of panicking on a nil pointer.
+func TestAuthService_ValidateAuthProviderTokenNilVerifier(t *testing.T) {
+	t.Parallel()
+
+	svc := NewAuthService[*testTeam](nil, nil, nil)
+
+	w := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(w)
+	ginCtx.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	userID, apiErr := svc.ValidateAuthProviderToken(t.Context(), ginCtx, "any-token")
+
+	require.NotNil(t, apiErr)
+	require.Equal(t, http.StatusUnauthorized, apiErr.Code)
+	require.Equal(t, "Backend authentication failed", apiErr.ClientMsg)
+	require.Equal(t, [16]byte{}, [16]byte(userID))
+}
+
+// testTeam is a minimal TeamItem implementation for tests in this file.
+type testTeam struct{ id string }
+
+func (t *testTeam) TeamID() string { return t.id }

--- a/packages/auth/pkg/auth/verifier.go
+++ b/packages/auth/pkg/auth/verifier.go
@@ -71,13 +71,20 @@ type Verifier struct {
 	strategies []strategy
 }
 
+// NewVerifier constructs a *Verifier from the given ProviderConfig.
+//
+// When the provided config has no JWT issuers and no legacy entry (i.e. the
+// AUTH_PROVIDER_CONFIG env var is unset or empty), NewVerifier returns
+// (nil, nil). This is a valid configuration: the caller can pass the nil
+// verifier to AuthService, and any token verification attempt will be denied
+// at runtime by Verifier.Verify / AuthService.ValidateAuthProviderToken.
 func NewVerifier(ctx context.Context, config ProviderConfig, oidcHTTPClient *http.Client, identities oidc.IdentityLookup) (*Verifier, error) {
 	normalized := config.normalize()
 	if err := normalized.validate(); err != nil {
 		return nil, err
 	}
 	if !normalized.Enabled() {
-		return nil, errors.New("auth provider not enabled")
+		return nil, nil
 	}
 
 	strategiesCap := len(normalized.JWT)

--- a/packages/auth/pkg/auth/verifier_test.go
+++ b/packages/auth/pkg/auth/verifier_test.go
@@ -62,6 +62,14 @@ func httpClientForServers(servers ...*httptest.Server) *http.Client {
 	}
 }
 
+func TestNewVerifier_DisabledConfigReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	verifier, err := NewVerifier(t.Context(), ProviderConfig{}, nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, verifier)
+}
+
 func TestVerifier_VerifyWithMultipleStrategies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Treat an unset/empty AUTH_PROVIDER_CONFIG as a valid configuration where all JWT-based authentication is universally denied, instead of failing at startup with 'auth provider not enabled'.

This unblocks running the API and dashboard-api without an OIDC issuer or legacy HMAC secret configured: API key and access token flows keep working, while every JWT path (AuthProviderBearer, SupabaseToken, AuthProviderTeam) returns 401.

Implementation:

- NewVerifier now returns (nil, nil) when ProviderConfig has no JWT issuers and no legacy entry. Malformed configs still error out via validate(), so misconfiguration is not silently swallowed.

- AuthService.ValidateAuthProviderToken short-circuits with a 401 'Backend authentication failed' when the verifier is nil, before touching the verifier or any downstream strategy. This is the only entry point used by the gin authenticators, so callers cannot bypass the guard.

- Verifier.Verify already had a nil-receiver guard, which remains as a defense-in-depth layer for any direct callers.

Tests:

- TestNewVerifier_DisabledConfigReturnsNil covers the constructor path.
- TestAuthService_ValidateAuthProviderTokenNilVerifier exercises the full ValidateAuthProviderToken path with a nil verifier and asserts a 401 response without panicking.