### PR TITLE
refactor(testutils): replace raw SQL with sqlc queries for team/env t…

### DIFF
--- a/packages/api/internal/db/snapshots_test.go
+++ b/packages/api/internal/db/snapshots_test.go
@@ -15,38 +15,6 @@ import (
 	"github.com/e2b-dev/infra/packages/db/queries"
 )
 
-// createTestTeam creates a test team in the database using raw SQL
-func createTestTeam(t *testing.T, db *testutils.Database) uuid.UUID {
-	t.Helper()
-	teamID := uuid.New()
-	slug := "test-team-" + teamID.String()[:8]
-
-	// Insert a team directly into the database using raw SQL
-	// Using the default tier 'base_v1' that is created in migrations
-	err := db.AuthDb.TestsRawSQL(t.Context(),
-		"INSERT INTO public.teams (id, name, tier, email, slug) VALUES ($1, $2, $3, $4, $5)",
-		teamID, "Test Team "+teamID.String(), "base_v1", "test-"+teamID.String()+"@example.com", slug,
-	)
-	require.NoError(t, err, "Failed to create test team")
-
-	return teamID
-}
-
-// createTestBaseEnv creates a base env in the database (required by foreign key constraint)
-func createTestBaseEnv(t *testing.T, db *testutils.Database, teamID uuid.UUID) string {
-	t.Helper()
-	envID := "base-env-" + uuid.New().String()
-
-	// Insert a base env directly into the database
-	err := db.SqlcClient.TestsRawSQL(t.Context(),
-		"INSERT INTO public.envs (id, team_id, public, updated_at, source) VALUES ($1, $2, $3, NOW(), 'template')",
-		envID, teamID, true,
-	)
-	require.NoError(t, err, "Failed to create test base env")
-
-	return envID
-}
-
 // createTestSnapshot creates a snapshot using UpsertSnapshot and returns the sandbox_id and env_id
 func createTestSnapshot(t *testing.T, db *testutils.Database, teamID uuid.UUID, baseEnvID string) (string, string, uuid.UUID) {
 	t.Helper()
@@ -142,8 +110,8 @@ func TestGetSnapshotWithBuilds_Success(t *testing.T) {
 	db := testutils.SetupDatabase(t)
 
 	// Create test data: team -> base env -> snapshot with env -> env builds
-	teamID := createTestTeam(t, db)
-	baseEnvID := createTestBaseEnv(t, db, teamID)
+	teamID := testutils.CreateTestTeam(t, db)
+	baseEnvID := testutils.CreateTestTemplate(t, db, teamID)
 	sandboxID, templateID, _ := createTestSnapshot(t, db, teamID, baseEnvID)
 
 	// Create additional builds for the env (UpsertSnapshot already created one)
@@ -176,8 +144,8 @@ func TestGetSnapshotWithBuilds_NoAdditionalBuilds(t *testing.T) {
 
 	// Create test data: team -> base env -> snapshot
 	// Note: UpsertSnapshot creates one build automatically
-	teamID := createTestTeam(t, db)
-	baseEnvID := createTestBaseEnv(t, db, teamID)
+	teamID := testutils.CreateTestTeam(t, db)
+	baseEnvID := testutils.CreateTestTemplate(t, db, teamID)
 	sandboxID, templateID, _ := createTestSnapshot(t, db, teamID, baseEnvID)
 
 	// Execute GetSnapshotBuilds (only the build created by UpsertSnapshot)
@@ -199,7 +167,7 @@ func TestGetSnapshotWithBuilds_NotFound(t *testing.T) {
 	db := testutils.SetupDatabase(t)
 
 	// Create a team but no snapshot
-	teamID := createTestTeam(t, db)
+	teamID := testutils.CreateTestTeam(t, db)
 	nonExistentSandboxID := "sandbox-does-not-exist"
 
 	// Execute GetSnapshotBuilds with non-existent sandbox ID
@@ -216,12 +184,12 @@ func TestGetSnapshotWithBuilds_WrongTeamID(t *testing.T) {
 	db := testutils.SetupDatabase(t)
 
 	// Create test data with one team
-	teamID := createTestTeam(t, db)
-	baseEnvID := createTestBaseEnv(t, db, teamID)
+	teamID := testutils.CreateTestTeam(t, db)
+	baseEnvID := testutils.CreateTestTemplate(t, db, teamID)
 	sandboxID, _, _ := createTestSnapshot(t, db, teamID, baseEnvID)
 
 	// Create a different team
-	differentTeamID := createTestTeam(t, db)
+	differentTeamID := testutils.CreateTestTeam(t, db)
 
 	// Execute GetSnapshotBuilds with wrong team ID
 	_, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, differentTeamID, sandboxID)
@@ -237,8 +205,8 @@ func TestGetSnapshotWithBuilds_NoBuilds(t *testing.T) {
 	db := testutils.SetupDatabase(t)
 
 	// Create test data
-	teamID := createTestTeam(t, db)
-	baseEnvID := createTestBaseEnv(t, db, teamID)
+	teamID := testutils.CreateTestTeam(t, db)
+	baseEnvID := testutils.CreateTestTemplate(t, db, teamID)
 	sandboxID, _, buildID := createTestSnapshot(t, db, teamID, baseEnvID)
 	deleteBuild(t, db, buildID)
 

--- a/packages/db/pkg/testutils/queries.go
+++ b/packages/db/pkg/testutils/queries.go
@@ -10,39 +10,43 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/stretchr/testify/require"
 
+	testqueries "github.com/e2b-dev/infra/packages/db/pkg/testutils/queries"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
 )
 
-// CreateTestTeam creates a test team in the database using raw SQL
+// CreateTestTeam creates a test team in the database.
+// Uses the default tier 'base_v1' that is created in migrations.
 func CreateTestTeam(t *testing.T, db *Database) uuid.UUID {
 	t.Helper()
 	teamID := uuid.New()
 	// Generate a unique slug from the team ID (first 8 chars)
 	slug := "test-team-" + teamID.String()[:8]
 
-	// Insert a team directly into the database using raw SQL
-	// Using the default tier 'base_v1' that is created in migrations
-	err := db.AuthDb.TestsRawSQL(t.Context(),
-		"INSERT INTO public.teams (id, name, tier, email, slug) VALUES ($1, $2, $3, $4, $5)",
-		teamID, "Test Team "+teamID.String(), "base_v1", "test-"+teamID.String()+"@example.com", slug,
-	)
+	err := db.TestQueries.InsertTestTeam(t.Context(), testqueries.InsertTestTeamParams{
+		ID:    teamID,
+		Name:  "Test Team " + teamID.String(),
+		Tier:  "base_v1",
+		Email: "test-" + teamID.String() + "@example.com",
+		Slug:  slug,
+	})
 	require.NoError(t, err, "Failed to create test team")
 
 	return teamID
 }
 
-// CreateTestTemplate creates a base env in the database (required by foreign key constraint)
+// CreateTestTemplate creates a base env (template) row in the database
+// (required by foreign key constraints in subsequent test inserts).
 func CreateTestTemplate(t *testing.T, db *Database, teamID uuid.UUID) string {
 	t.Helper()
 	envID := "base-env-" + uuid.New().String()
 
-	// Insert a base env directly into the database
-	// After the env_builds migration, envs table only has: id, team_id, public, updated_at, build_count, spawn_count, last_spawned_at
-	err := db.SqlcClient.TestsRawSQL(t.Context(),
-		"INSERT INTO public.envs (id, team_id, public, updated_at, source) VALUES ($1, $2, $3, NOW(), 'template')",
-		envID, teamID, true,
-	)
+	err := db.TestQueries.InsertTestEnv(t.Context(), testqueries.InsertTestEnvParams{
+		ID:     envID,
+		TeamID: teamID,
+		Public: true,
+		Source: "template",
+	})
 	require.NoError(t, err, "Failed to create test base env")
 
 	return envID

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -3,3 +3,248 @@
 //   sqlc v1.29.0
 
 package queries
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type AccessToken struct {
+	UserID    uuid.UUID
+	CreatedAt time.Time
+	ID        uuid.UUID
+	// sensitive
+	AccessTokenHash       string
+	Name                  string
+	AccessTokenPrefix     string
+	AccessTokenLength     int32
+	AccessTokenMaskPrefix string
+	AccessTokenMaskSuffix string
+}
+
+type ActiveTemplateBuild struct {
+	BuildID    uuid.UUID
+	TeamID     uuid.UUID
+	TemplateID string
+	Tags       []string
+	CreatedAt  time.Time
+}
+
+type Addon struct {
+	ID                            uuid.UUID
+	TeamID                        uuid.UUID
+	Name                          string
+	Description                   pgtype.Text
+	ExtraConcurrentSandboxes      int64
+	ExtraConcurrentTemplateBuilds int64
+	ExtraMaxVcpu                  int64
+	ExtraMaxRamMb                 int64
+	ExtraDiskMb                   int64
+	ValidFrom                     time.Time
+	ValidTo                       *time.Time
+	AddedBy                       uuid.UUID
+	IdempotencyKey                pgtype.Text
+}
+
+type AuthUser struct {
+	ID              uuid.UUID
+	Email           string
+	CreatedAt       time.Time
+	RawAppMetaData  []byte
+	RawUserMetaData []byte
+}
+
+type BillingSandboxLog struct {
+	SandboxID       string
+	EnvID           string
+	Vcpu            int64
+	RamMb           int64
+	TotalDiskSizeMb int64
+	StartedAt       time.Time
+	StoppedAt       *time.Time
+	CreatedAt       time.Time
+	TeamID          uuid.UUID
+}
+
+type Cluster struct {
+	ID                 uuid.UUID
+	Endpoint           string
+	EndpointTls        bool
+	Token              string
+	SandboxProxyDomain pgtype.Text
+	AuthOrgID          pgtype.Text
+}
+
+type Env struct {
+	ID         string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+	Public     bool
+	BuildCount int32
+	// Number of times the env was spawned
+	SpawnCount int64
+	// Timestamp of the last time the env was spawned
+	LastSpawnedAt *time.Time
+	TeamID        uuid.UUID
+	CreatedBy     *uuid.UUID
+	ClusterID     *uuid.UUID
+	Source        string
+}
+
+type EnvAlias struct {
+	Alias       string
+	IsRenamable bool
+	EnvID       string
+	Namespace   pgtype.Text
+	ID          uuid.UUID
+}
+
+type EnvBuild struct {
+	ID                 uuid.UUID
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	FinishedAt         *time.Time
+	Status             string
+	Dockerfile         pgtype.Text
+	StartCmd           pgtype.Text
+	Vcpu               int64
+	RamMb              int64
+	FreeDiskSizeMb     int64
+	TotalDiskSizeMb    pgtype.Int8
+	KernelVersion      string
+	FirecrackerVersion string
+	EnvID              pgtype.Text
+	EnvdVersion        pgtype.Text
+	ReadyCmd           pgtype.Text
+	ClusterNodeID      pgtype.Text
+	Reason             []byte
+	Version            pgtype.Text
+	CpuArchitecture    pgtype.Text
+	CpuFamily          pgtype.Text
+	CpuModel           pgtype.Text
+	CpuModelName       pgtype.Text
+	CpuFlags           []string
+	StatusGroup        string
+	TeamID             *uuid.UUID
+}
+
+type EnvBuildAssignment struct {
+	ID        uuid.UUID
+	EnvID     string
+	BuildID   uuid.UUID
+	Tag       string
+	Source    string
+	CreatedAt pgtype.Timestamptz
+}
+
+type Snapshot struct {
+	CreatedAt           pgtype.Timestamptz
+	EnvID               string
+	SandboxID           string
+	ID                  uuid.UUID
+	Metadata            []byte
+	BaseEnvID           string
+	SandboxStartedAt    pgtype.Timestamptz
+	EnvSecure           bool
+	OriginNodeID        string
+	AllowInternetAccess pgtype.Bool
+	AutoPause           bool
+	TeamID              uuid.UUID
+	Config              []byte
+}
+
+type SnapshotTemplate struct {
+	EnvID        string
+	SandboxID    string
+	CreatedAt    pgtype.Timestamptz
+	OriginNodeID pgtype.Text
+	BuildID      *uuid.UUID
+}
+
+type Team struct {
+	ID                      uuid.UUID
+	CreatedAt               time.Time
+	IsBlocked               bool
+	Name                    string
+	Tier                    string
+	Email                   string
+	IsBanned                bool
+	BlockedReason           pgtype.Text
+	ClusterID               *uuid.UUID
+	SandboxSchedulingLabels []string
+	Slug                    string
+}
+
+type TeamApiKey struct {
+	CreatedAt time.Time
+	TeamID    uuid.UUID
+	UpdatedAt *time.Time
+	Name      string
+	LastUsed  *time.Time
+	CreatedBy *uuid.UUID
+	ID        uuid.UUID
+	// sensitive
+	ApiKeyHash       string
+	ApiKeyPrefix     string
+	ApiKeyLength     int32
+	ApiKeyMaskPrefix string
+	ApiKeyMaskSuffix string
+}
+
+type TeamLimit struct {
+	ID                       uuid.UUID
+	MaxLengthHours           int64
+	ConcurrentSandboxes      int32
+	ConcurrentTemplateBuilds int32
+	MaxVcpu                  int32
+	MaxRamMb                 int32
+	DiskMb                   int32
+}
+
+type Tier struct {
+	ID     string
+	Name   string
+	DiskMb int64
+	// The number of instances the team can run concurrently
+	ConcurrentInstances int64
+	MaxLengthHours      int64
+	MaxVcpu             int64
+	MaxRamMb            int64
+	// The number of concurrent template builds the team can run
+	ConcurrentTemplateBuilds int64
+}
+
+type User struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	ID        uuid.UUID
+	Email     string
+}
+
+type UserIdentity struct {
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	OidcIss   string
+	OidcSub   string
+	UserID    uuid.UUID
+}
+
+type UsersTeam struct {
+	ID        int64
+	UserID    uuid.UUID
+	TeamID    uuid.UUID
+	IsDefault bool
+	AddedBy   *uuid.UUID
+	CreatedAt pgtype.Timestamp
+	UuidID    uuid.UUID
+}
+
+type Volume struct {
+	ID         uuid.UUID
+	TeamID     uuid.UUID
+	Name       string
+	VolumeType string
+	CreatedAt  pgtype.Timestamptz
+}

--- a/packages/db/pkg/testutils/queries/tests.sql.go
+++ b/packages/db/pkg/testutils/queries/tests.sql.go
@@ -7,6 +7,8 @@ package queries
 
 import (
 	"context"
+
+	"github.com/google/uuid"
 )
 
 const getRowLevelSecurity = `-- name: GetRowLevelSecurity :many
@@ -57,4 +59,67 @@ func (q *Queries) GetRowLevelSecurity(ctx context.Context) ([]GetRowLevelSecurit
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertTestEnv = `-- name: InsertTestEnv :exec
+INSERT INTO public.envs (id, team_id, public, updated_at, source)
+VALUES (
+    $1::text,
+    $2::uuid,
+    $3::boolean,
+    NOW(),
+    $4::text
+)
+`
+
+type InsertTestEnvParams struct {
+	ID     string
+	TeamID uuid.UUID
+	Public bool
+	Source string
+}
+
+// Inserts an env (template) row used as a base for tests. Mirrors what
+// production code does via CreateOrUpdateTemplate but without the build_count
+// bookkeeping so tests can seed deterministic rows.
+func (q *Queries) InsertTestEnv(ctx context.Context, arg InsertTestEnvParams) error {
+	_, err := q.db.Exec(ctx, insertTestEnv,
+		arg.ID,
+		arg.TeamID,
+		arg.Public,
+		arg.Source,
+	)
+	return err
+}
+
+const insertTestTeam = `-- name: InsertTestTeam :exec
+INSERT INTO public.teams (id, name, tier, email, slug)
+VALUES (
+    $1::uuid,
+    $2::text,
+    $3::text,
+    $4::text,
+    $5::text
+)
+`
+
+type InsertTestTeamParams struct {
+	ID    uuid.UUID
+	Name  string
+	Tier  string
+	Email string
+	Slug  string
+}
+
+// Inserts a team for tests with explicit id/slug. Uses the default 'base_v1'
+// tier created in migrations.
+func (q *Queries) InsertTestTeam(ctx context.Context, arg InsertTestTeamParams) error {
+	_, err := q.db.Exec(ctx, insertTestTeam,
+		arg.ID,
+		arg.Name,
+		arg.Tier,
+		arg.Email,
+		arg.Slug,
+	)
+	return err
 }

--- a/packages/db/pkg/testutils/tests.sql
+++ b/packages/db/pkg/testutils/tests.sql
@@ -12,3 +12,28 @@ where c.relkind in (
     'v', -- view
     'm'  -- materialized view
 );
+
+-- name: InsertTestTeam :exec
+-- Inserts a team for tests with explicit id/slug. Uses the default 'base_v1'
+-- tier created in migrations.
+INSERT INTO public.teams (id, name, tier, email, slug)
+VALUES (
+    sqlc.arg(id)::uuid,
+    sqlc.arg(name)::text,
+    sqlc.arg(tier)::text,
+    sqlc.arg(email)::text,
+    sqlc.arg(slug)::text
+);
+
+-- name: InsertTestEnv :exec
+-- Inserts an env (template) row used as a base for tests. Mirrors what
+-- production code does via CreateOrUpdateTemplate but without the build_count
+-- bookkeeping so tests can seed deterministic rows.
+INSERT INTO public.envs (id, team_id, public, updated_at, source)
+VALUES (
+    sqlc.arg(id)::text,
+    sqlc.arg(team_id)::uuid,
+    sqlc.arg(public)::boolean,
+    NOW(),
+    sqlc.arg(source)::text
+);

--- a/packages/db/sqlc.yaml
+++ b/packages/db/sqlc.yaml
@@ -101,6 +101,9 @@ sql:
 
   - engine: "postgresql"
     queries: "pkg/testutils/*.sql"
+    schema:
+      - "migrations"
+      - "schema"
     gen:
       go:
         package: "queries"


### PR DESCRIPTION
…est helpers

Introduce InsertTestTeam and InsertTestEnv sqlc queries (with explicit id/slug) so testutils.CreateTestTeam and CreateTestTemplate no longer rely on TestsRawSQL. Add schema to the testutils sqlc target so it can resolve public.teams and public.envs. Drop the duplicate local helpers in snapshots_test.go and call the shared testutils versions instead.