### PR TITLE
fix(orchestrator): preserve full ENV value across stdout chunks

### DIFF
--- a/packages/orchestrator/pkg/template/build/commands/env.go
+++ b/packages/orchestrator/pkg/template/build/commands/env.go
@@ -74,6 +74,7 @@ func evaluateValue(
 
 	cmd := fmt.Sprintf(`printf "%%s" "%s"`, escaped)
 
+	var out strings.Builder
 	err := sandboxtools.RunCommandWithOutput(
 		ctx,
 		proxy,
@@ -83,12 +84,12 @@ func evaluateValue(
 			User: "root",
 		},
 		func(stdout, _ string) {
-			envValue = stdout
+			out.WriteString(stdout)
 		},
 	)
 	if err != nil {
 		return "", err
 	}
 
-	return envValue, nil
+	return out.String(), nil
 }


### PR DESCRIPTION
evaluateValue overwrote envValue on every stdout chunk, so multi-chunk values (e.g. multiline) lost everything but the last chunk — making TestTemplateBuildENV/ENV_with_multiline_value flake.

Accumulate all stdout chunks into a strings.Builder and return the full result.