### PR TITLE
test: move tests into same package as production code

### DIFF
--- a/packages/api/internal/db/snapshots_test.go
+++ b/packages/api/internal/db/snapshots_test.go
@@ -1,4 +1,4 @@
-package db_test
+package db
 
 import (
 	"testing"
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	apidb "github.com/e2b-dev/infra/packages/api/internal/db"
 	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
@@ -119,7 +118,7 @@ func TestGetSnapshotWithBuilds_Success(t *testing.T) {
 	buildID2 := createTestEnvBuild(t, db, templateID)
 
 	// Execute GetSnapshotBuilds
-	result, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
+	result, err := GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
 	require.NoError(t, err, "GetSnapshotBuilds should succeed")
 
 	// Verify snapshot data
@@ -149,7 +148,7 @@ func TestGetSnapshotWithBuilds_NoAdditionalBuilds(t *testing.T) {
 	sandboxID, templateID, _ := createTestSnapshot(t, db, teamID, baseEnvID)
 
 	// Execute GetSnapshotBuilds (only the build created by UpsertSnapshot)
-	result, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
+	result, err := GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
 	require.NoError(t, err, "GetSnapshotBuilds should succeed")
 
 	// Verify snapshot data
@@ -171,11 +170,11 @@ func TestGetSnapshotWithBuilds_NotFound(t *testing.T) {
 	nonExistentSandboxID := "sandbox-does-not-exist"
 
 	// Execute GetSnapshotBuilds with non-existent sandbox ID
-	_, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, nonExistentSandboxID)
+	_, err := GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, nonExistentSandboxID)
 
 	// Verify error is returned
 	require.Error(t, err, "GetSnapshotBuilds should return an error")
-	assert.ErrorIs(t, err, apidb.ErrSnapshotNotFound, "Error should be ErrSnapshotNotFound")
+	assert.ErrorIs(t, err, ErrSnapshotNotFound, "Error should be ErrSnapshotNotFound")
 }
 
 func TestGetSnapshotWithBuilds_WrongTeamID(t *testing.T) {
@@ -192,11 +191,11 @@ func TestGetSnapshotWithBuilds_WrongTeamID(t *testing.T) {
 	differentTeamID := testutils.CreateTestTeam(t, db)
 
 	// Execute GetSnapshotBuilds with wrong team ID
-	_, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, differentTeamID, sandboxID)
+	_, err := GetSnapshotBuilds(t.Context(), db.SqlcClient, differentTeamID, sandboxID)
 
 	// Verify error is returned (snapshot exists but doesn't belong to this team)
 	require.Error(t, err, "GetSnapshotBuilds should return an error for wrong team")
-	assert.ErrorIs(t, err, apidb.ErrSnapshotNotFound, "Error should be ErrSnapshotNotFound")
+	assert.ErrorIs(t, err, ErrSnapshotNotFound, "Error should be ErrSnapshotNotFound")
 }
 
 func TestGetSnapshotWithBuilds_NoBuilds(t *testing.T) {
@@ -211,7 +210,7 @@ func TestGetSnapshotWithBuilds_NoBuilds(t *testing.T) {
 	deleteBuild(t, db, buildID)
 
 	// Execute GetSnapshotBuilds
-	result, err := apidb.GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
+	result, err := GetSnapshotBuilds(t.Context(), db.SqlcClient, teamID, sandboxID)
 	require.NoError(t, err, "GetSnapshotBuilds should succeed")
 	assert.Empty(t, result.Builds, "Should have 0 builds after deletion")
 }

--- a/packages/api/internal/orchestrator/nodemanager/node_test.go
+++ b/packages/api/internal/orchestrator/nodemanager/node_test.go
@@ -1,4 +1,4 @@
-package nodemanager_test
+package nodemanager
 
 import (
 	"testing"
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
-	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
@@ -26,11 +25,11 @@ func TestNode_OptimisticAdd_FlagEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. Initialize Node with the injected ffClient
-	node := nodemanager.NewTestNode("test-node", api.NodeStatusReady, 0, 4, nodemanager.WithFeatureFlags(ffClient))
+	node := NewTestNode("test-node", api.NodeStatusReady, 0, 4, WithFeatureFlags(ffClient))
 	initialMetrics := node.Metrics()
 
 	// 5. Call the method
-	res := nodemanager.SandboxResources{
+	res := SandboxResources{
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
@@ -56,11 +55,11 @@ func TestNode_OptimisticAdd_FlagDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. Initialize Node with the injected ffClient
-	node := nodemanager.NewTestNode("test-node", api.NodeStatusReady, 0, 4, nodemanager.WithFeatureFlags(ffClient))
+	node := NewTestNode("test-node", api.NodeStatusReady, 0, 4, WithFeatureFlags(ffClient))
 	initialMetrics := node.Metrics()
 
 	// 5. Call the method
-	res := nodemanager.SandboxResources{
+	res := SandboxResources{
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
@@ -86,11 +85,11 @@ func TestNode_OptimisticRemove_FlagEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. Initialize Node with the injected ffClient - some resources are already allocated at initialization
-	node := nodemanager.NewTestNode("test-node", api.NodeStatusReady, 4, 8192, nodemanager.WithFeatureFlags(ffClient))
+	node := NewTestNode("test-node", api.NodeStatusReady, 4, 8192, WithFeatureFlags(ffClient))
 	initialMetrics := node.Metrics()
 
 	// 5. Call the method
-	res := nodemanager.SandboxResources{
+	res := SandboxResources{
 		CPUs:      2,
 		MiBMemory: 1024,
 	}
@@ -116,11 +115,11 @@ func TestNode_OptimisticRemove_FlagDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// 4. Initialize Node with the injected ffClient - some resources are already allocated at initialization
-	node := nodemanager.NewTestNode("test-node", api.NodeStatusReady, 4, 8192, nodemanager.WithFeatureFlags(ffClient))
+	node := NewTestNode("test-node", api.NodeStatusReady, 4, 8192, WithFeatureFlags(ffClient))
 	initialMetrics := node.Metrics()
 
 	// 5. Call the method
-	res := nodemanager.SandboxResources{
+	res := SandboxResources{
 		CPUs:      2,
 		MiBMemory: 1024,
 	}

--- a/packages/shared/pkg/middleware/otel/joined/joined_test.go
+++ b/packages/shared/pkg/middleware/otel/joined/joined_test.go
@@ -1,26 +1,24 @@
-package joined_test
+package joined
 
 import (
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/middleware/otel/joined"
 )
 
 // Mark must be safe even when the context carries no holder.
 func TestMark_NoHolder_Noop(t *testing.T) {
 	t.Parallel()
-	joined.Mark(context.Background())
+	Mark(context.Background())
 }
 
 // Attribute must return request.joined=false when no holder is on ctx.
 func TestAttribute_NoHolder_ReturnsFalse(t *testing.T) {
 	t.Parallel()
 
-	a := joined.Attribute(context.Background())
-	assert.Equal(t, joined.AttributeKey, string(a.Key))
+	a := Attribute(context.Background())
+	assert.Equal(t, AttributeKey, string(a.Key))
 	assert.False(t, a.Value.AsBool())
 }
 
@@ -29,9 +27,9 @@ func TestAttribute_NoHolder_ReturnsFalse(t *testing.T) {
 func TestAttribute_FreshHolder_ReturnsFalse(t *testing.T) {
 	t.Parallel()
 
-	ctx := joined.WithHolder(context.Background())
+	ctx := WithHolder(context.Background())
 
-	a := joined.Attribute(ctx)
+	a := Attribute(ctx)
 	assert.False(t, a.Value.AsBool())
 }
 
@@ -39,10 +37,10 @@ func TestAttribute_FreshHolder_ReturnsFalse(t *testing.T) {
 func TestMark_FlipsAttributeToTrue(t *testing.T) {
 	t.Parallel()
 
-	ctx := joined.WithHolder(context.Background())
-	joined.Mark(ctx)
+	ctx := WithHolder(context.Background())
+	Mark(ctx)
 
-	a := joined.Attribute(ctx)
+	a := Attribute(ctx)
 	assert.True(t, a.Value.AsBool())
 }
 
@@ -52,12 +50,12 @@ func TestMark_FlipsAttributeToTrue(t *testing.T) {
 func TestWithHolder_Idempotent(t *testing.T) {
 	t.Parallel()
 
-	ctx1 := joined.WithHolder(context.Background())
-	ctx2 := joined.WithHolder(ctx1)
+	ctx1 := WithHolder(context.Background())
+	ctx2 := WithHolder(ctx1)
 
-	joined.Mark(ctx1)
+	Mark(ctx1)
 
-	a := joined.Attribute(ctx2)
+	a := Attribute(ctx2)
 	assert.True(t, a.Value.AsBool(), "second WithHolder must reuse the first holder")
 }
 
@@ -66,14 +64,14 @@ func TestWithHolder_Idempotent(t *testing.T) {
 func TestMark_DescendantGoroutine(t *testing.T) {
 	t.Parallel()
 
-	ctx := joined.WithHolder(context.Background())
+	ctx := WithHolder(context.Background())
 	done := make(chan struct{})
 	go func() {
-		joined.Mark(ctx)
+		Mark(ctx)
 		close(done)
 	}()
 	<-done
 
-	a := joined.Attribute(ctx)
+	a := Attribute(ctx)
 	assert.True(t, a.Value.AsBool())
 }

--- a/packages/shared/pkg/telemetry/pprof_test.go
+++ b/packages/shared/pkg/telemetry/pprof_test.go
@@ -1,4 +1,4 @@
-package telemetry_test
+package telemetry
 
 import (
 	"net/http"
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
 func TestDefaultServeMuxBlocksPprofPaths(t *testing.T) {
@@ -63,7 +61,7 @@ func TestDefaultServeMuxPassesThroughNonPprofPaths(t *testing.T) {
 func TestDedicatedPprofMuxServes(t *testing.T) {
 	t.Parallel()
 
-	mux := telemetry.NewPprofMux()
+	mux := NewPprofMux()
 
 	paths := []string{
 		"/debug/pprof/",


### PR DESCRIPTION
Convert package X_test → package X for snapshots_test.go, node_test.go, joined_test.go, and pprof_test.go. Drops the self-imports and strips package qualifiers from referenced symbols. Aligns these files with the repo convention of co-locating tests with the code they exercise.