### PR TITLE
perf(orch): batch per-sandbox iptables + install host-service redirects globally

### DIFF
--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/google/uuid"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -1525,7 +1524,7 @@ type noEgressProxy struct {
 	network.NoopEgressProxy
 }
 
-func (noEgressProxy) OnSlotCreate(s *network.Slot, _ *iptables.IPTables) error {
+func (noEgressProxy) OnSlotCreate(s *network.Slot, _ *network.RuleSet) error {
 	nsPath := filepath.Join("/var/run/netns", s.NamespaceID())
 
 	handle, err := ns.GetNS(nsPath)

--- a/packages/orchestrator/pkg/sandbox/envd_test.go
+++ b/packages/orchestrator/pkg/sandbox/envd_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,9 +22,9 @@ type mockEgressProxy struct {
 	bundle string
 }
 
-func (m *mockEgressProxy) OnSlotCreate(_ *network.Slot, _ *iptables.IPTables) error { return nil }
-func (m *mockEgressProxy) OnSlotDelete(_ *network.Slot, _ *iptables.IPTables) error { return nil }
-func (m *mockEgressProxy) CABundle() string                                         { return m.bundle }
+func (m *mockEgressProxy) OnSlotCreate(_ *network.Slot, _ *network.RuleSet) error { return nil }
+func (m *mockEgressProxy) OnSlotDelete(_ *network.Slot, _ *network.RuleSet) error { return nil }
+func (m *mockEgressProxy) CABundle() string                                       { return m.bundle }
 
 // newTestSandboxWithBundle builds a minimal Sandbox with CABundle set —
 // mirroring what Factory.CreateSandbox does with f.egressProxy.CABundle().

--- a/packages/orchestrator/pkg/sandbox/network/egressproxy.go
+++ b/packages/orchestrator/pkg/sandbox/network/egressproxy.go
@@ -2,13 +2,12 @@
 
 package network
 
-import (
-	"github.com/coreos/go-iptables/iptables"
-)
-
+// EgressProxy participates in per-sandbox host-side iptables setup by
+// appending its own PREROUTING rules into the shared RuleSet that is flushed
+// once per CreateNetwork / RemoveNetwork.
 type EgressProxy interface {
-	OnSlotCreate(s *Slot, tables *iptables.IPTables) error
-	OnSlotDelete(s *Slot, tables *iptables.IPTables) error
+	OnSlotCreate(s *Slot, rules *RuleSet) error
+	OnSlotDelete(s *Slot, rules *RuleSet) error
 
 	CABundle() string
 }
@@ -22,11 +21,11 @@ func NewNoopEgressProxy() NoopEgressProxy {
 	return NoopEgressProxy{}
 }
 
-func (NoopEgressProxy) OnSlotCreate(_ *Slot, _ *iptables.IPTables) error {
+func (NoopEgressProxy) OnSlotCreate(_ *Slot, _ *RuleSet) error {
 	return nil
 }
 
-func (NoopEgressProxy) OnSlotDelete(_ *Slot, _ *iptables.IPTables) error {
+func (NoopEgressProxy) OnSlotDelete(_ *Slot, _ *RuleSet) error {
 	return nil
 }
 

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -18,6 +18,33 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
+// installGlobalSandboxRules installs the host-side iptables rules that are
+// identical for every sandbox on this node. Previously these were appended
+// per sandbox with `-i veth-N`; since they all match dst IP
+// OrchestratorInSandboxIPAddress (only routable from inside a sandbox netns
+// and never seen on the host's external NIC), dropping the inbound-interface
+// constraint is safe and lets us install them once at orchestrator boot
+// instead of 3× per sandbox.
+func installGlobalSandboxRules(config Config) error {
+	tables, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("init iptables: %w", err)
+	}
+
+	dst := config.OrchestratorInSandboxIPAddress
+	rules := [][]string{
+		{"-p", "tcp", "-d", dst, "--dport", "111", "-j", "REDIRECT", "--to-port", strconv.Itoa(int(config.PortmapperPort))},
+		{"-p", "tcp", "-d", dst, "--dport", "2049", "-j", "REDIRECT", "--to-port", strconv.Itoa(int(config.NFSProxyPort))},
+		{"-p", "tcp", "-d", dst, "--dport", "80", "-j", "REDIRECT", "--to-port", strconv.Itoa(int(config.HyperloopProxyPort))},
+	}
+	for _, args := range rules {
+		if err := tables.AppendUnique("nat", "PREROUTING", args...); err != nil {
+			return fmt.Errorf("install global rule %v: %w", args, err)
+		}
+	}
+	return nil
+}
+
 func (s *Slot) CreateNetwork(ctx context.Context) error {
 	// Prevent thread changes so we can safely manipulate with namespaces
 	runtime.LockOSThread()
@@ -203,63 +230,35 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding route from host to FC: %w", err)
 	}
 
-	// Add host forwarding rules
-	err = tables.Append("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
-	if err != nil {
-		return fmt.Errorf("error creating forwarding rule to default gateway: %w", err)
-	}
+	// Batch the per-sandbox host-side iptables work so a single
+	// `iptables-restore --noflush` invocation handles all rules at once.
+	// On iptables-nft this avoids one full table rewrite per rule (the
+	// O(N²) cost that grows with the rule count on the host).
+	//
+	// The hyperloop / portmapper / NFS-proxy REDIRECT rules are *not*
+	// added here: they match on dst = OrchestratorInSandboxIPAddress and
+	// are installed once at orchestrator boot by installGlobalSandboxRules
+	// rather than per-sandbox.
+	hostRules := NewRuleSet()
 
-	err = tables.Append("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
-	if err != nil {
-		return fmt.Errorf("error creating forwarding rule from default gateway: %w", err)
-	}
+	hostRules.Append("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
+	hostRules.Append("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
+	hostRules.Append("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
 
-	// Add host postrouting rules
-	err = tables.Append("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
-	if err != nil {
-		return fmt.Errorf("error creating postrouting rule: %w", err)
-	}
-
-	// Redirect traffic destined for hyperloop proxy
-	err = tables.Append(
-		"nat", "PREROUTING", "-i", s.VethName(),
-		"-p", "tcp", "-d", s.config.OrchestratorInSandboxIPAddress, "--dport", "80",
-		"-j", "REDIRECT", "--to-port", s.hyperloopPort,
-	)
-	if err != nil {
-		return fmt.Errorf("error creating HTTP redirect rule to sandbox hyperloop proxy server: %w", err)
-	}
-
-	// Redirect traffic destined for portmapper
-	err = tables.Append("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
-		"--jump", "REDIRECT", "--to-port", fmt.Sprintf("%d", s.config.PortmapperPort),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating NFS redirect rule to sandbox portmapper server: %w", err)
-	}
-
-	// Redirect traffic destined for NFS proxy
-	err = tables.Append("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
-		"--jump", "REDIRECT", "--to-port", fmt.Sprintf("%d", s.config.NFSProxyPort),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating NFS redirect rule to sandbox NFS proxy server: %w", err)
-	}
-
-	// Create rules needed by egress proxy
-	err = s.egressProxy.OnSlotCreate(s, tables)
-	if err != nil {
+	// Egress proxy contributes its per-sandbox PREROUTING REDIRECTs into
+	// the same RuleSet so everything lands in one syscall.
+	if err := s.egressProxy.OnSlotCreate(s, hostRules); err != nil {
 		return err
+	}
+
+	if err := hostRules.Apply(ctx); err != nil {
+		return fmt.Errorf("error applying host iptables rules for slot: %w", err)
 	}
 
 	return nil
 }
 
-func (s *Slot) RemoveNetwork() error {
+func (s *Slot) RemoveNetwork(ctx context.Context) error {
 	var errs []error
 
 	err := s.CloseFirewall()
@@ -267,42 +266,24 @@ func (s *Slot) RemoveNetwork() error {
 		errs = append(errs, fmt.Errorf("error closing firewall: %w", err))
 	}
 
-	tables, err := iptables.New()
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error initializing iptables: %w", err))
-	} else {
-		// Delete host forwarding rules
-		err = tables.Delete("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule to default gateway: %w", err))
-		}
+	// Mirror of CreateNetwork's host-side batched setup: collect every
+	// per-sandbox rule we want gone into a single RuleSet and flush via
+	// iptables-restore --noflush. Global PREROUTING REDIRECTs are not
+	// touched: they live for the orchestrator's lifetime.
+	hostRules := NewRuleSet()
+	hostRules.Delete("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
+	hostRules.Delete("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
+	hostRules.Delete("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
 
-		err = tables.Delete("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule from default gateway: %w", err))
-		}
+	if err := s.egressProxy.OnSlotDelete(s, hostRules); err != nil {
+		errs = append(errs, err)
+	}
 
-		// Delete host postrouting rules
-		err = tables.Delete("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host postrouting rule: %w", err))
-		}
-
-		// Delete hyperloop proxy redirect rule
-		err = tables.Delete(
-			"nat", "PREROUTING", "-i", s.VethName(),
-			"-p", "tcp", "-d", s.config.OrchestratorInSandboxIPAddress, "--dport", "80",
-			"-j", "REDIRECT", "--to-port", s.hyperloopPort,
-		)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting sandbox hyperloop proxy redirect rule: %w", err))
-		}
-
-		// Delete changes made by egress proxy
-		err = s.egressProxy.OnSlotDelete(s, tables)
-		if err != nil {
-			errs = append(errs, err)
-		}
+	// Teardown happens on best-effort paths (e.g. a partial CreateNetwork
+	// may leave some rules missing). Fall back to per-rule shellouts so a
+	// missing rule does not abort the whole removal.
+	if err := hostRules.ApplyBestEffort(ctx); err != nil {
+		errs = append(errs, fmt.Errorf("error applying host iptables removals for slot: %w", err))
 	}
 
 	// Delete routing from host to FC namespace
@@ -326,26 +307,6 @@ func (s *Slot) RemoveNetwork() error {
 		if err != nil {
 			errs = append(errs, fmt.Errorf("error deleting veth device: %w", err))
 		}
-	}
-
-	// Delete NFS proxy redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.NFSProxyPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox NFS proxy redirect rule: %w", err))
-	}
-
-	// Delete portmapper redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.PortmapperPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox portmapper redirect rule: %w", err))
 	}
 
 	err = netns.DeleteNamed(s.NamespaceID())

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -300,7 +300,7 @@ func (p *Pool) recycle(ctx context.Context, slot *Slot) error {
 func (p *Pool) cleanup(ctx context.Context, slot *Slot) error {
 	var errs []error
 
-	err := slot.RemoveNetwork()
+	err := slot.RemoveNetwork(ctx)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("cannot remove network when releasing slot '%d': %w", slot.Idx, err))
 	}

--- a/packages/orchestrator/pkg/sandbox/network/rules.go
+++ b/packages/orchestrator/pkg/sandbox/network/rules.go
@@ -1,0 +1,145 @@
+//go:build linux
+
+package network
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/coreos/go-iptables/iptables"
+)
+
+// RuleSet buffers iptables rule mutations and applies them to the host
+// netfilter tables in a single `iptables-restore --noflush` invocation.
+//
+// Per-sandbox provisioning previously shelled out to `iptables` ~6 times in
+// CreateNetwork (plus ~3 from the egress proxy). On modern Ubuntu where
+// `iptables` is `iptables-nft`, every call reads, mutates and rewrites the
+// entire table under the xtables lock, so total cost is O(N²) in the number
+// of existing rules. Batching collapses that to one fork and one table
+// rewrite per CreateNetwork / RemoveNetwork.
+type RuleSet struct {
+	// keep deterministic ordering per table while still de-duplicating
+	// table names.
+	tables []string
+	rules  map[string][]rule
+}
+
+type rule struct {
+	op    op
+	chain string
+	args  []string
+}
+
+type op uint8
+
+const (
+	opAppend op = iota
+	opDelete
+)
+
+func (o op) flag() string {
+	if o == opAppend {
+		return "-A"
+	}
+	return "-D"
+}
+
+// NewRuleSet returns an empty RuleSet ready to accumulate rules.
+func NewRuleSet() *RuleSet {
+	return &RuleSet{rules: map[string][]rule{}}
+}
+
+// Append records an `-A CHAIN args...` line in the given table.
+func (r *RuleSet) Append(table, chain string, args ...string) {
+	r.addRule(table, rule{op: opAppend, chain: chain, args: args})
+}
+
+// Delete records a `-D CHAIN args...` line in the given table.
+func (r *RuleSet) Delete(table, chain string, args ...string) {
+	r.addRule(table, rule{op: opDelete, chain: chain, args: args})
+}
+
+// Empty reports whether the RuleSet has no buffered changes.
+func (r *RuleSet) Empty() bool {
+	return len(r.tables) == 0
+}
+
+// Apply writes the buffered rules to `iptables-restore --noflush` so all
+// changes land in one fork + one table rewrite per touched table. `--noflush`
+// preserves existing rules; only buffered `-A`/`-D` lines are merged in. The
+// operation is per-table atomic: either every line in a table parses and
+// applies, or none does.
+func (r *RuleSet) Apply(ctx context.Context) error {
+	if r.Empty() {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for _, t := range r.tables {
+		fmt.Fprintf(&buf, "*%s\n", t)
+		for _, rl := range r.rules[t] {
+			fmt.Fprintf(&buf, "%s %s", rl.op.flag(), rl.chain)
+			for _, a := range rl.args {
+				buf.WriteByte(' ')
+				buf.WriteString(a)
+			}
+			buf.WriteByte('\n')
+		}
+		buf.WriteString("COMMIT\n")
+	}
+
+	cmd := exec.CommandContext(ctx, "iptables-restore", "--noflush", "--wait")
+	cmd.Stdin = &buf
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("iptables-restore --noflush: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+// ApplyBestEffort tries Apply first; on failure (typically because a delete
+// targeted a rule that doesn't exist) it falls back to per-rule shellouts
+// and collects rather than aborts on individual errors. Use this from
+// teardown paths where partial state from a failed earlier CreateNetwork is
+// a normal occurrence.
+func (r *RuleSet) ApplyBestEffort(ctx context.Context) error {
+	if err := r.Apply(ctx); err == nil {
+		return nil
+	}
+
+	t, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("init iptables fallback: %w", err)
+	}
+
+	var errs []error
+	for _, table := range r.tables {
+		for _, rl := range r.rules[table] {
+			args := append([]string{rl.chain}, rl.args...)
+			switch rl.op {
+			case opAppend:
+				if e := t.Append(table, args[0], args[1:]...); e != nil {
+					errs = append(errs, fmt.Errorf("iptables append %s/%s: %w", table, rl.chain, e))
+				}
+			case opDelete:
+				if e := t.Delete(table, args[0], args[1:]...); e != nil {
+					errs = append(errs, fmt.Errorf("iptables delete %s/%s: %w", table, rl.chain, e))
+				}
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (r *RuleSet) addRule(table string, rl rule) {
+	if _, ok := r.rules[table]; !ok {
+		r.tables = append(r.tables, table)
+	}
+	r.rules[table] = append(r.rules[table], rl)
+}

--- a/packages/orchestrator/pkg/sandbox/network/storage_local.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_local.go
@@ -41,6 +41,10 @@ func NewStorageLocal(ctx context.Context, config Config, egressProxy EgressProxy
 		logger.L().Info(ctx, fmt.Sprintf("Found foreign namespace: %s", ns))
 	}
 
+	if err := installGlobalSandboxRules(config); err != nil {
+		return nil, fmt.Errorf("error installing global sandbox rules: %w", err)
+	}
+
 	return &StorageLocal{
 		config:       config,
 		foreignNs:    foreignNsMap,

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -4,12 +4,10 @@ package tcpfirewall
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/inetaf/tcpproxy"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -146,27 +144,18 @@ func (p *Proxy) ruleArgs(s *network.Slot, rule proxyRule) []string {
 	return args
 }
 
-func (p *Proxy) OnSlotCreate(s *network.Slot, tables *iptables.IPTables) error {
+func (p *Proxy) OnSlotCreate(s *network.Slot, rules *network.RuleSet) error {
 	for _, rule := range p.proxyRules {
-		err := tables.Append("nat", "PREROUTING", p.ruleArgs(s, rule)...)
-		if err != nil {
-			return fmt.Errorf("error creating redirect rule for %s traffic: %w", rule.desc, err)
-		}
+		rules.Append("nat", "PREROUTING", p.ruleArgs(s, rule)...)
 	}
-
 	return nil
 }
 
-func (p *Proxy) OnSlotDelete(s *network.Slot, tables *iptables.IPTables) error {
-	var errs []error
+func (p *Proxy) OnSlotDelete(s *network.Slot, rules *network.RuleSet) error {
 	for _, rule := range p.proxyRules {
-		err := tables.Delete("nat", "PREROUTING", p.ruleArgs(s, rule)...)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting %s egress proxy redirect rule: %w", rule.desc, err))
-		}
+		rules.Delete("nat", "PREROUTING", p.ruleArgs(s, rule)...)
 	}
-
-	return errors.Join(errs...)
+	return nil
 }
 
 func (p *Proxy) Close(_ context.Context) error {


### PR DESCRIPTION
## What

Two independent changes against the per-sandbox iptables cost:

**1. Batch the per-sandbox host iptables work.** Introduce a `RuleSet` builder in `pkg/sandbox/network` that accumulates appends/deletes and flushes them via a single `iptables-restore --noflush` per `CreateNetwork` / `RemoveNetwork`. The egress proxy contributes its rules into the same `RuleSet`. The in-namespace SNAT/DNAT rules keep using `*iptables.IPTables` (they live in per-sandbox netns and are not on the global host tables). `RemoveNetwork` uses `ApplyBestEffort` so a partial earlier `CreateNetwork` doesn't abort cleanup.

**2. Install host-service REDIRECT rules globally at boot.** The hyperloop / portmapper / NFS-proxy DNAT redirects all match `-d OrchestratorInSandboxIPAddress` (an unrouted host-side address only reachable from inside a sandbox netns), so the `-i veth-N` constraint is unnecessary. `installGlobalSandboxRules` runs once from `NewStorageLocal` using `AppendUnique`, and the three appends/deletes drop from `CreateNetwork`/`RemoveNetwork`.

## Why

On Ubuntu 22+ `iptables` is `iptables-nft`. Each `iptables -A` reads, mutates, and rewrites the whole table under the xtables lock — total host provisioning cost is **O(N²)** in the table size. At ~150 sandboxes that's already ~1300 nat PREROUTING entries; the 500 ms `Acquire` timeout starts firing well before 1000 sandboxes/node. See `design/2026-04-28-100x-scaling/00-orchestrator-scaling-bottlenecks.md` §1.1.

Batching collapses the ~6–9 shellouts per CreateNetwork into one fork + one rewrite per touched table. Moving the three global redirects out of per-sandbox path eliminates 3 of the 9 rules outright; the remaining per-sandbox rules are still batched. F28 (shrinking `runtime.LockOSThread` window) and the full nftables verdict-map rewrite (target) are out of scope and tracked separately.

## Risk

- `iptables-restore --noflush` is atomic per table — if any line fails to parse, none of that table's lines apply. For adds this is desirable. For deletes we use `ApplyBestEffort`, which falls back to per-rule `iptables.Delete()` on failure so a missing rule does not abort teardown.
- Global redirect install is idempotent (`AppendUnique`); restarts mid-fleet are safe. During the transition, old per-sandbox rules (still present from sandboxes created on the previous binary) coexist with the new global rule — both match the same packets and behavior is unchanged.

## Out of scope (deferred for follow-ups)

- nftables verdict-map keyed by `iifname` — the "target" rewrite. Would collapse per-sandbox `-A` into an atomic O(1) set-element insert.
- `runtime.LockOSThread` window reduction in `CreateNetwork`. Becomes more meaningful after iptables work shrinks further.
- TCP firewall: 3 ports (HTTP/TLS/other) per sandbox still go through batched iptables; collapsing them into one verdict-map needs nftables.