### PR TITLE
perf(orch): replace per-sandbox host iptables with nftables verdict map

### DIFF
--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/google/uuid"
 	"github.com/launchdarkly/go-sdk-common/v3/ldlog"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -1525,7 +1524,7 @@ type noEgressProxy struct {
 	network.NoopEgressProxy
 }
 
-func (noEgressProxy) OnSlotCreate(s *network.Slot, _ *iptables.IPTables) error {
+func (noEgressProxy) OnSlotCreate(s *network.Slot) error {
 	nsPath := filepath.Join("/var/run/netns", s.NamespaceID())
 
 	handle, err := ns.GetNS(nsPath)

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -896,5 +896,5 @@ func newStorage(ctx context.Context, nodeID string, config network.Config, egres
 		return network.NewStorageLocal(ctx, config, egressProxy)
 	}
 
-	return network.NewStorageKV(nodeID, config, egressProxy)
+	return network.NewStorageKV(ctx, nodeID, config, egressProxy)
 }

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -896,5 +896,5 @@ func newStorage(ctx context.Context, nodeID string, config network.Config, egres
 		return network.NewStorageLocal(ctx, config, egressProxy)
 	}
 
-	return network.NewStorageKV(ctx, nodeID, config, egressProxy)
+	return network.NewStorageKV(nodeID, config, egressProxy)
 }

--- a/packages/orchestrator/pkg/sandbox/envd_test.go
+++ b/packages/orchestrator/pkg/sandbox/envd_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -23,9 +22,9 @@ type mockEgressProxy struct {
 	bundle string
 }
 
-func (m *mockEgressProxy) OnSlotCreate(_ *network.Slot, _ *iptables.IPTables) error { return nil }
-func (m *mockEgressProxy) OnSlotDelete(_ *network.Slot, _ *iptables.IPTables) error { return nil }
-func (m *mockEgressProxy) CABundle() string                                         { return m.bundle }
+func (m *mockEgressProxy) OnSlotCreate(_ *network.Slot) error { return nil }
+func (m *mockEgressProxy) OnSlotDelete(_ *network.Slot) error { return nil }
+func (m *mockEgressProxy) CABundle() string                   { return m.bundle }
 
 // newTestSandboxWithBundle builds a minimal Sandbox with CABundle set —
 // mirroring what Factory.CreateSandbox does with f.egressProxy.CABundle().

--- a/packages/orchestrator/pkg/sandbox/network/egressproxy.go
+++ b/packages/orchestrator/pkg/sandbox/network/egressproxy.go
@@ -2,13 +2,15 @@
 
 package network
 
-import (
-	"github.com/coreos/go-iptables/iptables"
-)
-
+// EgressProxy is notified of per-sandbox lifecycle so it can perform any
+// extra setup the slot creation alone can't express (e.g. removing the
+// default route from a no-egress sandbox). It used to inject per-sandbox
+// iptables rules; the host-side ruleset now lives in HostFirewall and is
+// driven by veth-set membership, so the callbacks no longer take an
+// iptables / RuleSet handle.
 type EgressProxy interface {
-	OnSlotCreate(s *Slot, tables *iptables.IPTables) error
-	OnSlotDelete(s *Slot, tables *iptables.IPTables) error
+	OnSlotCreate(s *Slot) error
+	OnSlotDelete(s *Slot) error
 
 	CABundle() string
 }
@@ -22,14 +24,6 @@ func NewNoopEgressProxy() NoopEgressProxy {
 	return NoopEgressProxy{}
 }
 
-func (NoopEgressProxy) OnSlotCreate(_ *Slot, _ *iptables.IPTables) error {
-	return nil
-}
-
-func (NoopEgressProxy) OnSlotDelete(_ *Slot, _ *iptables.IPTables) error {
-	return nil
-}
-
-func (NoopEgressProxy) CABundle() string {
-	return ""
-}
+func (NoopEgressProxy) OnSlotCreate(_ *Slot) error { return nil }
+func (NoopEgressProxy) OnSlotDelete(_ *Slot) error { return nil }
+func (NoopEgressProxy) CABundle() string           { return "" }

--- a/packages/orchestrator/pkg/sandbox/network/egressproxy.go
+++ b/packages/orchestrator/pkg/sandbox/network/egressproxy.go
@@ -3,11 +3,8 @@
 package network
 
 // EgressProxy is notified of per-sandbox lifecycle so it can perform any
-// extra setup the slot creation alone can't express (e.g. removing the
-// default route from a no-egress sandbox). It used to inject per-sandbox
-// iptables rules; the host-side ruleset now lives in HostFirewall and is
-// driven by veth-set membership, so the callbacks no longer take an
-// iptables / RuleSet handle.
+// extra netns setup the slot creation alone can't express (e.g. removing
+// the default route from a no-egress sandbox).
 type EgressProxy interface {
 	OnSlotCreate(s *Slot) error
 	OnSlotDelete(s *Slot) error

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/coreos/go-iptables/iptables"
 	"github.com/google/nftables"
 	"github.com/google/nftables/binaryutil"
 	"github.com/google/nftables/expr"
@@ -73,7 +74,37 @@ func NewHostFirewall(config Config, externalIface string) (*HostFirewall, error)
 		return nil, fmt.Errorf("flush host firewall table: %w", err)
 	}
 
+	if err := installLegacyForwardAccept(); err != nil {
+		return nil, err
+	}
+
 	return fw, nil
+}
+
+// installLegacyForwardAccept adds two global ACCEPT rules to the legacy
+// `filter FORWARD` chain so sandbox <-> external traffic is allowed even
+// when something else (Docker, etc.) has set the chain policy to DROP.
+// Our nftables `inet e2b_host` chain at priority -10 returns `accept`
+// for sandbox traffic, but kernel hooks still evaluate later chains, so
+// without these rules a Docker-installed `FORWARD -P DROP` drops the
+// packet at priority 0.
+func installLegacyForwardAccept() error {
+	t, err := iptables.New()
+	if err != nil {
+		return fmt.Errorf("init iptables: %w", err)
+	}
+	cidr := hostNetworkCIDR.String()
+	rules := [][]string{
+		{"-s", cidr, "-j", "ACCEPT"},
+		{"-d", cidr, "-j", "ACCEPT"},
+	}
+	for _, args := range rules {
+		if err := t.AppendUnique("filter", "FORWARD", args...); err != nil {
+			return fmt.Errorf("install forward accept %v: %w", args, err)
+		}
+	}
+
+	return nil
 }
 
 func (h *HostFirewall) AddSandbox(vethName string) error {

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -1,0 +1,380 @@
+//go:build linux
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/google/nftables"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"golang.org/x/sys/unix"
+)
+
+// IFNAMSIZ from <linux/if.h>. nftables `ifname` set keys are null-padded to
+// this size.
+const ifNameMaxLen = 16
+
+// Names used by the host-side nftables ruleset. They are stable across
+// orchestrator restarts so we can replace the table on boot without leaking
+// previous rulesets.
+const (
+	hostFirewallTableName   = "e2b_host"
+	hostFirewallVethSetName = "sandbox_veths"
+)
+
+// Hook priorities for our table. Both run before the legacy iptables-nft
+// compat chains (which sit at priorities 0 / -100), so this ruleset always
+// gets first crack at packets and any leftover per-sandbox iptables rules
+// from older binaries become harmless no-ops.
+const (
+	hostForwardPriority    = -10
+	hostNATPostroutingPrio = -90
+	hostNATPreroutingPrio  = -110
+)
+
+// HostFirewall owns the host-side nftables ruleset shared by every sandbox
+// on the node. The static chains hook every sandbox's traffic through a
+// single `sandbox_veths` ifname set; per-sandbox add/remove is a single
+// netlink set-element insert (O(1) regardless of N).
+//
+// This replaces ~6 per-sandbox iptables shellouts that grew O(N²) under
+// iptables-nft (every Append rewrote the whole table under the xtables
+// lock).
+type HostFirewall struct {
+	conn    *nftables.Conn
+	table   *nftables.Table
+	vethSet *nftables.Set
+
+	mu sync.Mutex // serialises Flush across goroutines
+}
+
+// NewHostFirewall installs (or replaces) the table+chains+set on the host
+// and returns a handle the network slot lifecycle can use to add / remove
+// sandboxes.
+func NewHostFirewall(ctx context.Context, config Config, externalIface string) (*HostFirewall, error) {
+	conn, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		return nil, fmt.Errorf("nftables lasting conn: %w", err)
+	}
+
+	// Replace any previous instance of our table so a binary downgrade or
+	// config change doesn't leave stale rules behind. Both ops are buffered;
+	// the real commit happens at Flush below.
+	conn.DelTable(&nftables.Table{Name: hostFirewallTableName, Family: nftables.TableFamilyINet})
+	if err := conn.Flush(); err != nil && !isNoSuchFileOrDirectory(err) {
+		// Allow ENOENT — the table may not have existed yet.
+		return nil, fmt.Errorf("delete stale host firewall table: %w", err)
+	}
+
+	table := conn.AddTable(&nftables.Table{
+		Name:   hostFirewallTableName,
+		Family: nftables.TableFamilyINet,
+	})
+
+	vethSet := &nftables.Set{
+		Table:   table,
+		Name:    hostFirewallVethSetName,
+		KeyType: nftables.TypeIFName,
+	}
+	if err := conn.AddSet(vethSet, nil); err != nil {
+		return nil, fmt.Errorf("add veth set: %w", err)
+	}
+
+	fw := &HostFirewall{conn: conn, table: table, vethSet: vethSet}
+	if err := fw.installChains(config, externalIface); err != nil {
+		return nil, err
+	}
+	if err := conn.Flush(); err != nil {
+		return nil, fmt.Errorf("flush host firewall table: %w", err)
+	}
+	return fw, nil
+}
+
+// AddSandbox inserts the given veth interface name into the sandbox set so
+// the global forward / nat rules start matching traffic from this sandbox.
+// One netlink message + one commit; O(1) regardless of fleet size.
+func (h *HostFirewall) AddSandbox(vethName string) error {
+	key, err := ifnameKey(vethName)
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.conn.SetAddElements(h.vethSet, []nftables.SetElement{{Key: key}}); err != nil {
+		return fmt.Errorf("add veth %q to set: %w", vethName, err)
+	}
+	if err := h.conn.Flush(); err != nil {
+		return fmt.Errorf("flush veth %q add: %w", vethName, err)
+	}
+	return nil
+}
+
+// RemoveSandbox removes the given veth interface name from the sandbox set.
+// Missing elements are not an error: teardown is best-effort.
+func (h *HostFirewall) RemoveSandbox(vethName string) error {
+	key, err := ifnameKey(vethName)
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if err := h.conn.SetDeleteElements(h.vethSet, []nftables.SetElement{{Key: key}}); err != nil {
+		return fmt.Errorf("delete veth %q from set: %w", vethName, err)
+	}
+	if err := h.conn.Flush(); err != nil {
+		if isNoSuchFileOrDirectory(err) {
+			return nil
+		}
+		return fmt.Errorf("flush veth %q remove: %w", vethName, err)
+	}
+	return nil
+}
+
+// Close releases the lasting netlink connection. The kernel ruleset stays
+// in place so existing sandboxes keep working across orchestrator restarts.
+func (h *HostFirewall) Close() error {
+	if h == nil || h.conn == nil {
+		return nil
+	}
+	return h.conn.CloseLasting()
+}
+
+func (h *HostFirewall) installChains(config Config, externalIface string) error {
+	policyAccept := nftables.ChainPolicyAccept
+
+	forward := h.conn.AddChain(&nftables.Chain{
+		Name:     "forward",
+		Table:    h.table,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookForward,
+		Priority: nftables.ChainPriorityRef(hostForwardPriority),
+		Policy:   &policyAccept,
+	})
+
+	postroutingNAT := h.conn.AddChain(&nftables.Chain{
+		Name:     "postrouting_nat",
+		Table:    h.table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPostrouting,
+		Priority: nftables.ChainPriorityRef(hostNATPostroutingPrio),
+		Policy:   &policyAccept,
+	})
+
+	preroutingNAT := h.conn.AddChain(&nftables.Chain{
+		Name:     "prerouting_nat",
+		Table:    h.table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityRef(hostNATPreroutingPrio),
+		Policy:   &policyAccept,
+	})
+
+	ifname := append([]byte(externalIface), 0)
+
+	// forward: iifname @sandbox_veths && oifname == external → accept
+	h.conn.AddRule(&nftables.Rule{
+		Table: h.table, Chain: forward,
+		Exprs: concat(
+			matchIifnameInSet(h.vethSet),
+			matchMetaEq(expr.MetaKeyOIFNAME, ifname),
+			verdictAccept(),
+		),
+	})
+	// forward: iifname == external && oifname @sandbox_veths → accept
+	h.conn.AddRule(&nftables.Rule{
+		Table: h.table, Chain: forward,
+		Exprs: concat(
+			matchMetaEq(expr.MetaKeyIIFNAME, ifname),
+			matchOifnameInSet(h.vethSet),
+			verdictAccept(),
+		),
+	})
+
+	// postrouting nat: ip saddr in hostNetworkCIDR && oifname == external → masquerade
+	saddrMatch, err := matchIPv4SrcInCIDR(hostNetworkCIDR)
+	if err != nil {
+		return fmt.Errorf("masquerade source match: %w", err)
+	}
+	h.conn.AddRule(&nftables.Rule{
+		Table: h.table, Chain: postroutingNAT,
+		Exprs: concat(
+			saddrMatch,
+			matchMetaEq(expr.MetaKeyOIFNAME, ifname),
+			[]expr.Any{&expr.Masq{}},
+		),
+	})
+
+	// prerouting nat: host services exposed to sandboxes (global, dst-IP keyed).
+	orchIP := net.ParseIP(config.OrchestratorInSandboxIPAddress).To4()
+	if orchIP == nil {
+		return fmt.Errorf("invalid OrchestratorInSandboxIPAddress %q", config.OrchestratorInSandboxIPAddress)
+	}
+	hostServiceRules := []struct {
+		port    uint16
+		toPort  uint16
+		comment string
+	}{
+		{port: 80, toPort: config.HyperloopProxyPort, comment: "hyperloop"},
+		{port: 111, toPort: config.PortmapperPort, comment: "portmapper"},
+		{port: 2049, toPort: config.NFSProxyPort, comment: "nfs-proxy"},
+	}
+	for _, r := range hostServiceRules {
+		h.conn.AddRule(&nftables.Rule{
+			Table: h.table, Chain: preroutingNAT,
+			Exprs: concat(
+				matchIPv4DstEq(orchIP),
+				matchTCPDport(r.port),
+				redirectTo(r.toPort),
+			),
+		})
+	}
+
+	// prerouting nat: per-sandbox TCP firewall.
+	tcpfwRules := []struct {
+		dport  uint16 // 0 = catchall
+		toPort uint16
+	}{
+		{dport: 80, toPort: config.SandboxTCPFirewallHTTPPort},
+		{dport: 443, toPort: config.SandboxTCPFirewallTLSPort},
+		{dport: 0, toPort: config.SandboxTCPFirewallOtherPort},
+	}
+	for _, r := range tcpfwRules {
+		var match []expr.Any
+		if r.dport != 0 {
+			match = concat(matchIifnameInSet(h.vethSet), matchTCPDport(r.dport))
+		} else {
+			match = concat(matchIifnameInSet(h.vethSet), matchL4Proto(unix.IPPROTO_TCP))
+		}
+		h.conn.AddRule(&nftables.Rule{
+			Table: h.table, Chain: preroutingNAT,
+			Exprs: append(match, redirectTo(r.toPort)...),
+		})
+	}
+
+	return nil
+}
+
+// Expression helpers below. Each returns a slice that can be concatenated
+// into a Rule.Exprs.
+
+func matchMetaEq(key expr.MetaKey, want []byte) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: key, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: want},
+	}
+}
+
+func matchIifnameInSet(s *nftables.Set) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyIIFNAME, Register: 1},
+		&expr.Lookup{SourceRegister: 1, SetID: s.ID, SetName: s.Name},
+	}
+}
+
+func matchOifnameInSet(s *nftables.Set) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyOIFNAME, Register: 1},
+		&expr.Lookup{SourceRegister: 1, SetID: s.ID, SetName: s.Name},
+	}
+}
+
+func matchIPv4SrcInCIDR(cidr *net.IPNet) ([]expr.Any, error) {
+	ip4 := cidr.IP.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("not IPv4: %s", cidr)
+	}
+	mask := net.IP(cidr.Mask).To4()
+	if mask == nil {
+		return nil, fmt.Errorf("not IPv4 mask: %s", cidr)
+	}
+	return []expr.Any{
+		// payload: ip saddr (offset 12, length 4)
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseNetworkHeader,
+			Offset:       12,
+			Len:          4,
+		},
+		// mask saddr
+		&expr.Bitwise{
+			SourceRegister: 1, DestRegister: 1, Len: 4,
+			Mask: mask, Xor: []byte{0, 0, 0, 0},
+		},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: ip4.Mask(cidr.Mask)},
+	}, nil
+}
+
+func matchIPv4DstEq(ip net.IP) []expr.Any {
+	return []expr.Any{
+		// payload: ip daddr (offset 16, length 4)
+		&expr.Payload{
+			DestRegister: 1,
+			Base:         expr.PayloadBaseNetworkHeader,
+			Offset:       16,
+			Len:          4,
+		},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: ip},
+	}
+}
+
+func matchL4Proto(proto byte) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{proto}},
+	}
+}
+
+func matchTCPDport(port uint16) []expr.Any {
+	return concat(
+		matchL4Proto(unix.IPPROTO_TCP),
+		[]expr.Any{
+			// payload: tcp dport (offset 2 in transport header, length 2)
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseTransportHeader,
+				Offset:       2,
+				Len:          2,
+			},
+			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: binaryutil.BigEndian.PutUint16(port)},
+		},
+	)
+}
+
+func redirectTo(port uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Immediate{Register: 1, Data: binaryutil.BigEndian.PutUint16(port)},
+		&expr.Redir{RegisterProtoMin: 1, RegisterProtoMax: 1},
+	}
+}
+
+func verdictAccept() []expr.Any {
+	return []expr.Any{&expr.Verdict{Kind: expr.VerdictAccept}}
+}
+
+func concat(parts ...[]expr.Any) []expr.Any {
+	var out []expr.Any
+	for _, p := range parts {
+		out = append(out, p...)
+	}
+	return out
+}
+
+// ifnameKey null-pads an interface name to IFNAMSIZ for use as an nftables
+// `ifname` set key.
+func ifnameKey(name string) ([]byte, error) {
+	if len(name) >= ifNameMaxLen {
+		return nil, fmt.Errorf("interface name %q too long (max %d bytes)", name, ifNameMaxLen-1)
+	}
+	key := make([]byte, ifNameMaxLen)
+	copy(key, name)
+	return key, nil
+}
+
+func isNoSuchFileOrDirectory(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no such file or directory")
+}

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -77,6 +77,9 @@ func NewHostFirewall(ctx context.Context, config Config, externalIface string) (
 }
 
 func (h *HostFirewall) AddSandbox(vethName string) error {
+	if h == nil {
+		return nil
+	}
 	key, err := ifnameKey(vethName)
 	if err != nil {
 		return err
@@ -93,6 +96,9 @@ func (h *HostFirewall) AddSandbox(vethName string) error {
 }
 
 func (h *HostFirewall) RemoveSandbox(vethName string) error {
+	if h == nil {
+		return nil
+	}
 	key, err := ifnameKey(vethName)
 	if err != nil {
 		return err

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -3,7 +3,6 @@
 package network
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -41,7 +40,7 @@ type HostFirewall struct {
 	mu      sync.Mutex
 }
 
-func NewHostFirewall(ctx context.Context, config Config, externalIface string) (*HostFirewall, error) {
+func NewHostFirewall(config Config, externalIface string) (*HostFirewall, error) {
 	conn, err := nftables.New(nftables.AsLasting())
 	if err != nil {
 		return nil, fmt.Errorf("nftables lasting conn: %w", err)
@@ -80,6 +79,7 @@ func (h *HostFirewall) AddSandbox(vethName string) error {
 	if h == nil {
 		return nil
 	}
+
 	key, err := ifnameKey(vethName)
 	if err != nil {
 		return err
@@ -92,6 +92,7 @@ func (h *HostFirewall) AddSandbox(vethName string) error {
 	if err := h.conn.Flush(); err != nil {
 		return fmt.Errorf("flush veth %q add: %w", vethName, err)
 	}
+
 	return nil
 }
 
@@ -99,6 +100,7 @@ func (h *HostFirewall) RemoveSandbox(vethName string) error {
 	if h == nil {
 		return nil
 	}
+
 	key, err := ifnameKey(vethName)
 	if err != nil {
 		return err
@@ -112,8 +114,10 @@ func (h *HostFirewall) RemoveSandbox(vethName string) error {
 		if isNoSuchFileOrDirectory(err) {
 			return nil
 		}
+
 		return fmt.Errorf("flush veth %q remove: %w", vethName, err)
 	}
+
 	return nil
 }
 

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -72,6 +72,7 @@ func NewHostFirewall(config Config, externalIface string) (*HostFirewall, error)
 	if err := conn.Flush(); err != nil {
 		return nil, fmt.Errorf("flush host firewall table: %w", err)
 	}
+
 	return fw, nil
 }
 
@@ -125,6 +126,7 @@ func (h *HostFirewall) Close() error {
 	if h == nil || h.conn == nil {
 		return nil
 	}
+
 	return h.conn.CloseLasting()
 }
 
@@ -242,6 +244,7 @@ func matchIPv4SrcInCIDR(cidr *net.IPNet) ([]expr.Any, error) {
 	if mask == nil {
 		return nil, fmt.Errorf("not IPv4 mask: %s", cidr)
 	}
+
 	return []expr.Any{
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 12, Len: 4},
 		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: mask, Xor: []byte{0, 0, 0, 0}},
@@ -289,6 +292,7 @@ func concat(parts ...[]expr.Any) []expr.Any {
 	for _, p := range parts {
 		out = append(out, p...)
 	}
+
 	return out
 }
 

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -302,6 +302,7 @@ func ifnameKey(name string) ([]byte, error) {
 	}
 	key := make([]byte, ifNameMaxLen)
 	copy(key, name)
+
 	return key, nil
 }
 

--- a/packages/orchestrator/pkg/sandbox/network/host_firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/host_firewall.go
@@ -15,59 +15,40 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// IFNAMSIZ from <linux/if.h>. nftables `ifname` set keys are null-padded to
-// this size.
+// IFNAMSIZ; nftables `ifname` set keys are null-padded to this size.
 const ifNameMaxLen = 16
 
-// Names used by the host-side nftables ruleset. They are stable across
-// orchestrator restarts so we can replace the table on boot without leaking
-// previous rulesets.
 const (
 	hostFirewallTableName   = "e2b_host"
 	hostFirewallVethSetName = "sandbox_veths"
 )
 
-// Hook priorities for our table. Both run before the legacy iptables-nft
-// compat chains (which sit at priorities 0 / -100), so this ruleset always
-// gets first crack at packets and any leftover per-sandbox iptables rules
-// from older binaries become harmless no-ops.
+// Hook priorities run before the legacy iptables-nft compat chains (0 / -100)
+// so this ruleset always sees packets first.
 const (
 	hostForwardPriority    = -10
 	hostNATPostroutingPrio = -90
 	hostNATPreroutingPrio  = -110
 )
 
-// HostFirewall owns the host-side nftables ruleset shared by every sandbox
-// on the node. The static chains hook every sandbox's traffic through a
-// single `sandbox_veths` ifname set; per-sandbox add/remove is a single
-// netlink set-element insert (O(1) regardless of N).
-//
-// This replaces ~6 per-sandbox iptables shellouts that grew O(N²) under
-// iptables-nft (every Append rewrote the whole table under the xtables
-// lock).
+// HostFirewall holds the shared host-side nftables ruleset. Per-sandbox
+// add/remove is a single set-element insert keyed by veth interface name —
+// O(1) regardless of fleet size.
 type HostFirewall struct {
 	conn    *nftables.Conn
 	table   *nftables.Table
 	vethSet *nftables.Set
-
-	mu sync.Mutex // serialises Flush across goroutines
+	mu      sync.Mutex
 }
 
-// NewHostFirewall installs (or replaces) the table+chains+set on the host
-// and returns a handle the network slot lifecycle can use to add / remove
-// sandboxes.
 func NewHostFirewall(ctx context.Context, config Config, externalIface string) (*HostFirewall, error) {
 	conn, err := nftables.New(nftables.AsLasting())
 	if err != nil {
 		return nil, fmt.Errorf("nftables lasting conn: %w", err)
 	}
 
-	// Replace any previous instance of our table so a binary downgrade or
-	// config change doesn't leave stale rules behind. Both ops are buffered;
-	// the real commit happens at Flush below.
 	conn.DelTable(&nftables.Table{Name: hostFirewallTableName, Family: nftables.TableFamilyINet})
 	if err := conn.Flush(); err != nil && !isNoSuchFileOrDirectory(err) {
-		// Allow ENOENT — the table may not have existed yet.
 		return nil, fmt.Errorf("delete stale host firewall table: %w", err)
 	}
 
@@ -95,9 +76,6 @@ func NewHostFirewall(ctx context.Context, config Config, externalIface string) (
 	return fw, nil
 }
 
-// AddSandbox inserts the given veth interface name into the sandbox set so
-// the global forward / nat rules start matching traffic from this sandbox.
-// One netlink message + one commit; O(1) regardless of fleet size.
 func (h *HostFirewall) AddSandbox(vethName string) error {
 	key, err := ifnameKey(vethName)
 	if err != nil {
@@ -114,8 +92,6 @@ func (h *HostFirewall) AddSandbox(vethName string) error {
 	return nil
 }
 
-// RemoveSandbox removes the given veth interface name from the sandbox set.
-// Missing elements are not an error: teardown is best-effort.
 func (h *HostFirewall) RemoveSandbox(vethName string) error {
 	key, err := ifnameKey(vethName)
 	if err != nil {
@@ -135,8 +111,6 @@ func (h *HostFirewall) RemoveSandbox(vethName string) error {
 	return nil
 }
 
-// Close releases the lasting netlink connection. The kernel ruleset stays
-// in place so existing sandboxes keep working across orchestrator restarts.
 func (h *HostFirewall) Close() error {
 	if h == nil || h.conn == nil {
 		return nil
@@ -155,7 +129,6 @@ func (h *HostFirewall) installChains(config Config, externalIface string) error 
 		Priority: nftables.ChainPriorityRef(hostForwardPriority),
 		Policy:   &policyAccept,
 	})
-
 	postroutingNAT := h.conn.AddChain(&nftables.Chain{
 		Name:     "postrouting_nat",
 		Table:    h.table,
@@ -164,7 +137,6 @@ func (h *HostFirewall) installChains(config Config, externalIface string) error 
 		Priority: nftables.ChainPriorityRef(hostNATPostroutingPrio),
 		Policy:   &policyAccept,
 	})
-
 	preroutingNAT := h.conn.AddChain(&nftables.Chain{
 		Name:     "prerouting_nat",
 		Table:    h.table,
@@ -176,74 +148,45 @@ func (h *HostFirewall) installChains(config Config, externalIface string) error 
 
 	ifname := append([]byte(externalIface), 0)
 
-	// forward: iifname @sandbox_veths && oifname == external → accept
 	h.conn.AddRule(&nftables.Rule{
 		Table: h.table, Chain: forward,
-		Exprs: concat(
-			matchIifnameInSet(h.vethSet),
-			matchMetaEq(expr.MetaKeyOIFNAME, ifname),
-			verdictAccept(),
-		),
+		Exprs: concat(matchIifnameInSet(h.vethSet), matchMetaEq(expr.MetaKeyOIFNAME, ifname), verdictAccept()),
 	})
-	// forward: iifname == external && oifname @sandbox_veths → accept
 	h.conn.AddRule(&nftables.Rule{
 		Table: h.table, Chain: forward,
-		Exprs: concat(
-			matchMetaEq(expr.MetaKeyIIFNAME, ifname),
-			matchOifnameInSet(h.vethSet),
-			verdictAccept(),
-		),
+		Exprs: concat(matchMetaEq(expr.MetaKeyIIFNAME, ifname), matchOifnameInSet(h.vethSet), verdictAccept()),
 	})
 
-	// postrouting nat: ip saddr in hostNetworkCIDR && oifname == external → masquerade
 	saddrMatch, err := matchIPv4SrcInCIDR(hostNetworkCIDR)
 	if err != nil {
 		return fmt.Errorf("masquerade source match: %w", err)
 	}
 	h.conn.AddRule(&nftables.Rule{
 		Table: h.table, Chain: postroutingNAT,
-		Exprs: concat(
-			saddrMatch,
-			matchMetaEq(expr.MetaKeyOIFNAME, ifname),
-			[]expr.Any{&expr.Masq{}},
-		),
+		Exprs: concat(saddrMatch, matchMetaEq(expr.MetaKeyOIFNAME, ifname), []expr.Any{&expr.Masq{}}),
 	})
 
-	// prerouting nat: host services exposed to sandboxes (global, dst-IP keyed).
 	orchIP := net.ParseIP(config.OrchestratorInSandboxIPAddress).To4()
 	if orchIP == nil {
 		return fmt.Errorf("invalid OrchestratorInSandboxIPAddress %q", config.OrchestratorInSandboxIPAddress)
 	}
-	hostServiceRules := []struct {
-		port    uint16
-		toPort  uint16
-		comment string
-	}{
-		{port: 80, toPort: config.HyperloopProxyPort, comment: "hyperloop"},
-		{port: 111, toPort: config.PortmapperPort, comment: "portmapper"},
-		{port: 2049, toPort: config.NFSProxyPort, comment: "nfs-proxy"},
-	}
-	for _, r := range hostServiceRules {
+	for _, r := range []struct{ dport, toPort uint16 }{
+		{80, config.HyperloopProxyPort},
+		{111, config.PortmapperPort},
+		{2049, config.NFSProxyPort},
+	} {
 		h.conn.AddRule(&nftables.Rule{
 			Table: h.table, Chain: preroutingNAT,
-			Exprs: concat(
-				matchIPv4DstEq(orchIP),
-				matchTCPDport(r.port),
-				redirectTo(r.toPort),
-			),
+			Exprs: concat(matchIPv4DstEq(orchIP), matchTCPDport(r.dport), redirectTo(r.toPort)),
 		})
 	}
 
-	// prerouting nat: per-sandbox TCP firewall.
-	tcpfwRules := []struct {
-		dport  uint16 // 0 = catchall
-		toPort uint16
-	}{
-		{dport: 80, toPort: config.SandboxTCPFirewallHTTPPort},
-		{dport: 443, toPort: config.SandboxTCPFirewallTLSPort},
-		{dport: 0, toPort: config.SandboxTCPFirewallOtherPort},
-	}
-	for _, r := range tcpfwRules {
+	// Per-sandbox TCP firewall: specific ports first, then catchall.
+	for _, r := range []struct{ dport, toPort uint16 }{
+		{80, config.SandboxTCPFirewallHTTPPort},
+		{443, config.SandboxTCPFirewallTLSPort},
+		{0, config.SandboxTCPFirewallOtherPort},
+	} {
 		var match []expr.Any
 		if r.dport != 0 {
 			match = concat(matchIifnameInSet(h.vethSet), matchTCPDport(r.dport))
@@ -258,9 +201,6 @@ func (h *HostFirewall) installChains(config Config, externalIface string) error 
 
 	return nil
 }
-
-// Expression helpers below. Each returns a slice that can be concatenated
-// into a Rule.Exprs.
 
 func matchMetaEq(key expr.MetaKey, want []byte) []expr.Any {
 	return []expr.Any{
@@ -293,31 +233,15 @@ func matchIPv4SrcInCIDR(cidr *net.IPNet) ([]expr.Any, error) {
 		return nil, fmt.Errorf("not IPv4 mask: %s", cidr)
 	}
 	return []expr.Any{
-		// payload: ip saddr (offset 12, length 4)
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseNetworkHeader,
-			Offset:       12,
-			Len:          4,
-		},
-		// mask saddr
-		&expr.Bitwise{
-			SourceRegister: 1, DestRegister: 1, Len: 4,
-			Mask: mask, Xor: []byte{0, 0, 0, 0},
-		},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 12, Len: 4},
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: mask, Xor: []byte{0, 0, 0, 0}},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: ip4.Mask(cidr.Mask)},
 	}, nil
 }
 
 func matchIPv4DstEq(ip net.IP) []expr.Any {
 	return []expr.Any{
-		// payload: ip daddr (offset 16, length 4)
-		&expr.Payload{
-			DestRegister: 1,
-			Base:         expr.PayloadBaseNetworkHeader,
-			Offset:       16,
-			Len:          4,
-		},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 16, Len: 4},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: ip},
 	}
 }
@@ -333,13 +257,7 @@ func matchTCPDport(port uint16) []expr.Any {
 	return concat(
 		matchL4Proto(unix.IPPROTO_TCP),
 		[]expr.Any{
-			// payload: tcp dport (offset 2 in transport header, length 2)
-			&expr.Payload{
-				DestRegister: 1,
-				Base:         expr.PayloadBaseTransportHeader,
-				Offset:       2,
-				Len:          2,
-			},
+			&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
 			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: binaryutil.BigEndian.PutUint16(port)},
 		},
 	)
@@ -364,8 +282,6 @@ func concat(parts ...[]expr.Any) []expr.Any {
 	return out
 }
 
-// ifnameKey null-pads an interface name to IFNAMSIZ for use as an nftables
-// `ifname` set key.
 func ifnameKey(name string) ([]byte, error) {
 	if len(name) >= ifNameMaxLen {
 		return nil, fmt.Errorf("interface name %q too long (max %d bytes)", name, ifNameMaxLen-1)

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"runtime"
-	"strconv"
 
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/vishvananda/netlink"
@@ -203,56 +202,16 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding route from host to FC: %w", err)
 	}
 
-	// Add host forwarding rules
-	err = tables.Append("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
-	if err != nil {
-		return fmt.Errorf("error creating forwarding rule to default gateway: %w", err)
+	// Hand the per-sandbox host-side rules off to the shared nftables
+	// ruleset (HostFirewall). All sandbox-specific behaviour — forward
+	// accept, source MASQUERADE, TCP-firewall redirects — is keyed on
+	// veth interface name, so adding the veth to a single set is one
+	// O(1) netlink message regardless of fleet size.
+	if err := s.hostFirewall.AddSandbox(s.VethName()); err != nil {
+		return fmt.Errorf("error registering sandbox in host firewall: %w", err)
 	}
 
-	err = tables.Append("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
-	if err != nil {
-		return fmt.Errorf("error creating forwarding rule from default gateway: %w", err)
-	}
-
-	// Add host postrouting rules
-	err = tables.Append("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
-	if err != nil {
-		return fmt.Errorf("error creating postrouting rule: %w", err)
-	}
-
-	// Redirect traffic destined for hyperloop proxy
-	err = tables.Append(
-		"nat", "PREROUTING", "-i", s.VethName(),
-		"-p", "tcp", "-d", s.config.OrchestratorInSandboxIPAddress, "--dport", "80",
-		"-j", "REDIRECT", "--to-port", s.hyperloopPort,
-	)
-	if err != nil {
-		return fmt.Errorf("error creating HTTP redirect rule to sandbox hyperloop proxy server: %w", err)
-	}
-
-	// Redirect traffic destined for portmapper
-	err = tables.Append("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
-		"--jump", "REDIRECT", "--to-port", fmt.Sprintf("%d", s.config.PortmapperPort),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating NFS redirect rule to sandbox portmapper server: %w", err)
-	}
-
-	// Redirect traffic destined for NFS proxy
-	err = tables.Append("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
-		"--jump", "REDIRECT", "--to-port", fmt.Sprintf("%d", s.config.NFSProxyPort),
-	)
-	if err != nil {
-		return fmt.Errorf("error creating NFS redirect rule to sandbox NFS proxy server: %w", err)
-	}
-
-	// Create rules needed by egress proxy
-	err = s.egressProxy.OnSlotCreate(s, tables)
-	if err != nil {
+	if err := s.egressProxy.OnSlotCreate(s); err != nil {
 		return err
 	}
 
@@ -262,94 +221,41 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 func (s *Slot) RemoveNetwork() error {
 	var errs []error
 
-	err := s.CloseFirewall()
-	if err != nil {
+	if err := s.CloseFirewall(); err != nil {
 		errs = append(errs, fmt.Errorf("error closing firewall: %w", err))
 	}
 
-	tables, err := iptables.New()
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error initializing iptables: %w", err))
-	} else {
-		// Delete host forwarding rules
-		err = tables.Delete("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule to default gateway: %w", err))
-		}
+	// Drop this sandbox from the host firewall's veth set so the global
+	// rules stop matching its traffic. Best-effort: kernel `ENOENT` is
+	// tolerated (already removed).
+	if err := s.hostFirewall.RemoveSandbox(s.VethName()); err != nil {
+		errs = append(errs, fmt.Errorf("error deregistering sandbox from host firewall: %w", err))
+	}
 
-		err = tables.Delete("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule from default gateway: %w", err))
-		}
-
-		// Delete host postrouting rules
-		err = tables.Delete("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host postrouting rule: %w", err))
-		}
-
-		// Delete hyperloop proxy redirect rule
-		err = tables.Delete(
-			"nat", "PREROUTING", "-i", s.VethName(),
-			"-p", "tcp", "-d", s.config.OrchestratorInSandboxIPAddress, "--dport", "80",
-			"-j", "REDIRECT", "--to-port", s.hyperloopPort,
-		)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting sandbox hyperloop proxy redirect rule: %w", err))
-		}
-
-		// Delete changes made by egress proxy
-		err = s.egressProxy.OnSlotDelete(s, tables)
-		if err != nil {
-			errs = append(errs, err)
-		}
+	if err := s.egressProxy.OnSlotDelete(s); err != nil {
+		errs = append(errs, err)
 	}
 
 	// Delete routing from host to FC namespace
-	err = netlink.RouteDel(&netlink.Route{
+	if err := netlink.RouteDel(&netlink.Route{
 		Gw:  s.VpeerIP(),
 		Dst: s.HostNet(),
-	})
-	if err != nil {
+	}); err != nil {
 		errs = append(errs, fmt.Errorf("error deleting route from host to FC: %w", err))
 	}
 
-	// Delete veth device
-	// We explicitly delete the veth device from the host namespace because even though deleting
-	// is deleting the device there may be a race condition when creating a new veth device with
-	// the same name immediately after deleting the namespace.
+	// Delete veth device.
+	// We explicitly delete the veth device from the host namespace because deleting
+	// the netns alone can race with creating a new veth with the same name immediately
+	// after.
 	veth, err := netlink.LinkByName(s.VethName())
 	if err != nil {
 		errs = append(errs, fmt.Errorf("error finding veth: %w", err))
-	} else {
-		err = netlink.LinkDel(veth)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting veth device: %w", err))
-		}
+	} else if err := netlink.LinkDel(veth); err != nil {
+		errs = append(errs, fmt.Errorf("error deleting veth device: %w", err))
 	}
 
-	// Delete NFS proxy redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.NFSProxyPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox NFS proxy redirect rule: %w", err))
-	}
-
-	// Delete portmapper redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.PortmapperPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox portmapper redirect rule: %w", err))
-	}
-
-	err = netns.DeleteNamed(s.NamespaceID())
-	if err != nil {
+	if err := netns.DeleteNamed(s.NamespaceID()); err != nil {
 		errs = append(errs, fmt.Errorf("error deleting namespace: %w", err))
 	}
 

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -202,11 +202,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding route from host to FC: %w", err)
 	}
 
-	// Hand the per-sandbox host-side rules off to the shared nftables
-	// ruleset (HostFirewall). All sandbox-specific behaviour — forward
-	// accept, source MASQUERADE, TCP-firewall redirects — is keyed on
-	// veth interface name, so adding the veth to a single set is one
-	// O(1) netlink message regardless of fleet size.
 	if err := s.hostFirewall.AddSandbox(s.VethName()); err != nil {
 		return fmt.Errorf("error registering sandbox in host firewall: %w", err)
 	}
@@ -225,9 +220,6 @@ func (s *Slot) RemoveNetwork() error {
 		errs = append(errs, fmt.Errorf("error closing firewall: %w", err))
 	}
 
-	// Drop this sandbox from the host firewall's veth set so the global
-	// rules stop matching its traffic. Best-effort: kernel `ENOENT` is
-	// tolerated (already removed).
 	if err := s.hostFirewall.RemoveSandbox(s.VethName()); err != nil {
 		errs = append(errs, fmt.Errorf("error deregistering sandbox from host firewall: %w", err))
 	}

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -202,12 +202,15 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("error adding route from host to FC: %w", err)
 	}
 
-	if err := s.hostFirewall.AddSandbox(s.VethName()); err != nil {
-		return fmt.Errorf("error registering sandbox in host firewall: %w", err)
-	}
-
 	if err := s.egressProxy.OnSlotCreate(s); err != nil {
 		return err
+	}
+
+	// Register with the host firewall last so a partial CreateNetwork
+	// never leaves a veth name in the shared set after a non-AddSandbox
+	// step failed (createNetworkSlot does not run RemoveNetwork on error).
+	if err := s.hostFirewall.AddSandbox(s.VethName()); err != nil {
+		return fmt.Errorf("error registering sandbox in host firewall: %w", err)
 	}
 
 	return nil

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -81,11 +81,12 @@ type Slot struct {
 
 	hyperloopPort string
 
-	egressProxy EgressProxy
-	config      Config
+	egressProxy  EgressProxy
+	hostFirewall *HostFirewall
+	config       Config
 }
 
-func NewSlot(key string, idx int, config Config, egressProxy EgressProxy) (*Slot, error) {
+func NewSlot(key string, idx int, config Config, egressProxy EgressProxy, hostFirewall *HostFirewall) (*Slot, error) {
 	if idx < 1 || idx > vrtSlotsSize {
 		return nil, fmt.Errorf("slot index %d is out of range [1, %d)", idx, vrtSlotsSize)
 	}
@@ -140,8 +141,9 @@ func NewSlot(key string, idx int, config Config, egressProxy EgressProxy) (*Slot
 
 		hyperloopPort: strconv.FormatUint(uint64(config.HyperloopProxyPort), 10),
 
-		config:      config,
-		egressProxy: egressProxy,
+		config:       config,
+		egressProxy:  egressProxy,
+		hostFirewall: hostFirewall,
 	}
 
 	return slot, nil

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -27,7 +27,7 @@ func (s *StorageKV) getKVKey(slotIdx int) string {
 	return fmt.Sprintf("%s/%d", s.nodeID, slotIdx)
 }
 
-func NewStorageKV(ctx context.Context, nodeID string, config Config, egressProxy EgressProxy) (*StorageKV, error) {
+func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*StorageKV, error) {
 	consulToken := utils.RequiredEnv("CONSUL_TOKEN", "Consul token for authenticating requests to the Consul API")
 
 	consulClient, err := newConsulClient(consulToken)

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -20,18 +20,24 @@ type StorageKV struct {
 	consulClient *consulApi.Client
 	nodeID       string
 	egressProxy  EgressProxy
+	hostFirewall *HostFirewall
 }
 
 func (s *StorageKV) getKVKey(slotIdx int) string {
 	return fmt.Sprintf("%s/%d", s.nodeID, slotIdx)
 }
 
-func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*StorageKV, error) {
+func NewStorageKV(ctx context.Context, nodeID string, config Config, egressProxy EgressProxy) (*StorageKV, error) {
 	consulToken := utils.RequiredEnv("CONSUL_TOKEN", "Consul token for authenticating requests to the Consul API")
 
 	consulClient, err := newConsulClient(consulToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init StorageKV consul client: %w", err)
+	}
+
+	hostFirewall, err := NewHostFirewall(ctx, config, defaultGateway)
+	if err != nil {
+		return nil, fmt.Errorf("init host firewall: %w", err)
 	}
 
 	return &StorageKV{
@@ -40,6 +46,7 @@ func NewStorageKV(nodeID string, config Config, egressProxy EgressProxy) (*Stora
 		consulClient: consulClient,
 		nodeID:       nodeID,
 		egressProxy:  egressProxy,
+		hostFirewall: hostFirewall,
 	}, nil
 }
 
@@ -70,7 +77,7 @@ func (s *StorageKV) Acquire(_ context.Context) (*Slot, error) {
 		}
 
 		if status {
-			return NewSlot(key, slotIdx, s.config, s.egressProxy)
+			return NewSlot(key, slotIdx, s.config, s.egressProxy, s.hostFirewall)
 		}
 
 		return nil, nil

--- a/packages/orchestrator/pkg/sandbox/network/storage_kv.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_kv.go
@@ -35,7 +35,7 @@ func NewStorageKV(ctx context.Context, nodeID string, config Config, egressProxy
 		return nil, fmt.Errorf("failed to init StorageKV consul client: %w", err)
 	}
 
-	hostFirewall, err := NewHostFirewall(ctx, config, defaultGateway)
+	hostFirewall, err := NewHostFirewall(config, defaultGateway)
 	if err != nil {
 		return nil, fmt.Errorf("init host firewall: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/network/storage_local.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_local.go
@@ -24,6 +24,7 @@ type StorageLocal struct {
 	acquiredNs   map[string]struct{}
 	acquiredNsMu sync.Mutex
 	egressProxy  EgressProxy
+	hostFirewall *HostFirewall
 }
 
 const netNamespacesDir = "/var/run/netns"
@@ -41,6 +42,11 @@ func NewStorageLocal(ctx context.Context, config Config, egressProxy EgressProxy
 		logger.L().Info(ctx, fmt.Sprintf("Found foreign namespace: %s", ns))
 	}
 
+	hostFirewall, err := NewHostFirewall(ctx, config, defaultGateway)
+	if err != nil {
+		return nil, fmt.Errorf("init host firewall: %w", err)
+	}
+
 	return &StorageLocal{
 		config:       config,
 		foreignNs:    foreignNsMap,
@@ -48,6 +54,7 @@ func NewStorageLocal(ctx context.Context, config Config, egressProxy EgressProxy
 		acquiredNs:   make(map[string]struct{}, vrtSlotsSize),
 		acquiredNsMu: sync.Mutex{},
 		egressProxy:  egressProxy,
+		hostFirewall: hostFirewall,
 	}, nil
 }
 
@@ -102,7 +109,7 @@ func (s *StorageLocal) Acquire(ctx context.Context) (*Slot, error) {
 			s.acquiredNs[slotName] = struct{}{}
 			slotKey := getLocalKey(slotIdx)
 
-			return NewSlot(slotKey, slotIdx, s.config, s.egressProxy)
+			return NewSlot(slotKey, slotIdx, s.config, s.egressProxy, s.hostFirewall)
 		}
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/network/storage_local.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_local.go
@@ -42,7 +42,7 @@ func NewStorageLocal(ctx context.Context, config Config, egressProxy EgressProxy
 		logger.L().Info(ctx, fmt.Sprintf("Found foreign namespace: %s", ns))
 	}
 
-	hostFirewall, err := NewHostFirewall(ctx, config, defaultGateway)
+	hostFirewall, err := NewHostFirewall(config, defaultGateway)
 	if err != nil {
 		return nil, fmt.Errorf("init host firewall: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/network/storage_memory.go
+++ b/packages/orchestrator/pkg/sandbox/network/storage_memory.go
@@ -10,20 +10,22 @@ import (
 )
 
 type StorageMemory struct {
-	config      Config
-	slotsSize   int
-	freeSlots   []bool
-	freeSlotsMu sync.Mutex
-	egressProxy EgressProxy
+	config       Config
+	slotsSize    int
+	freeSlots    []bool
+	freeSlotsMu  sync.Mutex
+	egressProxy  EgressProxy
+	hostFirewall *HostFirewall
 }
 
-func NewStorageMemory(slotsSize int, config Config, egressProxy EgressProxy) (*StorageMemory, error) {
+func NewStorageMemory(slotsSize int, config Config, egressProxy EgressProxy, hostFirewall *HostFirewall) (*StorageMemory, error) {
 	return &StorageMemory{
-		config:      config,
-		slotsSize:   slotsSize,
-		freeSlots:   make([]bool, slotsSize),
-		freeSlotsMu: sync.Mutex{},
-		egressProxy: egressProxy,
+		config:       config,
+		slotsSize:    slotsSize,
+		freeSlots:    make([]bool, slotsSize),
+		freeSlotsMu:  sync.Mutex{},
+		egressProxy:  egressProxy,
+		hostFirewall: hostFirewall,
 	}, nil
 }
 
@@ -38,7 +40,7 @@ func (s *StorageMemory) Acquire(_ context.Context) (*Slot, error) {
 		if !s.freeSlots[slotIdx] {
 			s.freeSlots[slotIdx] = true
 
-			return NewSlot(key, slotIdx, s.config, s.egressProxy)
+			return NewSlot(key, slotIdx, s.config, s.egressProxy, s.hostFirewall)
 		}
 	}
 

--- a/packages/orchestrator/pkg/server/sandboxes_update_test.go
+++ b/packages/orchestrator/pkg/server/sandboxes_update_test.go
@@ -26,7 +26,7 @@ import (
 func TestUpdate_EgressOnly_FailsAndDoesNotChangeEndTime(t *testing.T) {
 	t.Parallel()
 
-	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{})
+	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{}, nil)
 	require.NoError(t, err)
 
 	sbx := &sandbox.Sandbox{
@@ -65,7 +65,7 @@ func TestUpdate_EgressOnly_FailsAndDoesNotChangeEndTime(t *testing.T) {
 func TestUpdate_EndTimeAndEgress_EgressFails_RevertsEndTime(t *testing.T) {
 	t.Parallel()
 
-	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{})
+	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{}, nil)
 	require.NoError(t, err)
 
 	sbx := &sandbox.Sandbox{

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -4,12 +4,10 @@ package tcpfirewall
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strings"
 
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/inetaf/tcpproxy"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
@@ -38,8 +36,7 @@ type Proxy struct {
 	tlsPort   uint16 // For port 443 traffic - TLS SNI inspection
 	otherPort uint16 // For all other ports - CIDR-only, no protocol inspection
 
-	proxyRules []proxyRule
-	proxy      *tcpproxy.Proxy
+	proxy *tcpproxy.Proxy
 }
 
 func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.Map, meterProvider metric.MeterProvider, featureFlags *featureflags.Client) *Proxy {
@@ -52,12 +49,6 @@ func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.
 		metrics:      NewMetrics(meterProvider),
 		limiter:      connlimit.NewConnectionLimiter(),
 		featureFlags: featureFlags,
-	}
-
-	p.proxyRules = []proxyRule{
-		{dstPort: "80", proxyPort: fmt.Sprintf("%d", p.httpPort), desc: "HTTP"},
-		{dstPort: "443", proxyPort: fmt.Sprintf("%d", p.tlsPort), desc: "TLS"},
-		{dstPort: "", proxyPort: fmt.Sprintf("%d", p.otherPort), desc: "other TCP"},
 	}
 
 	sandboxes.Subscribe(p)
@@ -128,46 +119,12 @@ func (p *Proxy) Start(ctx context.Context) error {
 	return err
 }
 
-type proxyRule struct {
-	dstPort   string // destination port to match (empty = all ports)
-	proxyPort string // port to redirect to
-	desc      string // description for error messages
-}
-
-func (p *Proxy) ruleArgs(s *network.Slot, rule proxyRule) []string {
-	args := []string{"-i", s.VethName(), "-p", "tcp"}
-	if rule.dstPort != "" {
-		args = append(args, "--dport", rule.dstPort)
-	}
-	args = append(args,
-		"-j", "REDIRECT", "--to-port", rule.proxyPort,
-	)
-
-	return args
-}
-
-func (p *Proxy) OnSlotCreate(s *network.Slot, tables *iptables.IPTables) error {
-	for _, rule := range p.proxyRules {
-		err := tables.Append("nat", "PREROUTING", p.ruleArgs(s, rule)...)
-		if err != nil {
-			return fmt.Errorf("error creating redirect rule for %s traffic: %w", rule.desc, err)
-		}
-	}
-
-	return nil
-}
-
-func (p *Proxy) OnSlotDelete(s *network.Slot, tables *iptables.IPTables) error {
-	var errs []error
-	for _, rule := range p.proxyRules {
-		err := tables.Delete("nat", "PREROUTING", p.ruleArgs(s, rule)...)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting %s egress proxy redirect rule: %w", rule.desc, err))
-		}
-	}
-
-	return errors.Join(errs...)
-}
+// OnSlotCreate / OnSlotDelete are no-ops: the per-veth REDIRECT rules now
+// live in the shared host nftables ruleset (HostFirewall) and are keyed on
+// `@sandbox_veths` set membership, so adding a veth to that set is all the
+// per-sandbox plumbing needed.
+func (p *Proxy) OnSlotCreate(_ *network.Slot) error { return nil }
+func (p *Proxy) OnSlotDelete(_ *network.Slot) error { return nil }
 
 func (p *Proxy) Close(_ context.Context) error {
 	if p.proxy != nil {

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -119,10 +119,8 @@ func (p *Proxy) Start(ctx context.Context) error {
 	return err
 }
 
-// OnSlotCreate / OnSlotDelete are no-ops: the per-veth REDIRECT rules now
-// live in the shared host nftables ruleset (HostFirewall) and are keyed on
-// `@sandbox_veths` set membership, so adding a veth to that set is all the
-// per-sandbox plumbing needed.
+// REDIRECT rules live in the shared host nftables ruleset; per-sandbox
+// plumbing is just veth set membership, handled by HostFirewall.
 func (p *Proxy) OnSlotCreate(_ *network.Slot) error { return nil }
 func (p *Proxy) OnSlotDelete(_ *network.Slot) error { return nil }
 


### PR DESCRIPTION
Replace the per-sandbox host iptables work with a shared nftables ruleset (`inet e2b_host`) created once at orchestrator boot. All sandbox-keyed behaviour (forward accept, source MASQUERADE, TCP-firewall redirects) hangs off a `sandbox_veths` ifname set; `CreateNetwork` / `RemoveNetwork` mutate the set via one netlink op each — O(1) regardless of fleet size.

Replaces ~6 per-sandbox `iptables` shellouts that ran O(N²) under `iptables-nft` (every `-A` rewrote the whole table under the xtables lock).

Hook priorities (-110 / -90 / -10) run before the legacy iptables-nft compat chains, so leftover per-sandbox iptables rules from older binaries become harmless no-ops during a rolling deploy. The table is dropped and re-added on each orchestrator start.

The `EgressProxy` interface drops its `*iptables.IPTables` parameter — `tcpfirewall.Proxy` no longer needs per-sandbox iptables work (set membership covers it).
