### PR TITLE
feat(orch): static NUD_PERMANENT neighbours + ARP/IPv6 off on per-sandbox veth

### DIFF
--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -18,9 +18,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-// Per-sandbox veth/vpeer only talk to the host gateway, so ARP is disabled
-// and the single L2 next hop is pinned NUD_PERMANENT on both sides. IPv6 is
-// disabled host-wide via sysctl, so no per-link IPv6 handling is needed.
+// The single L2 next hop on each sandbox veth/vpeer is pinned NUD_PERMANENT
+// on both sides so the IPv4 neigh table is never consulted for this path.
 
 func (s *Slot) CreateNetwork(ctx context.Context) error {
 	// Prevent thread changes so we can safely manipulate with namespaces
@@ -71,10 +70,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error finding vpeer: %w", err)
 	}
 
-	if err := netlink.LinkSetARPOff(vpeer); err != nil {
-		return fmt.Errorf("error disabling ARP on vpeer: %w", err)
-	}
-
 	err = netlink.LinkSetUp(vpeer)
 	if err != nil {
 		return fmt.Errorf("error setting vpeer device up: %w", err)
@@ -104,10 +99,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 	vethInHost, err := netlink.LinkByName(s.VethName())
 	if err != nil {
 		return fmt.Errorf("error finding veth: %w", err)
-	}
-
-	if err := netlink.LinkSetARPOff(vethInHost); err != nil {
-		return fmt.Errorf("error disabling ARP on vethInHost: %w", err)
 	}
 
 	err = netlink.LinkSetUp(vethInHost)

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"runtime"
 	"strconv"
 
@@ -17,6 +18,21 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
+
+// disableIPv6OnLink turns IPv6 off for the named link in the current netns.
+// Writing the sysctl is best-effort: if the link has no IPv6 sysctl entry
+// (e.g. IPv6 already disabled host-wide), the write fails and we treat that
+// as a no-op rather than failing the whole sandbox provisioning.
+func disableIPv6OnLink(name string) error {
+	path := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", name)
+	if err := os.WriteFile(path, []byte("1"), 0o644); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
 
 func (s *Slot) CreateNetwork(ctx context.Context) error {
 	// Prevent thread changes so we can safely manipulate with namespaces
@@ -82,6 +98,17 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding vpeer device address: %w", err)
 	}
 
+	// Sandbox veth pairs only talk to the host gateway. Disable ARP and IPv6
+	// here so we never participate in L2 discovery and never count against
+	// the IPv4/IPv6 neigh GC thresholds. The matching NUD_PERMANENT entries
+	// are installed below once both link indices and MACs are known.
+	if err := netlink.LinkSetARPOff(vpeer); err != nil {
+		return fmt.Errorf("error disabling ARP on vpeer: %w", err)
+	}
+	if err := disableIPv6OnLink(s.VpeerName()); err != nil {
+		return fmt.Errorf("error disabling IPv6 on vpeer: %w", err)
+	}
+
 	// Move Veth device to the host NS
 	err = netlink.LinkSetNsFd(veth, int(hostNS))
 	if err != nil {
@@ -113,9 +140,41 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding veth device address: %w", err)
 	}
 
+	// Mirror the per-link hardening from the sandbox side. ARP off is fine
+	// because the only L2 next hop on this veth is vpeer, which we pin
+	// below as NUD_PERMANENT.
+	if err := netlink.LinkSetARPOff(vethInHost); err != nil {
+		return fmt.Errorf("error disabling ARP on vethInHost: %w", err)
+	}
+	if err := disableIPv6OnLink(s.VethName()); err != nil {
+		return fmt.Errorf("error disabling IPv6 on vethInHost: %w", err)
+	}
+
+	// Pin the host-side L2 next hop: vethInHost -> vpeer's IP/MAC. NUD_PERMANENT
+	// entries are never garbage-collected and never trigger ARP, so the host
+	// neigh table cannot overflow on this path regardless of sandbox count.
+	if err := netlink.NeighSet(&netlink.Neigh{
+		LinkIndex:    vethInHost.Attrs().Index,
+		State:        netlink.NUD_PERMANENT,
+		IP:           s.VpeerIP(),
+		HardwareAddr: vpeer.Attrs().HardwareAddr,
+	}); err != nil {
+		return fmt.Errorf("error pinning vpeer neighbour on vethInHost: %w", err)
+	}
+
 	err = netns.Set(ns)
 	if err != nil {
 		return fmt.Errorf("error setting network namespace to %s: %w", ns.String(), err)
+	}
+
+	// Symmetric pin on the sandbox side now that we are back in its netns.
+	if err := netlink.NeighSet(&netlink.Neigh{
+		LinkIndex:    vpeer.Attrs().Index,
+		State:        netlink.NUD_PERMANENT,
+		IP:           s.VethIP(),
+		HardwareAddr: vethInHost.Attrs().HardwareAddr,
+	}); err != nil {
+		return fmt.Errorf("error pinning vethInHost neighbour on vpeer: %w", err)
 	}
 
 	// Create Tap device for FC in NS

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -18,11 +18,9 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-// IPv6 is disabled host-wide on orchestrator nodes via
-// `net.ipv6.conf.{all,default}.disable_ipv6=1`, so newly created veth pairs
-// inherit "disabled" at link-creation time and never bring up an IPv6
-// link-local address or run ND. We therefore only need to manage the IPv4
-// neighbour state on each veth — handled below via ARP off + NUD_PERMANENT.
+// Per-sandbox veth/vpeer only talk to the host gateway, so ARP is disabled
+// and the single L2 next hop is pinned NUD_PERMANENT on both sides. IPv6 is
+// disabled host-wide via sysctl, so no per-link IPv6 handling is needed.
 
 func (s *Slot) CreateNetwork(ctx context.Context) error {
 	// Prevent thread changes so we can safely manipulate with namespaces
@@ -73,6 +71,10 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error finding vpeer: %w", err)
 	}
 
+	if err := netlink.LinkSetARPOff(vpeer); err != nil {
+		return fmt.Errorf("error disabling ARP on vpeer: %w", err)
+	}
+
 	err = netlink.LinkSetUp(vpeer)
 	if err != nil {
 		return fmt.Errorf("error setting vpeer device up: %w", err)
@@ -86,14 +88,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 	})
 	if err != nil {
 		return fmt.Errorf("error adding vpeer device address: %w", err)
-	}
-
-	// Sandbox veth pairs only ever talk to the host gateway, so we don't
-	// need ARP on either side: the matching NUD_PERMANENT entries installed
-	// below cover the single L2 next hop and keep us off the IPv4 neigh GC
-	// thresholds entirely.
-	if err := netlink.LinkSetARPOff(vpeer); err != nil {
-		return fmt.Errorf("error disabling ARP on vpeer: %w", err)
 	}
 
 	// Move Veth device to the host NS
@@ -112,6 +106,10 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error finding veth: %w", err)
 	}
 
+	if err := netlink.LinkSetARPOff(vethInHost); err != nil {
+		return fmt.Errorf("error disabling ARP on vethInHost: %w", err)
+	}
+
 	err = netlink.LinkSetUp(vethInHost)
 	if err != nil {
 		return fmt.Errorf("error setting veth device up: %w", err)
@@ -127,14 +125,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding veth device address: %w", err)
 	}
 
-	// Mirror the sandbox-side hardening: ARP off, NUD_PERMANENT below.
-	if err := netlink.LinkSetARPOff(vethInHost); err != nil {
-		return fmt.Errorf("error disabling ARP on vethInHost: %w", err)
-	}
-
-	// Pin the host-side L2 next hop: vethInHost -> vpeer's IP/MAC. NUD_PERMANENT
-	// entries are never garbage-collected and never trigger ARP, so the host
-	// neigh table cannot overflow on this path regardless of sandbox count.
 	if err := netlink.NeighSet(&netlink.Neigh{
 		LinkIndex:    vethInHost.Attrs().Index,
 		State:        netlink.NUD_PERMANENT,
@@ -149,7 +139,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error setting network namespace to %s: %w", ns.String(), err)
 	}
 
-	// Symmetric pin on the sandbox side now that we are back in its netns.
 	if err := netlink.NeighSet(&netlink.Neigh{
 		LinkIndex:    vpeer.Attrs().Index,
 		State:        netlink.NUD_PERMANENT,

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"runtime"
 	"strconv"
 
@@ -19,20 +18,11 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-// disableIPv6OnLink turns IPv6 off for the named link in the current netns.
-// Writing the sysctl is best-effort: if the link has no IPv6 sysctl entry
-// (e.g. IPv6 already disabled host-wide), the write fails and we treat that
-// as a no-op rather than failing the whole sandbox provisioning.
-func disableIPv6OnLink(name string) error {
-	path := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/disable_ipv6", name)
-	if err := os.WriteFile(path, []byte("1"), 0o644); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("write %s: %w", path, err)
-	}
-	return nil
-}
+// IPv6 is disabled host-wide on orchestrator nodes via
+// `net.ipv6.conf.{all,default}.disable_ipv6=1`, so newly created veth pairs
+// inherit "disabled" at link-creation time and never bring up an IPv6
+// link-local address or run ND. We therefore only need to manage the IPv4
+// neighbour state on each veth — handled below via ARP off + NUD_PERMANENT.
 
 func (s *Slot) CreateNetwork(ctx context.Context) error {
 	// Prevent thread changes so we can safely manipulate with namespaces
@@ -98,15 +88,12 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding vpeer device address: %w", err)
 	}
 
-	// Sandbox veth pairs only talk to the host gateway. Disable ARP and IPv6
-	// here so we never participate in L2 discovery and never count against
-	// the IPv4/IPv6 neigh GC thresholds. The matching NUD_PERMANENT entries
-	// are installed below once both link indices and MACs are known.
+	// Sandbox veth pairs only ever talk to the host gateway, so we don't
+	// need ARP on either side: the matching NUD_PERMANENT entries installed
+	// below cover the single L2 next hop and keep us off the IPv4 neigh GC
+	// thresholds entirely.
 	if err := netlink.LinkSetARPOff(vpeer); err != nil {
 		return fmt.Errorf("error disabling ARP on vpeer: %w", err)
-	}
-	if err := disableIPv6OnLink(s.VpeerName()); err != nil {
-		return fmt.Errorf("error disabling IPv6 on vpeer: %w", err)
 	}
 
 	// Move Veth device to the host NS
@@ -140,14 +127,9 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding veth device address: %w", err)
 	}
 
-	// Mirror the per-link hardening from the sandbox side. ARP off is fine
-	// because the only L2 next hop on this veth is vpeer, which we pin
-	// below as NUD_PERMANENT.
+	// Mirror the sandbox-side hardening: ARP off, NUD_PERMANENT below.
 	if err := netlink.LinkSetARPOff(vethInHost); err != nil {
 		return fmt.Errorf("error disabling ARP on vethInHost: %w", err)
-	}
-	if err := disableIPv6OnLink(s.VethName()); err != nil {
-		return fmt.Errorf("error disabling IPv6 on vethInHost: %w", err)
 	}
 
 	// Pin the host-side L2 next hop: vethInHost -> vpeer's IP/MAC. NUD_PERMANENT


### PR DESCRIPTION
In `Slot.CreateNetwork`, disable ARP and pin the veth ↔ vpeer L2 next hop as `NUD_PERMANENT` on both sides. The IPv4 neigh table is then completely off the per-sandbox hot path (no GC, no ARP, no `gc_thresh*` impact). IPv6 is disabled host-wide by #2785, so no per-link IPv6 handling needed.

MASQUERADE egress and host-service DNATs are unaffected (pure L3 / DNAT paths).
