### PR TITLE
test(nbd): move path_direct tests into package nbd, break import cycle

### DIFF
--- a/packages/orchestrator/cmd/mount-build-rootfs/main.go
+++ b/packages/orchestrator/cmd/mount-build-rootfs/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/cmd/internal/cmdutil"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -118,7 +119,7 @@ func runEmpty(ctx, nbdContext context.Context, featureFlags *featureflags.Client
 	overlay := block.NewOverlay(emptyDevice, cache)
 	defer overlay.Close()
 
-	devicePath, deviceCleanup, err := testutils.GetNBDDevice(nbdContext, testutils.NewLoggerOverlay(overlay), featureFlags)
+	devicePath, deviceCleanup, err := nbd.GetNBDDevice(nbdContext, testutils.NewLoggerOverlay(overlay), featureFlags)
 	defer deviceCleanup.Run(ctx, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to get nbd device: %w", err)
@@ -159,7 +160,7 @@ func run(ctx, nbdContext context.Context, featureFlags *featureflags.Client, bui
 	overlay := block.NewOverlay(rootfs, cache)
 	defer overlay.Close()
 
-	devicePath, deviceCleanup, err := testutils.GetNBDDevice(nbdContext, overlay, featureFlags)
+	devicePath, deviceCleanup, err := nbd.GetNBDDevice(nbdContext, overlay, featureFlags)
 	defer deviceCleanup.Run(ctx, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to get nbd device: %w", err)
@@ -175,7 +176,7 @@ func run(ctx, nbdContext context.Context, featureFlags *featureflags.Client, bui
 
 		fmt.Fprintf(os.Stdout, "creating mount path directory: %s\n", mountPath)
 
-		mountCleanup, err := testutils.MountNBDDevice(devicePath, mountPath)
+		mountCleanup, err := nbd.MountNBDDevice(devicePath, mountPath)
 		defer mountCleanup.Run(ctx, 30*time.Second)
 		if err != nil {
 			return fmt.Errorf("failed to mount device to mount path: %w", err)

--- a/packages/orchestrator/pkg/sandbox/nbd/devicehelper.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/devicehelper.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package testutils
+package nbd
 
 import (
 	"context"
@@ -8,14 +8,18 @@ import (
 	"os"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
-	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 )
 
-func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *featureflags.Client, mountOpts ...nbd.MountOption) (nbd.DevicePath, *Cleaner, error) {
-	var cleaner Cleaner
+// GetNBDDevice provisions a one-shot device pool, opens a direct-path mount
+// against the supplied backend, and returns the resulting device path along
+// with a Cleaner that tears everything down. Intended for the mount-build-rootfs
+// debug utility and package tests.
+func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *featureflags.Client, mountOpts ...MountOption) (DevicePath, *testutils.Cleaner, error) {
+	var cleaner testutils.Cleaner
 
-	devicePool, err := nbd.NewDevicePool(64)
+	devicePool, err := NewDevicePool(64)
 	if err != nil {
 		return "", &cleaner, fmt.Errorf("failed to create device pool: %w", err)
 	}
@@ -46,7 +50,7 @@ func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *featu
 		close(poolClosed)
 	}()
 
-	mnt := nbd.NewDirectPathMount(backend, devicePool, featureFlags, mountOpts...)
+	mnt := NewDirectPathMount(backend, devicePool, featureFlags, mountOpts...)
 
 	mntIndex, err := mnt.Open(ctx)
 	if err != nil {
@@ -62,5 +66,5 @@ func GetNBDDevice(ctx context.Context, backend block.Device, featureFlags *featu
 		return nil
 	})
 
-	return nbd.GetDevicePath(mntIndex), &cleaner, nil
+	return GetDevicePath(mntIndex), &cleaner, nil
 }

--- a/packages/orchestrator/pkg/sandbox/nbd/mounthelper.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/mounthelper.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package testutils
+package nbd
 
 import (
 	"context"
@@ -10,11 +10,14 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd/testutils"
 )
 
-func MountNBDDevice(device nbd.DevicePath, mountPath string) (*Cleaner, error) {
-	var cleaner Cleaner
+// MountNBDDevice mounts the supplied nbd device path as ext4 at mountPath and
+// returns a Cleaner that unmounts it. Intended for the mount-build-rootfs
+// debug utility and package tests.
+func MountNBDDevice(device DevicePath, mountPath string) (*testutils.Cleaner, error) {
+	var cleaner testutils.Cleaner
 
 	err := unix.Mount(device, mountPath, "ext4", 0, "")
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_slow_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package nbd_test
+package nbd
 
 import (
 	"context"
@@ -14,26 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
-	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
-// SlowDevice wraps a ReadonlyDevice and adds a configurable delay to every
+// slowDevice wraps a ReadonlyDevice and adds a configurable delay to every
 // ReadAt call. Used to simulate slow GCS/NFS backends in tests.
-type SlowDevice struct {
+type slowDevice struct {
 	inner     block.ReadonlyDevice
 	readDelay time.Duration
 }
 
-var _ block.ReadonlyDevice = (*SlowDevice)(nil)
+var _ block.ReadonlyDevice = (*slowDevice)(nil)
 
-func NewSlowDevice(inner block.ReadonlyDevice, readDelay time.Duration) *SlowDevice {
-	return &SlowDevice{inner: inner, readDelay: readDelay}
+func newSlowDevice(inner block.ReadonlyDevice, readDelay time.Duration) *slowDevice {
+	return &slowDevice{inner: inner, readDelay: readDelay}
 }
 
-func (s *SlowDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+func (s *slowDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	select {
 	case <-time.After(s.readDelay):
 	case <-ctx.Done():
@@ -43,27 +42,27 @@ func (s *SlowDevice) ReadAt(ctx context.Context, p []byte, off int64) (int, erro
 	return s.inner.ReadAt(ctx, p, off)
 }
 
-func (s *SlowDevice) Size(ctx context.Context) (int64, error) {
+func (s *slowDevice) Size(ctx context.Context) (int64, error) {
 	return s.inner.Size(ctx)
 }
 
-func (s *SlowDevice) BlockSize() int64 {
+func (s *slowDevice) BlockSize() int64 {
 	return s.inner.BlockSize()
 }
 
-func (s *SlowDevice) Slice(ctx context.Context, off, length int64) ([]byte, error) {
+func (s *slowDevice) Slice(ctx context.Context, off, length int64) ([]byte, error) {
 	return s.inner.Slice(ctx, off, length)
 }
 
-func (s *SlowDevice) Header() *header.Header {
+func (s *slowDevice) Header() *header.Header {
 	return s.inner.Header()
 }
 
-func (s *SlowDevice) SwapHeader(h *header.Header) {
+func (s *slowDevice) SwapHeader(h *header.Header) {
 	s.inner.SwapHeader(h)
 }
 
-func (s *SlowDevice) Close() error {
+func (s *slowDevice) Close() error {
 	return s.inner.Close()
 }
 
@@ -89,7 +88,7 @@ func TestSlowBackend_ShortTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Backend delays every read by 8 seconds — longer than the kernel timeout below.
-	slowDevice := NewSlowDevice(emptyDevice, 8*time.Second)
+	slow := newSlowDevice(emptyDevice, 8*time.Second)
 
 	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-timeout-%s", uuid.New().String()))
 	t.Cleanup(func() { os.RemoveAll(cowCachePath) })
@@ -97,16 +96,16 @@ func TestSlowBackend_ShortTimeout(t *testing.T) {
 	cache, err := block.NewCache(size, blockSize, cowCachePath, false)
 	require.NoError(t, err)
 
-	overlay := block.NewOverlay(slowDevice, cache)
+	overlay := block.NewOverlay(slow, cache)
 	t.Cleanup(func() { overlay.Close() })
 
 	// Kernel I/O timeout of 5s + deadconn 5s = 10s total.
 	// The 8s backend delay exceeds the 5s I/O timeout, so the kernel
 	// will declare the connection dead and return EIO.
-	devicePath, cleanup, err := testutils.GetNBDDevice(
+	devicePath, cleanup, err := GetNBDDevice(
 		t.Context(), overlay, featureFlags,
-		nbd.WithIOTimeout(5*time.Second),
-		nbd.WithDeadconnTimeout(5*time.Second),
+		WithIOTimeout(5*time.Second),
+		WithDeadconnTimeout(5*time.Second),
 	)
 	t.Cleanup(func() { cleanup.Run(t.Context(), 30*time.Second) })
 	require.NoError(t, err)
@@ -142,7 +141,7 @@ func TestSlowBackend_SufficientTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Backend delays every read by 3 seconds.
-	slowDevice := NewSlowDevice(emptyDevice, 3*time.Second)
+	slow := newSlowDevice(emptyDevice, 3*time.Second)
 
 	cowCachePath := filepath.Join(os.TempDir(), fmt.Sprintf("test-slow-ok-%s", uuid.New().String()))
 	t.Cleanup(func() { os.RemoveAll(cowCachePath) })
@@ -150,14 +149,14 @@ func TestSlowBackend_SufficientTimeout(t *testing.T) {
 	cache, err := block.NewCache(size, blockSize, cowCachePath, false)
 	require.NoError(t, err)
 
-	overlay := block.NewOverlay(slowDevice, cache)
+	overlay := block.NewOverlay(slow, cache)
 	t.Cleanup(func() { overlay.Close() })
 
 	// Kernel I/O timeout of 30s — well above the 3s backend delay.
-	devicePath, cleanup, err := testutils.GetNBDDevice(
+	devicePath, cleanup, err := GetNBDDevice(
 		t.Context(), overlay, featureFlags,
-		nbd.WithIOTimeout(30*time.Second),
-		nbd.WithDeadconnTimeout(30*time.Second),
+		WithIOTimeout(30*time.Second),
+		WithDeadconnTimeout(30*time.Second),
 	)
 	t.Cleanup(func() { cleanup.Run(t.Context(), 30*time.Second) })
 	require.NoError(t, err)

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package nbd_test
+package nbd
 
 import (
 	"crypto/rand"
@@ -268,7 +268,7 @@ func setupNBDDevice(t *testing.T, featureFlags *featureflags.Client, size int64,
 		overlay.Close()
 	})
 
-	devicePath, deviceCleanup, err := testutils.GetNBDDevice(t.Context(), overlay, featureFlags)
+	devicePath, deviceCleanup, err := GetNBDDevice(t.Context(), overlay, featureFlags)
 	t.Cleanup(func() {
 		deviceCleanup.Run(t.Context(), 30*time.Second)
 	})


### PR DESCRIPTION
Move path_direct_test.go and path_direct_slow_test.go from package nbd_test to package nbd so tests live with the code they exercise, matching the convention applied to the rest of the repo.

This required breaking an import cycle. nbd/testutils previously hosted GetNBDDevice and MountNBDDevice, which in turn imported nbd (for NewDevicePool, NewDirectPathMount, MountOption, DevicePath, GetDevicePath). That was fine while the tests lived in package nbd_test because nbd_test is a distinct compilation unit:

  nbd_test → nbd/testutils → nbd     (chain, not a cycle)

Once the tests move into package nbd, the chain collapses:

  nbd (incl. _test.go) → nbd/testutils → nbd     (CYCLE)

To break the back-edge from nbd/testutils to nbd, move every helper in nbd/testutils that imports nbd into package nbd itself:

  - nbd/testutils/nbd_device.go → nbd/devicehelper.go (GetNBDDevice)
  - nbd/testutils/mount.go      → nbd/mounthelper.go  (MountNBDDevice)

After the move, nbd/testutils no longer imports nbd, and the only arrow is nbd → nbd/testutils (for the generic Cleaner type, which is also used by non-nbd helpers in testutils such as TemplateRootfs). slowDevice in path_direct_slow_test.go is lowercased so it does not widen the public API.

The trade-off: GetNBDDevice and MountNBDDevice are now exported from package nbd. They cannot live in a _test.go file because they have a real non-test consumer in cmd/mount-build-rootfs, which is updated to import both packages with the new qualifiers.

Rule going forward: do not re-introduce an import of nbd from nbd/testutils. New nbd-test helpers that need nbd belong in package nbd; helpers that do not need nbd belong in nbd/testutils.