### PR TITLE
refactor(auth): tighten package API surface

### DIFF
--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -76,7 +76,7 @@ type APIStore struct {
 	templateCache         *templatecache.TemplateCache
 	templateBuildsCache   *templatecache.TemplatesBuildCache
 	snapshotCache         *snapshotcache.SnapshotCache
-	authService           *sharedauth.AuthService
+	authService           sharedauth.Service
 	templateSpawnCounter  *utils.TemplateSpawnCounter
 	clickhouseStore       clickhouse.Clickhouse
 	accessTokenGenerator  *sandbox.AccessTokenGenerator

--- a/packages/auth/pkg/auth/middleware.go
+++ b/packages/auth/pkg/auth/middleware.go
@@ -18,15 +18,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-// authorizationHeaderMissingError is returned when the authorization header is missing.
-type authorizationHeaderMissingError struct{}
-
-func (e *authorizationHeaderMissingError) Error() string {
-	return "authorization header is missing"
-}
-
 var (
-	ErrNoAuthHeader      = &authorizationHeaderMissingError{}
+	ErrNoAuthHeader      = errors.New("authorization header is missing")
 	ErrInvalidAuthHeader = errors.New("authorization header is malformed")
 )
 

--- a/packages/auth/pkg/auth/middleware.go
+++ b/packages/auth/pkg/auth/middleware.go
@@ -18,23 +18,23 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
-// AuthorizationHeaderMissingError is returned when the authorization header is missing.
-type AuthorizationHeaderMissingError struct{}
+// authorizationHeaderMissingError is returned when the authorization header is missing.
+type authorizationHeaderMissingError struct{}
 
-func (e *AuthorizationHeaderMissingError) Error() string {
+func (e *authorizationHeaderMissingError) Error() string {
 	return "authorization header is missing"
 }
 
 var (
-	ErrNoAuthHeader      = &AuthorizationHeaderMissingError{}
+	ErrNoAuthHeader      = &authorizationHeaderMissingError{}
 	ErrInvalidAuthHeader = errors.New("authorization header is malformed")
 )
 
-// HeaderKey describes how to extract an authentication token from an HTTP request header.
-type HeaderKey struct {
-	Name         string
-	Prefix       string
-	RemovePrefix string
+// headerKey describes how to extract an authentication token from an HTTP request header.
+type headerKey struct {
+	name         string
+	prefix       string
+	removePrefix string
 }
 
 // Authenticator is implemented by types that can authenticate requests against a security scheme.
@@ -43,27 +43,27 @@ type Authenticator interface {
 	SecuritySchemeName() string
 }
 
-// CommonAuthenticator implements Authenticator using a header-based token with a pluggable validation function.
-type CommonAuthenticator[T any] struct {
-	SchemeName     string
-	Header         HeaderKey
-	ValidationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (T, *APIError)
-	SetContextFunc func(ginCtx *gin.Context, value T)
-	ErrorMessage   string
+// commonAuthenticator implements Authenticator using a header-based token with a pluggable validation function.
+type commonAuthenticator[T any] struct {
+	schemeName     string
+	header         headerKey
+	validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (T, *APIError)
+	setContextFunc func(ginCtx *gin.Context, value T)
+	errorMessage   string
 }
 
-// GetHeaderKeysFromRequest extracts the token from the request header.
-func (a *CommonAuthenticator[T]) GetHeaderKeysFromRequest(req *http.Request) (string, error) {
-	key := req.Header.Get(a.Header.Name)
+// getHeaderKeysFromRequest extracts the token from the request header.
+func (a *commonAuthenticator[T]) getHeaderKeysFromRequest(req *http.Request) (string, error) {
+	key := req.Header.Get(a.header.name)
 	if key == "" {
 		return "", ErrNoAuthHeader
 	}
 
-	if a.Header.RemovePrefix != "" {
-		key = strings.TrimSpace(strings.TrimPrefix(key, a.Header.RemovePrefix))
+	if a.header.removePrefix != "" {
+		key = strings.TrimSpace(strings.TrimPrefix(key, a.header.removePrefix))
 	}
 
-	if a.Header.Prefix != "" && !strings.HasPrefix(key, a.Header.Prefix) {
+	if a.header.prefix != "" && !strings.HasPrefix(key, a.header.prefix) {
 		return "", ErrInvalidAuthHeader
 	}
 
@@ -71,13 +71,13 @@ func (a *CommonAuthenticator[T]) GetHeaderKeysFromRequest(req *http.Request) (st
 }
 
 // Authenticate validates the request against the security scheme.
-func (a *CommonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.Context, input *openapi3filter.AuthenticationInput) error {
-	headerKey, err := a.GetHeaderKeysFromRequest(input.RequestValidationInput.Request)
+func (a *commonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.Context, input *openapi3filter.AuthenticationInput) error {
+	key, err := a.getHeaderKeysFromRequest(input.RequestValidationInput.Request)
 	if err != nil {
 		telemetry.ReportError(ctx,
 			"authorization header is missing",
 			err,
-			attribute.String("error.message", a.ErrorMessage),
+			attribute.String("error.message", a.errorMessage),
 		)
 
 		ginCtx.Status(http.StatusUnauthorized)
@@ -87,12 +87,12 @@ func (a *CommonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.C
 
 	telemetry.ReportEvent(ctx, "api key extracted")
 
-	result, validationError := a.ValidationFunc(ctx, ginCtx, headerKey)
+	result, validationError := a.validationFunc(ctx, ginCtx, key)
 	if validationError != nil {
 		telemetry.ReportError(ctx,
 			"validation error",
 			validationError.Err,
-			attribute.String("error.message", a.ErrorMessage),
+			attribute.String("error.message", a.errorMessage),
 			attribute.Int("http.status_code", validationError.Code),
 			attribute.String("http.status_text", http.StatusText(validationError.Code)),
 		)
@@ -109,21 +109,21 @@ func (a *CommonAuthenticator[T]) Authenticate(ctx context.Context, ginCtx *gin.C
 			return fmt.Errorf("blocked: %w", validationError.Err)
 		}
 
-		return fmt.Errorf("%s\n%s (%w)", a.ErrorMessage, validationError.ClientMsg, validationError.Err)
+		return fmt.Errorf("%s\n%s (%w)", a.errorMessage, validationError.ClientMsg, validationError.Err)
 	}
 
 	telemetry.ReportEvent(ctx, "api key validated")
 
-	if a.SetContextFunc != nil {
-		a.SetContextFunc(ginCtx, result)
+	if a.setContextFunc != nil {
+		a.setContextFunc(ginCtx, result)
 	}
 
 	return nil
 }
 
 // SecuritySchemeName returns the name of the security scheme this authenticator handles.
-func (a *CommonAuthenticator[T]) SecuritySchemeName() string {
-	return a.SchemeName
+func (a *commonAuthenticator[T]) SecuritySchemeName() string {
+	return a.schemeName
 }
 
 func adminValidationFunction(adminToken string) func(ctx context.Context, ginCtx *gin.Context, token string) (struct{}, *APIError) {
@@ -142,95 +142,95 @@ func adminValidationFunction(adminToken string) func(ctx context.Context, ginCtx
 
 // NewApiKeyAuthenticator creates an authenticator for the ApiKeyAuth security scheme (X-API-Key header, e2b_ prefix).
 func NewApiKeyAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (*types.Team, *APIError)) Authenticator {
-	return &CommonAuthenticator[*types.Team]{
-		SchemeName: "ApiKeyAuth",
-		Header: HeaderKey{
-			Name:   HeaderAPIKey,
-			Prefix: PrefixAPIKey,
+	return &commonAuthenticator[*types.Team]{
+		schemeName: "ApiKeyAuth",
+		header: headerKey{
+			name:   HeaderAPIKey,
+			prefix: PrefixAPIKey,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setTeamInfo,
-		ErrorMessage:   "Invalid API key, please visit https://e2b.dev/docs/api-key for more information.",
+		validationFunc: validationFunc,
+		setContextFunc: setTeamInfo,
+		errorMessage:   "Invalid API key, please visit https://e2b.dev/docs/api-key for more information.",
 	}
 }
 
 // NewAccessTokenAuthenticator creates an authenticator for the AccessTokenAuth security scheme (Authorization Bearer sk_e2b_).
 func NewAccessTokenAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError)) Authenticator {
-	return &CommonAuthenticator[uuid.UUID]{
-		SchemeName: "AccessTokenAuth",
-		Header: HeaderKey{
-			Name:         HeaderAuthorization,
-			Prefix:       PrefixAccessToken,
-			RemovePrefix: PrefixBearer,
+	return &commonAuthenticator[uuid.UUID]{
+		schemeName: "AccessTokenAuth",
+		header: headerKey{
+			name:         HeaderAuthorization,
+			prefix:       PrefixAccessToken,
+			removePrefix: PrefixBearer,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setUserID,
-		ErrorMessage:   "Invalid Access token, try to login again by running `e2b auth login`.",
+		validationFunc: validationFunc,
+		setContextFunc: setUserID,
+		errorMessage:   "Invalid Access token, try to login again by running `e2b auth login`.",
 	}
 }
 
 // NewAuthProviderBearerAuthenticator creates an authenticator for AuthProviderBearerAuth (Authorization Bearer token).
 func NewAuthProviderBearerAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError)) Authenticator {
-	return &CommonAuthenticator[uuid.UUID]{
-		SchemeName: "AuthProviderBearerAuth",
-		Header: HeaderKey{
-			Name:         HeaderAuthorization,
-			RemovePrefix: PrefixBearer,
+	return &commonAuthenticator[uuid.UUID]{
+		schemeName: "AuthProviderBearerAuth",
+		header: headerKey{
+			name:         HeaderAuthorization,
+			removePrefix: PrefixBearer,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setUserID,
-		ErrorMessage:   "Invalid auth provider token.",
+		validationFunc: validationFunc,
+		setContextFunc: setUserID,
+		errorMessage:   "Invalid auth provider token.",
 	}
 }
 
 // NewSupabaseTokenAuthenticator creates an authenticator for the Supabase1TokenAuth security scheme (X-Supabase-Token header).
 func NewSupabaseTokenAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError)) Authenticator {
-	return &CommonAuthenticator[uuid.UUID]{
-		SchemeName: "Supabase1TokenAuth",
-		Header: HeaderKey{
-			Name: HeaderSupabaseToken,
+	return &commonAuthenticator[uuid.UUID]{
+		schemeName: "Supabase1TokenAuth",
+		header: headerKey{
+			name: HeaderSupabaseToken,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setUserID,
-		ErrorMessage:   "Invalid Supabase token.",
+		validationFunc: validationFunc,
+		setContextFunc: setUserID,
+		errorMessage:   "Invalid Supabase token.",
 	}
 }
 
 // NewSupabaseTeamAuthenticator creates an authenticator for the Supabase2TeamAuth security scheme (X-Supabase-Team header).
 func NewSupabaseTeamAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (*types.Team, *APIError)) Authenticator {
-	return &CommonAuthenticator[*types.Team]{
-		SchemeName: "Supabase2TeamAuth",
-		Header: HeaderKey{
-			Name: HeaderSupabaseTeam,
+	return &commonAuthenticator[*types.Team]{
+		schemeName: "Supabase2TeamAuth",
+		header: headerKey{
+			name: HeaderSupabaseTeam,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setTeamInfo,
-		ErrorMessage:   "Invalid Supabase token teamID.",
+		validationFunc: validationFunc,
+		setContextFunc: setTeamInfo,
+		errorMessage:   "Invalid Supabase token teamID.",
 	}
 }
 
 // NewAuthProviderTeamAuthenticator creates an authenticator for the AuthProviderTeamAuth security scheme (X-Team-Id header).
 func NewAuthProviderTeamAuthenticator(validationFunc func(ctx context.Context, ginCtx *gin.Context, token string) (*types.Team, *APIError)) Authenticator {
-	return &CommonAuthenticator[*types.Team]{
-		SchemeName: "AuthProviderTeamAuth",
-		Header: HeaderKey{
-			Name: HeaderTeamID,
+	return &commonAuthenticator[*types.Team]{
+		schemeName: "AuthProviderTeamAuth",
+		header: headerKey{
+			name: HeaderTeamID,
 		},
-		ValidationFunc: validationFunc,
-		SetContextFunc: setTeamInfo,
-		ErrorMessage:   "Invalid auth provider token teamID.",
+		validationFunc: validationFunc,
+		setContextFunc: setTeamInfo,
+		errorMessage:   "Invalid auth provider token teamID.",
 	}
 }
 
 // NewAdminTokenAuthenticator creates an authenticator for the AdminTokenAuth security scheme (X-Admin-Token header).
 func NewAdminTokenAuthenticator(adminToken string) Authenticator {
-	return &CommonAuthenticator[struct{}]{
-		SchemeName: "AdminTokenAuth",
-		Header: HeaderKey{
-			Name: HeaderAdminToken,
+	return &commonAuthenticator[struct{}]{
+		schemeName: "AdminTokenAuth",
+		header: headerKey{
+			name: HeaderAdminToken,
 		},
-		ValidationFunc: adminValidationFunction(adminToken),
-		ErrorMessage:   "Invalid Access token.",
+		validationFunc: adminValidationFunction(adminToken),
+		errorMessage:   "Invalid Access token.",
 	}
 }
 

--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -26,9 +26,9 @@ type authStore interface {
 	GetTeamAPIKeyHashes(ctx context.Context, teamID uuid.UUID) ([]string, error)
 }
 
-// Service is the interface implemented by AuthService. It exposes the auth
-// validation, team lookup, and cache invalidation operations used by callers
-// such as APIStore and the dashboard-api handlers.
+// Service is the interface implemented by the unexported authService. It
+// exposes the auth validation, team lookup, and cache invalidation operations
+// used by callers such as APIStore and the dashboard-api handlers.
 type Service interface {
 	ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (*types.Team, *APIError)
 	ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError)
@@ -40,26 +40,28 @@ type Service interface {
 	Close(ctx context.Context) error
 }
 
-// AuthService encapsulates the cache, store, and JWT verifier for auth validation.
-type AuthService struct {
+// authService encapsulates the cache, store, and JWT verifier for auth validation.
+type authService struct {
 	store                authStore
 	teamCache            *authCache
 	authProviderVerifier *verifier
 }
 
-// Compile-time assertion that *AuthService satisfies the Service interface.
-var _ Service = (*AuthService)(nil)
+// Compile-time assertion that *authService satisfies the Service interface.
+var _ Service = (*authService)(nil)
 
 // NewAuthService wires up the team cache, auth store, identity lookup, and JWT
 // verifier from the supplied dependencies. The HTTP client is used for OIDC
 // discovery and JWKS fetches.
+//
+//nolint:revive // returning unexported type is intentional to prevent external instantiation
 func NewAuthService(
 	ctx context.Context,
 	redisClient redis.UniversalClient,
 	authDB *authdb.Client,
 	providerConfig ProviderConfig,
 	httpClient *http.Client,
-) (Service, error) {
+) (*authService, error) {
 	if redisClient == nil {
 		return nil, errors.New("redisClient is required")
 	}
@@ -78,7 +80,7 @@ func NewAuthService(
 		return nil, fmt.Errorf("initializing auth provider JWT verifier: %w", err)
 	}
 
-	return &AuthService{
+	return &authService{
 		store:                store,
 		teamCache:            cache,
 		authProviderVerifier: v,
@@ -86,7 +88,7 @@ func NewAuthService(
 }
 
 // ValidateAPIKey verifies the API key format and fetches the associated team via cache + store.
-func (s *AuthService) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (*types.Team, *APIError) {
+func (s *authService) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (*types.Team, *APIError) {
 	hashedKey, err := keys.VerifyKey(keys.ApiKeyPrefix, apiKey)
 	if err != nil {
 		return nil, &APIError{
@@ -135,14 +137,14 @@ func (s *AuthService) ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, a
 }
 
 // GetTeamByID fetches team auth data via cache + store.
-func (s *AuthService) GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error) {
+func (s *authService) GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error) {
 	return s.teamCache.GetOrSet(ctx, teamCacheKey(teamID), func(ctx context.Context, _ string) (*types.Team, error) {
 		return s.store.GetTeamByID(ctx, teamID)
 	})
 }
 
 // ValidateAccessToken verifies the access token format and fetches the associated user ID.
-func (s *AuthService) ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError) {
+func (s *authService) ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError) {
 	hashedToken, err := keys.VerifyKey(keys.AccessTokenPrefix, accessToken)
 	if err != nil {
 		return uuid.UUID{}, &APIError{
@@ -176,7 +178,7 @@ func (s *AuthService) ValidateAccessToken(ctx context.Context, ginCtx *gin.Conte
 // every token is denied with 401. This makes "no auth provider" a valid
 // configuration: API key / access token flows keep working, but JWT-based
 // flows are universally rejected.
-func (s *AuthService) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError) {
+func (s *authService) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError) {
 	if s.authProviderVerifier == nil {
 		return uuid.UUID{}, &APIError{
 			Err:       errors.New("auth provider is not configured"),
@@ -188,7 +190,7 @@ func (s *AuthService) ValidateAuthProviderToken(ctx context.Context, ginCtx *gin
 	return s.validateJWTWithProvider(ctx, ginCtx, s.authProviderVerifier, token, "auth provider")
 }
 
-func (s *AuthService) validateJWTWithProvider(ctx context.Context, ginCtx *gin.Context, v *verifier, token string, tokenSource string) (uuid.UUID, *APIError) {
+func (s *authService) validateJWTWithProvider(ctx context.Context, ginCtx *gin.Context, v *verifier, token string, tokenSource string) (uuid.UUID, *APIError) {
 	userID, _, err := v.Verify(ctx, token)
 	if err != nil {
 		return uuid.UUID{}, &APIError{
@@ -215,7 +217,7 @@ func (s *AuthService) validateJWTWithProvider(ctx context.Context, ginCtx *gin.C
 }
 
 // ValidateSupabaseTeam extracts the user ID from the gin context and fetches the team via cache + store.
-func (s *AuthService) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Context, teamID string) (*types.Team, *APIError) {
+func (s *authService) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Context, teamID string) (*types.Team, *APIError) {
 	userID, ok := GetUserID(ginCtx)
 	if !ok {
 		return nil, &APIError{
@@ -267,12 +269,12 @@ func (s *AuthService) ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Cont
 
 // InvalidateTeamMemberCache removes the cached auth entry for a specific user-team pair.
 // This should be called when team membership changes (member added or removed).
-func (s *AuthService) InvalidateTeamMemberCache(ctx context.Context, userID uuid.UUID, teamID string) {
+func (s *authService) InvalidateTeamMemberCache(ctx context.Context, userID uuid.UUID, teamID string) {
 	s.teamCache.Invalidate(ctx, supabaseTeamCacheKey(userID, teamID))
 }
 
 // InvalidateTeamCache queries the team's API key hashes and removes their cached entries.
-func (s *AuthService) InvalidateTeamCache(ctx context.Context, teamID uuid.UUID) error {
+func (s *authService) InvalidateTeamCache(ctx context.Context, teamID uuid.UUID) error {
 	s.teamCache.Invalidate(ctx, teamCacheKey(teamID))
 
 	hashes, err := s.store.GetTeamAPIKeyHashes(ctx, teamID)
@@ -296,6 +298,6 @@ func teamCacheKey(teamID uuid.UUID) string {
 }
 
 // Close stops the underlying cache's background refresh goroutines.
-func (s *AuthService) Close(ctx context.Context) error {
+func (s *authService) Close(ctx context.Context) error {
 	return s.teamCache.Close(ctx)
 }

--- a/packages/auth/pkg/auth/service.go
+++ b/packages/auth/pkg/auth/service.go
@@ -26,12 +26,29 @@ type authStore interface {
 	GetTeamAPIKeyHashes(ctx context.Context, teamID uuid.UUID) ([]string, error)
 }
 
+// Service is the interface implemented by AuthService. It exposes the auth
+// validation, team lookup, and cache invalidation operations used by callers
+// such as APIStore and the dashboard-api handlers.
+type Service interface {
+	ValidateAPIKey(ctx context.Context, ginCtx *gin.Context, apiKey string) (*types.Team, *APIError)
+	ValidateAccessToken(ctx context.Context, ginCtx *gin.Context, accessToken string) (uuid.UUID, *APIError)
+	ValidateAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *APIError)
+	ValidateSupabaseTeam(ctx context.Context, ginCtx *gin.Context, teamID string) (*types.Team, *APIError)
+	GetTeamByID(ctx context.Context, teamID uuid.UUID) (*types.Team, error)
+	InvalidateTeamMemberCache(ctx context.Context, userID uuid.UUID, teamID string)
+	InvalidateTeamCache(ctx context.Context, teamID uuid.UUID) error
+	Close(ctx context.Context) error
+}
+
 // AuthService encapsulates the cache, store, and JWT verifier for auth validation.
 type AuthService struct {
 	store                authStore
 	teamCache            *authCache
 	authProviderVerifier *verifier
 }
+
+// Compile-time assertion that *AuthService satisfies the Service interface.
+var _ Service = (*AuthService)(nil)
 
 // NewAuthService wires up the team cache, auth store, identity lookup, and JWT
 // verifier from the supplied dependencies. The HTTP client is used for OIDC
@@ -42,7 +59,7 @@ func NewAuthService(
 	authDB *authdb.Client,
 	providerConfig ProviderConfig,
 	httpClient *http.Client,
-) (*AuthService, error) {
+) (Service, error) {
 	if redisClient == nil {
 		return nil, errors.New("redisClient is required")
 	}

--- a/packages/auth/pkg/auth/verifier.go
+++ b/packages/auth/pkg/auth/verifier.go
@@ -76,8 +76,8 @@ type verifier struct {
 // When the provided config has no JWT issuers and no legacy entry (i.e. the
 // AUTH_PROVIDER_CONFIG env var is unset or empty), newVerifier returns
 // (nil, nil). This is a valid configuration: the caller can pass the nil
-// verifier to AuthService, and any token verification attempt will be denied
-// at runtime by verifier.Verify / AuthService.ValidateAuthProviderToken.
+// verifier to authService, and any token verification attempt will be denied
+// at runtime by verifier.Verify / Service.ValidateAuthProviderToken.
 func newVerifier(ctx context.Context, config ProviderConfig, oidcHTTPClient *http.Client, identities oidc.IdentityLookup) (*verifier, error) {
 	normalized := config.normalize()
 	if err := normalized.validate(); err != nil {

--- a/packages/auth/pkg/auth/verifier.go
+++ b/packages/auth/pkg/auth/verifier.go
@@ -23,8 +23,8 @@ type ProviderConfig struct {
 	Legacy *legacy.Config `json:"legacy"`
 }
 
-// Enabled returns true when at least one auth provider entry is configured.
-func (c ProviderConfig) Enabled() bool {
+// enabled returns true when at least one auth provider entry is configured.
+func (c ProviderConfig) enabled() bool {
 	return len(c.JWT) > 0 || c.Legacy != nil
 }
 
@@ -83,7 +83,7 @@ func newVerifier(ctx context.Context, config ProviderConfig, oidcHTTPClient *htt
 	if err := normalized.validate(); err != nil {
 		return nil, err
 	}
-	if !normalized.Enabled() {
+	if !normalized.enabled() {
 		return nil, nil
 	}
 

--- a/packages/dashboard-api/internal/handlers/store.go
+++ b/packages/dashboard-api/internal/handlers/store.go
@@ -27,11 +27,11 @@ type APIStore struct {
 	authDB            *authdb.Client
 	supabaseDB        *supabasedb.Client
 	clickhouse        clickhouse.Clickhouse
-	authService       *sharedauth.AuthService
+	authService       sharedauth.Service
 	teamProvisionSink internalteamprovision.TeamProvisionSink
 }
 
-func NewAPIStore(config cfg.Config, db *sqlcdb.Client, authDB *authdb.Client, supabaseDB *supabasedb.Client, ch clickhouse.Clickhouse, authService *sharedauth.AuthService, teamProvisionSink internalteamprovision.TeamProvisionSink) *APIStore {
+func NewAPIStore(config cfg.Config, db *sqlcdb.Client, authDB *authdb.Client, supabaseDB *supabasedb.Client, ch clickhouse.Clickhouse, authService sharedauth.Service, teamProvisionSink internalteamprovision.TeamProvisionSink) *APIStore {
 	return &APIStore{
 		config:            config,
 		db:                db,


### PR DESCRIPTION
## Summary

- Introduce a `Service` interface in `packages/auth/pkg/auth` covering the operations callers actually use (`ValidateAPIKey`, `ValidateAccessToken`, `ValidateAuthProviderToken`, `ValidateSupabaseTeam`, `GetTeamByID`, `InvalidateTeamMemberCache`, `InvalidateTeamCache`, `Close`), and consume it via `sharedauth.Service` in both `api` and `dashboard-api` APIStores so the dependency is mockable in tests.
- Unexport the concrete `AuthService` struct (now `authService`); `NewAuthService` is the only entry point.
- Unexport the middleware internals that should not be part of the package API: `HeaderKey` → `headerKey`, `CommonAuthenticator` → `commonAuthenticator` (plus its fields and `GetHeaderKeysFromRequest`), and `ProviderConfig.Enabled` → `enabled`. The exported `Authenticator` interface and the `NewXxxAuthenticator` constructors remain unchanged, so external callers are unaffected.
- Replace the bespoke `AuthorizationHeaderMissingError` type with a plain `errors.New` sentinel for `ErrNoAuthHeader`. Callers compare with `errors.Is`, so behavior is preserved.

## Notes

- No behavior change; this is purely an API-surface cleanup.
- Verified with `go build ./...` in `packages/auth`, `packages/api`, and `packages/dashboard-api`.
