### PR TITLE
docs(storage): fix stale BuildMap struct comment

### DIFF
--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -8,11 +8,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// Start, Length and SourceStart are in bytes of the data file
-// Length will be a multiple of BlockSize
-// The list of block mappings will be in order of increasing Start, covering the entire file
+// BuildMap maps a byte range in the block device to a region in a build's storage.
+// Offset, Length, and BuildStorageOffset are in bytes.
 type BuildMap struct {
-	// Offset defines which block of the current layer this mapping starts at
+	// Offset is the starting position of this range in the block device.
 	Offset             uint64
 	Length             uint64
 	BuildId            uuid.UUID


### PR DESCRIPTION
The comment on BuildMap was carried over unchanged from the blockMapping struct it replaced in 685988be1c7e ("[WIP] Fix serialization"). It still referenced the old field names (Start, SourceStart) and mentioned a BlockSize invariant that no longer applies.