### PR TITLE
Add CODEOWNERS rule for packages/dashboard-api

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 * @ValentaTomas @jakubno @dobrac
+/packages/dashboard-api/ @jakubno

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
 * @ValentaTomas @jakubno @dobrac
-/packages/dashboard-api/ @jakubno
+/packages/dashboard-api/ @ben-fornefeld


### PR DESCRIPTION
## Summary
- add a path-specific CODEOWNERS rule for `packages/dashboard-api`
- set `@ben-fornefeld` as the code owner for that path

