### PR TITLE
chore: regen testutils sqlc models

### DIFF
--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -220,7 +220,6 @@ type User struct {
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	ID        uuid.UUID
-	Email     string
 }
 
 type UserIdentity struct {


### PR DESCRIPTION
Drops `users.email` from the generated `User` struct (the column was removed in #2781 but the generated test models were never refreshed). Output of `make generate` in `packages/db`.

Without this, `generated-code-check / run-check` auto-commits the same one-line change on every unrelated PR.