### PR TITLE
fix(orchestrator): emit compression ratios as fractions, not BP

### DIFF
--- a/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot_metrics.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	snapshotDiffBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
-	snapshotDiffRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffRatioBp))
-	snapshotTotalBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
+	snapshotDiffBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotDiffBytes))
+	snapshotDiffRatio  = utils.Must(telemetry.GetFloatHistogram(meter, telemetry.SnapshotDiffRatio))
+	snapshotTotalBytes = utils.Must(telemetry.GetHistogram(meter, telemetry.SnapshotTotalBytes))
 )
 
 type SnapshotUseCase string
@@ -53,23 +53,23 @@ func recordSnapshotDiff(
 	} {
 		attrs := metric.WithAttributes(ft, attribute.String("kind", kind))
 		snapshotDiffBytes.Record(ctx, b, attrs)
-		snapshotDiffRatioBp.Record(ctx, ratioBp(b, total), attrs)
+		snapshotDiffRatio.Record(ctx, ratioFraction(b, total), attrs)
 	}
 }
 
-// ratioBp returns num/denom in basis points (10000 = 100.00%) so we keep
-// sub-percent resolution. Grafana panels divide by 100 to display percent.
-func ratioBp(num, denom int64) int64 {
+// ratioFraction returns num/denom as a fraction in [0,1] (1.0 = 100%). Emitted
+// with unit {1} so Grafana percent formatting renders it directly.
+func ratioFraction(num, denom int64) float64 {
 	if denom <= 0 {
 		return 0
 	}
-	bp := num * 10000 / denom
-	if bp < 0 {
+	r := float64(num) / float64(denom)
+	if r < 0 {
 		return 0
 	}
-	if bp > 10000 {
-		return 10000
+	if r > 1 {
+		return 1
 	}
 
-	return bp
+	return r
 }

--- a/packages/orchestrator/pkg/sandbox/upload_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metrics.go
@@ -20,9 +20,9 @@ const (
 )
 
 var (
-	uploadUncompressedBytes  = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadUncompressedBytes))
-	uploadCompressedBytes    = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadCompressedBytes))
-	uploadCompressionRatioBp = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadCompressionRatioBp))
+	uploadUncompressedBytes = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadUncompressedBytes))
+	uploadCompressedBytes   = utils.Must(telemetry.GetHistogram(meter, telemetry.UploadCompressedBytes))
+	uploadCompressionRatio  = utils.Must(telemetry.GetFloatHistogram(meter, telemetry.UploadCompressionRatio))
 )
 
 func recordUploadCompression(ctx context.Context, artifact, fileType string, cfg storage.CompressConfig, uncompressed, compressed int64) {
@@ -35,15 +35,17 @@ func recordUploadCompression(ctx context.Context, artifact, fileType string, cfg
 
 	uploadUncompressedBytes.Record(ctx, uncompressed, attrs)
 	uploadCompressedBytes.Record(ctx, compressed, attrs)
-	uploadCompressionRatioBp.Record(ctx, uploadRatioBp(compressed, uncompressed), attrs)
+	uploadCompressionRatio.Record(ctx, uploadRatio(compressed, uncompressed), attrs)
 }
 
-func uploadRatioBp(compressed, uncompressed int64) int64 {
+// uploadRatio returns compressed/uncompressed as a fraction (1.0 = no
+// compression). May exceed 1 when an artifact expands; emitted with unit {1}.
+func uploadRatio(compressed, uncompressed int64) float64 {
 	if uncompressed <= 0 || compressed < 0 {
 		return 0
 	}
 
-	return compressed * 10000 / uncompressed
+	return float64(compressed) / float64(uncompressed)
 }
 
 func storeHeaderWithMetrics(ctx context.Context, store storage.StorageProvider, path, fileType string, h *headers.Header) error {

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -122,13 +122,13 @@ const (
 	SandboxFCBlockIOEngineThrottled     HistogramType = "orchestrator.sandbox.fc.block.io_engine_throttled"
 	SandboxFCBlockRemainingReqs         HistogramType = "orchestrator.sandbox.fc.block.remaining_reqs"
 
-	SnapshotDiffBytes   HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
-	SnapshotDiffRatioBp HistogramType = "orchestrator.sandbox.snapshot.diff.ratio_bp"
-	SnapshotTotalBytes  HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
+	SnapshotDiffBytes  HistogramType = "orchestrator.sandbox.snapshot.diff.bytes"
+	SnapshotDiffRatio  HistogramType = "orchestrator.sandbox.snapshot.diff.ratio"
+	SnapshotTotalBytes HistogramType = "orchestrator.sandbox.snapshot.total.bytes"
 
-	UploadUncompressedBytes  HistogramType = "orchestrator.sandbox.upload.uncompressed.bytes"
-	UploadCompressedBytes    HistogramType = "orchestrator.sandbox.upload.compressed.bytes"
-	UploadCompressionRatioBp HistogramType = "orchestrator.sandbox.upload.compression.ratio_bp"
+	UploadUncompressedBytes HistogramType = "orchestrator.sandbox.upload.uncompressed.bytes"
+	UploadCompressedBytes   HistogramType = "orchestrator.sandbox.upload.compressed.bytes"
+	UploadCompressionRatio  HistogramType = "orchestrator.sandbox.upload.compression.ratio"
 )
 
 const (
@@ -364,13 +364,13 @@ var histogramDesc = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "Distribution of Firecracker VMM block ops throttled by io_uring engine per metrics flush",
 	SandboxFCBlockRemainingReqs:         "Distribution of Firecracker VMM block queue remaining-request events per metrics flush",
 
-	SnapshotDiffBytes:   "Per-snapshot dirty/empty bytes per file",
-	SnapshotDiffRatioBp: "Per-snapshot dirty/empty as fraction of total mapped size, in basis points (10000=100%)",
-	SnapshotTotalBytes:  "Per-snapshot total mapped size of the file",
+	SnapshotDiffBytes:  "Per-snapshot dirty/empty bytes per file",
+	SnapshotDiffRatio:  "Per-snapshot dirty/empty as fraction of total mapped size (1.0 = 100%)",
+	SnapshotTotalBytes: "Per-snapshot total mapped size of the file",
 
-	UploadUncompressedBytes:  "Per-upload uncompressed artifact size",
-	UploadCompressedBytes:    "Per-upload compressed artifact size",
-	UploadCompressionRatioBp: "Per-upload compressed/uncompressed ratio, in basis points (10000=100%)",
+	UploadUncompressedBytes: "Per-upload uncompressed artifact size",
+	UploadCompressedBytes:   "Per-upload compressed artifact size",
+	UploadCompressionRatio:  "Per-upload compressed/uncompressed ratio (1.0 = no compression)",
 }
 
 var histogramUnits = map[HistogramType]string{
@@ -402,13 +402,13 @@ var histogramUnits = map[HistogramType]string{
 	SandboxFCBlockIOEngineThrottled:     "{op}",
 	SandboxFCBlockRemainingReqs:         "{event}",
 
-	SnapshotDiffBytes:   "{By}",
-	SnapshotDiffRatioBp: "{1}",
-	SnapshotTotalBytes:  "{By}",
+	SnapshotDiffBytes:  "{By}",
+	SnapshotDiffRatio:  "{1}",
+	SnapshotTotalBytes: "{By}",
 
-	UploadUncompressedBytes:  "{By}",
-	UploadCompressedBytes:    "{By}",
-	UploadCompressionRatioBp: "{1}",
+	UploadUncompressedBytes: "{By}",
+	UploadCompressedBytes:   "{By}",
+	UploadCompressionRatio:  "{1}",
 }
 
 func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram, error) {
@@ -416,6 +416,16 @@ func GetHistogram(meter metric.Meter, name HistogramType) (metric.Int64Histogram
 	unit := histogramUnits[name]
 
 	return meter.Int64Histogram(string(name),
+		metric.WithDescription(desc),
+		metric.WithUnit(unit),
+	)
+}
+
+func GetFloatHistogram(meter metric.Meter, name HistogramType) (metric.Float64Histogram, error) {
+	desc := histogramDesc[name]
+	unit := histogramUnits[name]
+
+	return meter.Float64Histogram(string(name),
 		metric.WithDescription(desc),
 		metric.WithUnit(unit),
 	)


### PR DESCRIPTION
The upload/snapshot ratio metrics stored basis points (×10000) while their OTEL unit declared a 0–1 ratio, so percent-formatted Grafana panels rendered 20.48% as 204800%. Record the real fraction via a Float64 histogram and rename off the now-inaccurate _bp suffix (old series go stale rather than mixing scales).

**Removed `_bp` from the metric name**

Was:
<img width="480" height="284" alt="image" src="https://github.com/user-attachments/assets/94359925-f546-4ea2-a24b-eae9e22d85eb" />

Now (different servers):
<img width="574" height="228" alt="image" src="https://github.com/user-attachments/assets/483d54d6-f94c-42b0-8295-7bfa498e6af9" />
