### PR TITLE
feat(orch): record envd init duration histogram on failure with success attribute

### DIFF
--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1398,14 +1398,17 @@ func (s *Sandbox) WaitForEnvd(
 	defer span.End()
 
 	defer func() {
-		if e != nil {
-			return
-		}
 		duration := time.Since(start).Milliseconds()
 		waitForEnvdDurationHistogram.Record(ctx, duration, metric.WithAttributes(
 			telemetry.WithEnvdVersion(s.Config.Envd.Version),
 			attribute.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()),
+			attribute.Bool("success", e == nil),
 		))
+
+		if e != nil {
+			return
+		}
+
 		// Update the sandbox as started now
 		s.SetStartedAt(time.Now())
 	}()


### PR DESCRIPTION
The histogram was previously only recorded on successful envd init. This makes it impossible to compute success/failure ratio per envd version in Grafana. By always recording with a success=true/false attribute, we can query the histogram count to get per-sandbox init outcomes and their duration distributions for both cases.