### PR TITLE
perf(storage): zero-copy GCS multipart upload from disk

### DIFF
--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {

--- a/packages/shared/pkg/storage/gcp_multipart.go
+++ b/packages/shared/pkg/storage/gcp_multipart.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"hash"
 	"io"
 	"math"
 	"math/rand"
@@ -253,23 +252,17 @@ func (m *MultipartUploader) initiateUpload(ctx context.Context) (string, error) 
 	return result.UploadID, nil
 }
 
-func (m *MultipartUploader) uploadPart(ctx context.Context, uploadID string, partNumber int, data []byte) (string, error) {
-	// Calculate MD5 for data integrity
-	hasher := md5.New()
-	hasher.Write(data)
-	md5Sum := base64.StdEncoding.EncodeToString(hasher.Sum(nil))
-
+func (m *MultipartUploader) uploadPart(ctx context.Context, uploadID string, partNumber int, body retryablehttp.ReaderFunc, contentLen int64) (string, error) {
 	url := fmt.Sprintf("%s/%s?partNumber=%d&uploadId=%s",
 		m.baseURL, m.objectName, partNumber, uploadID)
 
-	req, err := retryablehttp.NewRequestWithContext(ctx, "PUT", url, bytes.NewReader(data))
+	req, err := retryablehttp.NewRequestWithContext(ctx, "PUT", url, body)
 	if err != nil {
 		return "", err
 	}
 
 	req.Header.Set("Authorization", "Bearer "+m.token)
-	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(data)))
-	req.Header.Set("Content-MD5", md5Sum)
+	req.ContentLength = contentLen
 
 	resp, err := m.client.Do(req)
 	if err != nil {
@@ -278,9 +271,9 @@ func (m *MultipartUploader) uploadPart(ctx context.Context, uploadID string, par
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body)
 
-		return "", fmt.Errorf("failed to upload part %d (status %d): %s", partNumber, resp.StatusCode, string(body))
+		return "", fmt.Errorf("failed to upload part %d (status %d): %s", partNumber, resp.StatusCode, string(respBody))
 	}
 
 	etag := resp.Header.Get("ETag")
@@ -384,63 +377,30 @@ func (m *MultipartUploader) completeUpload(ctx context.Context, uploadID string,
 	return nil
 }
 
-func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath string, maxConcurrency int, hasher hash.Hash) (int64, error) {
-	// Open file
+func (m *MultipartUploader) UploadFileInParallel(ctx context.Context, filePath string, maxConcurrency int) (int64, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
 
-	// Get file size
 	fileInfo, err := file.Stat()
 	if err != nil {
 		return 0, fmt.Errorf("failed to get file info: %w", err)
 	}
 	fileSize := fileInfo.Size()
 
-	// Calculate number of parts
 	numParts := int(math.Ceil(float64(fileSize) / float64(gcpMultipartUploadChunkSize)))
 	if numParts == 0 {
-		numParts = 1 // Always upload at least 1 part, even for empty files
+		numParts = 1
 	}
 
-	// Initiate multipart upload
 	uploadID, err := m.initiateUpload(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to initiate upload: %w", err)
 	}
 
-	// Hash on a sibling goroutine while parts upload — the read overlaps the
-	// upload, adding no wall-clock latency. Own file handle (separate from the
-	// part uploaders' ReadAt); opened here so a failed upload can close it.
-	var hashFile *os.File
-	if hasher != nil {
-		hashFile, err = os.Open(filePath)
-		if err != nil {
-			return 0, fmt.Errorf("failed to open file for checksum: %w", err)
-		}
-		defer hashFile.Close()
-	}
-
-	var eg errgroup.Group
-	if hashFile != nil {
-		eg.Go(func() error {
-			if _, err := io.Copy(hasher, hashFile); err != nil {
-				return fmt.Errorf("failed to checksum file: %w", err)
-			}
-
-			return nil
-		})
-	}
-
 	parts, err := m.uploadParts(ctx, maxConcurrency, numParts, fileSize, file, uploadID)
-	if hashFile != nil && err != nil {
-		hashFile.Close() // cancel the now-pointless io.Copy
-	}
-	if hashErr := eg.Wait(); err == nil {
-		err = hashErr
-	}
 	if err != nil {
 		return 0, fmt.Errorf("failed to upload file: %w", err)
 	}
@@ -470,21 +430,17 @@ func (m *MultipartUploader) uploadParts(ctx context.Context, maxConcurrency int,
 			default:
 			}
 
-			// Read chunk from file
 			offset := int64(partNumber-1) * gcpMultipartUploadChunkSize
-			chunkSize := gcpMultipartUploadChunkSize
-			if offset+int64(chunkSize) > fileSize {
-				chunkSize = int(fileSize - offset)
+			chunkSize := int64(gcpMultipartUploadChunkSize)
+			if offset+chunkSize > fileSize {
+				chunkSize = fileSize - offset
 			}
 
-			chunk := make([]byte, chunkSize)
-			_, err := file.ReadAt(chunk, offset)
-			if err != nil {
-				return fmt.Errorf("failed to read chunk for part %d: %w", partNumber, err)
-			}
+			body := retryablehttp.ReaderFunc(func() (io.Reader, error) {
+				return io.NewSectionReader(file, offset, chunkSize), nil
+			})
 
-			// Upload part
-			etag, err := m.uploadPart(ctx, uploadID, partNumber, chunk)
+			etag, err := m.uploadPart(ctx, uploadID, partNumber, body, chunkSize)
 			if err != nil {
 				return fmt.Errorf("failed to upload part %d: %w", partNumber, err)
 			}

--- a/packages/shared/pkg/storage/gcp_multipart_test.go
+++ b/packages/shared/pkg/storage/gcp_multipart_test.go
@@ -1,8 +1,8 @@
 package storage
 
 import (
+	"bytes"
 	"crypto/md5"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -110,10 +110,16 @@ func TestMultipartUploader_UploadPart_Success(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	etag, err := uploader.uploadPart(t.Context(), "test-upload-id", 1, testData)
+	etag, err := uploader.uploadPart(t.Context(), "test-upload-id", 1, bytesReaderFunc(testData), int64(len(testData)))
 
 	require.NoError(t, err)
 	require.Equal(t, expectedETag, etag)
+}
+
+func bytesReaderFunc(data []byte) retryablehttp.ReaderFunc {
+	return func() (io.Reader, error) {
+		return bytes.NewReader(data), nil
+	}
 }
 
 func TestMultipartUploader_UploadPartSlices_Success(t *testing.T) {
@@ -160,7 +166,8 @@ func TestMultipartUploader_UploadPart_MissingETag(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	etag, err := uploader.uploadPart(t.Context(), "test-upload-id", 1, []byte("test"))
+	data := []byte("test")
+	etag, err := uploader.uploadPart(t.Context(), "test-upload-id", 1, bytesReaderFunc(data), int64(len(data)))
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no ETag returned for part 1")
@@ -242,7 +249,7 @@ func TestMultipartUploader_UploadFileInParallel_Success(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 2, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 2)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&initiateCount))
@@ -257,42 +264,6 @@ func TestMultipartUploader_UploadFileInParallel_Success(t *testing.T) {
 		}
 	}
 	require.Equal(t, testContent, reconstructed.String())
-}
-
-func TestMultipartUploader_UploadFileInParallel_Checksum(t *testing.T) {
-	t.Parallel()
-
-	tempDir := t.TempDir()
-	testFile := filepath.Join(tempDir, "test.txt")
-	testContent := strings.Repeat("checksummed payload ", 5000) // multiple chunks
-	require.NoError(t, os.WriteFile(testFile, []byte(testContent), 0o644))
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.RawQuery == uploadsPath:
-			response := InitiateMultipartUploadResult{
-				Bucket:   testBucketName,
-				Key:      testObjectName,
-				UploadID: "checksum-upload-id",
-			}
-			xmlData, _ := xml.Marshal(response)
-			w.Header().Set("Content-Type", "application/xml")
-			w.WriteHeader(http.StatusOK)
-			w.Write(xmlData)
-		case strings.Contains(r.URL.RawQuery, "partNumber"):
-			w.Header().Set("ETag", `"etag"`)
-			w.WriteHeader(http.StatusOK)
-		case strings.Contains(r.URL.RawQuery, "uploadId"):
-			w.WriteHeader(http.StatusOK)
-		}
-	})
-
-	uploader := createTestMultipartUploader(t, handler)
-	hasher := sha256.New()
-	_, err := uploader.UploadFileInParallel(t.Context(), testFile, 4, hasher)
-	require.NoError(t, err)
-
-	require.Equal(t, sha256.Sum256([]byte(testContent)), sum256(hasher))
 }
 
 func TestMultipartUploader_InitiateUpload_WithRetries(t *testing.T) {
@@ -394,7 +365,7 @@ func TestMultipartUploader_HighConcurrency_StressTest(t *testing.T) {
 	uploader := createTestMultipartUploader(t, handler)
 
 	// Use high concurrency to stress test
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 50, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 50)
 	require.NoError(t, err)
 
 	// Verify all calls were made
@@ -465,7 +436,7 @@ func TestMultipartUploader_RandomFailures_ChaosTest(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 10, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 10)
 	require.NoError(t, err)
 
 	t.Logf("Chaos test: %d total attempts, %d successes",
@@ -530,7 +501,7 @@ func TestMultipartUploader_PartialFailures_Recovery(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5)
 	require.NoError(t, err)
 
 	// Verify that all parts eventually succeeded after retries
@@ -579,7 +550,7 @@ func TestMultipartUploader_EdgeCases_EmptyFile(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), emptyFile, 5, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), emptyFile, 5)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(1), atomic.LoadInt32(&initiateCalls))
@@ -623,7 +594,7 @@ func TestMultipartUploader_EdgeCases_VerySmallFile(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), smallFile, 10, nil) // High concurrency for small file
+	_, err = uploader.UploadFileInParallel(t.Context(), smallFile, 10) // High concurrency for small file
 	require.NoError(t, err)
 
 	// Small file should produce exactly one part
@@ -721,7 +692,7 @@ func TestMultipartUploader_ResourceExhaustion_TooManyConcurrentUploads(t *testin
 	uploader := createTestMultipartUploader(t, handler)
 
 	// Try with extremely high concurrency
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 1000, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 1000)
 	require.NoError(t, err)
 
 	// Should have observed significant concurrency but not necessarily 1000
@@ -770,7 +741,7 @@ func TestMultipartUploader_BoundaryConditions_ExactChunkSize(t *testing.T) {
 	})
 
 	uploader := createTestMultipartUploader(t, handler)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5, nil)
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 5)
 	require.NoError(t, err)
 
 	// Should have exactly 2 parts, each of ChunkSize
@@ -786,7 +757,7 @@ func TestMultipartUploader_FileNotFound_Error(t *testing.T) {
 		t.Error("Should not make any HTTP requests for missing file")
 	})
 
-	_, err := uploader.UploadFileInParallel(t.Context(), "/nonexistent/file.txt", 5, nil)
+	_, err := uploader.UploadFileInParallel(t.Context(), "/nonexistent/file.txt", 5)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to open file")
 }
@@ -849,7 +820,7 @@ func TestMultipartUploader_ConcurrentRetries_RaceCondition(t *testing.T) {
 	}
 
 	uploader := createTestMultipartUploader(t, handler, config)
-	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 20, nil) // High concurrency
+	_, err = uploader.UploadFileInParallel(t.Context(), testFile, 20) // High concurrency
 	require.NoError(t, err)
 
 	t.Logf("Total HTTP requests made: %d", totalRequests.Load())

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"hash"
 	"io"
 	"maps"
 	"net/http"
@@ -441,12 +440,6 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 		return ft, checksum, err
 	}
 
-	// Uncompressed uploads only hash when the caller asked for a checksum.
-	var hasher hash.Hash
-	if putOpts.Checksum {
-		hasher = sha256.New()
-	}
-
 	// If the file is too small, the overhead of writing in parallel isn't worth the effort.
 	// Write it in one shot instead.
 	if fileInfo.Size() < gcpMultipartUploadChunkSize {
@@ -474,11 +467,12 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 			zap.String("compression", "none"),
 		)
 
-		if hasher != nil {
-			hasher.Write(data)
+		var checksum [32]byte
+		if putOpts.Checksum {
+			checksum = sha256.Sum256(data)
 		}
 
-		return nil, sum256(hasher), e
+		return nil, checksum, e
 	}
 
 	uploader, err := NewMultipartUploaderWithRetryConfig(
@@ -495,7 +489,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 	}
 
 	start := time.Now()
-	count, err := uploader.UploadFileInParallel(ctx, path, maxConcurrency, hasher)
+	count, err := uploader.UploadFileInParallel(ctx, path, maxConcurrency)
 	if err != nil {
 		timer.Failure(ctx, count)
 
@@ -514,7 +508,7 @@ func (o *gcpObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 
 	timer.Success(ctx, count)
 
-	return nil, sum256(hasher), e
+	return nil, [32]byte{}, e
 }
 
 func (o *gcpObject) storeFileCompressed(ctx context.Context, localPath string, cfg CompressConfig, maxConcurrency int, putOpts PutOptions) (*FrameTable, [32]byte, error) {


### PR DESCRIPTION
Stream each multipart part body straight from the open file via a fresh `io.SectionReader` per attempt instead of allocating a 50 MB chunk per part. Drop per-part `Content-MD5` (final-object integrity is verified by GCS; TLS protects in-transit). Drop the sibling-goroutine SHA-256 in `UploadFileInParallel` — the compressed upload path already hashes the source while reading it, so the uncompressed multipart path no longer needs its own.

Inspired by #2570 (sectionReader pattern) and #2393 (drop per-part MD5).