### PR TITLE
Trim upload metric dimensions

### DIFF
--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1128,7 +1128,7 @@ func (s *Sandbox) Pause(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get memfile metadata: %w", err)
 	}
-	recordSnapshotDiff(ctx, "memfile", memfileDiffMetadata, originalMemfile.Header(), useCase)
+	recordSnapshotDiff(ctx, "memfile", memfileDiffMetadata, originalMemfile.Header())
 
 	// Start POSTPROCESSING
 	memfileDiff, memfileDiffHeader, err := pauseProcessMemory(
@@ -1155,7 +1155,6 @@ func (s *Sandbox) Pause(
 			closeHook: s.Close,
 		},
 		s.config.DefaultCacheDir,
-		useCase,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error while post processing: %w", err)
@@ -1242,7 +1241,6 @@ func pauseProcessRootfs(
 	originalHeader *header.Header,
 	diffCreator DiffCreator,
 	cacheDir string,
-	useCase SnapshotUseCase,
 ) (d build.Diff, h *header.Header, e error) {
 	ctx, span := tracer.Start(ctx, "process-rootfs")
 	defer span.End()
@@ -1259,7 +1257,7 @@ func pauseProcessRootfs(
 		return nil, nil, fmt.Errorf("error creating diff: %w", err)
 	}
 	telemetry.ReportEvent(ctx, "exported rootfs")
-	recordSnapshotDiff(ctx, "rootfs", rootfsDiffMetadata, originalHeader, useCase)
+	recordSnapshotDiff(ctx, "rootfs", rootfsDiffMetadata, originalHeader)
 
 	rootfsDiff, err := rootfsDiffFile.CloseToDiff(int64(originalHeader.Metadata.BlockSize))
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -29,7 +29,6 @@ func recordSnapshotDiff(
 	fileType string,
 	dm *header.DiffMetadata,
 	original *header.Header,
-	useCase SnapshotUseCase,
 ) {
 	if dm == nil || original == nil || original.Metadata == nil {
 		return
@@ -38,9 +37,8 @@ func recordSnapshotDiff(
 	total := int64(original.Metadata.Size)
 
 	ft := attribute.String("file_type", fileType)
-	uc := attribute.String("use_case", string(useCase))
 
-	snapshotTotalBytes.Record(ctx, total, metric.WithAttributes(ft, uc))
+	snapshotTotalBytes.Record(ctx, total, metric.WithAttributes(ft))
 
 	var dirtyBytes, emptyBytes int64
 	if dm.Dirty != nil {
@@ -53,7 +51,7 @@ func recordSnapshotDiff(
 		"dirty": dirtyBytes,
 		"empty": emptyBytes,
 	} {
-		attrs := metric.WithAttributes(ft, attribute.String("kind", kind), uc)
+		attrs := metric.WithAttributes(ft, attribute.String("kind", kind))
 		snapshotDiffBytes.Record(ctx, b, attrs)
 		snapshotDiffRatioBp.Record(ctx, ratioBp(b, total), attrs)
 	}

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -389,13 +389,15 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 	}
 
 	cfg := CompressConfigFromOpts(putOpts)
+	compressionType := cfg.CompressionType()
+	compressionMetricType := compressionType.String()
+	if cfg.IsCompressionEnabled() && compressionType == CompressionZstd {
+		compressionMetricType = fmt.Sprintf("%s-%d", compressionMetricType, cfg.Level)
+	}
 
-	// Tag the upload timer with the compression mode so dashboards can split
-	// duration/throughput by codec and level. Type is "none" when disabled.
 	timer := googleWriteTimerFactory.Begin(
 		attribute.String(gcsOperationAttr, gcsOperationAttrWriteFromFileSystem),
-		attribute.String("compression.type", cfg.CompressionType().String()),
-		attribute.Int("compression.level", cfg.Level),
+		attribute.String("compression.type", compressionMetricType),
 	)
 
 	maxConcurrency := gcloudDefaultUploadConcurrency


### PR DESCRIPTION
## Summary
Remove the snapshot `use_case` metric label and fold compression level into `compression.type` for upload metrics.

## Tests
`go test ./packages/shared/pkg/storage ./packages/orchestrator/pkg/sandbox`