### PR TITLE
refactor(envd): deduplicate cgroup Freeze/Unfreeze and use writeCgroupProp

### DIFF
--- a/packages/envd/internal/services/cgroups/cgroup2.go
+++ b/packages/envd/internal/services/cgroups/cgroup2.go
@@ -151,21 +151,20 @@ func (c Cgroup2Manager) GetFileDescriptor(procType ProcessType) (int, bool) {
 }
 
 func (c Cgroup2Manager) Freeze(procType ProcessType) error {
-	path, ok := c.cgroupPaths[procType]
-	if !ok {
-		return fmt.Errorf("unknown process type: %s", procType)
-	}
-
-	return os.WriteFile(filepath.Join(path, "cgroup.freeze"), []byte("1"), 0o644)
+	return c.setFreezeState(procType, "1")
 }
 
 func (c Cgroup2Manager) Unfreeze(procType ProcessType) error {
+	return c.setFreezeState(procType, "0")
+}
+
+func (c Cgroup2Manager) setFreezeState(procType ProcessType, value string) error {
 	path, ok := c.cgroupPaths[procType]
 	if !ok {
 		return fmt.Errorf("unknown process type: %s", procType)
 	}
 
-	return os.WriteFile(filepath.Join(path, "cgroup.freeze"), []byte("0"), 0o644)
+	return os.WriteFile(filepath.Join(path, "cgroup.freeze"), []byte(value), 0o644)
 }
 
 func (c Cgroup2Manager) Close() error {

--- a/packages/envd/internal/services/cgroups/cgroup2.go
+++ b/packages/envd/internal/services/cgroups/cgroup2.go
@@ -164,7 +164,7 @@ func (c Cgroup2Manager) setFreezeState(procType ProcessType, value string) error
 		return fmt.Errorf("unknown process type: %s", procType)
 	}
 
-	return os.WriteFile(filepath.Join(path, "cgroup.freeze"), []byte(value), 0o644)
+	return writeCgroupProp(filepath.Join(path, "cgroup.freeze"), value)
 }
 
 func (c Cgroup2Manager) Close() error {

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.0"
+const Version = "0.6.1"


### PR DESCRIPTION
Deduplicate the Freeze and Unfreeze methods on Cgroup2Manager by extracting the shared path-lookup and cgroup.freeze write into a private setFreezeState(procType, value) helper. Also switches the freeze write from os.WriteFile to the existing writeCgroupProp helper, which uses O_WRONLY without O_CREATE for consistency with other cgroup property writes.