### PR TITLE
refactor(auth): unexport SetUserID and SetTeamInfo, expose test helpers

### DIFF
--- a/packages/api/internal/handlers/sandbox_create_test.go
+++ b/packages/api/internal/handlers/sandbox_create_test.go
@@ -552,7 +552,7 @@ func TestPostSandboxes_MissingBareAliasUsesPromotedFallbackKey(t *testing.T) {
 
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID:   requesterTeamID,
 			Slug: requesterTeamSlug,
@@ -613,7 +613,7 @@ func TestPostSandboxes_PrivateTemplateHidesAccessDenied(t *testing.T) {
 
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID:   requesterTeamID,
 			Slug: requesterTeamSlug,
@@ -668,7 +668,7 @@ func assertMissingTagDisclosure(t *testing.T, public bool, alias string) {
 
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID:   requesterTeamID,
 			Slug: requesterTeamSlug,
@@ -730,7 +730,7 @@ func assertMissingDefaultTagDisclosure(t *testing.T) {
 
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/sandboxes", bytes.NewReader(body))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID:   requesterTeamID,
 			Slug: requesterTeamSlug,

--- a/packages/api/internal/handlers/template_alias_test.go
+++ b/packages/api/internal/handlers/template_alias_test.go
@@ -39,7 +39,7 @@ func TestQueryNotExistingTemplateAlias(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/templates/aliases/%s", alias), nil)
-	auth.SetTeamInfo(c, &types.Team{
+	auth.SetTeamInfoForTest(t, c, &types.Team{
 		Team: &authqueries.Team{
 			ID:   teamID,
 			Slug: teamSlug,
@@ -76,7 +76,7 @@ func TestQueryExistingTemplateAlias(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/templates/aliases/%s", alias), nil)
-	auth.SetTeamInfo(c, &types.Team{
+	auth.SetTeamInfoForTest(t, c, &types.Team{
 		Team: &authqueries.Team{
 			ID:   teamID,
 			Slug: teamSlug,
@@ -121,7 +121,7 @@ func TestQueryExistingTemplateAliasAsNotOwnerTeam(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, fmt.Sprintf("/templates/aliases/%s", alias), nil)
-	auth.SetTeamInfo(c,
+	auth.SetTeamInfoForTest(t, c,
 		&types.Team{
 			Team: &authqueries.Team{
 				ID:   foreignTeamID,

--- a/packages/api/internal/middleware/ratelimit/ratelimit_test.go
+++ b/packages/api/internal/middleware/ratelimit/ratelimit_test.go
@@ -65,10 +65,12 @@ func doRequest(t *testing.T, r *gin.Engine) *httptest.ResponseRecorder {
 }
 
 // newRouterWithTeam creates a Gin engine that injects a team then applies rate limiting.
-func newRouterWithTeam(limiter *redis_rate.Limiter, cfg Config, ff *featureflags.Client, teamID uuid.UUID) *gin.Engine {
+func newRouterWithTeam(t *testing.T, limiter *redis_rate.Limiter, cfg Config, ff *featureflags.Client, teamID uuid.UUID) *gin.Engine {
+	t.Helper()
+
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
-		auth.SetTeamInfo(c, &types.Team{
+		auth.SetTeamInfoForTest(t, c, &types.Team{
 			Team: &authqueries.Team{ID: teamID},
 		})
 		c.Next()
@@ -116,7 +118,7 @@ func TestMiddleware_FailOpen(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -133,7 +135,7 @@ func TestMiddleware_FailClosed(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(limiter, Config{FailOpen: false}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: false}, ff, uuid.New())
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -148,7 +150,7 @@ func TestMiddleware_UnconfiguredRouteAllowsThrough(t *testing.T) {
 	defer badClient.Close()
 
 	limiter := redis_rate.NewLimiter(badClient)
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	w := doRequest(t, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -169,7 +171,7 @@ func TestIntegration_AllowedRequestSetsHeaders(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(10, 20))
 
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	w := doRequest(t, r)
 
@@ -190,7 +192,7 @@ func TestIntegration_BurstThenDeny(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(1, 3))
 
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	// First 3 requests should succeed (burst).
 	for i := range 3 {
@@ -224,7 +226,7 @@ func TestIntegration_Refill(t *testing.T) {
 	limiter := redis_rate.NewLimiter(redisClient)
 	ff := newTestFF(t, routeConfig(10, 2))
 
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	// Exhaust burst.
 	for range 2 {
@@ -257,8 +259,8 @@ func TestIntegration_IndependentTeams(t *testing.T) {
 	teamA := uuid.New()
 	teamB := uuid.New()
 
-	rA := newRouterWithTeam(limiter, cfg, ff, teamA)
-	rB := newRouterWithTeam(limiter, cfg, ff, teamB)
+	rA := newRouterWithTeam(t, limiter, cfg, ff, teamA)
+	rB := newRouterWithTeam(t, limiter, cfg, ff, teamB)
 
 	// Team A uses its quota.
 	w := doRequest(t, rA)
@@ -285,7 +287,7 @@ func TestIntegration_ConcurrentAccess(t *testing.T) {
 	})
 
 	burst := 10
-	r := newRouterWithTeam(limiter, Config{FailOpen: true}, ff, uuid.New())
+	r := newRouterWithTeam(t, limiter, Config{FailOpen: true}, ff, uuid.New())
 
 	// Fire 20 concurrent requests; only `burst` should be allowed.
 	total := 20

--- a/packages/auth/pkg/auth/gin.go
+++ b/packages/auth/pkg/auth/gin.go
@@ -12,7 +12,7 @@ const (
 	userIDContextKey = "user_id"
 )
 
-func SetUserID(c *gin.Context, userID uuid.UUID) {
+func setUserID(c *gin.Context, userID uuid.UUID) {
 	setInGinContext(c, userIDContextKey, userID)
 }
 
@@ -29,7 +29,7 @@ func MustGetUserID(c *gin.Context) uuid.UUID {
 	return userID
 }
 
-func SetTeamInfo(c *gin.Context, t *types.Team) {
+func setTeamInfo(c *gin.Context, t *types.Team) {
 	setInGinContext(c, teamContextKey, t)
 }
 

--- a/packages/auth/pkg/auth/middleware.go
+++ b/packages/auth/pkg/auth/middleware.go
@@ -149,7 +149,7 @@ func NewApiKeyAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin
 			Prefix: PrefixAPIKey,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetTeamInfo,
+		SetContextFunc: setTeamInfo,
 		ErrorMessage:   "Invalid API key, please visit https://e2b.dev/docs/api-key for more information.",
 	}
 }
@@ -164,7 +164,7 @@ func NewAccessTokenAuthenticator(validationFunc func(ctx context.Context, ginCtx
 			RemovePrefix: PrefixBearer,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetUserID,
+		SetContextFunc: setUserID,
 		ErrorMessage:   "Invalid Access token, try to login again by running `e2b auth login`.",
 	}
 }
@@ -178,7 +178,7 @@ func NewAuthProviderBearerAuthenticator(validationFunc func(ctx context.Context,
 			RemovePrefix: PrefixBearer,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetUserID,
+		SetContextFunc: setUserID,
 		ErrorMessage:   "Invalid auth provider token.",
 	}
 }
@@ -191,7 +191,7 @@ func NewSupabaseTokenAuthenticator(validationFunc func(ctx context.Context, ginC
 			Name: HeaderSupabaseToken,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetUserID,
+		SetContextFunc: setUserID,
 		ErrorMessage:   "Invalid Supabase token.",
 	}
 }
@@ -204,7 +204,7 @@ func NewSupabaseTeamAuthenticator(validationFunc func(ctx context.Context, ginCt
 			Name: HeaderSupabaseTeam,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetTeamInfo,
+		SetContextFunc: setTeamInfo,
 		ErrorMessage:   "Invalid Supabase token teamID.",
 	}
 }
@@ -217,7 +217,7 @@ func NewAuthProviderTeamAuthenticator(validationFunc func(ctx context.Context, g
 			Name: HeaderTeamID,
 		},
 		ValidationFunc: validationFunc,
-		SetContextFunc: SetTeamInfo,
+		SetContextFunc: setTeamInfo,
 		ErrorMessage:   "Invalid auth provider token teamID.",
 	}
 }

--- a/packages/auth/pkg/auth/testing.go
+++ b/packages/auth/pkg/auth/testing.go
@@ -1,0 +1,24 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/auth/pkg/types"
+)
+
+// SetUserIDForTest sets the user ID on the gin context for use in tests.
+func SetUserIDForTest(t *testing.T, c *gin.Context, userID uuid.UUID) {
+	t.Helper()
+
+	setUserID(c, userID)
+}
+
+// SetTeamInfoForTest sets the team info on the gin context for use in tests.
+func SetTeamInfoForTest(t *testing.T, c *gin.Context, team *types.Team) {
+	t.Helper()
+
+	setTeamInfo(c, team)
+}

--- a/packages/dashboard-api/internal/handlers/sandbox_record_test.go
+++ b/packages/dashboard-api/internal/handlers/sandbox_record_test.go
@@ -48,7 +48,7 @@ func TestGetSandboxesSandboxIDRecordReturns404WhenRecordRetentionNotMet(t *testi
 	ctx.Request = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/sandboxes/sbx_1/record", nil)
 
 	teamID := uuid.New()
-	auth.SetTeamInfo(ctx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
 		Team: &authqueries.Team{
 			ID: teamID,
 		},

--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -67,7 +67,7 @@ func TestRequireAuthedTeamMatchesPath_Success(t *testing.T) {
 	ctx, _ := gin.CreateTestContext(recorder)
 
 	teamID := uuid.New()
-	auth.SetTeamInfo(ctx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
 		Team: &authqueries.Team{ID: teamID},
 	})
 
@@ -84,7 +84,7 @@ func TestRequireAuthedTeamMatchesPath_Mismatch(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
 
-	auth.SetTeamInfo(ctx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ctx, &authtypes.Team{
 		Team: &authqueries.Team{ID: uuid.New()},
 	})
 
@@ -117,8 +117,8 @@ func TestPostTeamsTeamIDMembers_DuplicateMemberReturnsBadRequest(t *testing.T) {
 	request.Header.Set("Content-Type", "application/json")
 	ginCtx.Request = request
 
-	auth.SetUserID(ginCtx, addedByUserID)
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetUserIDForTest(t, ginCtx, addedByUserID)
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{ID: teamID},
 	})
 
@@ -144,7 +144,7 @@ func TestDeleteTeamsTeamIDMembersUserId_NonMemberReturnsBadRequest(t *testing.T)
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodDelete, "/", nil)
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{ID: teamID},
 	})
 
@@ -197,7 +197,7 @@ func TestDeleteTeamsTeamIDMembersUserId_RechecksDefaultAfterLock(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodDelete, "/", nil)
-	auth.SetTeamInfo(ginCtx, &authtypes.Team{
+	auth.SetTeamInfoForTest(t, ginCtx, &authtypes.Team{
 		Team: &authqueries.Team{ID: teamID},
 	})
 
@@ -603,7 +603,7 @@ func TestPostTeams_LocalPolicyDeniedReturnsBadRequestWithoutCreatingTeam(t *test
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(`{"name":"Acme"}`))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetUserID(ginCtx, userID)
+	auth.SetUserIDForTest(t, ginCtx, userID)
 
 	store := &APIStore{
 		db:                testDB.SqlcClient,
@@ -641,7 +641,7 @@ func TestPostTeams_InvalidNameReturnsBadRequest(t *testing.T) {
 		ginCtx, _ := gin.CreateTestContext(recorder)
 		ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(body))
 		ginCtx.Request.Header.Set("Content-Type", "application/json")
-		auth.SetUserID(ginCtx, userID)
+		auth.SetUserIDForTest(t, ginCtx, userID)
 
 		sink := &fakeTeamProvisionSink{}
 		store := &APIStore{
@@ -673,7 +673,7 @@ func TestPostTeams_InvalidRequestBodyReturnsBadRequest(t *testing.T) {
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(`{"name":`))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetUserID(ginCtx, userID)
+	auth.SetUserIDForTest(t, ginCtx, userID)
 
 	store := &APIStore{
 		db:                testDB.SqlcClient,
@@ -706,7 +706,7 @@ func TestPostTeams_TrimsNameBeforeCreate(t *testing.T) {
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(`{"name":"  Acme  "}`))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetUserID(ginCtx, userID)
+	auth.SetUserIDForTest(t, ginCtx, userID)
 
 	store := &APIStore{
 		db:                testDB.SqlcClient,
@@ -758,7 +758,7 @@ func TestPostTeams_ProvisioningFailureRollsBackCreatedTeam(t *testing.T) {
 	ginCtx, _ := gin.CreateTestContext(recorder)
 	ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(`{"name":"Acme"}`))
 	ginCtx.Request.Header.Set("Content-Type", "application/json")
-	auth.SetUserID(ginCtx, userID)
+	auth.SetUserIDForTest(t, ginCtx, userID)
 
 	store := &APIStore{
 		db:                testDB.SqlcClient,
@@ -817,7 +817,7 @@ func TestPostTeams_ProvisioningFailurePreservesProvisionErrorStatus(t *testing.T
 			ginCtx, _ := gin.CreateTestContext(recorder)
 			ginCtx.Request = httptest.NewRequestWithContext(ctx, http.MethodPost, "/", strings.NewReader(`{"name":"Acme"}`))
 			ginCtx.Request.Header.Set("Content-Type", "application/json")
-			auth.SetUserID(ginCtx, userID)
+			auth.SetUserIDForTest(t, ginCtx, userID)
 
 			store := &APIStore{
 				db:                testDB.SqlcClient,


### PR DESCRIPTION
Production code outside the auth package has no legitimate need to mutate the gin context user ID or team info — only the authenticators in middleware.go set those values during request authentication. Keeping these setters exported invites unsafe usage from handlers or other middleware that could bypass the authentication flow.

Rename SetUserID -> setUserID and SetTeamInfo -> setTeamInfo so they are package-private, and update the three CommonAuthenticator constructors in middleware.go to reference the unexported functions.

Add a new packages/auth/pkg/auth/testing.go file exposing SetUserIDForTest(t, c, userID) and SetTeamInfoForTest(t, c, team) so tests that need to seed gin context values can still do so via an explicit test-only API (both call t.Helper() and delegate to the private setters).

Update all existing call sites in tests across packages/api and packages/dashboard-api to use the new helpers. For packages/api/internal/middleware/ratelimit/ratelimit_test.go, thread *testing.T through newRouterWithTeam so the helper can be used there too.