### PR TITLE
fix(compression): correctness findings from compression audit

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -148,7 +148,7 @@ runs:
         ./scripts/start-service.sh "Orchestrator" packages/orchestrator run-debug ~/logs/orchestrator.log http://localhost:5008/health
 
         echo "Start API"
-        ./scripts/start-service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
+        STARTUP_TIMEOUT=60 ./scripts/start-service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
 
         # Start client-proxy (needed for auto-resume tests)
         ./scripts/start-service.sh "ClientProxy" packages/client-proxy run ~/logs/client-proxy.log http://localhost:3003

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -342,6 +342,10 @@ func (c *Cache) WriteAtWithoutLock(b []byte, off int64) (int, error) {
 		return 0, nil
 	}
 
+	if int64(len(b))%c.blockSize != 0 || off%c.blockSize != 0 {
+		return 0, fmt.Errorf("misaligned write: len=%d off=%d block=%d", len(b), off, c.blockSize)
+	}
+
 	end := min(off+int64(len(b)), c.size)
 	if end <= off {
 		return 0, nil

--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -159,9 +160,8 @@ func (b *File) Slice(ctx context.Context, off, _ int64) ([]byte, error) {
 
 // retryOnTransition catches a PeerTransitionedError and swaps the header from
 // storage. Returns (true, nil) to signal the caller should continue the loop,
-// or (false, swapErr) if the swap itself failed. peerSeekable emits the
-// transition error at most once per seekable, so the loop is naturally
-// bounded — no retry counter needed here.
+// or (false, swapErr) if the swap itself failed. RetryAfter backs off repeated
+// post-transition storage 404s.
 //
 // The transition is signaled only after the source upload has finalized, so
 // the header object already exists in storage. A single LoadHeader is enough;
@@ -170,6 +170,16 @@ func (b *File) retryOnTransition(ctx context.Context, err error) (bool, error) {
 	var transErr *storage.PeerTransitionedError
 	if !errors.As(err, &transErr) {
 		return false, nil
+	}
+	if transErr.RetryAfter > 0 {
+		timer := time.NewTimer(transErr.RetryAfter)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
 	}
 
 	logger.L().Info(ctx, "peer transition detected, swapping header",

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/seekable.go
@@ -7,12 +7,18 @@ import (
 	"io"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+const (
+	postTransitionRetryWindow = 30 * time.Second
+	postTransitionRetryDelay  = 250 * time.Millisecond
 )
 
 var _ storage.Seekable = (*peerSeekable)(nil)
@@ -33,13 +39,11 @@ type peerSeekable struct {
 	baseCT storage.CompressionType
 	loaded bool
 
-	// transitionEmitted ensures we signal PeerTransitionedError at most once
-	// after the peer flips uploaded=true. The caller (build.File) reacts by
-	// loading the post-upload header from storage; whether that ends up V4
-	// (compressed) or V3 (no upgrade) determines how subsequent reads route.
-	// Either way, after the first emission we fall through to base so V3
-	// builds don't loop forever against PeerTransitionedError.
-	transitionEmitted atomic.Bool
+	// transitionAt is set on first PeerTransitionedError emission after
+	// uploaded flips to true; nil otherwise. Subsequent base 404s within
+	// postTransitionRetryWindow re-emit PeerTransitionedError so concurrent
+	// readers retry against the post-upload header.
+	transitionAt atomic.Pointer[time.Time]
 }
 
 // getBase returns a base Seekable opened against the storage path composed
@@ -126,8 +130,11 @@ func (s *peerSeekable) OpenRangeReader(ctx context.Context, off int64, length in
 		return res.value, err
 	}
 
-	if s.uploaded != nil && s.uploaded.Load() && s.transitionEmitted.CompareAndSwap(false, true) {
-		return nil, &storage.PeerTransitionedError{}
+	if s.uploaded != nil && s.uploaded.Load() {
+		now := time.Now()
+		if s.transitionAt.CompareAndSwap(nil, &now) {
+			return nil, &storage.PeerTransitionedError{}
+		}
 	}
 
 	base, err := s.getBase(ctx, frameTable.CompressionType())
@@ -135,7 +142,16 @@ func (s *peerSeekable) OpenRangeReader(ctx context.Context, off int64, length in
 		return nil, err
 	}
 
-	return base.OpenRangeReader(ctx, off, length, frameTable)
+	rc, err := base.OpenRangeReader(ctx, off, length, frameTable)
+	// GCS can briefly 404 a just-finalized object; within the retry window
+	// re-emit so build.File reloads the header and retries with backoff.
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		if at := s.transitionAt.Load(); at != nil && time.Since(*at) < postTransitionRetryWindow {
+			return nil, &storage.PeerTransitionedError{RetryAfter: postTransitionRetryDelay}
+		}
+	}
+
+	return rc, err
 }
 
 func (s *peerSeekable) StoreFile(context.Context, string, ...storage.PutOption) (*storage.FrameTable, [32]byte, error) {

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -3,6 +3,7 @@ package header
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -19,6 +20,8 @@ const v4SizePrefixLen = 4
 
 // v4FlagsLen is the length of the V4 flags byte. Bit 0 = IncompletePendingUpload.
 const v4FlagsLen = 1
+
+const v4MaxUncompressedHeaderSize = 64 << 20
 
 // v4FlagIncomplete is bit 0 of the V4 flags byte: when set, the header
 // describes a build whose upload has not yet finalized (an in-flight diff).
@@ -130,10 +133,17 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 	}
 
 	flags := blockData[0]
+	size := binary.LittleEndian.Uint32(blockData[v4FlagsLen:])
+	if size > v4MaxUncompressedHeaderSize {
+		return nil, fmt.Errorf("v4 header uncompressed size %d exceeds cap %d", size, v4MaxUncompressedHeaderSize)
+	}
 
-	decompressed, err := decompressLZ4(blockData[v4FlagsLen+v4SizePrefixLen:])
+	decompressed, err := decompressLZ4(blockData[v4FlagsLen+v4SizePrefixLen:], int(size))
 	if err != nil {
 		return nil, fmt.Errorf("failed to LZ4-decompress v4 header block: %w", err)
+	}
+	if len(decompressed) != int(size) {
+		return nil, fmt.Errorf("v4 header decompressed size %d != prefix %d", len(decompressed), size)
 	}
 
 	reader := bytes.NewReader(decompressed)
@@ -242,14 +252,15 @@ func extractRelevantRanges(mappings []BuildMap) map[uuid.UUID][]storage.Range {
 	return ranges
 }
 
-// decompressLZ4 decompresses an LZ4 frame from V4 header data.
-func decompressLZ4(src []byte) ([]byte, error) {
+// decompressLZ4 reads up to expected+1 bytes; deserializeV4 rejects any
+// overrun. Bound defends against LZ4's ~255x expansion on malformed input.
+func decompressLZ4(src []byte, expected int) ([]byte, error) {
 	r := lz4.NewReader(bytes.NewReader(src))
 
-	data, err := io.ReadAll(r)
-	if err != nil {
+	buf := bytes.NewBuffer(make([]byte, 0, expected))
+	if _, err := io.CopyN(buf, r, int64(expected)+1); err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("lz4 decompress: %w", err)
 	}
 
-	return data, nil
+	return buf.Bytes(), nil
 }

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -185,7 +185,9 @@ func UploadBlob(ctx context.Context, provider StorageProvider, remotePath string
 // PeerTransitionedError is returned by the peer Seekable when the remote
 // storage upload has completed; the caller should re-load the V4 header from
 // storage.
-type PeerTransitionedError struct{}
+type PeerTransitionedError struct {
+	RetryAfter time.Duration
+}
 
 func (e *PeerTransitionedError) Error() string {
 	return "peer upload completed, reload header from storage"

--- a/packages/shared/pkg/storage/storage_cache_seekable_compressed.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_compressed.go
@@ -29,23 +29,34 @@ func (c *cachedSeekable) openReaderCompressed(ctx context.Context, offsetU int64
 
 	timer := cacheSlabReadTimerFactory.Begin(compressedCacheReadAttrs...)
 
-	// Cache hit: open compressed frame from NFS and wrap with decompressor.
-	f, err := os.Open(path)
+	// Cache hit: open compressed frame from NFS, validate size, wrap with decompressor.
+	if f, err := os.Open(path); err == nil {
+		fi, statErr := f.Stat()
+		switch {
+		case statErr == nil && fi.Size() == int64(r.Length):
+			recordCacheRead(ctx, true, int64(r.Length), cacheTypeSeekable, cacheOpOpenRangeReader)
+			timer.Success(ctx, int64(r.Length))
 
-	switch {
-	case err == nil:
-		recordCacheRead(ctx, true, int64(r.Length), cacheTypeSeekable, cacheOpOpenRangeReader)
-		timer.Success(ctx, int64(r.Length))
+			decompressed, err := newDecompressingReadCloser(f, frameTable.CompressionType())
+			if err != nil {
+				f.Close()
 
-		decompressed, err := newDecompressingReadCloser(f, frameTable.CompressionType())
-		if err != nil {
+				return nil, fmt.Errorf("decompress cached frame: %w", err)
+			}
+
+			return withNFSGauge(ctx, decompressed), nil
+		case statErr == nil:
+			// Confirmed size mismatch: drop the file so the miss path rewrites it.
 			f.Close()
-
-			return nil, fmt.Errorf("decompress cached frame: %w", err)
+			_ = os.Remove(path)
+			recordCacheReadError(ctx, cacheTypeSeekable, cacheOpOpenRangeReader,
+				fmt.Errorf("cached frame %s size %d != expected %d", path, fi.Size(), r.Length))
+		default:
+			// Transient stat error: leave the file in place, fall through to miss.
+			f.Close()
+			recordCacheReadError(ctx, cacheTypeSeekable, cacheOpOpenRangeReader, statErr)
 		}
-
-		return withNFSGauge(ctx, decompressed), nil
-	case !os.IsNotExist(err):
+	} else if !os.IsNotExist(err) {
 		recordCacheReadError(ctx, cacheTypeSeekable, cacheOpOpenRangeReader, err)
 	}
 

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -265,27 +265,57 @@ func (o *gcpObject) Size(ctx context.Context) (int64, error) {
 }
 
 func (o *gcpObject) openRangeReader(ctx context.Context, off, length int64) (io.ReadCloser, error) {
-	ctx, cancel := context.WithTimeout(ctx, googleReadTimeout)
+	readCtx, cancel := context.WithCancel(ctx)
 
-	reader, err := o.handle.NewRangeReader(ctx, off, length)
+	openTimer := time.AfterFunc(googleReadTimeout, cancel)
+	reader, err := o.handle.NewRangeReader(readCtx, off, length)
+	// Stop returning false means the timer fired and cancel was/is being called,
+	// so readCtx is cancelled and reader (if any) is unusable.
+	if !openTimer.Stop() && err == nil {
+		reader.Close()
+		err = context.DeadlineExceeded
+	}
 	if err != nil {
 		cancel()
+
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, fmt.Errorf("failed to create GCS range reader for %q at %d+%d: %w", o.path, off, length, ErrObjectNotExist)
+		}
 
 		return nil, fmt.Errorf("failed to create GCS range reader for %q at %d+%d: %w", o.path, off, length, err)
 	}
 
-	return &cancelOnCloseReader{ReadCloser: reader, cancel: cancel}, nil
+	return &idleTimeoutReader{
+		ReadCloser: reader,
+		cancel:     cancel,
+		timer:      time.AfterFunc(googleReadTimeout, cancel),
+	}, nil
 }
 
-// cancelOnCloseReader wraps a ReadCloser and calls a CancelFunc on Close,
-// ensuring the context used to create the reader is cleaned up.
-type cancelOnCloseReader struct {
+// idleTimeoutReader fires cancel() after googleReadTimeout with no Read
+// activity (in-flight Read with no progress, or no Read called).
+type idleTimeoutReader struct {
 	io.ReadCloser
 
 	cancel context.CancelFunc
+	timer  *time.Timer
 }
 
-func (r *cancelOnCloseReader) Close() error {
+func (r *idleTimeoutReader) Read(p []byte) (int, error) {
+	r.timer.Reset(googleReadTimeout)
+
+	n, err := r.ReadCloser.Read(p)
+	if err != nil {
+		r.timer.Stop()
+	} else {
+		r.timer.Reset(googleReadTimeout)
+	}
+
+	return n, err
+}
+
+func (r *idleTimeoutReader) Close() error {
+	r.timer.Stop()
 	defer r.cancel()
 
 	return r.ReadCloser.Close()


### PR DESCRIPTION
Compression-audit correctness fixes:

- reject misaligned writes in `Cache.WriteAtWithoutLock`
- cap V4 header LZ4 decompression at the size prefix
- drop corrupt compressed cache entries on size mismatch
- retry GCS 404 within a post-transition window with backoff
- per-Read idle timeout on GCS range reads