### PR TITLE
perf(orchestrator): pace block.Cache dirty pages via sync_file_range

### DIFF
--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -127,6 +127,12 @@ net.ipv4.tcp_max_syn_backlog = 65535
 # Increase the maximum number of memory map areas
 vm.max_map_count=1048576
 
+# Allow more dirty pages and start writeback earlier so a per-resume
+# block.Cache fill on md0 does not pile up enough dirty memory to trigger
+# balance_dirty_pages throttling on these hosts.
+vm.dirty_ratio = 40
+vm.dirty_background_ratio = 5
+
 EOF
 sysctl -p
 

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -52,6 +52,7 @@ type Cache struct {
 	size      int64
 	blockSize int64
 	mmap      *mmap.MMap
+	file      *os.File
 	mu        sync.RWMutex
 	tracker   *Tracker // Dirty: payload in mmap; Zero: punched, emitted as Empty in the diff
 	dirtyFile bool
@@ -64,7 +65,12 @@ func NewCache(size, blockSize int64, filePath string, dirtyFile bool) (*Cache, e
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
 
-	defer f.Close()
+	keepFile := false
+	defer func() {
+		if !keepFile {
+			f.Close()
+		}
+	}()
 
 	if size == 0 {
 		return &Cache{
@@ -91,8 +97,11 @@ func NewCache(size, blockSize int64, filePath string, dirtyFile bool) (*Cache, e
 		return nil, fmt.Errorf("error mapping file: %w", err)
 	}
 
+	keepFile = true
+
 	return &Cache{
 		mmap:      &mm,
+		file:      f,
 		filePath:  filePath,
 		size:      size,
 		blockSize: blockSize,
@@ -256,6 +265,10 @@ func (c *Cache) Close() (e error) {
 		e = errors.Join(e, fmt.Errorf("error unmapping mmap: %w", err))
 	}
 
+	if err := c.file.Close(); err != nil {
+		e = errors.Join(e, fmt.Errorf("error closing file: %w", err))
+	}
+
 	// TODO: Move to to the scope of the caller
 	e = errors.Join(e, os.RemoveAll(c.filePath))
 
@@ -373,6 +386,9 @@ func (c *Cache) WriteAtWithoutLock(b []byte, off int64) (int, error) {
 		runZero = z
 	}
 	flush(runStart, end, runZero)
+
+	// Pace dirty pages so a large fill doesn't trip balance_dirty_pages.
+	_ = unix.SyncFileRange(int(c.file.Fd()), off, end-off, unix.SYNC_FILE_RANGE_WRITE)
 
 	return int(end - off), nil
 }


### PR DESCRIPTION
## Summary

Fresh-template fills write several GB into a per-resume `block.Cache` mmap on md0 within seconds. On affected hosts that exceeds the per-bdi share of `vm.dirty_ratio` and parks orchestrator threads in `balance_dirty_pages` for tens of seconds — observed: a 32 GB-memfile template resuming in ~55 s instead of a few seconds.

- `block.Cache`: hold the cache fd open and call `sync_file_range(WRITE)` after each `WriteAtWithoutLock` so the kernel drains writeback continuously instead of letting dirty pages pile up to the threshold.
- GCP client bootstrap: `vm.dirty_ratio` 20 → 40 and `vm.dirty_background_ratio` 10 → 5 — adds headroom and starts background writeback earlier.

`sync_file_range(SYNC_FILE_RANGE_WRITE)` is non-blocking and runs in kernel flusher threads; mmap reads (UFFD `Slice` → `UFFDIO_COPY`) don't conflict with `PG_writeback`, so this doesn't slow fetch or serving.

## Test plan

- [ ] `go vet`/`go build` for orchestrator block package on linux
- [ ] Time a fresh-template resume on a memory-heavy template before/after on staging
- [ ] Watch `/proc/meminfo` Dirty/Writeback during the fill and gRPC latency dashboard for regression
