### PR TITLE
chore(mockery): bump to v3.7.0 and opt in to auto-generated sources

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,5 +1,7 @@
 packages:
   github.com/e2b-dev/infra/packages/envd/internal/services/spec/filesystem/filesystemconnect:
+    config:
+      include-auto-generated: true
     interfaces:
       FilesystemHandler:
         config:
@@ -8,6 +10,8 @@ packages:
           pkgname: filesystemconnectmocks
 
   github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator:
+    config:
+      include-auto-generated: true
     interfaces:
       ChunkServiceClient:
         config:

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@ bun 1.3.2
 gcloud 534.0.0
 go 1.26.3
 go:golang.org/x/tools/gopls 0.21.1
-go:github.com/vektra/mockery/v3 v3.5.0
+go:github.com/vektra/mockery/v3 v3.7.0
 golangci-lint 2.11.4
 packer 1.13.1
 protoc 29.3


### PR DESCRIPTION
Bumps mockery from v3.5.0 to v3.7.0 in .tool-versions.

v3.6.0 changed the default of `include-auto-generated` to `false` and fixed the detection of auto-generated files (matching the `// Code generated ... DO NOT EDIT` header). After the bump, `go generate` fails with `interface not found in source` for six interfaces, all of which live in protoc/connect-generated files:

  - FilesystemHandler in filesystem.connect.go
  - ChunkServiceClient, ChunkService_ReadAtBuildSeekable{Client,Server}, ChunkService_GetBuildBlob{Client,Server} in chunks_grpc.pb.go

Sets `include-auto-generated: true` on the two affected packages so mockery parses those generated files. Scoped per-package instead of top-level to avoid pulling unrelated generated interfaces into other packages' mock collections.