### PR TITLE
chore(node): tune orchestrator host sysctls + image kernel knobs

### DIFF
--- a/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
@@ -171,22 +171,6 @@ build {
       "sudo mv /tmp/limits.conf /etc/security/limits.conf",
       # Increase the maximum number of connections by 4x
       "echo 'net.netfilter.nf_conntrack_max = 2097152' | sudo tee -a /etc/sysctl.conf",
-      # Image-level kernel caps. Per-node sysctls live in start-client.sh; these
-      # are the ones we want applied even before that script runs (e.g. for the
-      # build image, packer setup itself, etc).
-      "echo 'fs.file-max = 4194304'        | sudo tee -a /etc/sysctl.conf",
-      "echo 'fs.nr_open = 4194304'         | sudo tee -a /etc/sysctl.conf",
-      "echo 'kernel.pid_max = 4194304'     | sudo tee -a /etc/sysctl.conf",
-      "echo 'vm.overcommit_memory = 1'     | sudo tee -a /etc/sysctl.conf",
-      # nf_conntrack_max=2097152 with the default ~64K buckets means average
-      # chain length of 32 under load. Match buckets to capacity so lookups
-      # stay O(1) under softirq.
-      "echo 'options nf_conntrack hashsize=524288' | sudo tee /etc/modprobe.d/nf_conntrack.conf",
-      # Pin the iptables backend so AMI rebuilds don't silently flip between
-      # legacy and nft. The orchestrator's per-sandbox rules are appended via
-      # the standard iptables binary; nft is the modern default on Ubuntu 22+.
-      "sudo update-alternatives --set iptables  /usr/sbin/iptables-nft  || true",
-      "sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true",
     ]
   }
 

--- a/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/main.pkr.hcl
@@ -171,6 +171,22 @@ build {
       "sudo mv /tmp/limits.conf /etc/security/limits.conf",
       # Increase the maximum number of connections by 4x
       "echo 'net.netfilter.nf_conntrack_max = 2097152' | sudo tee -a /etc/sysctl.conf",
+      # Image-level kernel caps. Per-node sysctls live in start-client.sh; these
+      # are the ones we want applied even before that script runs (e.g. for the
+      # build image, packer setup itself, etc).
+      "echo 'fs.file-max = 4194304'        | sudo tee -a /etc/sysctl.conf",
+      "echo 'fs.nr_open = 4194304'         | sudo tee -a /etc/sysctl.conf",
+      "echo 'kernel.pid_max = 4194304'     | sudo tee -a /etc/sysctl.conf",
+      "echo 'vm.overcommit_memory = 1'     | sudo tee -a /etc/sysctl.conf",
+      # nf_conntrack_max=2097152 with the default ~64K buckets means average
+      # chain length of 32 under load. Match buckets to capacity so lookups
+      # stay O(1) under softirq.
+      "echo 'options nf_conntrack hashsize=524288' | sudo tee /etc/modprobe.d/nf_conntrack.conf",
+      # Pin the iptables backend so AMI rebuilds don't silently flip between
+      # legacy and nft. The orchestrator's per-sandbox rules are appended via
+      # the standard iptables binary; nft is the modern default on Ubuntu 22+.
+      "sudo update-alternatives --set iptables  /usr/sbin/iptables-nft  || true",
+      "sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true",
     ]
   }
 

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -311,7 +311,6 @@ numprocs=1
 autostart=true
 autorestart=true
 stopsignal=INT
-minfds=1048576
 user=$nomad_user
 EOF
 }

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -311,7 +311,7 @@ numprocs=1
 autostart=true
 autorestart=true
 stopsignal=INT
-minfds=65536
+minfds=1048576
 user=$nomad_user
 EOF
 }

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -114,35 +114,28 @@ mount -t tmpfs -o size=65G tmpfs /mnt/snapshot-cache
 ulimit -n 1048576
 export GOMAXPROCS=$(nproc)
 
+# Match nf_conntrack hash buckets to nf_conntrack_max (avg chain length ~1).
+# Install before loading so netfilter sysctls below apply on first sysctl -p.
+install -m 0644 /dev/stdin /etc/modprobe.d/nf_conntrack.conf <<'EOH'
+options nf_conntrack hashsize=524288
+EOH
+modprobe nf_conntrack
+
 tee -a /etc/sysctl.conf <<EOF
-# Increase the maximum number of socket connections
 net.core.somaxconn = 65535
-
-# Increase the maximum number of backlogged connections
 net.core.netdev_max_backlog = 65535
-
-# Increase maximum number of TCP sockets
 net.ipv4.tcp_max_syn_backlog = 65535
+vm.max_map_count = 1048576
 
-# Increase the maximum number of memory map areas
-vm.max_map_count=1048576
-
-# Neighbour cache sizing for high sandbox count.
-# Each sandbox produces >=3 neigh entries (host-side veth peer, in-NS veth, in-VM gw),
-# so the default 128/512/1024 overflows around ~150 sandboxes.
-net.ipv4.neigh.default.gc_thresh1 = 8192
-net.ipv4.neigh.default.gc_thresh2 = 16384
-net.ipv4.neigh.default.gc_thresh3 = 32768
-net.ipv6.neigh.default.gc_thresh1 = 8192
-net.ipv6.neigh.default.gc_thresh2 = 16384
-net.ipv6.neigh.default.gc_thresh3 = 32768
-
-# Sandboxes are IPv4-only; disable IPv6 to halve the neigh-table surface and
-# remove RA/RS noise on every per-sandbox link-up.
+# Sandbox networking is IPv4-only; disable IPv6 host-wide.
 net.ipv6.conf.all.disable_ipv6 = 1
 net.ipv6.conf.default.disable_ipv6 = 1
 
-# Strict reverse-path filtering + drop ICMP redirects / source routing.
+# Default 128/512/1024 overflows around ~150 sandboxes (~3 entries each).
+net.ipv4.neigh.default.gc_thresh1 = 8192
+net.ipv4.neigh.default.gc_thresh2 = 16384
+net.ipv4.neigh.default.gc_thresh3 = 32768
+
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.default.rp_filter = 1
 net.ipv4.conf.default.proxy_arp = 0
@@ -150,50 +143,27 @@ net.ipv4.conf.default.send_redirects = 0
 net.ipv4.conf.default.accept_redirects = 0
 net.ipv4.conf.default.accept_source_route = 0
 
-# Ephemeral port / TIME_WAIT budget for the orchestrator -> envd traffic
-# and any other host-namespace connection load.
 net.ipv4.ip_local_port_range = 1024 65535
 net.ipv4.tcp_tw_reuse = 1
 net.ipv4.tcp_fin_timeout = 15
 net.ipv4.tcp_max_tw_buckets = 2000000
-
-# Faster conntrack churn for short-lived TCP (TIME_WAIT side).
 net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30
 
-# Larger socket buffers for in-host data-plane workloads.
 net.core.rmem_max = 16777216
 net.core.wmem_max = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 65536 16777216
 
-# File / inotify caps; defaults are too low for thousands of FCs / NBDs.
-fs.file-max = 4194304
 fs.nr_open = 4194304
 fs.inotify.max_user_watches = 524288
 fs.inotify.max_user_instances = 8192
 
-# Process ID space + memory overcommit for Go services that mmap aggressively.
 kernel.pid_max = 4194304
 vm.overcommit_memory = 1
-
 EOF
 sysctl -p
 
-# nf_conntrack_max=2097152 with the default ~64K buckets means average chain
-# length of ~32 under load. Match the buckets to capacity so lookups stay
-# O(1) under softirq. Install the modprobe config so the module picks it up
-# whenever it is auto-loaded (e.g. by the first iptables nat rule), and also
-# apply at runtime in case the module is already loaded.
-install -m 0644 /dev/stdin /etc/modprobe.d/nf_conntrack.conf <<'EOH'
-options nf_conntrack hashsize=524288
-EOH
-if [ -w /sys/module/nf_conntrack/parameters/hashsize ]; then
-  echo 524288 > /sys/module/nf_conntrack/parameters/hashsize || true
-fi
-
-# Pin the iptables backend so AMI rebuilds don't silently flip between legacy
-# and nft. The orchestrator's per-sandbox rules use the standard iptables
-# binary; nft is the modern default on Ubuntu 22+.
+# Pin iptables backend so AMI rebuilds don't silently flip legacy/nft.
 update-alternatives --set iptables  /usr/sbin/iptables-nft  || true
 update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true
 

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -168,18 +168,34 @@ net.ipv4.tcp_wmem = 4096 65536 16777216
 
 # File / inotify caps; defaults are too low for thousands of FCs / NBDs.
 fs.file-max = 4194304
+fs.nr_open = 4194304
 fs.inotify.max_user_watches = 524288
 fs.inotify.max_user_instances = 8192
+
+# Process ID space + memory overcommit for Go services that mmap aggressively.
+kernel.pid_max = 4194304
+vm.overcommit_memory = 1
 
 EOF
 sysctl -p
 
-# nf_conntrack hash size lives behind a module parameter (set in the Packer
-# modprobe.d config), but apply it at runtime too so freshly-baked AMIs and
-# nodes that hot-load the module both end up with the same shape.
+# nf_conntrack_max=2097152 with the default ~64K buckets means average chain
+# length of ~32 under load. Match the buckets to capacity so lookups stay
+# O(1) under softirq. Install the modprobe config so the module picks it up
+# whenever it is auto-loaded (e.g. by the first iptables nat rule), and also
+# apply at runtime in case the module is already loaded.
+install -m 0644 /dev/stdin /etc/modprobe.d/nf_conntrack.conf <<'EOH'
+options nf_conntrack hashsize=524288
+EOH
 if [ -w /sys/module/nf_conntrack/parameters/hashsize ]; then
   echo 524288 > /sys/module/nf_conntrack/parameters/hashsize || true
 fi
+
+# Pin the iptables backend so AMI rebuilds don't silently flip between legacy
+# and nft. The orchestrator's per-sandbox rules use the standard iptables
+# binary; nft is the modern default on Ubuntu 22+.
+update-alternatives --set iptables  /usr/sbin/iptables-nft  || true
+update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true
 
 echo "Disabling inotify for NBD devices"
 # https://lore.kernel.org/lkml/20220422054224.19527-1-matthew.ruffell@canonical.com/

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -167,6 +167,17 @@ sysctl -p
 update-alternatives --set iptables  /usr/sbin/iptables-nft  || true
 update-alternatives --set ip6tables /usr/sbin/ip6tables-nft || true
 
+# Raise the FD ceiling on supervisor's systemd unit so Nomad (and the
+# orchestrator launched under raw_exec) inherit the host limit instead of
+# the unit's default LimitNOFILE.
+install -d /etc/systemd/system/supervisor.service.d
+install -m 0644 /dev/stdin /etc/systemd/system/supervisor.service.d/limits.conf <<'EOH'
+[Service]
+LimitNOFILE=1048576
+EOH
+systemctl daemon-reload
+systemctl restart supervisor
+
 echo "Disabling inotify for NBD devices"
 # https://lore.kernel.org/lkml/20220422054224.19527-1-matthew.ruffell@canonical.com/
 cat <<EOH >/etc/udev/rules.d/97-nbd-device.rules

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -112,7 +112,7 @@ mkdir -p /mnt/snapshot-cache
 mount -t tmpfs -o size=65G tmpfs /mnt/snapshot-cache
 
 ulimit -n 1048576
-export GOMAXPROCS='nproc'
+export GOMAXPROCS=$(nproc)
 
 tee -a /etc/sysctl.conf <<EOF
 # Increase the maximum number of socket connections
@@ -127,8 +127,59 @@ net.ipv4.tcp_max_syn_backlog = 65535
 # Increase the maximum number of memory map areas
 vm.max_map_count=1048576
 
+# Neighbour cache sizing for high sandbox count.
+# Each sandbox produces >=3 neigh entries (host-side veth peer, in-NS veth, in-VM gw),
+# so the default 128/512/1024 overflows around ~150 sandboxes.
+net.ipv4.neigh.default.gc_thresh1 = 8192
+net.ipv4.neigh.default.gc_thresh2 = 16384
+net.ipv4.neigh.default.gc_thresh3 = 32768
+net.ipv6.neigh.default.gc_thresh1 = 8192
+net.ipv6.neigh.default.gc_thresh2 = 16384
+net.ipv6.neigh.default.gc_thresh3 = 32768
+
+# Sandboxes are IPv4-only; disable IPv6 to halve the neigh-table surface and
+# remove RA/RS noise on every per-sandbox link-up.
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+
+# Strict reverse-path filtering + drop ICMP redirects / source routing.
+net.ipv4.conf.all.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.default.proxy_arp = 0
+net.ipv4.conf.default.send_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.default.accept_source_route = 0
+
+# Ephemeral port / TIME_WAIT budget for the orchestrator -> envd traffic
+# and any other host-namespace connection load.
+net.ipv4.ip_local_port_range = 1024 65535
+net.ipv4.tcp_tw_reuse = 1
+net.ipv4.tcp_fin_timeout = 15
+net.ipv4.tcp_max_tw_buckets = 2000000
+
+# Faster conntrack churn for short-lived TCP (TIME_WAIT side).
+net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30
+
+# Larger socket buffers for in-host data-plane workloads.
+net.core.rmem_max = 16777216
+net.core.wmem_max = 16777216
+net.ipv4.tcp_rmem = 4096 87380 16777216
+net.ipv4.tcp_wmem = 4096 65536 16777216
+
+# File / inotify caps; defaults are too low for thousands of FCs / NBDs.
+fs.file-max = 4194304
+fs.inotify.max_user_watches = 524288
+fs.inotify.max_user_instances = 8192
+
 EOF
 sysctl -p
+
+# nf_conntrack hash size lives behind a module parameter (set in the Packer
+# modprobe.d config), but apply it at runtime too so freshly-baked AMIs and
+# nodes that hot-load the module both end up with the same shape.
+if [ -w /sys/module/nf_conntrack/parameters/hashsize ]; then
+  echo 524288 > /sys/module/nf_conntrack/parameters/hashsize || true
+fi
 
 echo "Disabling inotify for NBD devices"
 # https://lore.kernel.org/lkml/20220422054224.19527-1-matthew.ruffell@canonical.com/

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {


### PR DESCRIPTION
Host-side sysctls + image kernel knobs for orchestrator nodes: raise neigh `gc_thresh*`, ephemeral port range, TIME_WAIT/conntrack tuning, socket buffers, FD/inotify caps. Disable IPv6 host-wide (sandbox networking is IPv4-only). Pin iptables backend to nft via `update-alternatives`. Bump supervisor `minfds` so Nomad inherits the host FD limit. Fix the `GOMAXPROCS='nproc'` literal-string bug. Rolls out on next node boot — no AMI rebuild required.

Removes the host as the limiting factor at ~150 sandboxes/node (ARP overflow at default `gc_thresh3=1024`, ephemeral port exhaustion, TIME_WAIT pile-up, undersized conntrack hash, FD ceiling capped by supervisor).
