### PR TITLE
perf(compression): pool zstd src/dst buffers in stream upload

### DIFF
--- a/packages/shared/pkg/storage/compress_encode.go
+++ b/packages/shared/pkg/storage/compress_encode.go
@@ -43,8 +43,33 @@ type zstdCompressor struct {
 	enc *zstd.Encoder
 }
 
+// dstBufPool holds frame-sized scratch buffers reused for zstd EncodeAll dst.
+// Caller recycles via putDstBuf after the part upload completes.
+var dstBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0)
+		return &b
+	},
+}
+
+func getDstBuf(want int) []byte {
+	b := dstBufPool.Get().(*[]byte)
+	if cap(*b) < want {
+		*b = make([]byte, 0, want)
+	}
+	return (*b)[:0]
+}
+
+func putDstBuf(b []byte) {
+	if cap(b) == 0 {
+		return
+	}
+	b = b[:0]
+	dstBufPool.Put(&b)
+}
+
 func (z *zstdCompressor) compress(src []byte) ([]byte, error) { //nolint:unparam // satisfies compressor interface
-	return z.enc.EncodeAll(src, make([]byte, 0, len(src))), nil
+	return z.enc.EncodeAll(src, getDstBuf(len(src))), nil
 }
 
 // newCompressorPool returns a pool of compressors for the given config.

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -83,16 +83,37 @@ func newPart(index int, parentCtx context.Context, workers int) (*part, context.
 	return p, ctx
 }
 
-func (p *part) addFrame(ctx context.Context, uncompressedData []byte, pool *sync.Pool) {
-	frameInPart := &frame{uncompressedSize: len(uncompressedData)}
+// srcBufPool holds frame-sized scratch buffers reused as the readLoop's
+// per-frame source. Recycled inside addFrame's goroutine once the
+// compressor has consumed the bytes.
+var srcBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0)
+		return &b
+	},
+}
+
+func getSrcBuf(size int) *[]byte {
+	b := srcBufPool.Get().(*[]byte)
+	if cap(*b) < size {
+		*b = make([]byte, size)
+	} else {
+		*b = (*b)[:size]
+	}
+	return b
+}
+
+func (p *part) addFrame(ctx context.Context, src *[]byte, validLen int, pool *sync.Pool) {
+	frameInPart := &frame{uncompressedSize: validLen}
 	p.frames = append(p.frames, frameInPart)
 
 	p.compress.Go(func() error {
+		defer srcBufPool.Put(src)
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		c := pool.Get().(compressor)
-		out, err := c.compress(uncompressedData)
+		out, err := c.compress((*src)[:validLen])
 		pool.Put(c)
 		if err != nil {
 			return err
@@ -194,17 +215,20 @@ func readLoop(ctx context.Context, in io.Reader, cfg CompressConfig, hasher io.W
 			return err
 		}
 
-		buf := make([]byte, frameSize)
-		n, err := io.ReadFull(in, buf)
+		buf := getSrcBuf(frameSize)
+		n, err := io.ReadFull(in, *buf)
 
 		eof := errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)
 		if err != nil && !eof {
+			srcBufPool.Put(buf)
 			return fmt.Errorf("read frame: %w", err)
 		}
 
 		if n > 0 {
-			hasher.Write(buf[:n])
-			p.addFrame(compressCtx, buf[:n], compressors)
+			hasher.Write((*buf)[:n])
+			p.addFrame(compressCtx, buf, n, compressors)
+		} else {
+			srcBufPool.Put(buf)
 		}
 
 		if eof {

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -148,8 +148,14 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 		}
 
 		pi := p.index
+		frames := p.frames
 		work.Go(func() error {
-			return uploader.UploadPart(workCtx, pi, compressed...)
+			err := uploader.UploadPart(workCtx, pi, compressed...)
+			for _, f := range frames {
+				putDstBuf(f.compressed)
+				f.compressed = nil
+			}
+			return err
 		})
 	}
 


### PR DESCRIPTION
Pulls the two pool fixes out of #2803 so the correctness PR can land independently.

- **B6 / O2** Pool the zstd `EncodeAll` dst buffer; recycle in the part-upload completion goroutine. Audit pprof had it at ~40% of total alloc bytes and ~3% of CPU.
- **O4** Pool the readLoop per-frame source buffer (~32% of total alloc bytes). `addFrame` now takes a `*[]byte` + valid length and recycles via `defer` once the compressor has consumed it.

Local bench (M1 Pro, `BenchmarkCompress/w4_unlimited`, `-benchtime=2s`):
- B/op drops from ~810 MB to ~279 MB (-66%)
- throughput rises from ~750 MB/s to ~843 MB/s (+13%)

Race tests on the full storage package pass.

Independent of the other compression-audit fixes; can land before or after #2803.

---

### How much further could the pipeline copy be reduced (analysis, not in scope here)

Tracing the full upload path with these fixes applied:

```
file → srcBuf  →  zstd.EncodeAll(src, dst)  →  dstBuf
                                                  ↓
                                     bytes.NewReader(dst)        no copy (slice wrapper)
                                     io.MultiReader(...)         no copy (reader wrapper)
                                     retryablehttp.ReaderFunc    no copy (replays bytes.Reader)
                                                  ↓
                                     net/http transport          1 copy: bytes.Reader.Read → write buf
                                                  ↓
                                     crypto/tls record encrypt   1 copy, runtime
                                                  ↓
                                     kernel copy_from_user       1 copy, kernel
```

`uploadPartSlices` already does the right thing — `bytes.NewReader` + `io.MultiReader` are pure wrappers around our `dstBuf` slices, MD5 is computed in place over each slice, and `retryablehttp.ReaderFunc` is replayed on retry without buffering. So no extra copy occurs between `dstBuf` and the http body.

What's left, and whether it's recoverable:

1. **`io.ReadFull(in, *buf)` in `readLoop`** (kernel page cache → srcBuf). Recoverable via mmap of the source file and passing mmap'd slices into `addFrame`. Bounded gain: at ~50 GB/s memcpy ceiling, ~80 ms on a 4 GiB memfile vs ~3 s of zstd cost at workers=4. Plus extra lifetime/munmap plumbing (mmap regions can't go in `sync.Pool`). Not worth it given current zstd-bound numbers.
2. **`zstd.EncodeAll` src → dst**. This is the compression itself, not a "copy". The streaming alternative `zstd.Writer` could pipe directly into an `io.Pipe` reader serving as the HTTP body, eliminating `dstBuf`, **but**:
   - a multipart part contains multiple frames concatenated, and frame workers finish out of order;
   - to stream you'd either serialize frame compression per part (kills `frameEncodeWorkers` parallelism, ~4× slower at workers=4) or stage frames somewhere — i.e. the `dstBuf` you just removed.
   - One-frame-per-PUT removes the staging but trades it for thousands of small HTTPS round-trips instead of ~16 parallel multipart parts; net throughput is meaningfully worse.
3. **`bytes.Reader.Read` → http transport write buffer**. Could be avoided with a custom `RoundTripper` using `net.Buffers.WriteTo` (`writev(2)`), but `crypto/tls.Conn.Write` reads the body in chunks regardless because each chunk is encrypted into a TLS record — the gain over HTTPS rounds back to zero.
4. **TLS encrypt + `copy_from_user`**. Owned by Go runtime / kernel.

Net: after B6 + O4, the only user-space copy that's both recoverable and architecturally simple is the kernel→srcBuf one (option 1), and it's tiny. True zero-copy would require giving up either multipart amortization or frame-level parallelism — both make the pipeline slower, not faster.