### PR TITLE
feat(otel): instrument auth service HTTP client with otelhttp

### DIFF
--- a/packages/api/go.mod
+++ b/packages/api/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/redis/go-redis/v9 v9.17.3
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.39.0
 	go.opentelemetry.io/otel/metric v1.43.0
@@ -372,7 +373,6 @@ require (
 	go.opentelemetry.io/contrib/exporters/autoexport v0.61.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.68.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.64.0 // indirect
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.66.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.35.0 // indirect
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0 // indirect

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/redis/go-redis/v9"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -198,7 +199,10 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		logger.L().Fatal(ctx, "Initializing Orchestrator client", zap.Error(err))
 	}
 
-	authService, err := sharedauth.NewAuthService(ctx, redisClient, authDB, config.AuthProvider, &http.Client{})
+	authClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+	authService, err := sharedauth.NewAuthService(ctx, redisClient, authDB, config.AuthProvider, authClient)
 	if err != nil {
 		logger.L().Fatal(ctx, "Initializing auth service", zap.Error(err))
 	}

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	middleware "github.com/oapi-codegen/gin-middleware"
 	"github.com/riverqueue/river"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -185,7 +186,10 @@ func run() int {
 		}
 	}()
 
-	authService, err := sharedauth.NewAuthService(ctx, redisClient, authDB, config.AuthProvider, &http.Client{})
+	authClient := &http.Client{
+		Transport: otelhttp.NewTransport(http.DefaultTransport),
+	}
+	authService, err := sharedauth.NewAuthService(ctx, redisClient, authDB, config.AuthProvider, authClient)
 	if err != nil {
 		l.Error(ctx, "Initializing auth service", zap.Error(err))
 


### PR DESCRIPTION
Wrap the http.Client used by sharedauth.NewAuthService with otelhttp.NewTransport in both the API and dashboard-api entrypoints so outbound auth provider requests produce OpenTelemetry spans and propagate trace context.