### PR TITLE
fix(envd): ignore closed pty read errors

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -221,7 +221,7 @@ func New(
 					}
 				}
 
-				if errors.Is(readErr, io.EOF) {
+				if errors.Is(readErr, io.EOF) || errors.Is(readErr, syscall.EIO) {
 					break
 				}
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.5.27"
+const Version = "0.5.28"


### PR DESCRIPTION
## Summary
Handle PTY master EIO reads as normal teardown in envd, matching the common Linux behavior when the slave side closes.

References:
- https://github.com/creack/pty/issues/184
- https://github.com/owenthereal/upterm/pull/11

## Test plan
`go test ./internal/services/process/...` from `packages/envd`.