### PR TITLE
fix(orchestrator): pin UFFD copy source buffers

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -151,6 +151,10 @@ type Fd uintptr
 
 // copy requires UFFDIO_COPY_MODE_WP when both MISSING and WP tracking are active.
 func (f Fd) copy(addr, pagesize uintptr, data []byte, mode CULong) error {
+	if len(data) == 0 {
+		return fmt.Errorf("cannot copy from an empty buffer")
+	}
+
 	// UFFDIO_COPY hides src as an integer, so keep data pinned while the kernel reads it.
 	var pinner runtime.Pinner
 	pinner.Pin(&data[0])

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -32,6 +32,7 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
 	"syscall"
 	"unsafe"
 )
@@ -150,6 +151,10 @@ type Fd uintptr
 
 // copy requires UFFDIO_COPY_MODE_WP when both MISSING and WP tracking are active.
 func (f Fd) copy(addr, pagesize uintptr, data []byte, mode CULong) error {
+	var pinner runtime.Pinner
+	pinner.Pin(&data[0])
+	defer pinner.Unpin()
+
 	cpy := newUffdioCopy(data, CULong(addr)&^CULong(pagesize-1), CULong(pagesize), mode, 0)
 
 	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(f), UFFDIO_COPY, uintptr(unsafe.Pointer(&cpy))); errno != 0 {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -151,6 +151,7 @@ type Fd uintptr
 
 // copy requires UFFDIO_COPY_MODE_WP when both MISSING and WP tracking are active.
 func (f Fd) copy(addr, pagesize uintptr, data []byte, mode CULong) error {
+	// UFFDIO_COPY hides src as an integer, so keep data pinned while the kernel reads it.
 	var pinner runtime.Pinner
 	pinner.Pin(&data[0])
 	defer pinner.Unpin()

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/fd.go
@@ -31,6 +31,7 @@ struct uffd_remove {
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"syscall"
@@ -152,7 +153,7 @@ type Fd uintptr
 // copy requires UFFDIO_COPY_MODE_WP when both MISSING and WP tracking are active.
 func (f Fd) copy(addr, pagesize uintptr, data []byte, mode CULong) error {
 	if len(data) == 0 {
-		return fmt.Errorf("cannot copy from an empty buffer")
+		return errors.New("cannot copy from an empty buffer")
 	}
 
 	// UFFDIO_COPY hides src as an integer, so keep data pinned while the kernel reads it.


### PR DESCRIPTION
## Summary
Pin UFFDIO_COPY source buffers for the duration of the ioctl so the kernel does not read from a Go buffer hidden from the GC via uintptr.

## Test plan
- go test ./packages/orchestrator/pkg/sandbox/uffd/userfaultfd -run '^$'