### PR TITLE
Potential fix for code scanning alert no. 85: Excessive Secrets Exposure

### DIFF
--- a/.github/workflows/periodic-test.yml
+++ b/.github/workflows/periodic-test.yml
@@ -89,11 +89,23 @@ jobs:
         working-directory: tests/periodic-test
         run: bun install --frozen-lockfile
 
-      - name: Set env variables from secrets
-        if: always()
+      - name: Set env variables from secrets (foxtrot)
+        if: matrix.e2b-domain == 'e2b-foxtrot.dev'
         run: |
-          echo "E2B_API_KEY=${{ secrets[format('{0}', matrix.api_key)] }}" >> $GITHUB_ENV
-          echo "E2B_ACCESS_TOKEN=${{ secrets[format('{0}', matrix.access_token)] }}" >> $GITHUB_ENV
+          echo "E2B_API_KEY=${{ secrets.E2B_API_KEY }}" >> $GITHUB_ENV
+          echo "E2B_ACCESS_TOKEN=${{ secrets.E2B_ACCESS_TOKEN }}" >> $GITHUB_ENV
+
+      - name: Set env variables from secrets (juliett)
+        if: matrix.e2b-domain == 'e2b-juliett.dev'
+        run: |
+          echo "E2B_API_KEY=${{ secrets.E2B_API_KEY_JULIETT }}" >> $GITHUB_ENV
+          echo "E2B_ACCESS_TOKEN=${{ secrets.E2B_ACCESS_TOKEN_JULIETT }}" >> $GITHUB_ENV
+
+      - name: Set env variables from secrets (staging)
+        if: matrix.e2b-domain == 'e2b-staging.dev'
+        run: |
+          echo "E2B_API_KEY=${{ secrets.E2B_API_KEY }}" >> $GITHUB_ENV
+          echo "E2B_ACCESS_TOKEN=${{ secrets.E2B_ACCESS_TOKEN }}" >> $GITHUB_ENV
 
       - name: ${{ matrix.test-command.name }}
         run: bun run ${{ matrix.test-command.command }}


### PR DESCRIPTION
Potential fix for [https://github.com/e2b-dev/infra/security/code-scanning/85](https://github.com/e2b-dev/infra/security/code-scanning/85)

Use explicit, statically resolvable secret references and split secret assignment by matrix condition so the runner can determine exactly which secrets are needed per job path.

Best fix here (without changing functionality): replace the single “Set env variables from secrets” step that uses dynamic indexing with three conditional steps, one per `matrix.e2b-domain`, each writing concrete secret names to `$GITHUB_ENV`. This preserves the existing downstream test step (`env.E2B_API_KEY` / `env.E2B_ACCESS_TOKEN`) and matrix behavior, while removing dynamic `secrets[...]` access.

Edit only `.github/workflows/periodic-test.yml` in the shown region around lines 92–97:
- Remove the dynamic lookup step.
- Add 3 explicit conditional steps:
  - foxtrot: `secrets.E2B_API_KEY`, `secrets.E2B_ACCESS_TOKEN`
  - juliett: `secrets.E2B_API_KEY_JULIETT`, `secrets.E2B_ACCESS_TOKEN_JULIETT`
  - staging: `secrets.E2B_API_KEY`, `secrets.E2B_ACCESS_TOKEN`

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
