### PR TITLE
Make sandbox traffic routable over ingress

### DIFF
--- a/iac/modules/job-ingress/main.tf
+++ b/iac/modules/job-ingress/main.tf
@@ -12,6 +12,9 @@ locals {
 
     otel_collector_grpc_endpoint = var.otel_collector_grpc_endpoint
   })
+
+  ingress_cpu_count = var.ingress_cpu_count == null ? 1 : var.ingress_cpu_count
+  ingress_memory_mb = var.ingress_memory_mb == null ? 512 : var.ingress_memory_mb
 }
 
 resource "nomad_job" "ingress" {
@@ -19,8 +22,9 @@ resource "nomad_job" "ingress" {
     count         = var.ingress_count
     node_pool     = var.node_pool
     update_stanza = var.update_stanza
-    cpu_count     = var.ingress_cpu_count
-    memory_mb     = var.ingress_memory_mb
+
+    cpu_count = local.ingress_cpu_count
+    memory_mb = local.ingress_memory_mb
 
     control_port          = var.control_port
     ingress_port          = var.ingress_port

--- a/iac/modules/job-ingress/variables.tf
+++ b/iac/modules/job-ingress/variables.tf
@@ -45,12 +45,12 @@ variable "ingress_count" {
 
 variable "ingress_cpu_count" {
   type    = number
-  default = 1
+  default = null
 }
 
 variable "ingress_memory_mb" {
   type    = number
-  default = 512
+  default = null
 }
 
 variable "otel_collector_grpc_endpoint" {

--- a/iac/provider-aws/Makefile
+++ b/iac/provider-aws/Makefile
@@ -38,6 +38,8 @@ tf_vars := AWS_PROFILE=$(AWS_PROFILE) AWS_REGION=$(AWS_REGION) \
 	$(call tfvar, API_SERVER_MACHINE_TYPE) \
 	$(call tfvar, CLIENT_PROXY_COUNT) \
 	$(call tfvar, INGRESS_COUNT) \
+	$(call tfvar, INGRESS_MEMORY_MB) \
+	$(call tfvar, INGRESS_CPU_COUNT) \
 	$(call tfvar, BUILD_CLUSTER_SIZE) \
 	$(call tfvar, BUILD_SERVER_MACHINE_TYPE) \
 	$(call tfvar, BUILD_SERVER_NESTED_VIRTUALIZATION) \

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -212,6 +212,8 @@ module "nomad" {
   sandbox_access_token_hash_seed = module.init.sandbox_access_token_hash_seed
 
   ingress_count         = var.ingress_count
+  ingress_cpu_count     = var.ingress_cpu_count
+  ingress_memory_mb     = var.ingress_memory_mb
   ingress_port          = local.ingress_port
   ingress_internal_port = local.ingress_internal_port
 

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -79,6 +79,9 @@ module "ingress" {
   ingress_port          = var.ingress_port
   ingress_internal_port = var.ingress_internal_port
 
+  ingress_cpu_count = var.ingress_cpu_count
+  ingress_memory_mb = var.ingress_memory_mb
+
   traefik_config_files = var.traefik_config_files
 
   node_pool     = var.api_node_pool

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -55,6 +55,18 @@ variable "ingress_count" {
   type = number
 }
 
+variable "ingress_cpu_count" {
+  type        = number
+  default     = null
+  description = "CPU count for each ingress instance"
+}
+
+variable "ingress_memory_mb" {
+  type        = number
+  default     = null
+  description = "Memory in MB for each ingress instance"
+}
+
 # Client Proxy
 variable "client_proxy_count" {
   type    = number

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -59,6 +59,18 @@ variable "ingress_count" {
   default = 1
 }
 
+variable "ingress_cpu_count" {
+  type        = number
+  default     = null
+  description = "CPU count for each ingress instance"
+}
+
+variable "ingress_memory_mb" {
+  type        = number
+  default     = null
+  description = "Memory in MB for each ingress instance"
+}
+
 variable "client_proxy_count" {
   type    = number
   default = 1

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -101,7 +101,8 @@ tf_vars := \
 	$(call tfvar, CLIENT_PROXY_OIDC_ISSUER_URL) \
 	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE) \
 	$(call tfvar, ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS) \
-	$(call tfvar, ANYWHERE_CACHE_ENABLED)
+	$(call tfvar, ANYWHERE_CACHE_ENABLED) \
+	$(call tfvar, INGRESS_SANDBOX_TRAFFIC_WEIGHT)
 
 .PHONY: init
 init:

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -49,6 +49,8 @@ tf_vars := \
 	$(call tfvar, API_RESOURCES_CPU_COUNT) \
 	$(call tfvar, API_RESOURCES_MEMORY_MB) \
 	$(call tfvar, INGRESS_COUNT) \
+	$(call tfvar, INGRESS_MEMORY_MB) \
+	$(call tfvar, INGRESS_CPU_COUNT) \
 	$(call tfvar, CLIENT_PROXY_COUNT) \
 	$(call tfvar, CLIENT_PROXY_RESOURCES_CPU_COUNT) \
 	$(call tfvar, CLIENT_PROXY_RESOURCES_MEMORY_MB) \

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -229,6 +229,8 @@ module "nomad" {
 
   # Ingress
   ingress_count         = var.ingress_count
+  ingress_cpu_count     = var.ingress_cpu_count
+  ingress_memory_mb     = var.ingress_memory_mb
   ingress_port          = var.ingress_port.port
   ingress_internal_port = var.ingress_internal_port.port
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -168,6 +168,7 @@ module "cluster" {
 
   additional_domains                      = local.additional_domains
   additional_api_paths_handled_by_ingress = local.normalized_api_paths_handled_by_ingress
+  ingress_sandbox_traffic_weight          = var.ingress_sandbox_traffic_weight
 
   docker_contexts_bucket_name = module.init.envs_docker_context_bucket_name
   cluster_setup_bucket_name   = module.init.cluster_setup_bucket_name

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -117,6 +117,7 @@ module "network" {
   domain_name                             = var.domain_name
   additional_domains                      = var.additional_domains
   additional_api_paths_handled_by_ingress = var.additional_api_paths_handled_by_ingress
+  ingress_sandbox_traffic_weight          = var.ingress_sandbox_traffic_weight
 
   client_proxy_port        = var.client_proxy_port
   client_proxy_health_port = var.client_proxy_health_port

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -303,8 +303,19 @@ resource "google_compute_url_map" "orch_map" {
   }
 
   path_matcher {
-    name            = "session-paths"
-    default_service = google_compute_backend_service.default["session"].self_link
+    name = "session-paths"
+
+    default_route_action {
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.default["session"].self_link
+        weight          = 99
+      }
+
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.ingress.self_link
+        weight          = 1
+      }
+    }
   }
 
   path_matcher {

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -308,12 +308,12 @@ resource "google_compute_url_map" "orch_map" {
     default_route_action {
       weighted_backend_services {
         backend_service = google_compute_backend_service.default["session"].self_link
-        weight          = 99
+        weight          = 100 - var.ingress_sandbox_traffic_weight
       }
 
       weighted_backend_services {
         backend_service = google_compute_backend_service.ingress.self_link
-        weight          = 1
+        weight          = var.ingress_sandbox_traffic_weight
       }
     }
   }

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -113,5 +113,5 @@ variable "additional_api_paths_handled_by_ingress" {
 variable "ingress_sandbox_traffic_weight" {
   type        = number
   description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
-  default     = 1
+  default     = 0
 }

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -109,3 +109,9 @@ variable "additional_api_paths_handled_by_ingress" {
     timeout_sec = optional(number)
   }))
 }
+
+variable "ingress_sandbox_traffic_weight" {
+  type        = number
+  description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
+  default     = 1
+}

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -388,3 +388,9 @@ variable "additional_api_paths_handled_by_ingress" {
     timeout_sec = optional(number)
   }))
 }
+
+variable "ingress_sandbox_traffic_weight" {
+  type        = number
+  description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
+  default     = 1
+}

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -392,5 +392,5 @@ variable "additional_api_paths_handled_by_ingress" {
 variable "ingress_sandbox_traffic_weight" {
   type        = number
   description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
-  default     = 1
+  default     = 0
 }

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -118,6 +118,9 @@ module "ingress" {
   nomad_token  = var.nomad_acl_token_secret
   consul_token = var.consul_acl_token_secret
 
+  ingress_cpu_count = var.ingress_cpu_count
+  ingress_memory_mb = var.ingress_memory_mb
+
   otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
 }
 

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -84,6 +84,18 @@ variable "ingress_count" {
   type = number
 }
 
+variable "ingress_cpu_count" {
+  type        = number
+  default     = null
+  description = "CPU count for each ingress instance"
+}
+
+variable "ingress_memory_mb" {
+  type        = number
+  default     = null
+  description = "Memory in MB for each ingress instance"
+}
+
 variable "traefik_config_files" {
   type        = map(string)
   description = "Map of filename => content for additional Traefik dynamic configuration files"

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -131,6 +131,18 @@ variable "ingress_count" {
   default = 1
 }
 
+variable "ingress_cpu_count" {
+  type        = number
+  default     = null
+  description = "CPU count for each ingress instance"
+}
+
+variable "ingress_memory_mb" {
+  type        = number
+  default     = null
+  description = "Memory in MB for each ingress instance"
+}
+
 variable "additional_api_paths_handled_by_ingress" {
   type        = any
   description = <<-EOT

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -159,7 +159,7 @@ variable "additional_api_paths_handled_by_ingress" {
 variable "ingress_sandbox_traffic_weight" {
   type        = number
   description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
-  default     = 1
+  default     = 0
 }
 
 variable "client_proxy_resources_memory_mb" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -156,6 +156,12 @@ variable "additional_api_paths_handled_by_ingress" {
   default     = []
 }
 
+variable "ingress_sandbox_traffic_weight" {
+  type        = number
+  description = "Weight (out of 100) of sandbox traffic routed to the ingress backend. The remainder goes to the session backend."
+  default     = 1
+}
+
 variable "client_proxy_resources_memory_mb" {
   type    = number
   default = 1024


### PR DESCRIPTION
- Load balancer setup for sharing sbx connections between client-proxy directly and ingress
- Expose cpu and memory envs for ingress
- Expose env for configuring ingress traffic weight 
- Default weight is zero

`INGRESS_SANDBOX_TRAFFIC_WEIGHT` works are the handbrake when it's set to 0.
Configuration change is not affecting already established connections.