### PR TITLE
fix(orchestrator): avoid serializing upload headers twice

### DIFF
--- a/packages/orchestrator/pkg/sandbox/upload_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metrics.go
@@ -48,16 +48,11 @@ func uploadRatioBp(compressed, uncompressed int64) int64 {
 }
 
 func storeHeaderWithMetrics(ctx context.Context, store storage.StorageProvider, path, fileType, useCase string, h *headers.Header) error {
-	if err := headers.StoreHeader(ctx, store, path, h); err != nil {
-		return err
-	}
-
-	data, err := headers.SerializeHeader(h)
+	size, err := headers.StoreHeader(ctx, store, path, h)
 	if err != nil {
 		return err
 	}
 
-	size := int64(len(data))
 	recordUploadCompression(ctx, uploadArtifactHeader, fileType, useCase, storage.CompressConfig{}, size, size)
 
 	return nil

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -60,6 +60,10 @@ func LoadHeader(ctx context.Context, s storage.StorageProvider, path string) (*H
 // Refuses to persist a header still flagged as in-flight — the upload pipeline
 // must clear IncompletePendingUpload before reaching here.
 func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h *Header) (int64, error) {
+	if h == nil {
+		return 0, fmt.Errorf("header is nil")
+	}
+
 	if h.IncompletePendingUpload {
 		return 0, fmt.Errorf("refusing to persist incomplete header for %s", path)
 	}
@@ -75,7 +79,7 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 	}
 
 	if err := blob.Put(ctx, data); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("put blob %s: %w", path, err)
 	}
 
 	return int64(len(data)), nil

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -56,25 +56,29 @@ func LoadHeader(ctx context.Context, s storage.StorageProvider, path string) (*H
 	return DeserializeBytes(data)
 }
 
-// StoreHeader serializes a header and uploads it to long-term storage.
+// StoreHeader serializes a header, uploads it, and returns the stored byte count.
 // Refuses to persist a header still flagged as in-flight — the upload pipeline
 // must clear IncompletePendingUpload before reaching here.
-func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h *Header) error {
+func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h *Header) (int64, error) {
 	if h.IncompletePendingUpload {
-		return fmt.Errorf("refusing to persist incomplete header for %s", path)
+		return 0, fmt.Errorf("refusing to persist incomplete header for %s", path)
 	}
 
 	data, err := SerializeHeader(h)
 	if err != nil {
-		return fmt.Errorf("serialize header: %w", err)
+		return 0, fmt.Errorf("serialize header: %w", err)
 	}
 
 	blob, err := s.OpenBlob(ctx, path, storage.MetadataObjectType)
 	if err != nil {
-		return fmt.Errorf("open blob %s: %w", path, err)
+		return 0, fmt.Errorf("open blob %s: %w", path, err)
 	}
 
-	return blob.Put(ctx, data)
+	if err := blob.Put(ctx, data); err != nil {
+		return 0, err
+	}
+
+	return int64(len(data)), nil
 }
 
 // Deserialize reads a header from a storage Blob (legacy API).

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -2,6 +2,7 @@ package header
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -61,7 +62,7 @@ func LoadHeader(ctx context.Context, s storage.StorageProvider, path string) (*H
 // must clear IncompletePendingUpload before reaching here.
 func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h *Header) (int64, error) {
 	if h == nil {
-		return 0, fmt.Errorf("header is nil")
+		return 0, errors.New("header is nil")
 	}
 
 	if h.IncompletePendingUpload {


### PR DESCRIPTION
## Summary
- Return the stored header byte count from StoreHeader.
- Reuse that count for upload header metrics instead of serializing again.

## Test plan
- go test ./packages/shared/pkg/storage/header ./packages/orchestrator/pkg/sandbox