### PR TITLE
refactor(dashboard-api): use auth metadata for default team names

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -20,6 +20,7 @@ import (
 	internalteamprovision "github.com/e2b-dev/infra/packages/dashboard-api/internal/teamprovision"
 	"github.com/e2b-dev/infra/packages/dashboard-api/internal/userprofile"
 	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	supabasequeries "github.com/e2b-dev/infra/packages/db/pkg/supabase/queries"
 	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
@@ -383,6 +384,66 @@ func handlerTestUserEmail(userID uuid.UUID) string {
 	return "user-" + userID.String() + "@example.com"
 }
 
+func TestDefaultTeamNameFromAuthUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		authUser supabasequeries.AuthUser
+		want     string
+	}{
+		{
+			name: "first name",
+			authUser: supabasequeries.AuthUser{
+				Email:           "fallback@example.com",
+				RawUserMetaData: []byte(`{"first_name":"ada","username":"fallback"}`),
+			},
+			want: "Ada's Default Team",
+		},
+		{
+			name: "full name first word",
+			authUser: supabasequeries.AuthUser{
+				Email:           "fallback@example.com",
+				RawUserMetaData: []byte(`{"full_name":"grace hopper"}`),
+			},
+			want: "Grace's Default Team",
+		},
+		{
+			name: "username",
+			authUser: supabasequeries.AuthUser{
+				Email:           "fallback@example.com",
+				RawUserMetaData: []byte(`{"username":"linus"}`),
+			},
+			want: "Linus's Default Team",
+		},
+		{
+			name: "email prefix",
+			authUser: supabasequeries.AuthUser{
+				Email: "barbara@example.com",
+			},
+			want: "Barbara's Default Team",
+		},
+		{
+			name: "fallback",
+			authUser: supabasequeries.AuthUser{
+				RawUserMetaData: []byte(`{`),
+			},
+			want: "User's Default Team",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := defaultTeamNameFromAuthUser(tt.authUser)
+			if got != tt.want {
+				t.Fatalf("defaultTeamNameFromAuthUser() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func insertHandlerTestTeamMember(t *testing.T, db *testutils.Database, userID, teamID uuid.UUID, isDefault bool) {
 	t.Helper()
 
@@ -423,6 +484,13 @@ func TestPostUsersBootstrap_CreatesDefaultTeamAndCallsSink(t *testing.T) {
 	if err := testDB.AuthDB.Write.DeletePublicUser(ctx, userID); err != nil {
 		t.Fatalf("failed to remove public user: %v", err)
 	}
+	if err := testDB.SupabaseDB.TestsRawSQL(ctx, `
+UPDATE auth.users
+SET raw_user_meta_data = '{"first_name":"ada"}'::jsonb
+WHERE id = $1
+`, userID); err != nil {
+		t.Fatalf("failed to update auth user metadata: %v", err)
+	}
 
 	recorder := httptest.NewRecorder()
 	ginCtx, _ := gin.CreateTestContext(recorder)
@@ -444,6 +512,9 @@ func TestPostUsersBootstrap_CreatesDefaultTeamAndCallsSink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected default team to be created: %v", err)
 	}
+	if team.Name != "Ada's Default Team" {
+		t.Fatalf("expected team name %q, got %q", "Ada's Default Team", team.Name)
+	}
 
 	if len(sink.requests) != 1 {
 		t.Fatalf("expected one billing provisioning call, got %d", len(sink.requests))
@@ -455,6 +526,9 @@ func TestPostUsersBootstrap_CreatesDefaultTeamAndCallsSink(t *testing.T) {
 	}
 	if req.Reason != teamprovision.ReasonDefaultSignupTeam {
 		t.Fatalf("expected default signup reason, got %s", req.Reason)
+	}
+	if req.TeamName != team.Name {
+		t.Fatalf("expected sink team name %q, got %q", team.Name, req.TeamName)
 	}
 
 	var responseBody map[string]any

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -2,10 +2,13 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -14,6 +17,7 @@ import (
 	internalteamprovision "github.com/e2b-dev/infra/packages/dashboard-api/internal/teamprovision"
 	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
+	supabasequeries "github.com/e2b-dev/infra/packages/db/pkg/supabase/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -91,8 +95,9 @@ func (s *APIStore) bootstrapUser(ctx context.Context, userID uuid.UUID) (provisi
 		return provisionedTeam{}, fmt.Errorf("get default team: %w", err)
 	}
 
+	defaultTeamName := defaultTeamNameFromAuthUser(authUser)
 	team, err := authTxDB.CreateTeam(ctx, authqueries.CreateTeamParams{
-		Name:          authUser.Email,
+		Name:          defaultTeamName,
 		Tier:          baseTierID,
 		Email:         authUser.Email,
 		IsBlocked:     false,
@@ -253,6 +258,91 @@ func validateTeamCreationAllowed(ctx context.Context, authTxDB *authqueries.Quer
 	}
 
 	return nil
+}
+
+func defaultTeamNameFromAuthUser(authUser supabasequeries.AuthUser) string {
+	metadata := rawUserMetadata(authUser.RawUserMetaData)
+
+	baseName := firstNonEmpty(
+		firstWord(metadataString(metadata, "first_name")),
+		firstWord(metadataString(metadata, "firstName")),
+		firstWord(metadataString(metadata, "given_name")),
+		firstWord(metadataString(metadata, "givenName")),
+		firstWord(metadataString(metadata, "name")),
+		firstWord(metadataString(metadata, "full_name")),
+		firstWord(metadataString(metadata, "fullName")),
+		metadataString(metadata, "username"),
+		metadataString(metadata, "user_name"),
+		metadataString(metadata, "userName"),
+		metadataString(metadata, "preferred_username"),
+		metadataString(metadata, "preferredUsername"),
+		emailPrefix(authUser.Email),
+		"User",
+	)
+
+	return capitalizeFirstLetter(baseName) + "'s Default Team"
+}
+
+func rawUserMetadata(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var metadata map[string]any
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return nil
+	}
+
+	return metadata
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	if metadata == nil {
+		return ""
+	}
+
+	value, ok := metadata[key].(string)
+	if !ok {
+		return ""
+	}
+
+	return strings.TrimSpace(value)
+}
+
+func firstWord(value string) string {
+	parts := strings.Fields(value)
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return parts[0]
+}
+
+func emailPrefix(email string) string {
+	prefix, _, _ := strings.Cut(strings.TrimSpace(email), "@")
+
+	return prefix
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+
+	return ""
+}
+
+func capitalizeFirstLetter(value string) string {
+	runes := []rune(strings.TrimSpace(value))
+	if len(runes) == 0 {
+		return ""
+	}
+
+	runes[0] = unicode.ToUpper(runes[0])
+
+	return string(runes)
 }
 
 func (s *APIStore) handleProvisioningError(ctx context.Context, c *gin.Context, operation string, err error) {

--- a/packages/db/migrations/20000101000000_auth.sql
+++ b/packages/db/migrations/20000101000000_auth.sql
@@ -18,6 +18,7 @@ CREATE TABLE auth.users (
     email text NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),
     raw_app_meta_data jsonb,
+    raw_user_meta_data jsonb,
     PRIMARY KEY (id)
 );
 -- +goose StatementEnd

--- a/packages/db/pkg/supabase/queries/get_auth_user.sql.go
+++ b/packages/db/pkg/supabase/queries/get_auth_user.sql.go
@@ -12,7 +12,12 @@ import (
 )
 
 const getAuthUserByID = `-- name: GetAuthUserByID :one
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE id = $1::uuid
 `
@@ -25,12 +30,18 @@ func (q *Queries) GetAuthUserByID(ctx context.Context, dollar_1 uuid.UUID) (Auth
 		&i.Email,
 		&i.CreatedAt,
 		&i.RawAppMetaData,
+		&i.RawUserMetaData,
 	)
 	return i, err
 }
 
 const getAuthUsersByEmail = `-- name: GetAuthUsersByEmail :many
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE email = $1::text
 `
@@ -49,6 +60,7 @@ func (q *Queries) GetAuthUsersByEmail(ctx context.Context, email string) ([]Auth
 			&i.Email,
 			&i.CreatedAt,
 			&i.RawAppMetaData,
+			&i.RawUserMetaData,
 		); err != nil {
 			return nil, err
 		}
@@ -61,7 +73,12 @@ func (q *Queries) GetAuthUsersByEmail(ctx context.Context, email string) ([]Auth
 }
 
 const getAuthUsersByIDs = `-- name: GetAuthUsersByIDs :many
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE id = ANY($1::uuid[])
 `
@@ -80,6 +97,7 @@ func (q *Queries) GetAuthUsersByIDs(ctx context.Context, ids []uuid.UUID) ([]Aut
 			&i.Email,
 			&i.CreatedAt,
 			&i.RawAppMetaData,
+			&i.RawUserMetaData,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/supabase/queries/models.go
+++ b/packages/db/pkg/supabase/queries/models.go
@@ -18,8 +18,9 @@ type AuthSession struct {
 }
 
 type AuthUser struct {
-	ID             uuid.UUID
-	Email          string
-	CreatedAt      *time.Time
-	RawAppMetaData []byte
+	ID              uuid.UUID
+	Email           string
+	CreatedAt       *time.Time
+	RawAppMetaData  []byte
+	RawUserMetaData []byte
 }

--- a/packages/db/pkg/supabase/schema/auth_users_override.sql
+++ b/packages/db/pkg/supabase/schema/auth_users_override.sql
@@ -16,6 +16,7 @@ CREATE TABLE auth.users (
     email text NOT NULL,
     created_at timestamptz DEFAULT now(),
     raw_app_meta_data jsonb,
+    raw_user_meta_data jsonb,
     PRIMARY KEY (id)
 );
 

--- a/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
+++ b/packages/db/pkg/supabase/sql_queries/users/get_auth_user.sql
@@ -1,15 +1,30 @@
 -- name: GetAuthUserByID :one
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE id = $1::uuid;
 
 -- name: GetAuthUsersByIDs :many
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE id = ANY(sqlc.arg(ids)::uuid[]);
 
 -- name: GetAuthUsersByEmail :many
-SELECT id, COALESCE(email, '') AS email, created_at, COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data
+SELECT
+    id,
+    COALESCE(email, '') AS email,
+    created_at,
+    COALESCE(raw_app_meta_data, '{}'::jsonb) AS raw_app_meta_data,
+    COALESCE(raw_user_meta_data, '{}'::jsonb) AS raw_user_meta_data
 FROM auth.users
 WHERE email = sqlc.arg(email)::text;
 


### PR DESCRIPTION
## Summary
- Read `raw_user_meta_data` from Supabase auth user queries.
- Derive default team names from profile metadata before falling back to the email prefix.
- Cover the default team naming behavior in dashboard-api handler tests.
