### PR TITLE
fix(tests): refresh envd client after network resume

### DIFF
--- a/tests/integration/internal/tests/api/sandboxes/sandbox_network_update_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_network_update_test.go
@@ -397,7 +397,8 @@ func TestUpdateNetworkConfig(t *testing.T) { //nolint:tparallel // subtests are 
 			AllowInternetAccess: ptrB(false),
 		})
 		require.Equal(t, http.StatusNoContent, resp.StatusCode())
-		verifyConnectivity(t, ctx, sbx, envdClient, []connectivityCheck{
+		freshEnvdClient := setup.GetEnvdClient(t, ctx)
+		verifyConnectivity(t, ctx, sbx, freshEnvdClient, []connectivityCheck{
 			{"https://8.8.8.8", false},
 			{"https://1.1.1.1", false},
 		})

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_network_update_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_network_update_test.go
@@ -384,7 +384,8 @@ func TestUpdateNetworkConfig(t *testing.T) { //nolint:tparallel // subtests are 
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resumeResp.StatusCode())
 
-		verifyConnectivityEventually(t, ctx, sbx, envdClient, []connectivityCheck{
+		resumedEnvdClient := setup.GetEnvdClient(t, ctx)
+		verifyConnectivityEventually(t, ctx, sbx, resumedEnvdClient, []connectivityCheck{
 			{"https://8.8.8.8", true},
 			{"https://1.1.1.1", false},
 		})
@@ -414,7 +415,8 @@ func TestUpdateNetworkConfig(t *testing.T) { //nolint:tparallel // subtests are 
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resumeResp.StatusCode())
 
-		verifyConnectivityEventually(t, ctx, sbx, envdClient, []connectivityCheck{
+		resumedEnvdClient := setup.GetEnvdClient(t, ctx)
+		verifyConnectivityEventually(t, ctx, sbx, resumedEnvdClient, []connectivityCheck{
 			{"https://8.8.8.8", false},
 			{"https://1.1.1.1", false},
 		})


### PR DESCRIPTION
## Summary
Fix the flaky network update integration test by refreshing the envd client after pause/resume before checking connectivity. This avoids carrying stale client/proxy connections across the sandbox lifecycle change.

## Test plan
- env TESTS_API_SERVER_URL=http://127.0.0.1 TESTS_SANDBOX_TEMPLATE_ID=base TESTS_E2B_API_KEY=dummy TESTS_E2B_ACCESS_TOKEN=dummy TESTS_ENVD_PROXY=http://127.0.0.1 bash -c 'cd tests/integration && go test ./internal/tests/api/sandboxes -run "^$"'