### PR TITLE
fix(iac): wire auth provider config into nomad

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -243,6 +243,7 @@ module "nomad" {
   api_port                                               = var.api_port
   api_internal_grpc_port                                 = var.api_internal_grpc_port
   client_proxy_oidc_issuer_url                           = var.client_proxy_oidc_issuer_url
+  auth_provider_config                                   = var.auth_provider_config
   environment                                            = var.environment
   google_service_account_key                             = module.init.google_service_account_key
   api_secret                                             = random_password.api_secret.result

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -222,6 +222,27 @@ variable "client_proxy_oidc_issuer_url" {
   default = ""
 }
 
+variable "auth_provider_config" {
+  type = object({
+    jwt = optional(list(object({
+      issuer = object({
+        url                 = string
+        discoveryURL        = optional(string)
+        audiences           = list(string)
+        audienceMatchPolicy = optional(string)
+      })
+      cacheDuration = optional(string)
+    })))
+    legacy = optional(object({
+      hmac = object({
+        secrets = list(string)
+      })
+    }))
+  })
+  sensitive = true
+  default   = null
+}
+
 variable "ingress_port" {
   type = object({
     name        = string


### PR DESCRIPTION
## Summary
- Add the root GCP Terraform `auth_provider_config` variable so env-specific tfvars can configure auth provider JWT issuers.
- Pass that variable through to the `nomad` module, where API and dashboard-api jobs already render `AUTH_PROVIDER_CONFIG`.