### PR TITLE
fix(iac): convert the condtion to seconds

### DIFF
--- a/iac/provider-gcp/remote-repository/main.tf
+++ b/iac/provider-gcp/remote-repository/main.tf
@@ -41,7 +41,7 @@ resource "google_artifact_registry_repository" "dockerhub_remote_repository" {
     id     = "delete-older-than-90-days"
     action = "DELETE"
     condition {
-      older_than = "90d"
+      older_than = "7776000s" // 90 days in seconds
     }
   }
 


### PR DESCRIPTION
```
  # module.remote_repository[0].google_artifact_registry_repository.dockerhub_remote_repository must be replaced
...
      - cleanup_policies {
          - action = "DELETE" -> null
          - id     = "delete-older-than-90-days" -> null

          - condition {
              - older_than            = "7776000s" -> null
              - package_name_prefixes = [] -> null
              - tag_prefixes          = [] -> null
              - tag_state             = "ANY" -> null
              - version_name_prefixes = [] -> null
            }
        }
      + cleanup_policies {
          + action = "DELETE"
          + id     = "delete-older-than-90-days"

          + condition {
              + older_than            = "90d"
              + package_name_prefixes = []
              + tag_prefixes          = []
              + tag_state             = "ANY"
              + version_name_prefixes = []
            }
        }
```