### PR TITLE
refactor(auth): drop generics from AuthCache, AuthService, AuthStore

### DIFF
--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -75,7 +75,7 @@ type APIStore struct {
 	templateCache         *templatecache.TemplateCache
 	templateBuildsCache   *templatecache.TemplatesBuildCache
 	snapshotCache         *snapshotcache.SnapshotCache
-	authService           *sharedauth.AuthService[*types.Team]
+	authService           *sharedauth.AuthService
 	templateSpawnCounter  *utils.TemplateSpawnCounter
 	clickhouseStore       clickhouse.Clickhouse
 	accessTokenGenerator  *sandbox.AccessTokenGenerator
@@ -198,7 +198,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		logger.L().Fatal(ctx, "Initializing Orchestrator client", zap.Error(err))
 	}
 
-	authCache := sharedauth.NewAuthCache[*types.Team](redisClient)
+	authCache := sharedauth.NewAuthCache(redisClient)
 	authStore := sharedauth.NewAuthStore(authDB)
 	authHTTPClient := &http.Client{}
 	authIdentityLookup := sharedauth.NewAuthIdentityLookup(authDB.Read)
@@ -206,7 +206,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 	if err != nil {
 		logger.L().Fatal(ctx, "Initializing auth provider JWT verifier", zap.Error(err))
 	}
-	authService := sharedauth.NewAuthService[*types.Team](authStore, authCache, authProviderVerifier)
+	authService := sharedauth.NewAuthService(authStore, authCache, authProviderVerifier)
 	templateCache := templatecache.NewTemplateCache(sqlcDB, redisClient)
 	templateSpawnCounter := utils.NewTemplateSpawnCounter(ctx, time.Minute, sqlcDB)
 

--- a/packages/auth/pkg/auth/auth_store.go
+++ b/packages/auth/pkg/auth/auth_store.go
@@ -20,7 +20,7 @@ type AuthStoreImpl struct {
 	authDB *authdb.Client
 }
 
-var _ AuthStore[*types.Team] = (*AuthStoreImpl)(nil)
+var _ AuthStore = (*AuthStoreImpl)(nil)
 
 func NewAuthStore(authDB *authdb.Client) *AuthStoreImpl {
 	return &AuthStoreImpl{authDB: authDB}

--- a/packages/auth/pkg/auth/cache.go
+++ b/packages/auth/pkg/auth/cache.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/cache"
 )
 
@@ -17,15 +18,15 @@ const (
 	authCacheRedisPrefix = "auth:team"
 )
 
-// AuthCache is a Redis-backed TTL cache for authentication data (teams, users, etc.).
-type AuthCache[T any] struct {
-	cache *cache.RedisCache[T]
+// AuthCache is a Redis-backed TTL cache for team authentication data.
+type AuthCache struct {
+	cache *cache.RedisCache[*types.Team]
 }
 
 // NewAuthCache creates a new Redis-backed AuthCache with default TTL and refresh settings.
-func NewAuthCache[T any](redisClient redis.UniversalClient) *AuthCache[T] {
-	return &AuthCache[T]{
-		cache: cache.NewRedisCache(cache.RedisConfig[T]{
+func NewAuthCache(redisClient redis.UniversalClient) *AuthCache {
+	return &AuthCache{
+		cache: cache.NewRedisCache(cache.RedisConfig[*types.Team]{
 			RedisClient:     redisClient,
 			TTL:             authInfoExpiration,
 			RefreshInterval: refreshInterval,
@@ -36,16 +37,16 @@ func NewAuthCache[T any](redisClient redis.UniversalClient) *AuthCache[T] {
 }
 
 // GetOrSet returns the cached value for the key, or calls dataCallback to populate it.
-func (c *AuthCache[T]) GetOrSet(ctx context.Context, key string, dataCallback func(ctx context.Context, key string) (T, error)) (T, error) {
+func (c *AuthCache) GetOrSet(ctx context.Context, key string, dataCallback func(ctx context.Context, key string) (*types.Team, error)) (*types.Team, error) {
 	return c.cache.GetOrSet(ctx, key, dataCallback)
 }
 
 // Invalidate removes a single entry from the cache by key.
-func (c *AuthCache[T]) Invalidate(ctx context.Context, key string) {
+func (c *AuthCache) Invalidate(ctx context.Context, key string) {
 	c.cache.Delete(ctx, key)
 }
 
 // Close is a no-op for the Redis-backed cache (no background goroutines).
-func (c *AuthCache[T]) Close(ctx context.Context) error {
+func (c *AuthCache) Close(ctx context.Context) error {
 	return c.cache.Close(ctx)
 }

--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -10,33 +10,30 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/keys"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-type TeamItem interface {
-	TeamID() string
-}
-
 // AuthStore abstracts the DB operations needed for auth validation.
-type AuthStore[T TeamItem] interface {
-	GetTeamByHashedAPIKey(ctx context.Context, hashedKey string) (T, error)
-	GetTeamByID(ctx context.Context, teamID uuid.UUID) (T, error)
-	GetTeamByIDAndUserID(ctx context.Context, userID uuid.UUID, teamID string) (T, error)
+type AuthStore interface {
+	GetTeamByHashedAPIKey(ctx context.Context, hashedKey string) (*types.Team, error)
+	GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error)
+	GetTeamByIDAndUserID(ctx context.Context, userID uuid.UUID, teamID string) (*types.Team, error)
 	GetUserIDByHashedAccessToken(ctx context.Context, hashedToken string) (uuid.UUID, error)
 	GetTeamAPIKeyHashes(ctx context.Context, teamID uuid.UUID) ([]string, error)
 }
 
 // AuthService encapsulates the cache, store, and JWT verifier for auth validation.
-type AuthService[T TeamItem] struct {
-	store                AuthStore[T]
-	teamCache            *AuthCache[T]
+type AuthService struct {
+	store                AuthStore
+	teamCache            *AuthCache
 	authProviderVerifier *Verifier
 }
 
 // NewAuthService creates an AuthService with the given store, cache, and auth provider verifier.
-func NewAuthService[T TeamItem](store AuthStore[T], teamCache *AuthCache[T], authProviderVerifier *Verifier) *AuthService[T] {
-	return &AuthService[T]{
+func NewAuthService(store AuthStore, teamCache *AuthCache, authProviderVerifier *Verifier) *AuthService {
+	return &AuthService{
 		store:                store,
 		teamCache:            teamCache,
 		authProviderVerifier: authProviderVerifier,
@@ -44,27 +41,23 @@ func NewAuthService[T TeamItem](store AuthStore[T], teamCache *AuthCache[T], aut
 }
 
 // ValidateAPIKey verifies the API key format and fetches the associated team via cache + store.
-func (s *AuthService[T]) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (T, *APIError) {
+func (s *AuthService) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (*types.Team, *APIError) {
 	hashedKey, err := keys.VerifyKey(keys.ApiKeyPrefix, apiKey)
 	if err != nil {
-		var zero T
-
-		return zero, &APIError{
+		return nil, &APIError{
 			Err:       fmt.Errorf("failed to verify api key: %w", err),
 			ClientMsg: "Invalid API key format",
 			Code:      http.StatusUnauthorized,
 		}
 	}
 
-	result, err := s.teamCache.GetOrSet(ctx, hashedKey, func(ctx context.Context, key string) (T, error) {
+	result, err := s.teamCache.GetOrSet(ctx, hashedKey, func(ctx context.Context, key string) (*types.Team, error) {
 		return s.store.GetTeamByHashedAPIKey(ctx, key)
 	})
 	if err != nil {
-		var zero T
-
 		var forbiddenErr *TeamForbiddenError
 		if errors.As(err, &forbiddenErr) {
-			return zero, &APIError{
+			return nil, &APIError{
 				Err:       err,
 				ClientMsg: err.Error(),
 				Code:      http.StatusForbidden,
@@ -73,14 +66,14 @@ func (s *AuthService[T]) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context
 
 		var blockedErr *TeamBlockedError
 		if errors.As(err, &blockedErr) {
-			return zero, &APIError{
+			return nil, &APIError{
 				Err:       err,
 				ClientMsg: err.Error(),
 				Code:      http.StatusForbidden,
 			}
 		}
 
-		return zero, &APIError{
+		return nil, &APIError{
 			Err:       fmt.Errorf("failed to get the team from db for an api key: %w", err),
 			ClientMsg: "Cannot get the team for the given API key",
 			Code:      http.StatusUnauthorized,
@@ -97,14 +90,14 @@ func (s *AuthService[T]) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context
 }
 
 // GetTeamByID fetches team auth data via cache + store.
-func (s *AuthService[T]) GetTeamByID(ctx context.Context, teamID uuid.UUID) (T, error) {
-	return s.teamCache.GetOrSet(ctx, teamCacheKey(teamID), func(ctx context.Context, _ string) (T, error) {
+func (s *AuthService) GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error) {
+	return s.teamCache.GetOrSet(ctx, teamCacheKey(teamID), func(ctx context.Context, _ string) (*types.Team, error) {
 		return s.store.GetTeamByID(ctx, teamID)
 	})
 }
 
 // ValidateAccessToken verifies the access token format and fetches the associated user ID.
-func (s *AuthService[T]) ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError) {
+func (s *AuthService) ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError) {
 	hashedToken, err := keys.VerifyKey(keys.AccessTokenPrefix, accessToken)
 	if err != nil {
 		return uuid.UUID{}, &APIError{
@@ -138,7 +131,7 @@ func (s *AuthService[T]) ValidateAccessToken(ctx context.Context, ginCtx *gin.Co
 // every token is denied with 401. This makes "no auth provider" a valid
 // configuration: API key / access token flows keep working, but JWT-based
 // flows are universally rejected.
-func (s *AuthService[T]) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError) {
+func (s *AuthService) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError) {
 	if s.authProviderVerifier == nil {
 		return uuid.UUID{}, &APIError{
 			Err:       errors.New("auth provider is not configured"),
@@ -150,7 +143,7 @@ func (s *AuthService[T]) ValidateAuthProviderToken(ctx context.Context, ginCtx *
 	return s.validateJWTWithProvider(ctx, ginCtx, s.authProviderVerifier, token, "auth provider")
 }
 
-func (s *AuthService[T]) validateJWTWithProvider(ctx context.Context, ginCtx *gin.Context, verifier *Verifier, token string, tokenSource string) (uuid.UUID, *APIError) {
+func (s *AuthService) validateJWTWithProvider(ctx context.Context, ginCtx *gin.Context, verifier *Verifier, token string, tokenSource string) (uuid.UUID, *APIError) {
 	userID, _, err := verifier.Verify(ctx, token)
 	if err != nil {
 		return uuid.UUID{}, &APIError{
@@ -177,12 +170,10 @@ func (s *AuthService[T]) validateJWTWithProvider(ctx context.Context, ginCtx *gi
 }
 
 // ValidateSupabaseTeam extracts the user ID from the gin context and fetches the team via cache + store.
-func (s *AuthService[T]) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Context, teamID string) (T, *APIError) {
+func (s *AuthService) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Context, teamID string) (*types.Team, *APIError) {
 	userID, ok := GetUserID(ginCtx)
 	if !ok {
-		var zero T
-
-		return zero, &APIError{
+		return nil, &APIError{
 			Err:       errors.New("user ID has invalid type"),
 			ClientMsg: "Backend authentication failed",
 			Code:      http.StatusInternalServerError,
@@ -191,15 +182,13 @@ func (s *AuthService[T]) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.C
 
 	cacheKey := supabaseTeamCacheKey(userID, teamID)
 
-	result, err := s.teamCache.GetOrSet(ctx, cacheKey, func(ctx context.Context, _ string) (T, error) {
+	result, err := s.teamCache.GetOrSet(ctx, cacheKey, func(ctx context.Context, _ string) (*types.Team, error) {
 		return s.store.GetTeamByIDAndUserID(ctx, userID, teamID)
 	})
 	if err != nil {
-		var zero T
-
 		var forbiddenErr *TeamForbiddenError
 		if errors.As(err, &forbiddenErr) {
-			return zero, &APIError{
+			return nil, &APIError{
 				Err:       fmt.Errorf("failed getting team: %w", err),
 				ClientMsg: fmt.Sprintf("Forbidden: %s", err.Error()),
 				Code:      http.StatusForbidden,
@@ -208,14 +197,14 @@ func (s *AuthService[T]) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.C
 
 		var blockedErr *TeamBlockedError
 		if errors.As(err, &blockedErr) {
-			return zero, &APIError{
+			return nil, &APIError{
 				Err:       fmt.Errorf("failed getting team: %w", err),
 				ClientMsg: fmt.Sprintf("Blocked: %s", err.Error()),
 				Code:      http.StatusForbidden,
 			}
 		}
 
-		return zero, &APIError{
+		return nil, &APIError{
 			Err:       fmt.Errorf("failed getting team: %w", err),
 			ClientMsg: "Backend authentication failed",
 			Code:      http.StatusUnauthorized,
@@ -233,12 +222,12 @@ func (s *AuthService[T]) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.C
 
 // InvalidateTeamMemberCache removes the cached auth entry for a specific user-team pair.
 // This should be called when team membership changes (member added or removed).
-func (s *AuthService[T]) InvalidateTeamMemberCache(ctx context.Context, userID uuid.UUID, teamID string) {
+func (s *AuthService) InvalidateTeamMemberCache(ctx context.Context, userID uuid.UUID, teamID string) {
 	s.teamCache.Invalidate(ctx, supabaseTeamCacheKey(userID, teamID))
 }
 
 // InvalidateTeamCache queries the team's API key hashes and removes their cached entries.
-func (s *AuthService[T]) InvalidateTeamCache(ctx context.Context, teamID uuid.UUID) error {
+func (s *AuthService) InvalidateTeamCache(ctx context.Context, teamID uuid.UUID) error {
 	s.teamCache.Invalidate(ctx, teamCacheKey(teamID))
 
 	hashes, err := s.store.GetTeamAPIKeyHashes(ctx, teamID)
@@ -262,6 +251,6 @@ func teamCacheKey(teamID uuid.UUID) string {
 }
 
 // Close stops the underlying cache's background refresh goroutines.
-func (s *AuthService[T]) Close(ctx context.Context) error {
+func (s *AuthService) Close(ctx context.Context) error {
 	return s.teamCache.Close(ctx)
 }

--- a/packages/auth/pkg/auth/service_test.go
+++ b/packages/auth/pkg/auth/service_test.go
@@ -15,7 +15,7 @@ import (
 func TestAuthService_ValidateAuthProviderTokenNilVerifier(t *testing.T) {
 	t.Parallel()
 
-	svc := NewAuthService[*testTeam](nil, nil, nil)
+	svc := NewAuthService(nil, nil, nil)
 
 	w := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(w)
@@ -28,8 +28,3 @@ func TestAuthService_ValidateAuthProviderTokenNilVerifier(t *testing.T) {
 	require.Equal(t, "Backend authentication failed", apiErr.ClientMsg)
 	require.Equal(t, [16]byte{}, [16]byte(userID))
 }
-
-// testTeam is a minimal TeamItem implementation for tests in this file.
-type testTeam struct{ id string }
-
-func (t *testTeam) TeamID() string { return t.id }

--- a/packages/dashboard-api/internal/handlers/store.go
+++ b/packages/dashboard-api/internal/handlers/store.go
@@ -27,11 +27,11 @@ type APIStore struct {
 	authDB            *authdb.Client
 	supabaseDB        *supabasedb.Client
 	clickhouse        clickhouse.Clickhouse
-	authService       *sharedauth.AuthService[*types.Team]
+	authService       *sharedauth.AuthService
 	teamProvisionSink internalteamprovision.TeamProvisionSink
 }
 
-func NewAPIStore(config cfg.Config, db *sqlcdb.Client, authDB *authdb.Client, supabaseDB *supabasedb.Client, ch clickhouse.Clickhouse, authService *sharedauth.AuthService[*types.Team], teamProvisionSink internalteamprovision.TeamProvisionSink) *APIStore {
+func NewAPIStore(config cfg.Config, db *sqlcdb.Client, authDB *authdb.Client, supabaseDB *supabasedb.Client, ch clickhouse.Clickhouse, authService *sharedauth.AuthService, teamProvisionSink internalteamprovision.TeamProvisionSink) *APIStore {
 	return &APIStore{
 		config:            config,
 		db:                db,

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -26,7 +26,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	sharedauth "github.com/e2b-dev/infra/packages/auth/pkg/auth"
-	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	"github.com/e2b-dev/infra/packages/dashboard-api/internal/api"
 	"github.com/e2b-dev/infra/packages/dashboard-api/internal/backgroundworker"
@@ -186,7 +185,7 @@ func run() int {
 		}
 	}()
 
-	authCache := sharedauth.NewAuthCache[*types.Team](redisClient)
+	authCache := sharedauth.NewAuthCache(redisClient)
 	authStore := sharedauth.NewAuthStore(authDB)
 	authHTTPClient := &http.Client{}
 	authIdentityLookup := sharedauth.NewAuthIdentityLookup(authDB.Read)
@@ -197,7 +196,7 @@ func run() int {
 		return 1
 	}
 
-	authService := sharedauth.NewAuthService[*types.Team](authStore, authCache, authProviderVerifier)
+	authService := sharedauth.NewAuthService(authStore, authCache, authProviderVerifier)
 	defer authService.Close(ctx)
 
 	teamProvisionSink, err := internalteamprovision.NewProvisionSink(


### PR DESCRIPTION
The generic type parameter on AuthCache[T any], AuthService[T TeamItem], and AuthStore[T TeamItem] was only ever instantiated with *types.Team at every call site (packages/api and packages/dashboard-api). The TeamItem interface existed solely to constrain that single type, so the generics added indirection without buying any reuse.

Hardcode all three to *types.Team:
- Remove the TeamItem interface and its sole method TeamID() (still defined on *types.Team itself, used directly by AuthService).
- AuthCache wraps cache.RedisCache[*types.Team] directly.
- AuthService methods return *types.Team / nil instead of T / var zero T.
- AuthStoreImpl's compile-time interface assertion becomes 'var _ AuthStore = (*AuthStoreImpl)(nil)'.
- Update call sites in packages/api/internal/handlers/store.go and packages/dashboard-api (main.go, internal/handlers/store.go) to drop the [*types.Team] type argument.
- Replace the testTeam stub in service_test.go (only used to satisfy TeamItem) with a plain NewAuthService(nil, nil, nil) call.

CommonAuthenticator[T] in middleware.go keeps its generic parameter because it is genuinely instantiated with *types.Team, uuid.UUID, and struct{}.