### PR TITLE
fix(shared): isolate proxy test HTTP clients

### DIFF
--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -420,14 +420,25 @@ func httpGetWithHeaders(t *testing.T, proxyURL string, headers http.Header) (*ht
 		}
 	}
 
-	rsp, err := (&http.Client{
-		Transport: &http.Transport{DisableKeepAlives: true},
-	}).Do(req)
+	transport := &http.Transport{}
+	rsp, err := (&http.Client{Transport: transport}).Do(req)
 	if err != nil {
 		return nil, err
 	}
 
+	rsp.Body = closeIdleConnsBody{ReadCloser: rsp.Body, transport: transport}
 	return rsp, nil
+}
+
+type closeIdleConnsBody struct {
+	io.ReadCloser
+	transport *http.Transport
+}
+
+func (b closeIdleConnsBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.transport.CloseIdleConnections()
+	return err
 }
 
 type instrumentedConn struct {

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -420,7 +420,9 @@ func httpGetWithHeaders(t *testing.T, proxyURL string, headers http.Header) (*ht
 		}
 	}
 
-	rsp, err := (&http.Client{}).Do(req)
+	rsp, err := (&http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}).Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -41,6 +41,8 @@ func (b *testBackend) RequestCount() uint64 {
 
 const bodyWriteDelayHeader = "body-write-delay"
 
+var testHTTPClients sync.Map
+
 // newTestBackend creates a new test backend server
 func newTestBackend(listener net.Listener, id string) (*testBackend, error) {
 	var requestCount atomic.Uint64
@@ -420,25 +422,29 @@ func httpGetWithHeaders(t *testing.T, proxyURL string, headers http.Header) (*ht
 		}
 	}
 
-	transport := &http.Transport{}
-	rsp, err := (&http.Client{Transport: transport}).Do(req)
+	rsp, err := testHTTPClient(t).Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	rsp.Body = closeIdleConnsBody{ReadCloser: rsp.Body, transport: transport}
 	return rsp, nil
 }
 
-type closeIdleConnsBody struct {
-	io.ReadCloser
-	transport *http.Transport
-}
+func testHTTPClient(t *testing.T) *http.Client {
+	t.Helper()
 
-func (b closeIdleConnsBody) Close() error {
-	err := b.ReadCloser.Close()
-	b.transport.CloseIdleConnections()
-	return err
+	transport := &http.Transport{}
+	client := &http.Client{Transport: transport}
+
+	actual, loaded := testHTTPClients.LoadOrStore(t.Name(), client)
+	if !loaded {
+		t.Cleanup(func() {
+			transport.CloseIdleConnections()
+			testHTTPClients.Delete(t.Name())
+		})
+	}
+
+	return actual.(*http.Client)
 }
 
 type instrumentedConn struct {


### PR DESCRIPTION
## Summary
Fix flaky proxy tests by giving each test an isolated HTTP transport, so parallel tests do not share stale keepalive connections through the global default transport. Keepalives stay enabled within a test and idle connections are cleaned up with test cleanup.

## Test plan
- go test ./pkg/proxy -count=10