### PR TITLE
Replace colordiff and diff with git diff

### DIFF
--- a/scripts/download-prod-env.sh
+++ b/scripts/download-prod-env.sh
@@ -22,7 +22,7 @@ if [[ -f "$ENV_FILE" ]]; then
   if ! diff -q "$ENV_FILE" "$TMP_FILE" > /dev/null; then
     echo "⚠️ Diff detected:"
 
-    git --no-pager diff --no-index "$ENV_FILE" "$TMP_FILE" || true
+    git --no-pager diff --no-index "$ENV_FILE" "$TMP_FILE" || [ $? -eq 1 ]
 
     read -p "Do you want to overwrite $ENV_FILE? (y/N): " CONFIRM
     if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then

--- a/scripts/download-prod-env.sh
+++ b/scripts/download-prod-env.sh
@@ -22,11 +22,7 @@ if [[ -f "$ENV_FILE" ]]; then
   if ! diff -q "$ENV_FILE" "$TMP_FILE" > /dev/null; then
     echo "⚠️ Diff detected:"
 
-    if command -v colordiff > /dev/null; then
-      colordiff -u "$ENV_FILE" "$TMP_FILE" || true
-    else
-      diff --no-index  "$ENV_FILE" "$TMP_FILE" || true
-    fi
+    git --no-pager diff --no-index "$ENV_FILE" "$TMP_FILE" || true
 
     read -p "Do you want to overwrite $ENV_FILE? (y/N): " CONFIRM
     if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
Removes the need to install `colordiff` and uses the already available' git diff' instead.