### PR TITLE
fix(orchestrator): normalize upload metric file labels

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -32,7 +32,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), u.useCase, finalizeV3(u.snap.MemfileDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(u.snap.MemfileDiffHeader))
 	})
 
 	eg.Go(func() error {
@@ -40,7 +40,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), u.useCase, finalizeV3(u.snap.RootfsDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(u.snap.RootfsDiffHeader))
 	})
 
 	meta := storage.WithMetadata(u.objectMetadata)
@@ -58,7 +58,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		recordUploadCompression(egCtx, uploadArtifactData, string(build.Memfile), u.useCase, storage.CompressConfig{}, info.Size(), info.Size())
+		recordUploadCompression(egCtx, uploadArtifactData, string(build.Memfile), storage.CompressConfig{}, info.Size(), info.Size())
 
 		return nil
 	})
@@ -76,7 +76,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		recordUploadCompression(egCtx, uploadArtifactData, string(build.Rootfs), u.useCase, storage.CompressConfig{}, info.Size(), info.Size())
+		recordUploadCompression(egCtx, uploadArtifactData, string(build.Rootfs), storage.CompressConfig{}, info.Size(), info.Size())
 
 		return nil
 	})

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -81,7 +81,7 @@ func (u *Upload) uploadFramed(
 			compressedSize = size
 		}
 
-		recordUploadCompression(ctx, uploadArtifactData, string(fileType), u.useCase, cfg, size, compressedSize)
+		recordUploadCompression(ctx, uploadArtifactData, string(fileType), cfg, size, compressedSize)
 		selfBuild = headers.BuildData{Size: size, Checksum: checksum, FrameData: ft}
 	}
 
@@ -96,7 +96,7 @@ func (u *Upload) uploadFramed(
 	}
 	h.Builds[u.buildID] = selfBuild
 
-	if err := storeHeaderWithMetrics(ctx, u.store, u.paths.HeaderFile(string(fileType)), string(fileType), u.useCase, h); err != nil {
+	if err := storeHeaderWithMetrics(ctx, u.store, u.paths.HeaderFile(string(fileType)), string(fileType), h); err != nil {
 		return fmt.Errorf("store %s header: %w", fileType, err)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/upload_metric_labels.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metric_labels.go
@@ -1,0 +1,11 @@
+package sandbox
+
+import "github.com/e2b-dev/infra/packages/shared/pkg/storage"
+
+func uploadMetricFileType(fileType string) string {
+	if fileType == storage.RootfsName {
+		return "rootfs"
+	}
+
+	return fileType
+}

--- a/packages/orchestrator/pkg/sandbox/upload_metric_labels_test.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metric_labels_test.go
@@ -1,0 +1,16 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+func TestUploadMetricFileType(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "memfile", uploadMetricFileType(storage.MemfileName))
+	require.Equal(t, "rootfs", uploadMetricFileType(storage.RootfsName))
+}

--- a/packages/orchestrator/pkg/sandbox/upload_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metrics.go
@@ -28,7 +28,7 @@ var (
 func recordUploadCompression(ctx context.Context, artifact, fileType, useCase string, cfg storage.CompressConfig, uncompressed, compressed int64) {
 	attrs := metric.WithAttributes(
 		attribute.String("artifact", artifact),
-		attribute.String("file_type", fileType),
+		attribute.String("file_type", uploadMetricFileType(fileType)),
 		attribute.String("use_case", useCase),
 		attribute.String("compression.type", cfg.CompressionType().String()),
 		attribute.Int("compression.level", cfg.Level),

--- a/packages/orchestrator/pkg/sandbox/upload_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metrics.go
@@ -25,11 +25,10 @@ var (
 	uploadCompressionRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadCompressionRatioBp))
 )
 
-func recordUploadCompression(ctx context.Context, artifact, fileType, useCase string, cfg storage.CompressConfig, uncompressed, compressed int64) {
+func recordUploadCompression(ctx context.Context, artifact, fileType string, cfg storage.CompressConfig, uncompressed, compressed int64) {
 	attrs := metric.WithAttributes(
 		attribute.String("artifact", artifact),
 		attribute.String("file_type", uploadMetricFileType(fileType)),
-		attribute.String("use_case", useCase),
 		attribute.String("compression.type", cfg.CompressionType().String()),
 		attribute.Int("compression.level", cfg.Level),
 	)
@@ -47,13 +46,13 @@ func uploadRatioBp(compressed, uncompressed int64) int64 {
 	return compressed * 10000 / uncompressed
 }
 
-func storeHeaderWithMetrics(ctx context.Context, store storage.StorageProvider, path, fileType, useCase string, h *headers.Header) error {
+func storeHeaderWithMetrics(ctx context.Context, store storage.StorageProvider, path, fileType string, h *headers.Header) error {
 	size, err := headers.StoreHeader(ctx, store, path, h)
 	if err != nil {
 		return err
 	}
 
-	recordUploadCompression(ctx, uploadArtifactHeader, fileType, useCase, storage.CompressConfig{}, size, size)
+	recordUploadCompression(ctx, uploadArtifactHeader, fileType, storage.CompressConfig{}, size, size)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Report rootfs upload metrics with `file_type=rootfs` to match snapshot metrics.
- Drop `use_case` from upload compression metric labels.
- Keep storage paths and compression flag targeting unchanged.

## Test plan
- `go test ./packages/orchestrator/pkg/sandbox -run TestUploadMetricFileType` (fails on darwin: package has Linux-only meter definitions)