### PR TITLE
fix(tests): reduce integration flakes

### DIFF
--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -57,7 +57,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
-        allow_internet_access = excluded.allow_internet_access,
+        allow_internet_access = COALESCE(excluded.allow_internet_access, snapshots.allow_internet_access),
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,
         config = excluded.config

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -57,6 +57,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
+        env_secure = excluded.env_secure,
         allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -57,6 +57,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
+        allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,
         config = excluded.config

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -57,7 +57,6 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
-        env_secure = excluded.env_secure,
         allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -43,6 +43,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
+        allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,
         config = excluded.config

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -43,6 +43,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
+        env_secure = excluded.env_secure,
         allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -43,7 +43,7 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
-        allow_internet_access = excluded.allow_internet_access,
+        allow_internet_access = COALESCE(excluded.allow_internet_access, snapshots.allow_internet_access),
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,
         config = excluded.config

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -43,7 +43,6 @@ snapshot as (
     ON CONFLICT (sandbox_id) DO UPDATE SET
         metadata = excluded.metadata,
         sandbox_started_at = excluded.sandbox_started_at,
-        env_secure = excluded.env_secure,
         allow_internet_access = excluded.allow_internet_access,
         origin_node_id = excluded.origin_node_id,
         auto_pause = excluded.auto_pause,

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_network_out_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_network_out_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
@@ -63,8 +65,10 @@ func ensureNetworkTestTemplate(t *testing.T) string {
 // assertSuccessfulHTTPRequest asserts that an HTTP/HTTPS request to the given URL succeeds
 func assertSuccessfulHTTPRequest(t *testing.T, ctx context.Context, sbx *api.Sandbox, envdClient *setup.EnvdClient, url string, msg string) {
 	t.Helper()
-	err := utils.ExecCommand(t, ctx, sbx, envdClient, "curl", "--connect-timeout", "5", "--max-time", "10", "-Iks", url)
-	require.NoError(t, err, msg)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		err := utils.ExecCommand(t, ctx, sbx, envdClient, "curl", "--connect-timeout", "5", "--max-time", "10", "-Iks", url)
+		require.NoError(c, err, msg)
+	}, 30*time.Second, time.Second)
 }
 
 // assertBlockedHTTPRequest asserts that an HTTP/HTTPS request to the given URL is blocked

--- a/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
+++ b/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,9 +71,20 @@ echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 		require.NoError(t, err)
 
 		hashCmd := fmt.Sprintf(`sha256sum "%s" | awk '{print $1}'`, tmpfsFile)
-		hashCmdOutput, err := utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", hashCmd)
-		require.NoError(t, err)
-		hashCmdOutput = strings.TrimSpace(hashCmdOutput)
+		readHash := func() string {
+			t.Helper()
+
+			var output string
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				var err error
+				output, err = utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", hashCmd)
+				require.NoError(c, err)
+			}, 30*time.Second, time.Second)
+
+			return strings.TrimSpace(output)
+		}
+
+		hashCmdOutput := readHash()
 		require.NotEmpty(t, hashCmdOutput, "Failed to extract hash from command output")
 
 		pauseIterations := 2
@@ -95,9 +107,7 @@ echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 			assert.Equal(t, sbxResume.JSON201.SandboxID, sbxId)
 
 			// Check the tmpfs hash and compare it with the original hash
-			hashCmdOutputAfterResume, err := utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", hashCmd)
-			require.NoError(t, err)
-			hashCmdOutputAfterResume = strings.TrimSpace(hashCmdOutputAfterResume)
+			hashCmdOutputAfterResume := readHash()
 
 			assert.Equal(t, hashCmdOutput, hashCmdOutputAfterResume, "Hash mismatch on iteration %d: memory integrity check failed", i)
 		}

--- a/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
+++ b/tests/integration/internal/tests/orchestrator/sandbox_memory_integrity_test.go
@@ -79,7 +79,7 @@ echo "Used memory after tmpfs mount and file fill: ${USED_MEM_MB_AFTER} MB"
 				var err error
 				output, err = utils.ExecCommandAsRootWithOutput(t, t.Context(), sbx, envdClient, "bash", "-c", hashCmd)
 				require.NoError(c, err)
-			}, 30*time.Second, time.Second)
+			}, 90*time.Second, 2*time.Second)
 
 			return strings.TrimSpace(output)
 		}

--- a/tests/integration/internal/tests/proxies/traffic_access_token_test.go
+++ b/tests/integration/internal/tests/proxies/traffic_access_token_test.go
@@ -287,10 +287,8 @@ func TestSandboxWithTrafficAccessTokenAutoResumeViaProxy(t *testing.T) {
 	require.Equal(t, api.Paused, res.JSON200.State)
 
 	// Valid token request should auto-resume and succeed.
-	req = utils.NewRequest(sbx, proxyURL, port, nil)
-	resp, err = client.Do(req)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	resp = utils.WaitForStatus(t, client, sbx, proxyURL, port, nil, http.StatusOK)
+	require.NotNil(t, resp)
 	require.NoError(t, resp.Body.Close())
 
 	res, err = c.GetSandboxesSandboxIDWithResponse(ctx, sbx.SandboxID, setup.WithAPIKey())


### PR DESCRIPTION
Persists updated sandbox internet access state when refreshing snapshots and narrows flaky integration assertions around resume/proxy readiness.