### PR TITLE
feat(orchestrator): add dummy orchestrator binary for local API dev

### DIFF
--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -25,6 +25,10 @@ const (
 	ServiceDiscoveryProviderNomad = "nomad"
 	// ServiceDiscoveryProviderKubernetes queries the in-cluster K8s API (the K8s deploy).
 	ServiceDiscoveryProviderKubernetes = "kubernetes"
+	// ServiceDiscoveryProviderLocal returns a single statically configured
+	// orchestrator address. Used to develop the API against the darwin dummy
+	// orchestrator on macOS, where neither Nomad nor Kubernetes is available.
+	ServiceDiscoveryProviderLocal = "local"
 )
 
 type Config struct {
@@ -47,6 +51,12 @@ type Config struct {
 
 	NomadAddress string `env:"NOMAD_ADDRESS" envDefault:"http://localhost:4646"`
 	NomadToken   string `env:"NOMAD_TOKEN"`
+
+	// LocalOrchestratorAddress is the "host:port" address of a statically
+	// configured orchestrator instance. Required when
+	// ServiceDiscoveryProvider=local. Used for local dev against the darwin
+	// dummy orchestrator.
+	LocalOrchestratorAddress string `env:"LOCAL_ORCHESTRATOR_ADDRESS" envDefault:"127.0.0.1:5008"`
 
 	// Used when ServiceDiscoveryProvider=kubernetes.
 	K8sNamespace                       string `env:"K8S_NAMESPACE"                           envDefault:"default"`
@@ -159,7 +169,7 @@ func Parse() (Config, error) {
 		return config, fmt.Errorf("invalid sandbox storage backend: %s", config.SandboxStorageBackend)
 	}
 
-	if !slices.Contains([]string{ServiceDiscoveryProviderNomad, ServiceDiscoveryProviderKubernetes}, config.ServiceDiscoveryProvider) {
+	if !slices.Contains([]string{ServiceDiscoveryProviderNomad, ServiceDiscoveryProviderKubernetes, ServiceDiscoveryProviderLocal}, config.ServiceDiscoveryProvider) {
 		return config, fmt.Errorf("invalid service discovery provider: %s", config.ServiceDiscoveryProvider)
 	}
 

--- a/packages/api/internal/clusters/discovery/static.go
+++ b/packages/api/internal/clusters/discovery/static.go
@@ -1,0 +1,27 @@
+package discovery
+
+import "context"
+
+// StaticServiceDiscovery returns a fixed (possibly empty) list of items on
+// every Query. It is used for local development against the darwin dummy
+// orchestrator where no template-builder instances exist.
+type StaticServiceDiscovery struct {
+	items []Item
+}
+
+// NewStaticDiscovery returns a Discovery that always responds with the given
+// items. Passing nil yields an empty-but-non-error discovery.
+func NewStaticDiscovery(items []Item) Discovery {
+	return &StaticServiceDiscovery{items: items}
+}
+
+func (sd *StaticServiceDiscovery) Query(_ context.Context) ([]Item, error) {
+	if sd.items == nil {
+		return []Item{}, nil
+	}
+
+	out := make([]Item, len(sd.items))
+	copy(out, sd.items)
+
+	return out, nil
+}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -150,6 +150,15 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 			config.K8sNamespace,
 			config.K8sTemplateManagerPodLabelSelector,
 		)
+	case cfg.ServiceDiscoveryProviderLocal:
+		localND, localErr := orchdiscovery.NewLocal(config.LocalOrchestratorAddress)
+		if localErr != nil {
+			logger.L().Fatal(ctx, "Initializing local orchestrator discovery", zap.Error(localErr))
+		}
+		nodeDiscovery = localND
+		// No template builders in local dev — return an empty list so the
+		// clusters pool initializes cleanly.
+		templateBuilderDiscovery = clustersdiscovery.NewStaticDiscovery(nil)
 	default: // ServiceDiscoveryProviderNomad
 		nomadClient, nomadErr := nomadapi.NewClient(&nomadapi.Config{
 			Address:  config.NomadAddress,

--- a/packages/api/internal/orchestrator/discovery/local.go
+++ b/packages/api/internal/orchestrator/discovery/local.go
@@ -1,0 +1,52 @@
+package discovery
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+)
+
+// localDiscovery returns a single statically configured orchestrator address.
+//
+// It is meant for local development against the darwin dummy orchestrator
+// (packages/orchestrator/main_darwin.go) where neither Nomad nor Kubernetes is
+// available. The single returned Node is fixed at construction time.
+type localDiscovery struct {
+	node Node
+}
+
+// NewLocal builds a Discovery that always returns one orchestrator instance
+// reachable at addr. addr may be "host:port" or just "host"; when the port is
+// omitted, consts.OrchestratorAPIPort is used.
+func NewLocal(addr string) (Discovery, error) {
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Allow plain "host" without a port.
+		host = addr
+		portStr = strconv.FormatUint(uint64(consts.OrchestratorAPIPort), 10)
+	}
+	if host == "" {
+		return nil, fmt.Errorf("local discovery: empty host in %q", addr)
+	}
+	if _, err := strconv.ParseUint(portStr, 10, 16); err != nil {
+		return nil, fmt.Errorf("local discovery: invalid port %q: %w", portStr, err)
+	}
+
+	return &localDiscovery{
+		node: Node{
+			ShortID:             "local",
+			IPAddress:           host,
+			OrchestratorAddress: net.JoinHostPort(host, portStr),
+		},
+	}, nil
+}
+
+func (d *localDiscovery) ListNodes(ctx context.Context) ([]Node, error) {
+	_, span := tracer.Start(ctx, "list-local-nodes")
+	defer span.End()
+
+	return []Node{d.node}, nil
+}

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -48,6 +48,19 @@ build-local:
 build-debug:
 	CGO_ENABLED=1 GOOS=linux GOARCH=$(BUILD_ARCH) go build -race -gcflags=all="-N -l" -o bin/orchestrator .
 
+# Builds the dummy orchestrator. It only implements the orchestrator.proto
+# SandboxService surface against an in-memory store, and is meant for local
+# API development and lightweight tests where the full Linux orchestrator
+# (firecracker, NBD, NFS, cgroups) is not needed.
+.PHONY: build-dummy
+build-dummy:
+	$(eval COMMIT_SHA ?= $(shell git rev-parse --short HEAD))
+	CGO_ENABLED=0 go build -o bin/dummy-orchestrator -ldflags "-X=main.commitSHA=$(COMMIT_SHA)" ./cmd/dummy-orchestrator
+
+.PHONY: run-dummy
+run-dummy: build-dummy
+	NODE_ID=$(HOSTNAME) GRPC_PORT=5008 HEALTH_PORT=5018 ./bin/dummy-orchestrator
+
 .PHONY: run-debug
 run-debug:
 	make build-debug

--- a/packages/orchestrator/cmd/dummy-orchestrator/main.go
+++ b/packages/orchestrator/cmd/dummy-orchestrator/main.go
@@ -1,0 +1,188 @@
+// Command dummy-orchestrator is a non-functional implementation of the
+// orchestrator gRPC surface used for local API development.
+//
+// It compiles and runs on every supported platform (most importantly macOS,
+// where the real Linux-only orchestrator cannot be built), implements the
+// orchestrator.proto SandboxService against an in-memory store, and returns
+// codes.Unimplemented for Chunk/Volume calls. It is meant only for wiring
+// up the api package end-to-end without bringing up firecracker, NBD, NFS,
+// cgroups, etc.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/dummyserver"
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	orchestratorinfo "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
+)
+
+// defaultVersion identifies the dummy orchestrator binary so ServiceInfo
+// responses are distinguishable from real orchestrators.
+const defaultVersion = "0.0.0-dummy"
+
+// commitSHA is populated by the linker via -ldflags on build.
+var commitSHA string
+
+func main() {
+	grpcPort := envOrDefault("GRPC_PORT", "5008")
+	healthPort := envOrDefault("HEALTH_PORT", "5018")
+	nodeID := envOrDefault("NODE_ID", "dummy")
+	labels := splitCSV(os.Getenv("NODE_LABELS"))
+
+	version := envOrDefault("SERVICE_VERSION", defaultVersion)
+	commit := commitSHA
+	if commit == "" {
+		commit = "unknown"
+	}
+
+	if _, err := strconv.ParseUint(grpcPort, 10, 16); err != nil {
+		log.Fatalf("invalid GRPC_PORT %q: %v", grpcPort, err)
+	}
+	if _, err := strconv.ParseUint(healthPort, 10, 16); err != nil {
+		log.Fatalf("invalid HEALTH_PORT %q: %v", healthPort, err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	var lc net.ListenConfig
+	grpcLis, err := lc.Listen(ctx, "tcp", ":"+grpcPort)
+	if err != nil {
+		cancel()
+		//nolint:gocritic // cancel() is called explicitly above before log.Fatalf
+		log.Fatalf("failed to listen on gRPC port %s: %v", grpcPort, err)
+	}
+
+	srv := grpc.NewServer()
+
+	sbxServer := dummyserver.NewSandbox()
+	orchestrator.RegisterSandboxServiceServer(srv, sbxServer)
+	orchestrator.RegisterChunkServiceServer(srv, &orchestrator.UnimplementedChunkServiceServer{})
+	orchestrator.RegisterVolumeServiceServer(srv, &orchestrator.UnimplementedVolumeServiceServer{})
+
+	serviceID := uuid.NewString()
+	orchestratorinfo.RegisterInfoServiceServer(srv, dummyserver.NewInfo(nodeID, serviceID, version, commit, labels))
+
+	healthSrv := health.NewServer()
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	healthSrv.SetServingStatus("SandboxService", healthpb.HealthCheckResponse_SERVING)
+	healthpb.RegisterHealthServer(srv, healthSrv)
+
+	// Plain-HTTP /health endpoint so the integration test harness
+	// (scripts/start-service.sh polls http://localhost:<grpc-port-or-similar>/health)
+	// can detect readiness. Served on a separate port to avoid the cmux
+	// machinery the real orchestrator uses.
+	httpMux := http.NewServeMux()
+	httpMux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	httpSrv := &http.Server{
+		Addr:              ":" + healthPort,
+		Handler:           httpMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	log.Printf("dummy orchestrator listening grpc=:%s health=:%s nodeID=%s serviceID=%s clientID=%s version=%s commit=%s",
+		grpcPort, healthPort, nodeID, serviceID, sbxServer.ClientID(), version, commit)
+
+	grpcErr := make(chan error, 1)
+	go func() {
+		grpcErr <- srv.Serve(grpcLis)
+	}()
+
+	httpErr := make(chan error, 1)
+	go func() {
+		err := httpSrv.ListenAndServe()
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		httpErr <- err
+	}()
+
+	shutdown := func() {
+		log.Printf("shutting down")
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		if err := httpSrv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("http server shutdown error: %v", err)
+		}
+
+		srv.GracefulStop()
+	}
+
+	var grpcDone, httpDone bool
+
+	select {
+	case <-ctx.Done():
+		shutdown()
+	case err := <-grpcErr:
+		grpcDone = true
+		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			log.Printf("grpc server crashed: %v", err)
+		}
+		shutdown()
+	case err := <-httpErr:
+		httpDone = true
+		if err != nil {
+			log.Printf("http server crashed: %v", err)
+		}
+		shutdown()
+	}
+
+	// Drain remaining goroutines (only those that haven't sent yet).
+	if !grpcDone {
+		if err := <-grpcErr; err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			log.Printf("grpc server returned an error: %v", err)
+		}
+	}
+	if !httpDone {
+		if err := <-httpErr; err != nil {
+			log.Printf("http server returned an error: %v", err)
+		}
+	}
+}
+
+func envOrDefault(key, def string) string {
+	if v, ok := os.LookupEnv(key); ok && v != "" {
+		return v
+	}
+
+	return def
+}
+
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		out = append(out, p)
+	}
+
+	return out
+}

--- a/packages/orchestrator/pkg/dummyserver/info.go
+++ b/packages/orchestrator/pkg/dummyserver/info.go
@@ -1,0 +1,63 @@
+package dummyserver
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	orchestratorinfo "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
+)
+
+// InfoServer is a static implementation of orchestratorinfo.InfoServiceServer
+// returning the bare minimum the api needs to route to this orchestrator.
+type InfoServer struct {
+	orchestratorinfo.UnimplementedInfoServiceServer
+
+	nodeID      string
+	serviceID   string
+	version     string
+	commit      string
+	labels      []string
+	startedAt   time.Time
+	machineInfo *orchestratorinfo.MachineInfo
+}
+
+// NewInfo creates a new InfoServer with a stable per-process serviceID.
+func NewInfo(nodeID, serviceID, version, commit string, labels []string) *InfoServer {
+	return &InfoServer{
+		nodeID:    nodeID,
+		serviceID: serviceID,
+		version:   version,
+		commit:    commit,
+		labels:    labels,
+		startedAt: time.Now(),
+		machineInfo: &orchestratorinfo.MachineInfo{
+			CpuArchitecture: runtime.GOARCH,
+			CpuFamily:       "darwin-dummy",
+			CpuModel:        "darwin-dummy",
+			CpuModelName:    "darwin-dummy",
+		},
+	}
+}
+
+func (s *InfoServer) ServiceInfo(_ context.Context, _ *emptypb.Empty) (*orchestratorinfo.ServiceInfoResponse, error) {
+	return &orchestratorinfo.ServiceInfoResponse{
+		NodeId:         s.nodeID,
+		ServiceId:      s.serviceID,
+		ServiceVersion: s.version,
+		ServiceCommit:  s.commit,
+		ServiceStatus:  orchestratorinfo.ServiceInfoStatus_Healthy,
+		ServiceRoles:   []orchestratorinfo.ServiceInfoRole{orchestratorinfo.ServiceInfoRole_Orchestrator},
+		ServiceStartup: timestamppb.New(s.startedAt),
+		MachineInfo:    s.machineInfo,
+		Labels:         s.labels,
+	}, nil
+}
+
+func (s *InfoServer) ServiceStatusOverride(_ context.Context, _ *orchestratorinfo.ServiceStatusChangeRequest) (*emptypb.Empty, error) {
+	// No-op on the dummy server.
+	return &emptypb.Empty{}, nil
+}

--- a/packages/orchestrator/pkg/dummyserver/sandbox.go
+++ b/packages/orchestrator/pkg/dummyserver/sandbox.go
@@ -1,0 +1,152 @@
+// Package dummyserver provides a non-functional implementation of the
+// orchestrator gRPC surface. It exists so the api package can be wired up
+// against a real gRPC orchestrator (including on macOS dev machines, where
+// the real Linux-only orchestrator with firecracker, NBD, NFS, cgroup, etc.
+// cannot run) and to give CI a lightweight orchestrator process for tests
+// that only need the SandboxService control plane.
+//
+// Nothing here actually starts a sandbox; calls just record state in memory
+// and return plausible responses.
+package dummyserver
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+)
+
+// SandboxServer is an in-memory dummy implementation of orchestrator.SandboxServiceServer.
+type SandboxServer struct {
+	orchestrator.UnimplementedSandboxServiceServer
+
+	clientID string
+
+	mu        sync.Mutex
+	sandboxes map[string]*orchestrator.RunningSandbox
+}
+
+// NewSandbox returns a SandboxServer with an empty sandbox map and a fixed
+// per-process clientID (a UUID). The clientID is returned from Create so the
+// api side can route follow-up calls back to this orchestrator.
+func NewSandbox() *SandboxServer {
+	return &SandboxServer{
+		clientID:  uuid.NewString(),
+		sandboxes: make(map[string]*orchestrator.RunningSandbox),
+	}
+}
+
+// ClientID returns the synthetic client identifier for this dummy node.
+func (s *SandboxServer) ClientID() string {
+	return s.clientID
+}
+
+func (s *SandboxServer) Create(_ context.Context, req *orchestrator.SandboxCreateRequest) (*orchestrator.SandboxCreateResponse, error) {
+	if req == nil || req.GetSandbox() == nil {
+		return nil, status.Error(codes.InvalidArgument, "sandbox config is required")
+	}
+
+	sbxID := req.GetSandbox().GetSandboxId()
+	if sbxID == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+
+	startTime := req.GetStartTime()
+	if startTime == nil {
+		startTime = timestamppb.Now()
+	}
+
+	cfg, _ := proto.Clone(req.GetSandbox()).(*orchestrator.SandboxConfig)
+
+	running := &orchestrator.RunningSandbox{
+		Config:    cfg,
+		ClientId:  s.clientID,
+		StartTime: startTime,
+		EndTime:   req.GetEndTime(),
+	}
+
+	s.mu.Lock()
+	s.sandboxes[sbxID] = running
+	s.mu.Unlock()
+
+	return &orchestrator.SandboxCreateResponse{ClientId: s.clientID}, nil
+}
+
+func (s *SandboxServer) Update(_ context.Context, req *orchestrator.SandboxUpdateRequest) (*emptypb.Empty, error) {
+	if req.GetSandboxId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sbx, ok := s.sandboxes[req.GetSandboxId()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "sandbox %q not found", req.GetSandboxId())
+	}
+
+	if req.GetEndTime() != nil {
+		sbx.EndTime = req.GetEndTime()
+	}
+
+	// Egress updates are accepted but ignored — there's no real network here.
+	_ = req.GetEgress()
+
+	return &emptypb.Empty{}, nil
+}
+
+func (s *SandboxServer) List(_ context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make([]*orchestrator.RunningSandbox, 0, len(s.sandboxes))
+	for _, sbx := range s.sandboxes {
+		// Clone to avoid handing out internal pointers.
+		if cloned, ok := proto.Clone(sbx).(*orchestrator.RunningSandbox); ok {
+			out = append(out, cloned)
+		}
+	}
+
+	return &orchestrator.SandboxListResponse{Sandboxes: out}, nil
+}
+
+func (s *SandboxServer) Delete(_ context.Context, req *orchestrator.SandboxDeleteRequest) (*emptypb.Empty, error) {
+	if req.GetSandboxId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+
+	s.mu.Lock()
+	delete(s.sandboxes, req.GetSandboxId())
+	s.mu.Unlock()
+
+	return &emptypb.Empty{}, nil
+}
+
+func (s *SandboxServer) Pause(_ context.Context, req *orchestrator.SandboxPauseRequest) (*emptypb.Empty, error) {
+	if req.GetSandboxId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "sandbox_id is required")
+	}
+
+	// Pause is treated as a delete in the dummy: no real snapshotting happens.
+	s.mu.Lock()
+	delete(s.sandboxes, req.GetSandboxId())
+	s.mu.Unlock()
+
+	return &emptypb.Empty{}, nil
+}
+
+func (s *SandboxServer) Checkpoint(_ context.Context, _ *orchestrator.SandboxCheckpointRequest) (*orchestrator.SandboxCheckpointResponse, error) {
+	// No-op: there is no real disk/memory to checkpoint.
+	return &orchestrator.SandboxCheckpointResponse{}, nil
+}
+
+func (s *SandboxServer) ListCachedBuilds(_ context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListCachedBuildsResponse, error) {
+	return &orchestrator.SandboxListCachedBuildsResponse{Builds: nil}, nil
+}


### PR DESCRIPTION
The real orchestrator is //go:build linux throughout (firecracker, NBD, NFS, cgroups, network namespaces), so on macOS dev machines there is nothing the api package can talk to. This adds a parallel, platform- agnostic dummy orchestrator binary that implements the orchestrator.proto SandboxService surface against an in-memory map so the api side mostly works end-to-end, plus an empty Chunk/Volume/Info surface and a HTTP /health endpoint that scripts/start-service.sh can probe.

Orchestrator changes:

- cmd/dummy-orchestrator/main.go: new binary entry point, no build tag. Plain grpc.NewServer (no cmux, no telemetry/feature-flags/redis). Wires up SandboxService (the in-memory dummy impl), Chunk/Volume services as Unimplemented embeds so calls return codes.Unimplemented instead of "connection refused", InfoService, and grpc health (status SERVING). Adds a separate HTTP /health endpoint on HEALTH_PORT (default 5018) so the integration-test harness can detect readiness without bringing in cmux. Reads GRPC_PORT (default 5008), HEALTH_PORT, NODE_ID, NODE_LABELS, SERVICE_VERSION; commitSHA is linker-set. Graceful shutdown on SIGINT/SIGTERM.
- pkg/dummyserver/sandbox.go: in-memory SandboxServiceServer. Create stores a clone of the SandboxConfig keyed by sandbox_id and returns a fixed per-process client_id. Update mutates end_time and returns NotFound if the sandbox is missing. List clones the map. Delete and Pause remove the entry (idempotent). Checkpoint returns an empty response. ListCachedBuilds returns an empty list.
- pkg/dummyserver/info.go: static InfoServiceServer. ServiceInfo returns Healthy, role Orchestrator, version/commit/labels from the binary, plus a minimal MachineInfo (cpu_architecture = runtime.GOARCH). ServiceStatusOverride is a no-op.
- Makefile: build-dummy (CGO_ENABLED=0, builds for the host GOOS, -ldflags sets main.commitSHA, outputs bin/dummy-orchestrator) and run-dummy (NODE_ID=\$(HOSTNAME) GRPC_PORT=5008 HEALTH_PORT=5018).

API changes:

- internal/cfg/model.go: new ServiceDiscoveryProviderLocal = "local" constant, accepted by the Parse() validator, plus LOCAL_ORCHESTRATOR_ADDRESS (default 127.0.0.1:5008).
- internal/orchestrator/discovery/local.go: NewLocal(addr) Discovery that always returns one Node at the configured host:port. Falls back to consts.OrchestratorAPIPort when the port is omitted.
- internal/clusters/discovery/static.go: NewStaticDiscovery(nil) so the template-builder discovery branch has an empty-but-non-error implementation in local mode (no template builders on a dev mac).
- internal/handlers/store.go: new case for cfg.ServiceDiscoveryProviderLocal that wires both discoveries without touching Nomad or k8s.

Run flow:

  cd packages/orchestrator && make run-dummy   # grpc :5008, health :5018
  SERVICE_DISCOVERY_PROVIDER=local make -C packages/api run