### PR TITLE
feat(orch): add less, nftables, iputils-ping, and jq to base provisioning

### DIFF
--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -19,7 +19,7 @@ is_package_installed() {
 }
 
 # Install required packages if not already installed
-PACKAGES="systemd systemd-sysv openssh-server sudo chrony socat curl ca-certificates fuse3 iptables git nfs-common"
+PACKAGES="systemd systemd-sysv openssh-server sudo chrony socat curl ca-certificates fuse3 iptables git nfs-common less nftables iputils-ping jq"
 echo "Checking presence of the following packages: $PACKAGES"
 
 MISSING=""

--- a/tests/integration/internal/tests/api/templates/build_template_test.go
+++ b/tests/integration/internal/tests/api/templates/build_template_test.go
@@ -1036,6 +1036,10 @@ func TestTemplateBuildInstalledPackagesAvailable(t *testing.T) {
 		"fuse3",
 		"iptables",
 		"git",
+		"less",
+		"nftables",
+		"iputils-ping",
+		"jq",
 	}
 
 	steps := make([]api.TemplateStep, 0, len(packages))


### PR DESCRIPTION
Include common debugging and inspection tools in the sandbox base image so they are available out of the box:
- less: pager for viewing file contents and command output
- nftables: modern firewall/packet filtering (alongside existing iptables)
- iputils-ping: network connectivity diagnostics
- jq: JSON parsing and manipulation