### PR TITLE
ci: retry gotestsum install on transient proxy.golang.org errors

### DIFF
--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -146,7 +146,14 @@ jobs:
         if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        # Retry to ride out transient proxy.golang.org HTTP/2 stream errors.
+        run: |
+          for i in 1 2 3; do
+            go install gotest.tools/gotestsum@v1.13.0 && exit 0
+            echo "gotestsum install attempt $i failed, retrying" >&2
+            sleep $((i * 5))
+          done
+          exit 1
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -113,7 +113,14 @@ jobs:
         if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.13.0
+        # Retry to ride out transient proxy.golang.org HTTP/2 stream errors.
+        run: |
+          for i in 1 2 3; do
+            go install gotest.tools/gotestsum@v1.13.0 && exit 0
+            echo "gotestsum install attempt $i failed, retrying" >&2
+            sleep $((i * 5))
+          done
+          exit 1
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
       # toolchain (1.26.3) instead of /usr/bin/go. Trap chowns reports back to


### PR DESCRIPTION
## Summary
- pr-tests and pr-tests-arm64 occasionally cancel a whole run because `go install gotest.tools/gotestsum@v1.13.0` hits an HTTP/2 stream reset against `proxy.golang.org` (`INTERNAL_ERROR; received from peer`).
- Wrap the install in a 3-attempt loop with backoff so a single transient network fault doesn't sink the run. No new dependencies, no behaviour change on the success path.

## Test plan
- Verify both workflows still install gotestsum on first try in green CI.
- Watch for naturally recurring proxy hiccups; retry should silently absorb them.