### PR TITLE
refactor(sandbox): extract domain types into sandboxtypes leaf package

### DIFF
--- a/packages/api/internal/sandbox/aliases.go
+++ b/packages/api/internal/sandbox/aliases.go
@@ -1,0 +1,56 @@
+package sandbox
+
+import "github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
+
+// This file re-exports the sandbox domain types defined in the sandboxtypes
+// leaf package. The types live in sandboxtypes (rather than directly in
+// package sandbox) so storage backends like sandbox/storage/memory and
+// sandbox/storage/redis can implement the Storage interface without creating
+// an import cycle back into package sandbox. External callers can continue to
+// reference these symbols through sandbox.Sandbox, sandbox.State, etc.
+
+// Domain types.
+type (
+	Sandbox     = sandboxtypes.Sandbox
+	State       = sandboxtypes.State
+	StateAction = sandboxtypes.StateAction
+	RemoveOpts  = sandboxtypes.RemoveOpts
+
+	TransitionEffect = sandboxtypes.TransitionEffect
+
+	InvalidStateTransitionError = sandboxtypes.InvalidStateTransitionError
+	LimitExceededError          = sandboxtypes.LimitExceededError
+	NotRunningError             = sandboxtypes.NotRunningError
+)
+
+// State constants.
+const (
+	StateRunning      = sandboxtypes.StateRunning
+	StatePausing      = sandboxtypes.StatePausing
+	StateKilling      = sandboxtypes.StateKilling
+	StateSnapshotting = sandboxtypes.StateSnapshotting
+
+	TransitionExpires   = sandboxtypes.TransitionExpires
+	TransitionTransient = sandboxtypes.TransitionTransient
+
+	StaleCutoff           = sandboxtypes.StaleCutoff
+	SandboxTimeoutDefault = sandboxtypes.SandboxTimeoutDefault
+	AutoPauseDefault      = sandboxtypes.AutoPauseDefault
+)
+
+// Errors and pre-defined state actions / transition tables.
+var (
+	ErrAlreadyExists      = sandboxtypes.ErrAlreadyExists
+	ErrNotFound           = sandboxtypes.ErrNotFound
+	ErrEvictionInProgress = sandboxtypes.ErrEvictionInProgress
+	ErrEvictionNotNeeded  = sandboxtypes.ErrEvictionNotNeeded
+
+	AllowedTransitions = sandboxtypes.AllowedTransitions
+
+	StateActionPause    = sandboxtypes.StateActionPause
+	StateActionKill     = sandboxtypes.StateActionKill
+	StateActionSnapshot = sandboxtypes.StateActionSnapshot
+)
+
+// NewSandbox constructs a Sandbox. Re-exported from sandboxtypes.
+var NewSandbox = sandboxtypes.NewSandbox

--- a/packages/api/internal/sandbox/reservations/redis/reservation.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -27,7 +27,7 @@ const (
 	staleTTL = 90 * time.Second
 )
 
-var _ sandbox.ReservationStorage = (*ReservationStorage)(nil)
+var _ sandboxtypes.ReservationStorage = (*ReservationStorage)(nil)
 
 // Publish is fire-and-forget — drops on queue saturation are recovered by the waiter's fallback ticker.
 type Notifier interface {
@@ -47,7 +47,7 @@ func NewReservationStorage(redisClient redis.UniversalClient, notifier Notifier)
 	}
 }
 
-func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(sandbox.Sandbox, error), waitForStart func(ctx context.Context) (sandbox.Sandbox, error), err error) {
+func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(sandboxtypes.Sandbox, error), waitForStart func(ctx context.Context) (sandboxtypes.Sandbox, error), err error) {
 	teamIDStr := teamID.String()
 	storageIndexKey := getStorageIndexKey(teamIDStr)
 	pendingSetKey := getPendingSetKey(teamIDStr)
@@ -69,13 +69,13 @@ func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sand
 		return s.createFinishStart(ctx, teamID, sandboxID), nil, nil
 
 	case reserveResultAlreadyInStorage:
-		return nil, nil, sandbox.ErrAlreadyExists
+		return nil, nil, sandboxtypes.ErrAlreadyExists
 
 	case reserveResultAlreadyPending:
 		return nil, s.createWaitForStart(teamID, sandboxID), nil
 
 	case reserveResultLimitExceeded:
-		return nil, nil, &sandbox.LimitExceededError{TeamID: teamID}
+		return nil, nil, &sandboxtypes.LimitExceededError{TeamID: teamID}
 
 	default:
 		return nil, nil, fmt.Errorf("unexpected reserve script result: %d", result)
@@ -102,8 +102,8 @@ func (s *ReservationStorage) Release(ctx context.Context, teamID uuid.UUID, sand
 }
 
 // createFinishStart returns a callback that completes the reservation.
-func (s *ReservationStorage) createFinishStart(ctx context.Context, teamID uuid.UUID, sandboxID string) func(sandbox.Sandbox, error) {
-	return func(sbx sandbox.Sandbox, startErr error) {
+func (s *ReservationStorage) createFinishStart(ctx context.Context, teamID uuid.UUID, sandboxID string) func(sandboxtypes.Sandbox, error) {
+	return func(sbx sandboxtypes.Sandbox, startErr error) {
 		teamIDStr := teamID.String()
 		pendingSetKey := getPendingSetKey(teamIDStr)
 		resultKeyStr := getResultKey(teamIDStr, sandboxID)
@@ -149,8 +149,8 @@ func (s *ReservationStorage) createFinishStart(ctx context.Context, teamID uuid.
 
 // createWaitForStart returns a function that polls Redis for the result of a sandbox creation
 // initiated by another instance.
-func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID string) func(ctx context.Context) (sandbox.Sandbox, error) {
-	return func(ctx context.Context) (sandbox.Sandbox, error) {
+func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID string) func(ctx context.Context) (sandboxtypes.Sandbox, error) {
+	return func(ctx context.Context) (sandboxtypes.Sandbox, error) {
 		teamIDStr := teamID.String()
 		resultKeyStr := getResultKey(teamIDStr, sandboxID)
 		pendingSetKey := getPendingSetKey(teamIDStr)
@@ -171,7 +171,7 @@ func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID stri
 		for {
 			select {
 			case <-ctx.Done():
-				return sandbox.Sandbox{}, ctx.Err()
+				return sandboxtypes.Sandbox{}, ctx.Err()
 			case <-ch:
 			case <-ticker.C:
 			}
@@ -195,7 +195,7 @@ func (s *ReservationStorage) createWaitForStart(teamID uuid.UUID, sandboxID stri
 func (s *ReservationStorage) tryReadResult(
 	ctx context.Context,
 	resultKey, pendingSetKey, sandboxID string,
-) (done bool, sbx sandbox.Sandbox, err error) {
+) (done bool, sbx sandboxtypes.Sandbox, err error) {
 	data, getErr := s.redisClient.Get(ctx, resultKey).Bytes()
 	if getErr == nil {
 		sbx, err = decodeResult(data)
@@ -203,7 +203,7 @@ func (s *ReservationStorage) tryReadResult(
 		return true, sbx, err
 	}
 	if !errors.Is(getErr, redis.Nil) {
-		return true, sandbox.Sandbox{}, fmt.Errorf("failed to check result key: %w", getErr)
+		return true, sandboxtypes.Sandbox{}, fmt.Errorf("failed to check result key: %w", getErr)
 	}
 
 	// No result yet, so check whether another instance is still creating the sandbox.
@@ -218,15 +218,15 @@ func (s *ReservationStorage) tryReadResult(
 			return true, sbx, err
 		}
 		if !errors.Is(getErr, redis.Nil) {
-			return true, sandbox.Sandbox{}, fmt.Errorf("failed to check result key: %w", getErr)
+			return true, sandboxtypes.Sandbox{}, fmt.Errorf("failed to check result key: %w", getErr)
 		}
 
-		return true, sandbox.Sandbox{}, fmt.Errorf("sandbox %s is no longer pending and has no result", sandboxID)
+		return true, sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %s is no longer pending and has no result", sandboxID)
 	}
 	if scoreErr != nil {
-		return true, sandbox.Sandbox{}, fmt.Errorf("failed to check pending set: %w", scoreErr)
+		return true, sandboxtypes.Sandbox{}, fmt.Errorf("failed to check pending set: %w", scoreErr)
 	}
 
 	// Still pending, no result yet.
-	return false, sandbox.Sandbox{}, nil
+	return false, sandboxtypes.Sandbox{}, nil
 }

--- a/packages/api/internal/sandbox/reservations/redis/reservation_pubsub_test.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation_pubsub_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	storage_redis "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
 // testSandbox is the canonical successful-finish payload used across pubsub tests.
-func testSandbox(teamID uuid.UUID, sandboxID string) sandbox.Sandbox {
-	return sandbox.Sandbox{
+func testSandbox(teamID uuid.UUID, sandboxID string) sandboxtypes.Sandbox {
+	return sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sandboxID,
 		TemplateID:        "test",
@@ -62,7 +62,7 @@ func TestWaitForStart_WokenByFinishStartPublish(t *testing.T) {
 	require.NotNil(t, waitForStart)
 
 	waiterDone := make(chan struct{})
-	var got sandbox.Sandbox
+	var got sandboxtypes.Sandbox
 	var waitErr error
 	go func() {
 		got, waitErr = waitForStart(t.Context())
@@ -186,7 +186,7 @@ func TestWaitForStart_ResultLandedBeforeSubscribe(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	done := make(chan struct{})
-	var got sandbox.Sandbox
+	var got sandboxtypes.Sandbox
 	var waitErr error
 	start := time.Now()
 	go func() {
@@ -244,7 +244,7 @@ func TestWaitForStart_MultipleWaitersOnePublish(t *testing.T) {
 	finishStart, _, err := storage.Reserve(t.Context(), teamID, sbxID, 50)
 	require.NoError(t, err)
 
-	waiters := make([]func(ctx context.Context) (sandbox.Sandbox, error), numWaiters)
+	waiters := make([]func(ctx context.Context) (sandboxtypes.Sandbox, error), numWaiters)
 	for i := range numWaiters {
 		_, w, err := storage.Reserve(t.Context(), teamID, sbxID, 50)
 		require.NoError(t, err)
@@ -257,7 +257,7 @@ func TestWaitForStart_MultipleWaitersOnePublish(t *testing.T) {
 	completions := make([]time.Duration, numWaiters)
 	for i, w := range waiters {
 		wg.Add(1)
-		go func(i int, w func(ctx context.Context) (sandbox.Sandbox, error)) {
+		go func(i int, w func(ctx context.Context) (sandboxtypes.Sandbox, error)) {
 			defer wg.Done()
 			start := time.Now()
 			_, errs[i] = w(t.Context())
@@ -308,7 +308,7 @@ func TestWaitForStart_FailedStartPropagatesPromptly(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	start := time.Now()
-	finishStart(sandbox.Sandbox{}, errors.New("boom"))
+	finishStart(sandboxtypes.Sandbox{}, errors.New("boom"))
 
 	select {
 	case err := <-waiterErr:

--- a/packages/api/internal/sandbox/reservations/redis/reservation_test.go
+++ b/packages/api/internal/sandbox/reservations/redis/reservation_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/metric/noop"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	storage_redis "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
@@ -67,7 +67,7 @@ func TestReservation_Exceeded(t *testing.T) {
 	_, _, err := storage.Reserve(t.Context(), teamID, testSandboxID, 1)
 	require.NoError(t, err)
 	_, _, err = storage.Reserve(t.Context(), teamID, "sandbox-2", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 }
 
 func TestReservation_SameSandbox(t *testing.T) {
@@ -116,7 +116,7 @@ func TestReservation_MultipleWaiters(t *testing.T) {
 	require.NotNil(t, waitForStart2)
 
 	// Finish the start operation
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         testSandboxID,
 		TemplateID:        "test",
@@ -146,7 +146,7 @@ func TestReservation_Remove(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finishStart)
 
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         testSandboxID,
 		TemplateID:        "test",
@@ -186,11 +186,11 @@ func TestReservation_MultipleTeams(t *testing.T) {
 
 	// team1 should be at limit
 	_, _, err = storage.Reserve(t.Context(), team1, "sandbox-3", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 
 	// team2 should also be at limit
 	_, _, err = storage.Reserve(t.Context(), team2, "sandbox-4", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 }
 
 func TestReservation_FailedStart(t *testing.T) {
@@ -206,7 +206,7 @@ func TestReservation_FailedStart(t *testing.T) {
 	require.NotNil(t, finishStart)
 
 	// Finish with an error — this should auto-release
-	finishStart(sandbox.Sandbox{}, errors.New("start failed"))
+	finishStart(sandboxtypes.Sandbox{}, errors.New("start failed"))
 
 	// After failed start, should be able to reserve again
 	finishStart2, _, err := storage.Reserve(t.Context(), teamID, sbxID, 10)
@@ -228,7 +228,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 	require.NotNil(t, finishStart)
 
 	var wg errgroup.Group
-	waiters := make([]func(ctx context.Context) (sandbox.Sandbox, error), numWaiters)
+	waiters := make([]func(ctx context.Context) (sandboxtypes.Sandbox, error), numWaiters)
 
 	// Multiple waiters
 	for i := range numWaiters {
@@ -250,7 +250,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Finish with an error
-	finishStart(sandbox.Sandbox{}, errors.New("start failed"))
+	finishStart(sandboxtypes.Sandbox{}, errors.New("start failed"))
 
 	// All waiters should receive an error
 	var wg2 sync.WaitGroup
@@ -258,7 +258,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 
 	for _, waiter := range waiters {
 		wg2.Add(1)
-		go func(w func(ctx context.Context) (sandbox.Sandbox, error)) {
+		go func(w func(ctx context.Context) (sandboxtypes.Sandbox, error)) {
 			defer wg2.Done()
 			_, err := w(t.Context())
 			if err != nil {
@@ -292,7 +292,7 @@ func TestReservation_ConcurrentReservations(t *testing.T) {
 			if err == nil {
 				successCount.Add(1)
 			} else {
-				var limitExceededError *sandbox.LimitExceededError
+				var limitExceededError *sandboxtypes.LimitExceededError
 				if errors.As(err, &limitExceededError) {
 					limitExceededCount.Add(1)
 				}
@@ -360,7 +360,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 	require.NotNil(t, finishStart)
 
 	var wg errgroup.Group
-	waiters := make([]func(ctx context.Context) (sandbox.Sandbox, error), numWaiters)
+	waiters := make([]func(ctx context.Context) (sandboxtypes.Sandbox, error), numWaiters)
 
 	// Multiple waiters
 	for i := range numWaiters {
@@ -382,7 +382,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 	require.NoError(t, err)
 
 	// Finish the start operation
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sbxID,
 		TemplateID:        "test",
@@ -399,7 +399,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 
 	for _, waiter := range waiters {
 		wg2.Add(1)
-		go func(w func(ctx context.Context) (sandbox.Sandbox, error)) {
+		go func(w func(ctx context.Context) (sandboxtypes.Sandbox, error)) {
 			defer wg2.Done()
 			result, err := w(t.Context())
 			if err == nil && result.SandboxID == sbxID {
@@ -441,15 +441,15 @@ func TestReservation_RaceConditionStressTest(t *testing.T) {
 						// Immediately finish
 						go func() {
 							time.Sleep(time.Millisecond)
-							finishStart(sandbox.Sandbox{
+							finishStart(sandboxtypes.Sandbox{
 								SandboxID: sbxID,
 								TeamID:    teamID,
 							}, nil)
 						}()
 					}
 				} else {
-					var limitExceededError *sandbox.LimitExceededError
-					if errors.As(err, &limitExceededError) || errors.Is(err, sandbox.ErrAlreadyExists) {
+					var limitExceededError *sandboxtypes.LimitExceededError
+					if errors.As(err, &limitExceededError) || errors.Is(err, sandboxtypes.ErrAlreadyExists) {
 						operationCount.Add(1)
 					}
 				}
@@ -480,7 +480,7 @@ func TestReservation_ResultKeyTTL(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finishStart)
 
-	finishStart(sandbox.Sandbox{SandboxID: sbxID, TeamID: teamID}, nil)
+	finishStart(sandboxtypes.Sandbox{SandboxID: sbxID, TeamID: teamID}, nil)
 
 	// Result key should exist with a TTL
 	resultKeyStr := getResultKey(teamID.String(), sbxID)

--- a/packages/api/internal/sandbox/reservations/redis/result.go
+++ b/packages/api/internal/sandbox/reservations/redis/result.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 )
 
 // reservationResult is the serializable result stored in Redis for cross-instance communication.
 type reservationResult struct {
-	Sandbox sandbox.Sandbox   `json:"sandbox,omitzero"`
+	Sandbox sandboxtypes.Sandbox   `json:"sandbox,omitzero"`
 	Error   *reservationError `json:"error,omitempty"`
 }
 
@@ -22,7 +22,7 @@ type reservationError struct {
 	ClientMsg string `json:"client_msg,omitempty"`
 }
 
-func encodeResult(sbx sandbox.Sandbox, err error) ([]byte, error) {
+func encodeResult(sbx sandboxtypes.Sandbox, err error) ([]byte, error) {
 	result := reservationResult{
 		Sandbox: sbx,
 	}
@@ -40,14 +40,14 @@ func encodeResult(sbx sandbox.Sandbox, err error) ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func decodeResult(data []byte) (sandbox.Sandbox, error) {
+func decodeResult(data []byte) (sandboxtypes.Sandbox, error) {
 	var result reservationResult
 	if err := json.Unmarshal(data, &result); err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to unmarshal reservation result: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to unmarshal reservation result: %w", err)
 	}
 
 	if result.Error != nil {
-		return sandbox.Sandbox{}, reconstructError(result.Error)
+		return sandboxtypes.Sandbox{}, reconstructError(result.Error)
 	}
 
 	return result.Sandbox, nil

--- a/packages/api/internal/sandbox/reservations/redis/result.go
+++ b/packages/api/internal/sandbox/reservations/redis/result.go
@@ -11,8 +11,8 @@ import (
 
 // reservationResult is the serializable result stored in Redis for cross-instance communication.
 type reservationResult struct {
-	Sandbox sandboxtypes.Sandbox   `json:"sandbox,omitzero"`
-	Error   *reservationError `json:"error,omitempty"`
+	Sandbox sandboxtypes.Sandbox `json:"sandbox,omitzero"`
+	Error   *reservationError    `json:"error,omitempty"`
 }
 
 // reservationError preserves api.APIError fields for cross-instance error propagation.

--- a/packages/api/internal/sandbox/reservations/reservation.go
+++ b/packages/api/internal/sandbox/reservations/reservation.go
@@ -6,17 +6,17 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 type sandboxReservation struct {
-	start *utils.SetOnce[sandbox.Sandbox]
+	start *utils.SetOnce[sandboxtypes.Sandbox]
 }
 
-func newSandboxReservation(start *utils.SetOnce[sandbox.Sandbox]) *sandboxReservation {
+func newSandboxReservation(start *utils.SetOnce[sandboxtypes.Sandbox]) *sandboxReservation {
 	return &sandboxReservation{
 		start: start,
 	}
@@ -28,7 +28,7 @@ type ReservationStorage struct {
 	reservations *smap.Map[TeamSandboxes]
 }
 
-var _ sandbox.ReservationStorage = &ReservationStorage{}
+var _ sandboxtypes.ReservationStorage = &ReservationStorage{}
 
 func NewReservationStorage() *ReservationStorage {
 	return &ReservationStorage{
@@ -36,10 +36,10 @@ func NewReservationStorage() *ReservationStorage {
 	}
 }
 
-func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(sandbox.Sandbox, error), waitForStart func(ctx context.Context) (sandbox.Sandbox, error), err error) {
+func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(sandboxtypes.Sandbox, error), waitForStart func(ctx context.Context) (sandboxtypes.Sandbox, error), err error) {
 	alreadyPresent := false
 	limitExceeded := false
-	var startResult *utils.SetOnce[sandbox.Sandbox]
+	var startResult *utils.SetOnce[sandboxtypes.Sandbox]
 
 	teamIDStr := teamID.String()
 	s.reservations.Upsert(teamIDStr, nil, func(exist bool, teamSandboxes, _ TeamSandboxes) TeamSandboxes {
@@ -60,21 +60,21 @@ func (s *ReservationStorage) Reserve(ctx context.Context, teamID uuid.UUID, sand
 			return teamSandboxes
 		}
 
-		startResult = utils.NewSetOnce[sandbox.Sandbox]()
+		startResult = utils.NewSetOnce[sandboxtypes.Sandbox]()
 		teamSandboxes[sandboxID] = newSandboxReservation(startResult)
 
 		return teamSandboxes
 	})
 
 	if limitExceeded {
-		return nil, nil, &sandbox.LimitExceededError{TeamID: teamID}
+		return nil, nil, &sandboxtypes.LimitExceededError{TeamID: teamID}
 	}
 
 	if alreadyPresent {
 		return nil, startResult.WaitWithContext, nil
 	}
 
-	return func(sbx sandbox.Sandbox, err error) {
+	return func(sbx sandboxtypes.Sandbox, err error) {
 		setErr := startResult.SetResult(sbx, err)
 		if setErr != nil {
 			logger.L().Error(ctx, "failed to set the result of the reservation", zap.Error(setErr), logger.WithSandboxID(sandboxID))

--- a/packages/api/internal/sandbox/reservations/reservation_test.go
+++ b/packages/api/internal/sandbox/reservations/reservation_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
@@ -45,7 +45,7 @@ func TestReservation_Exceeded(t *testing.T) {
 	_, _, err := cache.Reserve(t.Context(), teamID, sandboxID, 1)
 	require.NoError(t, err)
 	_, _, err = cache.Reserve(t.Context(), teamID, "sandbox-2", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 }
 
 func TestReservation_SameSandbox(t *testing.T) {
@@ -99,7 +99,7 @@ func TestReservation_WaitForStart(t *testing.T) {
 	require.NotNil(t, waitForStart)
 
 	// Finish the start operation
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sandboxID,
 		TemplateID:        "test",
@@ -133,7 +133,7 @@ func TestReservation_WaitForStartError(t *testing.T) {
 
 	// Finish with an error
 	expectedErr := assert.AnError
-	finishStart(sandbox.Sandbox{}, expectedErr)
+	finishStart(sandboxtypes.Sandbox{}, expectedErr)
 
 	// Wait should return the error
 	ctx := t.Context()
@@ -160,7 +160,7 @@ func TestReservation_MultipleWaiters(t *testing.T) {
 	require.NotNil(t, waitForStart2)
 
 	// Finish the start operation
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sandboxID,
 		TemplateID:        "test",
@@ -190,7 +190,7 @@ func TestReservation_Remove(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, finishStart)
 
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sandboxID,
 		TemplateID:        "test",
@@ -230,11 +230,11 @@ func TestReservation_MultipleTeams(t *testing.T) {
 
 	// team1 should be at limit
 	_, _, err = cache.Reserve(t.Context(), team1, "sandbox-3", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 
 	// team2 should also be at limit
 	_, _, err = cache.Reserve(t.Context(), team2, "sandbox-4", 1)
-	require.ErrorAs(t, err, new(&sandbox.LimitExceededError{}))
+	require.ErrorAs(t, err, new(&sandboxtypes.LimitExceededError{}))
 }
 
 func TestReservation_FailedStart(t *testing.T) {
@@ -250,7 +250,7 @@ func TestReservation_FailedStart(t *testing.T) {
 
 	// Finish with an error
 	expectedErr := errors.New("start failed")
-	finishStart(sandbox.Sandbox{}, expectedErr)
+	finishStart(sandboxtypes.Sandbox{}, expectedErr)
 
 	// After failed start, should be able to reserve again
 	finishStart2, _, err := cache.Reserve(t.Context(), team, sbxID, 10)
@@ -271,7 +271,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 	require.NotNil(t, finishStart)
 
 	var wg errgroup.Group
-	waiters := make([]func(ctx context.Context) (sandbox.Sandbox, error), numWaiters)
+	waiters := make([]func(ctx context.Context) (sandboxtypes.Sandbox, error), numWaiters)
 
 	// Multiple waiters
 	for i := range numWaiters {
@@ -294,7 +294,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 
 	// Finish with an error
 	expectedErr := errors.New("start failed")
-	finishStart(sandbox.Sandbox{}, expectedErr)
+	finishStart(sandboxtypes.Sandbox{}, expectedErr)
 
 	// All waiters should receive the error
 	var wg2 sync.WaitGroup
@@ -302,7 +302,7 @@ func TestReservation_FailedStartWithWaiters(t *testing.T) {
 
 	for _, waiter := range waiters {
 		wg2.Add(1)
-		go func(w func(ctx context.Context) (sandbox.Sandbox, error)) {
+		go func(w func(ctx context.Context) (sandboxtypes.Sandbox, error)) {
 			defer wg2.Done()
 			_, err := w(t.Context())
 			if err != nil {
@@ -333,7 +333,7 @@ func TestReservation_ConcurrentReservations(t *testing.T) {
 			if err == nil {
 				successCount.Add(1)
 			} else {
-				var limitExceededError *sandbox.LimitExceededError
+				var limitExceededError *sandboxtypes.LimitExceededError
 				if errors.As(err, &limitExceededError) {
 					limitExceededCount.Add(1)
 				}
@@ -398,7 +398,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 	require.NotNil(t, finishStart)
 
 	var wg errgroup.Group
-	waiters := make([]func(ctx context.Context) (sandbox.Sandbox, error), numWaiters)
+	waiters := make([]func(ctx context.Context) (sandboxtypes.Sandbox, error), numWaiters)
 
 	// Multiple waiters
 	for i := range numWaiters {
@@ -421,7 +421,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 	wg.Wait()
 
 	// Finish the start operation
-	expectedSbx := sandbox.Sandbox{
+	expectedSbx := sandboxtypes.Sandbox{
 		ClientID:          consts.ClientID,
 		SandboxID:         sbxID,
 		TemplateID:        "test",
@@ -438,7 +438,7 @@ func TestReservation_ConcurrentWaitAndFinish(t *testing.T) {
 
 	for _, waiter := range waiters {
 		wg2.Add(1)
-		go func(w func(ctx context.Context) (sandbox.Sandbox, error)) {
+		go func(w func(ctx context.Context) (sandboxtypes.Sandbox, error)) {
 			defer wg2.Done()
 			result, err := w(t.Context())
 			if err == nil && result.SandboxID == sbxID {
@@ -516,7 +516,7 @@ func TestReservation_RaceConditionStressTest(t *testing.T) {
 						// Immediately finish
 						go func() {
 							time.Sleep(time.Millisecond)
-							finishStart(sandbox.Sandbox{
+							finishStart(sandboxtypes.Sandbox{
 								SandboxID: sbxID,
 								TeamID:    team,
 							}, nil)
@@ -529,7 +529,7 @@ func TestReservation_RaceConditionStressTest(t *testing.T) {
 						}()
 					}
 				} else {
-					var limitExceededError *sandbox.LimitExceededError
+					var limitExceededError *sandboxtypes.LimitExceededError
 					if errors.As(err, &limitExceededError) {
 						operationCount.Add(1)
 					}

--- a/packages/api/internal/sandbox/sandboxtypes/errors.go
+++ b/packages/api/internal/sandbox/sandboxtypes/errors.go
@@ -1,4 +1,4 @@
-package sandbox
+package sandboxtypes
 
 import (
 	"errors"

--- a/packages/api/internal/sandbox/sandboxtypes/sandbox.go
+++ b/packages/api/internal/sandbox/sandboxtypes/sandbox.go
@@ -1,4 +1,4 @@
-package sandbox
+package sandboxtypes
 
 import (
 	"time"

--- a/packages/api/internal/sandbox/sandboxtypes/states.go
+++ b/packages/api/internal/sandbox/sandboxtypes/states.go
@@ -1,4 +1,4 @@
-package sandbox
+package sandboxtypes
 
 import (
 	"time"

--- a/packages/api/internal/sandbox/sandboxtypes/storage.go
+++ b/packages/api/internal/sandbox/sandboxtypes/storage.go
@@ -1,0 +1,39 @@
+package sandboxtypes
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+const (
+	StorageNameMemory        = "memory"
+	StorageNameRedis         = "redis"
+	StorageNamePopulateRedis = "populate_redis"
+)
+
+// Storage is the persistence interface implemented by the memory and redis backends.
+//
+// TODO [ENG-3514]: Remove Name() and Sync() and nolint once migrated to Redis
+type Storage interface { //nolint: interfacebloat
+	Name() string
+	Add(ctx context.Context, sandbox Sandbox) error
+	Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (Sandbox, error)
+	Remove(ctx context.Context, teamID uuid.UUID, sandboxID string) error
+
+	TeamItems(ctx context.Context, teamID uuid.UUID, states []State) ([]Sandbox, error)
+	ExpiredItems(ctx context.Context) ([]Sandbox, error)
+	TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int64, error)
+
+	Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox Sandbox) (Sandbox, error)) (Sandbox, error)
+	StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts RemoveOpts) (Sandbox, bool, func(context.Context, error), error)
+	WaitForStateChange(ctx context.Context, teamID uuid.UUID, sandboxID string) error
+	Reconcile(ctx context.Context, sandboxes []Sandbox, nodeID string) []Sandbox
+}
+
+// ReservationStorage tracks per-team sandbox-start reservations to enforce
+// concurrency limits.
+type ReservationStorage interface {
+	Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(Sandbox, error), waitForStart func(ctx context.Context) (Sandbox, error), err error)
+	Release(ctx context.Context, teamID uuid.UUID, sandboxID string) error
+}

--- a/packages/api/internal/sandbox/storage/memory/main.go
+++ b/packages/api/internal/sandbox/storage/memory/main.go
@@ -3,16 +3,16 @@ package memory
 import (
 	cmap "github.com/orcaman/concurrent-map/v2"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 )
 
-var _ sandbox.Storage = (*Storage)(nil)
+var _ sandboxtypes.Storage = (*Storage)(nil)
 
 type Storage struct {
 	items cmap.ConcurrentMap[string, *memorySandbox]
 }
 
-func (s *Storage) Name() string { return sandbox.StorageNameMemory }
+func (s *Storage) Name() string { return sandboxtypes.StorageNameMemory }
 
 func NewStorage() *Storage {
 	instanceCache := &Storage{

--- a/packages/api/internal/sandbox/storage/memory/operations.go
+++ b/packages/api/internal/sandbox/storage/memory/operations.go
@@ -10,17 +10,17 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/middleware/otel/joined"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // Add the sandbox to the cache
-func (s *Storage) Add(_ context.Context, sbx sandbox.Sandbox) error {
+func (s *Storage) Add(_ context.Context, sbx sandboxtypes.Sandbox) error {
 	added := s.items.SetIfAbsent(sbx.SandboxID, newMemorySandbox(sbx))
 	if !added {
-		return sandbox.ErrAlreadyExists
+		return sandboxtypes.ErrAlreadyExists
 	}
 
 	return nil
@@ -42,15 +42,15 @@ func (s *Storage) get(sandboxID string) (*memorySandbox, error) {
 }
 
 // Get the item from the cache.
-func (s *Storage) Get(_ context.Context, teamID uuid.UUID, sandboxID string) (sandbox.Sandbox, error) {
+func (s *Storage) Get(_ context.Context, teamID uuid.UUID, sandboxID string) (sandboxtypes.Sandbox, error) {
 	item, ok := s.items.Get(sandboxID)
 	if !ok {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	data := item.Data()
 	if data.TeamID != teamID {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	return data, nil
@@ -62,8 +62,8 @@ func (s *Storage) Remove(_ context.Context, _ uuid.UUID, sandboxID string) error
 	return nil
 }
 
-func (s *Storage) getItems(teamID *uuid.UUID, states []sandbox.State) []sandbox.Sandbox {
-	items := make([]sandbox.Sandbox, 0)
+func (s *Storage) getItems(teamID *uuid.UUID, states []sandboxtypes.State) []sandboxtypes.Sandbox {
+	items := make([]sandboxtypes.Sandbox, 0)
 
 	s.items.IterCb(func(_ string, item *memorySandbox) {
 		data := item.Data()
@@ -82,7 +82,7 @@ func (s *Storage) getItems(teamID *uuid.UUID, states []sandbox.State) []sandbox.
 	return items
 }
 
-func (s *Storage) TeamItems(_ context.Context, teamID uuid.UUID, states []sandbox.State) ([]sandbox.Sandbox, error) {
+func (s *Storage) TeamItems(_ context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
 	return s.getItems(&teamID, states), nil
 }
 
@@ -96,13 +96,13 @@ func (s *Storage) TeamsWithSandboxCount(_ context.Context) (map[uuid.UUID]int64,
 	return teams, nil
 }
 
-func (s *Storage) ExpiredItems(_ context.Context) ([]sandbox.Sandbox, error) {
+func (s *Storage) ExpiredItems(_ context.Context) ([]sandboxtypes.Sandbox, error) {
 	now := time.Now()
-	expired := make([]sandbox.Sandbox, 0)
+	expired := make([]sandboxtypes.Sandbox, 0)
 
 	s.items.IterCb(func(_ string, item *memorySandbox) {
 		sbx := item.Data()
-		if sbx.State != sandbox.StateRunning {
+		if sbx.State != sandboxtypes.StateRunning {
 			return
 		}
 
@@ -114,22 +114,22 @@ func (s *Storage) ExpiredItems(_ context.Context) ([]sandbox.Sandbox, error) {
 	return expired, nil
 }
 
-func (s *Storage) Update(_ context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox.Sandbox) (sandbox.Sandbox, error)) (sandbox.Sandbox, error) {
+func (s *Storage) Update(_ context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error)) (sandboxtypes.Sandbox, error) {
 	item, ok := s.items.Get(sandboxID)
 	if !ok {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	item.mu.Lock()
 	defer item.mu.Unlock()
 
 	if item._data.TeamID != teamID {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	sbx, err := updateFunc(item._data)
 	if err != nil {
-		return sandbox.Sandbox{}, err
+		return sandboxtypes.Sandbox{}, err
 	}
 
 	item._data = sbx
@@ -137,15 +137,15 @@ func (s *Storage) Update(_ context.Context, teamID uuid.UUID, sandboxID string, 
 	return sbx, nil
 }
 
-func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandbox.RemoveOpts) (sandbox.Sandbox, bool, func(context.Context, error), error) {
+func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandboxtypes.RemoveOpts) (sandboxtypes.Sandbox, bool, func(context.Context, error), error) {
 	sbx, err := s.get(sandboxID)
 	if err != nil {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	data := sbx.Data()
 	if data.TeamID != teamID {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 
 	alreadyDone, callback, err := startRemoving(ctx, sbx, opts)
@@ -153,7 +153,7 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	return sbx.Data(), alreadyDone, callback, err
 }
 
-func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveOpts) (alreadyDone bool, callback func(ctx context.Context, err error), err error) {
+func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandboxtypes.RemoveOpts) (alreadyDone bool, callback func(ctx context.Context, err error), err error) {
 	sbx.mu.Lock()
 	transition := sbx.transition
 
@@ -163,14 +163,14 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		if transition != nil {
 			sbx.mu.Unlock()
 
-			return false, nil, sandbox.ErrEvictionInProgress
+			return false, nil, sandboxtypes.ErrEvictionInProgress
 		}
 
 		// If sandbox isn't expired (e.g. race condition with KeepAliveFor), skip.
 		if !sbx._data.IsExpired(time.Now()) {
 			sbx.mu.Unlock()
 
-			return false, nil, sandbox.ErrEvictionNotNeeded
+			return false, nil, sandboxtypes.ErrEvictionNotNeeded
 		}
 	}
 
@@ -180,8 +180,8 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		currentState := sbx._data.State
 		sbx.mu.Unlock()
 
-		if currentState != newState && !sandbox.AllowedTransitions[currentState][newState] {
-			return false, nil, &sandbox.InvalidStateTransitionError{CurrentState: currentState, TargetState: newState}
+		if currentState != newState && !sandboxtypes.AllowedTransitions[currentState][newState] {
+			return false, nil, &sandboxtypes.InvalidStateTransitionError{CurrentState: currentState, TargetState: newState}
 		}
 
 		if currentState == newState {
@@ -202,8 +202,8 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		switch {
 		case currentState == newState:
 			return true, func(context.Context, error) {}, nil
-		case sandbox.AllowedTransitions[currentState][newState]:
-			return startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: opts.Action})
+		case sandboxtypes.AllowedTransitions[currentState][newState]:
+			return startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: opts.Action})
 		default:
 			return false, nil, errors.New("unexpected state transition")
 		}
@@ -216,11 +216,11 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		return true, func(context.Context, error) {}, nil
 	}
 
-	if _, ok := sandbox.AllowedTransitions[sbx._data.State][newState]; !ok {
-		return false, nil, &sandbox.InvalidStateTransitionError{CurrentState: sbx._data.State, TargetState: newState}
+	if _, ok := sandboxtypes.AllowedTransitions[sbx._data.State][newState]; !ok {
+		return false, nil, &sandboxtypes.InvalidStateTransitionError{CurrentState: sbx._data.State, TargetState: newState}
 	}
 
-	if opts.Action.Effect == sandbox.TransitionExpires {
+	if opts.Action.Effect == sandboxtypes.TransitionExpires {
 		sbx.setExpired()
 	}
 
@@ -232,9 +232,9 @@ func startRemoving(ctx context.Context, sbx *memorySandbox, opts sandbox.RemoveO
 		sbx.mu.Lock()
 		defer sbx.mu.Unlock()
 
-		if opts.Action.Effect == sandbox.TransitionTransient {
+		if opts.Action.Effect == sandboxtypes.TransitionTransient {
 			if err == nil && sbx._data.State == newState {
-				sbx._data.State = sandbox.StateRunning
+				sbx._data.State = sandboxtypes.StateRunning
 			}
 
 			// Signal nil to waiters so concurrent callers (e.g. kill)

--- a/packages/api/internal/sandbox/storage/memory/operations_benchmark_test.go
+++ b/packages/api/internal/sandbox/storage/memory/operations_benchmark_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 )
 
 type benchFixture struct {
@@ -15,7 +15,7 @@ type benchFixture struct {
 	teamIDs     []uuid.UUID
 	runningTeam uuid.UUID
 	syncNodeID  string
-	syncInput   []sandbox.Sandbox
+	syncInput   []sandboxtypes.Sandbox
 }
 
 func buildFixture(total int) benchFixture {
@@ -36,25 +36,25 @@ func buildFixture(total int) benchFixture {
 
 	runningTeam := teamIDs[0]
 	syncNodeID := nodeIDs[0]
-	syncInput := make([]sandbox.Sandbox, 0, total/nodeCount+1)
+	syncInput := make([]sandboxtypes.Sandbox, 0, total/nodeCount+1)
 
 	for i := range total {
 		teamID := teamIDs[i%teamCount]
 		nodeID := nodeIDs[i%nodeCount]
 
-		state := sandbox.StateRunning
+		state := sandboxtypes.StateRunning
 		if i%5 == 0 {
-			state = sandbox.StatePausing
+			state = sandboxtypes.StatePausing
 		}
 
 		endTime := now.Add(1 * time.Hour)
 		// Keep a stable 5% expired-running subset for ExpiredItems benchmarks.
 		if i%20 == 0 {
-			state = sandbox.StateRunning
+			state = sandboxtypes.StateRunning
 			endTime = now.Add(-1 * time.Minute)
 		}
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID: fmt.Sprintf("sbx-%06d", i),
 			TeamID:    teamID,
 			NodeID:    nodeID,
@@ -98,7 +98,7 @@ func BenchmarkStorageGetItemsRunningByTeam(b *testing.B) {
 		b.Helper()
 
 		for range b.N {
-			_ = f.storage.getItems(&f.runningTeam, []sandbox.State{sandbox.StateRunning})
+			_ = f.storage.getItems(&f.runningTeam, []sandboxtypes.State{sandboxtypes.StateRunning})
 		}
 	})
 }

--- a/packages/api/internal/sandbox/storage/memory/operations_test.go
+++ b/packages/api/internal/sandbox/storage/memory/operations_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 )
 
 func createTestSandbox() *memorySandbox {
-	return newMemorySandbox(sandbox.Sandbox{
+	return newMemorySandbox(sandboxtypes.Sandbox{
 		SandboxID:         "test-sandbox",
 		TemplateID:        "test-template",
 		ClientID:          "test-client",
@@ -25,7 +25,7 @@ func createTestSandbox() *memorySandbox {
 		StartTime:         time.Now(),
 		EndTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,
-		State:             sandbox.StateRunning,
+		State:             sandboxtypes.StateRunning,
 	})
 }
 
@@ -35,20 +35,20 @@ func TestStartRemoving_BasicTransitions(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		fromState   sandbox.State
-		stateAction sandbox.StateAction
-		expState    sandbox.State
+		fromState   sandboxtypes.State
+		stateAction sandboxtypes.StateAction
+		expState    sandboxtypes.State
 		shouldError bool
 	}{
-		{"Running to Paused", sandbox.StateRunning, sandbox.StateActionPause, sandbox.StatePausing, false},
-		{"Running to Killed", sandbox.StateRunning, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Running to Snapshotting", sandbox.StateRunning, sandbox.StateActionSnapshot, sandbox.StateSnapshotting, false},
-		{"Paused to Killed", sandbox.StatePausing, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Killed to Paused (invalid)", sandbox.StateKilling, sandbox.StateActionPause, sandbox.StatePausing, true},
-		{"Killed to Killed (same)", sandbox.StateKilling, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Paused to Paused (same)", sandbox.StatePausing, sandbox.StateActionPause, sandbox.StatePausing, false},
-		{"Snapshotting to Killed", sandbox.StateSnapshotting, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Snapshotting to Paused", sandbox.StateSnapshotting, sandbox.StateActionPause, sandbox.StatePausing, false},
+		{"Running to Paused", sandboxtypes.StateRunning, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
+		{"Running to Killed", sandboxtypes.StateRunning, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Running to Snapshotting", sandboxtypes.StateRunning, sandboxtypes.StateActionSnapshot, sandboxtypes.StateSnapshotting, false},
+		{"Paused to Killed", sandboxtypes.StatePausing, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Killed to Paused (invalid)", sandboxtypes.StateKilling, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, true},
+		{"Killed to Killed (same)", sandboxtypes.StateKilling, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Paused to Paused (same)", sandboxtypes.StatePausing, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
+		{"Snapshotting to Killed", sandboxtypes.StateSnapshotting, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Snapshotting to Paused", sandboxtypes.StateSnapshotting, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
 	}
 
 	for _, tt := range tests {
@@ -59,7 +59,7 @@ func TestStartRemoving_BasicTransitions(t *testing.T) {
 			sbx._data.State = tt.fromState
 			ctx := t.Context()
 
-			alreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: tt.stateAction})
+			alreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: tt.stateAction})
 
 			switch {
 			case tt.shouldError:
@@ -89,13 +89,13 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	ctx := t.Context()
 
 	// Simulate a pause operation that takes time
-	alreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, finish)
 
 	// The state should be changed immediately
-	assert.Equal(t, sandbox.StatePausing, sbx.State())
+	assert.Equal(t, sandboxtypes.StatePausing, sbx.State())
 
 	// Simulate the actual pause operation taking time
 	started := make(chan struct{})
@@ -104,7 +104,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 		started <- struct{}{}
 		time.Sleep(100 * time.Millisecond)
 		// The state should still be Paused
-		assert.Equal(t, sandbox.StatePausing, sbx.State())
+		assert.Equal(t, sandboxtypes.StatePausing, sbx.State())
 		finish(ctx, nil)
 	}()
 
@@ -112,7 +112,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	<-started // Ensure the pause operation has started
 
 	start := time.Now()
-	alreadyDone2, finish2, err2 := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	alreadyDone2, finish2, err2 := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	elapsed := time.Since(start)
 
 	// Should have waited for the pause to complete
@@ -120,11 +120,11 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	require.NoError(t, err2)
 	assert.False(t, alreadyDone2)
 	assert.NotNil(t, finish2)
-	assert.Equal(t, sandbox.StateKilling, sbx.State())
+	assert.Equal(t, sandboxtypes.StateKilling, sbx.State())
 
 	// Complete the kill operation
 	finish2(ctx, nil)
-	assert.Equal(t, sandbox.StateKilling, sbx.State())
+	assert.Equal(t, sandboxtypes.StateKilling, sbx.State())
 }
 
 // Test concurrent requests to transition to the same state (idempotency)
@@ -142,7 +142,7 @@ func TestStartRemoving_ConcurrentSameState(t *testing.T) {
 	// Three concurrent requests to pause the sandbox
 	for range 3 {
 		go func() {
-			alreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+			alreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 			if err == nil {
 				if alreadyDone {
 					// Already alreadyDone (waited for another transition)
@@ -185,7 +185,7 @@ func TestStartRemoving_ConcurrentSameState(t *testing.T) {
 	// But others waiting should get alreadyDone=true after the transition completes
 	assert.Equal(t, 1, performedCount, "Only one request should actually perform the transition")
 	assert.Equal(t, 2, alreadyDoneCount, "Two concurrent requests should see it's already alreadyDone")
-	assert.Equal(t, sandbox.StatePausing, sbx.State())
+	assert.Equal(t, sandboxtypes.StatePausing, sbx.State())
 }
 
 // Test transition fails and subsequent request handles it
@@ -196,7 +196,7 @@ func TestStartRemoving_Error(t *testing.T) {
 	ctx := t.Context()
 
 	// First attempt to pause
-	alreadyDone1, finish1, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyDone1, finish1, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone1)
 	require.NotNil(t, finish1)
@@ -209,7 +209,7 @@ func TestStartRemoving_Error(t *testing.T) {
 
 	go func() {
 		// This should wait for the first transition, then try to go to Killed
-		alreadyDone2, finish2, err2 = startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+		alreadyDone2, finish2, err2 = startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		completed <- true
 	}()
 
@@ -230,14 +230,14 @@ func TestStartRemoving_Error(t *testing.T) {
 	assert.Nil(t, finish2)
 
 	// From Failed state, no transitions are allowed
-	alreadyDone3, finish3, err3 := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyDone3, finish3, err3 := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.Error(t, err3)
 	require.ErrorIs(t, err3, failureErr)
 	assert.False(t, alreadyDone3)
 	assert.Nil(t, finish3)
 
 	// Trying to transition to Killed should also fail
-	alreadyDone4, finish4, err4 := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	alreadyDone4, finish4, err4 := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	require.Error(t, err4)
 	require.ErrorIs(t, err4, failureErr)
 	assert.False(t, alreadyDone4)
@@ -251,7 +251,7 @@ func TestStartRemoving_ContextTimeout(t *testing.T) {
 	sbx := createTestSandbox()
 
 	// Start a long-running transition
-	alreadyDone1, finish1, err := startRemoving(t.Context(), sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyDone1, finish1, err := startRemoving(t.Context(), sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone1)
 	require.NotNil(t, finish1)
@@ -261,7 +261,7 @@ func TestStartRemoving_ContextTimeout(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	_, _, err2 := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, _, err2 := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	elapsed := time.Since(start)
 
 	// Should timeout after about 20ms
@@ -271,7 +271,7 @@ func TestStartRemoving_ContextTimeout(t *testing.T) {
 
 	// Clean up
 	finish1(ctx, nil)
-	assert.Equal(t, sandbox.StatePausing, sbx.State())
+	assert.Equal(t, sandboxtypes.StatePausing, sbx.State())
 }
 
 func TestWaitForStateChange_NoTransition(t *testing.T) {
@@ -294,7 +294,7 @@ func TestWaitForStateChange_WaitForCompletion(t *testing.T) {
 	ctx := t.Context()
 
 	// Start a transition
-	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyalreadyDone)
 	require.NotNil(t, finish)
@@ -325,7 +325,7 @@ func TestWaitForStateChange_WaitWithError(t *testing.T) {
 	ctx := t.Context()
 
 	// Start a transition
-	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyalreadyDone)
 	require.NotNil(t, finish)
@@ -358,7 +358,7 @@ func TestWaitForStateChange_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 
 	// Start a transition
-	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyalreadyDone)
 	require.NotNil(t, finish)
@@ -393,7 +393,7 @@ func TestWaitForStateChange_MultipleWaiters(t *testing.T) {
 	ctx := t.Context()
 
 	// Start a transition
-	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	alreadyalreadyDone, finish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyalreadyDone)
 	require.NotNil(t, finish)
@@ -435,7 +435,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "snap-pause-test",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -443,13 +443,13 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 			StartTime:         time.Now(),
 			EndTime:           time.Now().Add(time.Hour),
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionSnapshot})
+		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionSnapshot})
 		require.NoError(t, err)
 		assert.False(t, snapAlreadyDone)
 		require.NotNil(t, finishSnap)
@@ -461,14 +461,14 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 
 		go func() {
 			defer close(pauseDone)
-			_, pauseAlreadyDone, pauseFinish, pauseErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+			_, pauseAlreadyDone, pauseFinish, pauseErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 		}()
 
 		time.Sleep(50 * time.Millisecond)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateSnapshotting, got.State)
+		assert.Equal(t, sandboxtypes.StateSnapshotting, got.State)
 
 		finishSnap(ctx, nil)
 
@@ -480,7 +480,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 
 		got, getErr = storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StatePausing, got.State)
+		assert.Equal(t, sandboxtypes.StatePausing, got.State)
 
 		pauseFinish(ctx, nil)
 	})
@@ -491,7 +491,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "snap-kill-test",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -499,13 +499,13 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 			StartTime:         time.Now(),
 			EndTime:           time.Now().Add(time.Hour),
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionSnapshot})
+		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionSnapshot})
 		require.NoError(t, err)
 		assert.False(t, snapAlreadyDone)
 
@@ -517,7 +517,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 
 		go func() {
 			defer close(killDone)
-			_, killAlreadyDone, killFinish, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+			_, killAlreadyDone, killFinish, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		}()
 
 		// Give the kill goroutine time to start waiting
@@ -526,7 +526,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 		// Verify the sandbox is still snapshotting (kill is blocked)
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateSnapshotting, got.State)
+		assert.Equal(t, sandboxtypes.StateSnapshotting, got.State)
 
 		// Complete snapshotting — this unblocks the kill
 		finishSnap(ctx, nil)
@@ -539,7 +539,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 
 		got, getErr = storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateKilling, got.State)
+		assert.Equal(t, sandboxtypes.StateKilling, got.State)
 
 		killFinish(ctx, nil)
 	})
@@ -550,7 +550,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "snap-fail-kill-test",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -558,13 +558,13 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 			StartTime:         time.Now(),
 			EndTime:           time.Now().Add(time.Hour),
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, _, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionSnapshot})
+		_, _, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionSnapshot})
 		require.NoError(t, err)
 
 		// Finish with error — state stays Snapshotting, transition cleared
@@ -572,17 +572,17 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateSnapshotting, got.State)
+		assert.Equal(t, sandboxtypes.StateSnapshotting, got.State)
 
 		// Kill proceeds immediately — no active transition, Snapshotting→Killing is allowed
-		_, killAlreadyDone, killFinish, killErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+		_, killAlreadyDone, killFinish, killErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		require.NoError(t, killErr)
 		assert.False(t, killAlreadyDone)
 		require.NotNil(t, killFinish)
 
 		got, getErr = storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateKilling, got.State)
+		assert.Equal(t, sandboxtypes.StateKilling, got.State)
 
 		killFinish(ctx, nil)
 	})
@@ -593,7 +593,7 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "snap-resume-test",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -601,19 +601,19 @@ func TestStartRemoving_DuringSnapshotting(t *testing.T) {
 			StartTime:         time.Now(),
 			EndTime:           time.Now().Add(time.Hour),
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionSnapshot})
+		_, snapAlreadyDone, finishSnap, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionSnapshot})
 		require.NoError(t, err)
 		assert.False(t, snapAlreadyDone)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateSnapshotting, got.State)
+		assert.Equal(t, sandboxtypes.StateSnapshotting, got.State)
 
 		finishSnap(ctx, nil)
 	})
@@ -630,7 +630,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "evict-ok",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -638,20 +638,20 @@ func TestStartRemoving_Eviction(t *testing.T) {
 			StartTime:         time.Now().Add(-2 * time.Hour),
 			EndTime:           time.Now().Add(-time.Second), // already expired
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
+		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
 		require.NoError(t, err)
 		assert.False(t, alreadyDone)
 		require.NotNil(t, finish)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateKilling, got.State)
+		assert.Equal(t, sandboxtypes.StateKilling, got.State)
 
 		finish(ctx, nil)
 	})
@@ -662,7 +662,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "evict-not-expired",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -670,21 +670,21 @@ func TestStartRemoving_Eviction(t *testing.T) {
 			StartTime:         time.Now(),
 			EndTime:           time.Now().Add(time.Hour), // not expired
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
-		require.ErrorIs(t, err, sandbox.ErrEvictionNotNeeded)
+		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
+		require.ErrorIs(t, err, sandboxtypes.ErrEvictionNotNeeded)
 		assert.False(t, alreadyDone)
 		assert.Nil(t, finish)
 
 		// State must remain Running — sandbox was not touched.
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateRunning, got.State)
+		assert.Equal(t, sandboxtypes.StateRunning, got.State)
 	})
 
 	t.Run("expired sandbox with active transition returns eviction in progress", func(t *testing.T) {
@@ -693,7 +693,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "evict-in-transition",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -701,23 +701,23 @@ func TestStartRemoving_Eviction(t *testing.T) {
 			StartTime:         time.Now().Add(-2 * time.Hour),
 			EndTime:           time.Now().Add(-time.Second), // expired
 			MaxInstanceLength: time.Hour,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
 		// Start a non-eviction pause transition to occupy the transition slot.
-		_, _, pauseFinish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+		_, _, pauseFinish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 		require.NoError(t, err)
 		require.NotNil(t, pauseFinish)
 
 		// Eviction should be rejected immediately (not block).
 		start := time.Now()
-		_, alreadyDone, finish, evictErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
+		_, alreadyDone, finish, evictErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
 		elapsed := time.Since(start)
 
-		require.ErrorIs(t, evictErr, sandbox.ErrEvictionInProgress)
+		require.ErrorIs(t, evictErr, sandboxtypes.ErrEvictionInProgress)
 		assert.False(t, alreadyDone)
 		assert.Nil(t, finish)
 		assert.Less(t, elapsed, 50*time.Millisecond, "eviction should return immediately, not wait for the transition")
@@ -732,7 +732,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		ctx := t.Context()
 		storage := NewStorage()
 
-		sbx := sandbox.Sandbox{
+		sbx := sandboxtypes.Sandbox{
 			SandboxID:         "evict-autopause",
 			TemplateID:        "test-template",
 			ClientID:          "test-client",
@@ -741,20 +741,20 @@ func TestStartRemoving_Eviction(t *testing.T) {
 			EndTime:           time.Now().Add(-time.Second), // expired
 			MaxInstanceLength: time.Hour,
 			AutoPause:         true,
-			State:             sandbox.StateRunning,
+			State:             sandboxtypes.StateRunning,
 		}
 
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause, Eviction: true})
+		_, alreadyDone, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause, Eviction: true})
 		require.NoError(t, err)
 		assert.False(t, alreadyDone)
 		require.NotNil(t, finish)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StatePausing, got.State)
+		assert.Equal(t, sandboxtypes.StatePausing, got.State)
 
 		finish(ctx, nil)
 	})
@@ -775,7 +775,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		sbx._data.EndTime = time.Now().Add(-time.Second)
 
 		// Start a non-eviction pause.
-		alreadyDone, pauseFinish, err := startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+		alreadyDone, pauseFinish, err := startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 		require.NoError(t, err)
 		assert.False(t, alreadyDone)
 		require.NotNil(t, pauseFinish)
@@ -788,7 +788,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 
 		go func() {
 			defer close(killDone)
-			killAlreadyDone, killFinish, killErr = startRemoving(ctx, sbx, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+			killAlreadyDone, killFinish, killErr = startRemoving(ctx, sbx, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		}()
 
 		time.Sleep(50 * time.Millisecond)
@@ -809,7 +809,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		require.NoError(t, killErr)
 		assert.False(t, killAlreadyDone)
 		require.NotNil(t, killFinish)
-		assert.Equal(t, sandbox.StateKilling, sbx.State())
+		assert.Equal(t, sandboxtypes.StateKilling, sbx.State())
 
 		killFinish(ctx, nil)
 	})
@@ -849,10 +849,10 @@ func TestConcurrency_StressTest(t *testing.T) {
 					// Random operation
 					switch workerID % 4 {
 					case 0: // State transitions
-						stateActions := []sandbox.StateAction{sandbox.StateActionPause, sandbox.StateActionKill}
+						stateActions := []sandboxtypes.StateAction{sandboxtypes.StateActionPause, sandboxtypes.StateActionKill}
 						stateAction := stateActions[rand.Intn(len(stateActions))]
 
-						alreadyDone, finish, err := startRemoving(t.Context(), sbx, sandbox.RemoveOpts{Action: stateAction})
+						alreadyDone, finish, err := startRemoving(t.Context(), sbx, sandboxtypes.RemoveOpts{Action: stateAction})
 						if err == nil && (finish != nil || alreadyDone) {
 							if finish != nil {
 								finish(t.Context(), nil)

--- a/packages/api/internal/sandbox/storage/memory/sandbox.go
+++ b/packages/api/internal/sandbox/storage/memory/sandbox.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 type memorySandbox struct {
-	_data sandbox.Sandbox
+	_data sandboxtypes.Sandbox
 
 	transition *utils.ErrorOnce
 	mu         sync.RWMutex
 }
 
-func newMemorySandbox(data sandbox.Sandbox) *memorySandbox {
+func newMemorySandbox(data sandboxtypes.Sandbox) *memorySandbox {
 	return &memorySandbox{
 		_data: data,
 	}
@@ -37,14 +37,14 @@ func (i *memorySandbox) setExpired() {
 	}
 }
 
-func (i *memorySandbox) Data() sandbox.Sandbox {
+func (i *memorySandbox) Data() sandboxtypes.Sandbox {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
 	return i._data
 }
 
-func (i *memorySandbox) State() sandbox.State {
+func (i *memorySandbox) State() sandboxtypes.State {
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 

--- a/packages/api/internal/sandbox/storage/memory/sync.go
+++ b/packages/api/internal/sandbox/storage/memory/sync.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -13,13 +13,13 @@ import (
 // This is to prevent remove instances that are still being started
 const syncSandboxRemoveGracePeriod = 10 * time.Second
 
-func (s *Storage) Reconcile(ctx context.Context, sandboxes []sandbox.Sandbox, nodeID string) []sandbox.Sandbox {
-	sandboxMap := make(map[string]sandbox.Sandbox)
+func (s *Storage) Reconcile(ctx context.Context, sandboxes []sandboxtypes.Sandbox, nodeID string) []sandboxtypes.Sandbox {
+	sandboxMap := make(map[string]sandboxtypes.Sandbox)
 	now := time.Now()
 
 	// Use a map for faster lookup
-	for _, sandbox := range sandboxes {
-		sandboxMap[sandbox.SandboxID] = sandbox
+	for _, sbx := range sandboxes {
+		sandboxMap[sbx.SandboxID] = sbx
 	}
 
 	// Remove sandboxes that are not in Orchestrator anymore
@@ -50,21 +50,21 @@ func (s *Storage) Reconcile(ctx context.Context, sandboxes []sandbox.Sandbox, no
 		}
 	})
 
-	toBeAdded := make([]sandbox.Sandbox, 0, len(sandboxes))
+	toBeAdded := make([]sandboxtypes.Sandbox, 0, len(sandboxes))
 	// Add sandboxes that are not in the cache with the default TTL
-	for _, sandbox := range sandboxes {
-		if s.exists(sandbox.SandboxID) {
+	for _, sbx := range sandboxes {
+		if s.exists(sbx.SandboxID) {
 			continue
 		}
 
 		logger.L().Debug(
 			ctx,
 			"sync discovered sandbox missing from cache",
-			logger.WithSandboxID(sandbox.SandboxID),
-			logger.WithTeamID(sandbox.TeamID.String()),
+			logger.WithSandboxID(sbx.SandboxID),
+			logger.WithTeamID(sbx.TeamID.String()),
 			logger.WithNodeID(nodeID),
 		)
-		toBeAdded = append(toBeAdded, sandbox)
+		toBeAdded = append(toBeAdded, sbx)
 	}
 
 	return toBeAdded

--- a/packages/api/internal/sandbox/storage/populate_redis/main.go
+++ b/packages/api/internal/sandbox/storage/populate_redis/main.go
@@ -6,22 +6,22 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/memory"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-var _ sandbox.Storage = (*PopulateRedisStorage)(nil)
+var _ sandboxtypes.Storage = (*PopulateRedisStorage)(nil)
 
 type PopulateRedisStorage struct {
 	memoryBackend *memory.Storage
 	redisBackend  *redis.Storage
 }
 
-func (m *PopulateRedisStorage) Name() string { return sandbox.StorageNamePopulateRedis }
+func (m *PopulateRedisStorage) Name() string { return sandboxtypes.StorageNamePopulateRedis }
 
-func (m *PopulateRedisStorage) Add(ctx context.Context, sandbox sandbox.Sandbox) error {
+func (m *PopulateRedisStorage) Add(ctx context.Context, sandbox sandboxtypes.Sandbox) error {
 	err := m.memoryBackend.Add(ctx, sandbox)
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (m *PopulateRedisStorage) Add(ctx context.Context, sandbox sandbox.Sandbox)
 	return nil
 }
 
-func (m *PopulateRedisStorage) Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (sandbox.Sandbox, error) {
+func (m *PopulateRedisStorage) Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (sandboxtypes.Sandbox, error) {
 	return m.memoryBackend.Get(ctx, teamID, sandboxID)
 }
 
@@ -53,11 +53,11 @@ func (m *PopulateRedisStorage) Remove(ctx context.Context, teamID uuid.UUID, san
 	return nil
 }
 
-func (m *PopulateRedisStorage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandbox.State) ([]sandbox.Sandbox, error) {
+func (m *PopulateRedisStorage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
 	return m.memoryBackend.TeamItems(ctx, teamID, states)
 }
 
-func (m *PopulateRedisStorage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
+func (m *PopulateRedisStorage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, error) {
 	return m.memoryBackend.ExpiredItems(ctx)
 }
 
@@ -65,10 +65,10 @@ func (m *PopulateRedisStorage) TeamsWithSandboxCount(ctx context.Context) (map[u
 	return m.memoryBackend.TeamsWithSandboxCount(ctx)
 }
 
-func (m *PopulateRedisStorage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox sandbox.Sandbox) (sandbox.Sandbox, error)) (sandbox.Sandbox, error) {
+func (m *PopulateRedisStorage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error)) (sandboxtypes.Sandbox, error) {
 	sbx, err := m.memoryBackend.Update(ctx, teamID, sandboxID, updateFunc)
 	if err != nil {
-		return sandbox.Sandbox{}, err
+		return sandboxtypes.Sandbox{}, err
 	}
 
 	_, err = m.redisBackend.Update(ctx, teamID, sandboxID, updateFunc)
@@ -79,7 +79,7 @@ func (m *PopulateRedisStorage) Update(ctx context.Context, teamID uuid.UUID, san
 	return sbx, nil
 }
 
-func (m *PopulateRedisStorage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandbox.RemoveOpts) (sandbox.Sandbox, bool, func(context.Context, error), error) {
+func (m *PopulateRedisStorage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandboxtypes.RemoveOpts) (sandboxtypes.Sandbox, bool, func(context.Context, error), error) {
 	return m.memoryBackend.StartRemoving(ctx, teamID, sandboxID, opts)
 }
 
@@ -87,7 +87,7 @@ func (m *PopulateRedisStorage) WaitForStateChange(ctx context.Context, teamID uu
 	return m.memoryBackend.WaitForStateChange(ctx, teamID, sandboxID)
 }
 
-func (m *PopulateRedisStorage) Reconcile(ctx context.Context, sandboxes []sandbox.Sandbox, nodeID string) []sandbox.Sandbox {
+func (m *PopulateRedisStorage) Reconcile(ctx context.Context, sandboxes []sandboxtypes.Sandbox, nodeID string) []sandboxtypes.Sandbox {
 	return m.memoryBackend.Reconcile(ctx, sandboxes, nodeID)
 }
 

--- a/packages/api/internal/sandbox/storage/redis/cleaner.go
+++ b/packages/api/internal/sandbox/storage/redis/cleaner.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -78,7 +78,7 @@ func (c *Cleaner) RunOnce(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func (c *Cleaner) evictExpired(ctx context.Context, expired []sandbox.Sandbox) {
+func (c *Cleaner) evictExpired(ctx context.Context, expired []sandboxtypes.Sandbox) {
 	if len(expired) == 0 {
 		return
 	}
@@ -86,7 +86,7 @@ func (c *Cleaner) evictExpired(ctx context.Context, expired []sandbox.Sandbox) {
 	logger.L().Info(ctx, "Cleaner found expired sandboxes", zap.Int("count", len(expired)))
 
 	for _, sbx := range expired {
-		if time.Since(sbx.EndTime) < sandbox.StaleCutoff {
+		if time.Since(sbx.EndTime) < sandboxtypes.StaleCutoff {
 			continue
 		}
 

--- a/packages/api/internal/sandbox/storage/redis/cleaner_test.go
+++ b/packages/api/internal/sandbox/storage/redis/cleaner_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 )
 
 // TestCleaner_PrunesOrphanedExpirationEntry is the smoke test for the whole
@@ -230,14 +230,14 @@ func TestCleaner_EvictsStaleExpiredSandbox(t *testing.T) {
 	ctx := t.Context()
 
 	sbx := createTestSandbox("stale-expired-" + uuid.NewString())
-	sbx.EndTime = time.Now().Add(-sandbox.StaleCutoff - time.Minute)
+	sbx.EndTime = time.Now().Add(-sandboxtypes.StaleCutoff - time.Minute)
 	require.NoError(t, storage.Add(ctx, sbx))
 
 	cleaner := NewCleaner(storage)
 	require.NoError(t, cleaner.RunOnce(ctx))
 
 	_, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
-	require.ErrorIs(t, err, sandbox.ErrNotFound, "stale expired sandbox JSON should be removed")
+	require.ErrorIs(t, err, sandboxtypes.ErrNotFound, "stale expired sandbox JSON should be removed")
 
 	_, err = client.ZScore(ctx, globalExpirationSet,
 		expirationMember(sbx.TeamID.String(), sbx.SandboxID)).Result()
@@ -271,11 +271,11 @@ func TestCleaner_PreservesRecentlyExpiredSandbox(t *testing.T) {
 	require.Equal(t, sbx.SandboxID, got.SandboxID)
 }
 
-// Compile-time guard so future refactors of sandbox.StaleCutoff get noticed
+// Compile-time guard so future refactors of sandboxtypes.StaleCutoff get noticed
 // here: the cleaner's correctness depends on it being > 0.
 var _ = func() bool {
-	if sandbox.StaleCutoff <= 0 {
-		panic("sandbox.StaleCutoff must be positive for cleaner race guards to hold")
+	if sandboxtypes.StaleCutoff <= 0 {
+		panic("sandboxtypes.StaleCutoff must be positive for cleaner race guards to hold")
 	}
 
 	return true

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -9,7 +9,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -17,7 +17,7 @@ const expiredItemsBatchSize = 256
 
 // ExpiredItems returns running sandboxes whose EndTime has passed.
 // It bounds per-cycle work via LIMIT and cleans up orphaned ZSET entries.
-func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
+func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, error) {
 	now := time.Now()
 	nowMs := float64(now.UnixMilli())
 
@@ -81,7 +81,7 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 	}
 
 	// Deserialize and filter; collect stale ZSET members for cleanup.
-	var result []sandbox.Sandbox
+	var result []sandboxtypes.Sandbox
 	var staleMembers []any
 
 	for _, batch := range batches {
@@ -98,7 +98,7 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 				continue
 			}
 
-			var sbx sandbox.Sandbox
+			var sbx sandboxtypes.Sandbox
 			if err := json.Unmarshal([]byte(str), &sbx); err != nil {
 				logger.L().Error(ctx, "Failed to unmarshal sandbox", zap.Error(err))
 
@@ -113,9 +113,9 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandbox.Sandbox, error) {
 			}
 
 			// Only evict running sandboxes
-			if sbx.State != sandbox.StateRunning {
+			if sbx.State != sandboxtypes.StateRunning {
 				// If the sandbox is in transitioning state for more than stale cutoff, it's likely failed removal. Let it be cleaned up by the regular expiration process.
-				if time.Since(sbx.EndTime) <= sandbox.StaleCutoff {
+				if time.Since(sbx.EndTime) <= sandboxtypes.StaleCutoff {
 					// Let the current removal finish
 
 					continue

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -28,7 +28,7 @@ const (
 	orphanGracePeriod = time.Minute
 )
 
-var _ sandbox.Storage = (*Storage)(nil)
+var _ sandboxtypes.Storage = (*Storage)(nil)
 
 type Storage struct {
 	redisClient redis.UniversalClient
@@ -37,7 +37,7 @@ type Storage struct {
 	publisher   *publisher
 }
 
-func (s *Storage) Name() string { return sandbox.StorageNameRedis }
+func (s *Storage) Name() string { return sandboxtypes.StorageNameRedis }
 
 const meterScope = "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 
@@ -81,7 +81,7 @@ func (s *Storage) Close(ctx context.Context) {
 }
 
 // Reconcile returns a list of sandboxes that are considered orphans on the current node.
-func (s *Storage) Reconcile(ctx context.Context, sbxs []sandbox.Sandbox, nodeID string) []sandbox.Sandbox {
+func (s *Storage) Reconcile(ctx context.Context, sbxs []sandboxtypes.Sandbox, nodeID string) []sandboxtypes.Sandbox {
 	if len(sbxs) == 0 {
 		return nil
 	}
@@ -90,7 +90,7 @@ func (s *Storage) Reconcile(ctx context.Context, sbxs []sandbox.Sandbox, nodeID 
 
 	// Filter out sandboxes that are too young to be considered orphans.
 	type candidate struct {
-		sbx sandbox.Sandbox
+		sbx sandboxtypes.Sandbox
 		key string
 	}
 
@@ -141,7 +141,7 @@ func (s *Storage) Reconcile(ctx context.Context, sbxs []sandbox.Sandbox, nodeID 
 		return nil
 	}
 
-	var orphans []sandbox.Sandbox
+	var orphans []sandboxtypes.Sandbox
 	for _, batch := range batches {
 		results := batch.cmd.Val()
 		for i, raw := range results {

--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -12,14 +12,14 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // Add stores a sandbox in Redis atomically with its team index entry.
-func (s *Storage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
+func (s *Storage) Add(ctx context.Context, sbx sandboxtypes.Sandbox) error {
 	data, err := json.Marshal(sbx)
 	if err != nil {
 		return fmt.Errorf("failed to marshal sandbox: %w", err)
@@ -55,20 +55,20 @@ func (s *Storage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
 }
 
 // Get retrieves a sandbox from Redis
-func (s *Storage) Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (sandbox.Sandbox, error) {
+func (s *Storage) Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (sandboxtypes.Sandbox, error) {
 	key := getSandboxKey(teamID.String(), sandboxID)
 	data, err := s.redisClient.Get(ctx, key).Bytes()
 	if errors.Is(err, redis.Nil) {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 	if err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to get sandbox from Redis: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to get sandbox from Redis: %w", err)
 	}
 
-	var sbx sandbox.Sandbox
+	var sbx sandboxtypes.Sandbox
 	err = json.Unmarshal(data, &sbx)
 	if err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to unmarshal sandbox: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to unmarshal sandbox: %w", err)
 	}
 
 	return sbx, nil
@@ -108,7 +108,7 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 }
 
 // TeamItems retrieves sandboxes for a specific team, filtered by states and options
-func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandbox.State) ([]sandbox.Sandbox, error) {
+func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sandboxtypes.State) ([]sandboxtypes.Sandbox, error) {
 	// Get sandbox IDs from team index
 	teamKey := GetSandboxStorageTeamIndexKey(teamID.String())
 	sandboxIDs, err := s.redisClient.SMembers(ctx, teamKey).Result()
@@ -117,7 +117,7 @@ func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sand
 	}
 
 	if len(sandboxIDs) == 0 {
-		return []sandbox.Sandbox{}, nil
+		return []sandboxtypes.Sandbox{}, nil
 	}
 
 	// Build keys and batch fetch with MGET
@@ -132,13 +132,13 @@ func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sand
 	}
 
 	// Deserialize and filter
-	var sandboxes []sandbox.Sandbox
+	var sandboxes []sandboxtypes.Sandbox
 	for _, rawResult := range results {
 		if rawResult == nil {
 			continue // Stale index entry - sandbox was deleted
 		}
 
-		var sbx sandbox.Sandbox
+		var sbx sandboxtypes.Sandbox
 		result, ok := rawResult.(string)
 		if !ok {
 			logger.L().Error(ctx, "Invalid sandbox data type in Redis")
@@ -164,13 +164,13 @@ func (s *Storage) TeamItems(ctx context.Context, teamID uuid.UUID, states []sand
 }
 
 // Update modifies a sandbox atomically
-func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox.Sandbox) (sandbox.Sandbox, error)) (sandbox.Sandbox, error) {
+func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error)) (sandboxtypes.Sandbox, error) {
 	key := getSandboxKey(teamID.String(), sandboxID)
 
 	lockKey := redis_utils.GetLockKey(key)
 	lock, err := s.locker.Obtain(ctx, lockKey, lockTimeout)
 	if err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to obtain lock: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to obtain lock: %w", err)
 	}
 
 	defer func() {
@@ -183,34 +183,34 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 	// Get current value
 	data, err := s.redisClient.Get(ctx, key).Bytes()
 	if errors.Is(err, redis.Nil) {
-		return sandbox.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 	if err != nil {
-		return sandbox.Sandbox{}, err
+		return sandboxtypes.Sandbox{}, err
 	}
 
-	var sbx sandbox.Sandbox
+	var sbx sandboxtypes.Sandbox
 	err = json.Unmarshal(data, &sbx)
 	if err != nil {
-		return sandbox.Sandbox{}, err
+		return sandboxtypes.Sandbox{}, err
 	}
 
 	// Apply update
 	updatedSbx, err := updateFunc(sbx)
 	if err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to update sandbox: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to update sandbox: %w", err)
 	}
 
 	// Serialize updated sandbox
 	newData, err := json.Marshal(updatedSbx)
 	if err != nil {
-		return sandbox.Sandbox{}, err
+		return sandboxtypes.Sandbox{}, err
 	}
 
 	// Execute transaction
 	err = s.redisClient.Set(ctx, key, newData, redis.KeepTTL).Err()
 	if err != nil {
-		return sandbox.Sandbox{}, fmt.Errorf("failed to store sandbox in Redis: %w", err)
+		return sandboxtypes.Sandbox{}, fmt.Errorf("failed to store sandbox in Redis: %w", err)
 	}
 
 	// Re-score the expiration index if EndTime changed.
@@ -219,7 +219,7 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 			Score:  float64(updatedSbx.EndTime.UnixMilli()),
 			Member: expirationMember(teamID.String(), sandboxID),
 		}).Err(); err != nil {
-			return sandbox.Sandbox{}, fmt.Errorf("failed to update sandbox in global expiration index: %w", err)
+			return sandboxtypes.Sandbox{}, fmt.Errorf("failed to update sandbox in global expiration index: %w", err)
 		}
 	}
 
@@ -266,7 +266,7 @@ func (s *Storage) TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int6
 	}
 
 	nowSec := time.Now().Unix()
-	cutoff := nowSec - int64(sandbox.StaleCutoff.Seconds())
+	cutoff := nowSec - int64(sandboxtypes.StaleCutoff.Seconds())
 
 	teams := make(map[uuid.UUID]int64, len(entries))
 	var stale []any

--- a/packages/api/internal/sandbox/storage/redis/state_change.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change.go
@@ -12,7 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/middleware/otel/joined"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
@@ -32,7 +32,7 @@ import (
 //
 // The callback is critical: it deletes the transition key
 // and sets the result value with short TTL to notify waiters of the outcome.
-func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandbox.RemoveOpts) (sandbox.Sandbox, bool, func(context.Context, error), error) {
+func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts sandboxtypes.RemoveOpts) (sandboxtypes.Sandbox, bool, func(context.Context, error), error) {
 	key := getSandboxKey(teamID.String(), sandboxID)
 	transitionKey := getTransitionKey(teamID.String(), sandboxID)
 	lockKey := redis_utils.GetLockKey(key)
@@ -40,7 +40,7 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	// Acquire distributed lock
 	lock, err := s.locker.Obtain(ctx, lockKey, lockTimeout)
 	if err != nil {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("failed to obtain lock: %w", err)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("failed to obtain lock: %w", err)
 	}
 
 	// Ensure lock is released once
@@ -58,15 +58,15 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	// Get current sandbox state first
 	data, err := s.redisClient.Get(ctx, key).Bytes()
 	if errors.Is(err, redis.Nil) {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandbox.ErrNotFound)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("sandbox %q: %w", sandboxID, sandboxtypes.ErrNotFound)
 	}
 	if err != nil {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("failed to get sandbox from Redis: %w", err)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("failed to get sandbox from Redis: %w", err)
 	}
 
-	var sbx sandbox.Sandbox
+	var sbx sandboxtypes.Sandbox
 	if err = json.Unmarshal(data, &sbx); err != nil {
-		return sandbox.Sandbox{}, false, nil, fmt.Errorf("failed to unmarshal sandbox: %w", err)
+		return sandboxtypes.Sandbox{}, false, nil, fmt.Errorf("failed to unmarshal sandbox: %w", err)
 	}
 
 	// Check if there's an existing transition
@@ -79,12 +79,12 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	if opts.Eviction {
 		// if there's a transition already in place, don't do anything
 		if transactionID != "" {
-			return sbx, false, nil, sandbox.ErrEvictionInProgress
+			return sbx, false, nil, sandboxtypes.ErrEvictionInProgress
 		}
 
 		// if sandbox isn't expired (e.g. race condition with SetTimeout)
 		if !sbx.IsExpired(time.Now()) {
-			return sbx, false, nil, sandbox.ErrEvictionNotNeeded
+			return sbx, false, nil, sandboxtypes.ErrEvictionNotNeeded
 		}
 	}
 
@@ -107,15 +107,15 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 	}
 
 	// Validate state transition is allowed
-	if !sandbox.AllowedTransitions[sbx.State][newState] {
-		return sbx, false, nil, &sandbox.InvalidStateTransitionError{CurrentState: sbx.State, TargetState: newState}
+	if !sandboxtypes.AllowedTransitions[sbx.State][newState] {
+		return sbx, false, nil, &sandboxtypes.InvalidStateTransitionError{CurrentState: sbx.State, TargetState: newState}
 	}
 
 	// Build the updated sandbox for Redis without mutating the original.
 	// This ensures that on failure the caller sees the pre-mutation state,
 	updated := sbx
 	updated.State = newState
-	if opts.Action.Effect == sandbox.TransitionExpires {
+	if opts.Action.Effect == sandboxtypes.TransitionExpires {
 		now := time.Now()
 		if !updated.IsExpired(now) {
 			updated.EndTime = now
@@ -149,12 +149,12 @@ func (s *Storage) StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID
 // For transient actions, it first restores the sandbox state to Running.
 // On success, the callback deletes the transition key and sets empty result.
 // On error, the callback deletes the transition key and sets error message in result.
-func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, resultKey, transitionID string, stateAction sandbox.StateAction) func(context.Context, error) {
+func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, resultKey, transitionID string, stateAction sandboxtypes.StateAction) func(context.Context, error) {
 	return func(cbCtx context.Context, cbErr error) {
 		logger.L().Debug(cbCtx, "Transition complete", logger.WithSandboxID(sandboxID), zap.String("state", string(stateAction.TargetState)), zap.String("transitionID", transitionID), zap.Error(cbErr))
 
 		var restoreErr error
-		if stateAction.Effect == sandbox.TransitionTransient && cbErr == nil {
+		if stateAction.Effect == sandboxtypes.TransitionTransient && cbErr == nil {
 			restoreErr = s.restoreToRunning(cbCtx, teamID, sandboxID, stateAction.TargetState)
 		}
 
@@ -180,7 +180,7 @@ func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, res
 		resultValue := ""
 		if restoreErr != nil {
 			resultValue = fmt.Errorf("failed to restore sandbox to running: %w", restoreErr).Error()
-		} else if cbErr != nil && stateAction.Effect != sandbox.TransitionTransient {
+		} else if cbErr != nil && stateAction.Effect != sandboxtypes.TransitionTransient {
 			resultValue = cbErr.Error()
 		}
 
@@ -207,13 +207,13 @@ func (s *Storage) createCallback(teamID uuid.UUID, sandboxID, transitionKey, res
 }
 
 // restoreToRunning restores the sandbox to Running if it is still in the given transient state.
-func (s *Storage) restoreToRunning(ctx context.Context, teamID uuid.UUID, sandboxID string, fromState sandbox.State) error {
-	_, err := s.Update(ctx, teamID, sandboxID, func(sbx sandbox.Sandbox) (sandbox.Sandbox, error) {
+func (s *Storage) restoreToRunning(ctx context.Context, teamID uuid.UUID, sandboxID string, fromState sandboxtypes.State) error {
+	_, err := s.Update(ctx, teamID, sandboxID, func(sbx sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
 		if sbx.State != fromState {
 			return sbx, nil
 		}
 
-		sbx.State = sandbox.StateRunning
+		sbx.State = sandboxtypes.StateRunning
 
 		return sbx, nil
 	})
@@ -306,11 +306,11 @@ func (s *Storage) checkTransitionResult(ctx context.Context, resultKey string) e
 func (s *Storage) handleExistingTransition(
 	ctx context.Context,
 	teamID uuid.UUID,
-	sbx sandbox.Sandbox,
-	stateAction sandbox.StateAction,
-	newState sandbox.State,
+	sbx sandboxtypes.Sandbox,
+	stateAction sandboxtypes.StateAction,
+	newState sandboxtypes.State,
 	transactionID string,
-) (sandbox.Sandbox, bool, func(context.Context, error), error) {
+) (sandboxtypes.Sandbox, bool, func(context.Context, error), error) {
 	if sbx.State == newState {
 		// Same target state - wait for completion and return alreadyDone=true.
 		// The caller inherits the in-flight transition's result without
@@ -330,8 +330,8 @@ func (s *Storage) handleExistingTransition(
 	}
 
 	// Different state - validate transition and wait
-	if !sandbox.AllowedTransitions[sbx.State][newState] {
-		return sbx, false, nil, &sandbox.InvalidStateTransitionError{CurrentState: sbx.State, TargetState: newState}
+	if !sandboxtypes.AllowedTransitions[sbx.State][newState] {
+		return sbx, false, nil, &sandboxtypes.InvalidStateTransitionError{CurrentState: sbx.State, TargetState: newState}
 	}
 
 	err := s.waitForTransition(ctx, teamID, sbx.SandboxID, transactionID)
@@ -340,5 +340,5 @@ func (s *Storage) handleExistingTransition(
 	}
 
 	// Retry with new state after transition completes
-	return s.StartRemoving(ctx, teamID, sbx.SandboxID, sandbox.RemoveOpts{Action: stateAction})
+	return s.StartRemoving(ctx, teamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: stateAction})
 }

--- a/packages/api/internal/sandbox/storage/redis/state_change_test.go
+++ b/packages/api/internal/sandbox/storage/redis/state_change_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
@@ -27,8 +27,8 @@ func setupTestStorage(t *testing.T) (*Storage, redis.UniversalClient) {
 	return storage, client
 }
 
-func createTestSandbox(sandboxID string) sandbox.Sandbox {
-	return sandbox.Sandbox{
+func createTestSandbox(sandboxID string) sandboxtypes.Sandbox {
+	return sandboxtypes.Sandbox{
 		SandboxID:         sandboxID,
 		TemplateID:        "test-template",
 		ClientID:          "test-client",
@@ -37,7 +37,7 @@ func createTestSandbox(sandboxID string) sandbox.Sandbox {
 		StartTime:         time.Now(),
 		EndTime:           time.Now().Add(time.Hour),
 		MaxInstanceLength: time.Hour,
-		State:             sandbox.StateRunning,
+		State:             sandboxtypes.StateRunning,
 	}
 }
 
@@ -47,20 +47,20 @@ func TestStartRemoving_BasicTransitions(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		fromState   sandbox.State
-		stateAction sandbox.StateAction
-		expState    sandbox.State
+		fromState   sandboxtypes.State
+		stateAction sandboxtypes.StateAction
+		expState    sandboxtypes.State
 		shouldError bool
 	}{
-		{"Running to Pausing", sandbox.StateRunning, sandbox.StateActionPause, sandbox.StatePausing, false},
-		{"Running to Killing", sandbox.StateRunning, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Running to Snapshotting", sandbox.StateRunning, sandbox.StateActionSnapshot, sandbox.StateSnapshotting, false},
-		{"Pausing to Killing", sandbox.StatePausing, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Killing to Pausing (invalid)", sandbox.StateKilling, sandbox.StateActionPause, sandbox.StatePausing, true},
-		{"Killing to Killing (same)", sandbox.StateKilling, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Pausing to Pausing (same)", sandbox.StatePausing, sandbox.StateActionPause, sandbox.StatePausing, false},
-		{"Snapshotting to Killed", sandbox.StateSnapshotting, sandbox.StateActionKill, sandbox.StateKilling, false},
-		{"Snapshotting to Paused", sandbox.StateSnapshotting, sandbox.StateActionPause, sandbox.StatePausing, false},
+		{"Running to Pausing", sandboxtypes.StateRunning, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
+		{"Running to Killing", sandboxtypes.StateRunning, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Running to Snapshotting", sandboxtypes.StateRunning, sandboxtypes.StateActionSnapshot, sandboxtypes.StateSnapshotting, false},
+		{"Pausing to Killing", sandboxtypes.StatePausing, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Killing to Pausing (invalid)", sandboxtypes.StateKilling, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, true},
+		{"Killing to Killing (same)", sandboxtypes.StateKilling, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Pausing to Pausing (same)", sandboxtypes.StatePausing, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
+		{"Snapshotting to Killed", sandboxtypes.StateSnapshotting, sandboxtypes.StateActionKill, sandboxtypes.StateKilling, false},
+		{"Snapshotting to Paused", sandboxtypes.StateSnapshotting, sandboxtypes.StateActionPause, sandboxtypes.StatePausing, false},
 	}
 
 	for _, tt := range tests {
@@ -76,7 +76,7 @@ func TestStartRemoving_BasicTransitions(t *testing.T) {
 			err := storage.Add(ctx, sbx)
 			require.NoError(t, err)
 
-			_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: tt.stateAction})
+			_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: tt.stateAction})
 
 			switch {
 			case tt.shouldError:
@@ -121,7 +121,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start pause operation
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -129,7 +129,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	// State should be changed immediately
 	updated, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 	require.NoError(t, err)
-	assert.Equal(t, sandbox.StatePausing, updated.State)
+	assert.Equal(t, sandboxtypes.StatePausing, updated.State)
 
 	// Simulate the actual pause operation taking time
 	started := make(chan struct{})
@@ -147,7 +147,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 
 	// Meanwhile, another request tries to kill the sandbox
 	start := time.Now()
-	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	elapsed := time.Since(start)
 
 	// Should have waited for the pause to complete
@@ -159,7 +159,7 @@ func TestStartRemoving_PauseThenKill(t *testing.T) {
 	// State should now be Killing
 	updated, err = storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 	require.NoError(t, err)
-	assert.Equal(t, sandbox.StateKilling, updated.State)
+	assert.Equal(t, sandboxtypes.StateKilling, updated.State)
 
 	// Complete the kill operation
 	callback2(ctx, nil)
@@ -188,7 +188,7 @@ func TestStartRemoving_ConcurrentSameState(t *testing.T) {
 	// Three concurrent requests to pause the sandbox
 	for range 3 {
 		go func() {
-			_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+			_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 			if err != nil {
 				results <- struct {
 					alreadyDone bool
@@ -243,7 +243,7 @@ func TestStartRemoving_ConcurrentSameState(t *testing.T) {
 	// Final state should be Pausing
 	updated, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 	require.NoError(t, err)
-	assert.Equal(t, sandbox.StatePausing, updated.State)
+	assert.Equal(t, sandboxtypes.StatePausing, updated.State)
 }
 
 func TestStartRemoving_NotFound(t *testing.T) {
@@ -253,12 +253,12 @@ func TestStartRemoving_NotFound(t *testing.T) {
 	ctx := t.Context()
 
 	teamID := uuid.New()
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, teamID, "non-existent", sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, teamID, "non-existent", sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	require.Error(t, err)
 	assert.False(t, alreadyDone)
 	assert.Nil(t, callback)
 
-	assert.ErrorIs(t, err, sandbox.ErrNotFound)
+	assert.ErrorIs(t, err, sandboxtypes.ErrNotFound)
 }
 
 func TestStartRemoving_ContextCancellation(t *testing.T) {
@@ -271,7 +271,7 @@ func TestStartRemoving_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone1, callback1, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone1, callback1, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone1)
 	require.NotNil(t, callback1)
@@ -281,7 +281,7 @@ func TestStartRemoving_ContextCancellation(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	_, alreadyDone2, _, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, alreadyDone2, _, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	elapsed := time.Since(start)
 
 	// Should timeout
@@ -321,7 +321,7 @@ func TestWaitForStateChange_WaitForCompletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -360,7 +360,7 @@ func TestWaitForStateChange_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -401,7 +401,7 @@ func TestWaitForStateChange_MultipleWaiters(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -445,7 +445,7 @@ func TestStartRemoving_TransitionKeyTTL(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition but don't complete it
-	_, alreadyDone, _, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, _, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 
@@ -473,7 +473,7 @@ func TestStartRemoving_CallbackMarksTransitionCompleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -515,7 +515,7 @@ func TestStartRemoving_CallbackSetsErrorOnFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -560,7 +560,7 @@ func TestStartRemoving_SetsEndTimeWhenNotExpired(t *testing.T) {
 	beforeTransition := time.Now()
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -587,7 +587,7 @@ func TestStartRemoving_WaiterCompletesOnCallbackSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -615,7 +615,7 @@ func TestStartRemoving_WaiterCompletesOnCallbackSuccess(t *testing.T) {
 	}
 
 	// Retry should work now - sandbox is already in pausing state
-	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err2)
 	// Already in pausing state from first transition
 	assert.True(t, alreadyDone2)
@@ -633,7 +633,7 @@ func TestStartRemoving_WaiterReceivesErrorOnCallbackFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -671,12 +671,12 @@ func TestStartRemoving_DifferentExecutionID(t *testing.T) {
 	ctx := t.Context()
 
 	sbx := createTestSandbox("exec-id-test")
-	sbx.State = sandbox.StateRunning
+	sbx.State = sandboxtypes.StateRunning
 	err := storage.Add(ctx, sbx)
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -691,15 +691,15 @@ func TestStartRemoving_DifferentExecutionID(t *testing.T) {
 	assert.Equal(t, int64(0), exists)
 
 	// Simulate resume: update sandbox with new ExecutionID and Running state
-	_, err = storage.Update(ctx, sbx.TeamID, sbx.SandboxID, func(s sandbox.Sandbox) (sandbox.Sandbox, error) {
-		s.State = sandbox.StateRunning
+	_, err = storage.Update(ctx, sbx.TeamID, sbx.SandboxID, func(s sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
+		s.State = sandboxtypes.StateRunning
 
 		return s, nil
 	})
 	require.NoError(t, err)
 
 	// Now start a new pause transition - should work since previous transition completed
-	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err2)
 	assert.False(t, alreadyDone2, "Should not be alreadyDone since we have a new execution")
 	require.NotNil(t, callback2)
@@ -715,7 +715,7 @@ func TestStartRemoving_DifferentExecutionID(t *testing.T) {
 // transientAction is used for all transient-transition tests.
 // Snapshot is currently the only transient action; if more are added
 // these tests automatically cover the shared behaviour.
-var transientAction = sandbox.StateActionSnapshot
+var transientAction = sandboxtypes.StateActionSnapshot
 
 func TestStartRemoving_TransientTransition(t *testing.T) {
 	t.Parallel()
@@ -729,14 +729,14 @@ func TestStartRemoving_TransientTransition(t *testing.T) {
 		sbx := createTestSandbox("transient-restore")
 		require.NoError(t, storage.Add(ctx, sbx))
 
-		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: transientAction})
+		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: transientAction})
 		require.NoError(t, err)
 
 		finish(ctx, nil)
 
 		got, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, err)
-		assert.Equal(t, sandbox.StateRunning, got.State)
+		assert.Equal(t, sandboxtypes.StateRunning, got.State)
 	})
 
 	t.Run("failure signals success to waiters", func(t *testing.T) {
@@ -748,7 +748,7 @@ func TestStartRemoving_TransientTransition(t *testing.T) {
 		sbx := createTestSandbox("transient-fail-result")
 		require.NoError(t, storage.Add(ctx, sbx))
 
-		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: transientAction})
+		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: transientAction})
 		require.NoError(t, err)
 
 		transitionKey := getTransitionKey(sbx.TeamID.String(), sbx.SandboxID)
@@ -774,7 +774,7 @@ func TestStartRemoving_TransientTransition(t *testing.T) {
 		sbx := createTestSandbox("transient-restore-fail")
 		require.NoError(t, storage.Add(ctx, sbx))
 
-		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: transientAction})
+		_, _, finish, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: transientAction})
 		require.NoError(t, err)
 
 		// Remove the sandbox key to force restoreToRunning to fail
@@ -811,14 +811,14 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
+		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
 		require.NoError(t, err)
 		assert.False(t, alreadyDone)
 		require.NotNil(t, callback)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateKilling, got.State)
+		assert.Equal(t, sandboxtypes.StateKilling, got.State)
 
 		callback(ctx, nil)
 	})
@@ -835,15 +835,15 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
-		require.ErrorIs(t, err, sandbox.ErrEvictionNotNeeded)
+		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
+		require.ErrorIs(t, err, sandboxtypes.ErrEvictionNotNeeded)
 		assert.False(t, alreadyDone)
 		assert.Nil(t, callback)
 
 		// State must remain Running — sandbox was not touched.
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateRunning, got.State)
+		assert.Equal(t, sandboxtypes.StateRunning, got.State)
 	})
 
 	t.Run("expired sandbox with active transition returns eviction in progress", func(t *testing.T) {
@@ -860,16 +860,16 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Start a non-eviction pause transition to occupy the transition slot.
-		_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+		_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 		require.NoError(t, err)
 		require.NotNil(t, pauseCallback)
 
 		// Eviction should be rejected immediately (not block waiting for the transition).
 		start := time.Now()
-		_, alreadyDone, callback, evictErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill, Eviction: true})
+		_, alreadyDone, callback, evictErr := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill, Eviction: true})
 		elapsed := time.Since(start)
 
-		require.ErrorIs(t, evictErr, sandbox.ErrEvictionInProgress)
+		require.ErrorIs(t, evictErr, sandboxtypes.ErrEvictionInProgress)
 		assert.False(t, alreadyDone)
 		assert.Nil(t, callback)
 		assert.Less(t, elapsed, 500*time.Millisecond, "eviction should return immediately, not wait for the transition")
@@ -892,14 +892,14 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		err := storage.Add(ctx, sbx)
 		require.NoError(t, err)
 
-		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause, Eviction: true})
+		_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause, Eviction: true})
 		require.NoError(t, err)
 		assert.False(t, alreadyDone)
 		require.NotNil(t, callback)
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StatePausing, got.State)
+		assert.Equal(t, sandboxtypes.StatePausing, got.State)
 
 		callback(ctx, nil)
 	})
@@ -921,7 +921,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 		require.NoError(t, err)
 
 		// Start a non-eviction pause.
-		_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+		_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 		require.NoError(t, err)
 		require.NotNil(t, pauseCallback)
 
@@ -933,14 +933,14 @@ func TestStartRemoving_Eviction(t *testing.T) {
 
 		go func() {
 			defer close(killDone)
-			_, killAlreadyDone, killCallback, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+			_, killAlreadyDone, killCallback, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		}()
 
 		time.Sleep(50 * time.Millisecond)
 
 		// Extend the sandbox timeout while the pause is in progress
 		// (simulating KeepAliveFor extending EndTime).
-		_, updateErr := storage.Update(ctx, sbx.TeamID, sbx.SandboxID, func(s sandbox.Sandbox) (sandbox.Sandbox, error) {
+		_, updateErr := storage.Update(ctx, sbx.TeamID, sbx.SandboxID, func(s sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
 			s.EndTime = time.Now().Add(time.Hour)
 
 			return s, nil
@@ -960,7 +960,7 @@ func TestStartRemoving_Eviction(t *testing.T) {
 
 		got, getErr := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 		require.NoError(t, getErr)
-		assert.Equal(t, sandbox.StateKilling, got.State)
+		assert.Equal(t, sandboxtypes.StateKilling, got.State)
 
 		killCallback(ctx, nil)
 	})
@@ -979,7 +979,7 @@ func TestWaitForStateChange_PubSubWakesWaiterFast(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -1027,7 +1027,7 @@ func TestWaitForStateChange_MultipleWaitersPubSub(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start a transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	require.NotNil(t, callback)
@@ -1094,7 +1094,7 @@ func TestCallback_PublishesNotification(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Start a transition
-	_, _, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, _, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	require.NotNil(t, callback)
 
@@ -1134,7 +1134,7 @@ func TestStartRemoving_PauseThenKill_PubSubFastWake(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start pause
-	_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, _, pauseCallback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 
 	// Concurrently start a kill (will wait for pause to finish)
@@ -1142,7 +1142,7 @@ func TestStartRemoving_PauseThenKill_PubSubFastWake(t *testing.T) {
 	var killErr error
 	var killCallback func(context.Context, error)
 	go func() {
-		_, _, killCallback, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+		_, _, killCallback, killErr = storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 		close(killDone)
 	}()
 
@@ -1177,7 +1177,7 @@ func TestWaitForTransition_StalePubSubNotification(t *testing.T) {
 	require.NoError(t, storage.Add(t.Context(), sbx))
 
 	// --- Transition A: pause ---
-	_, _, callbackA, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, _, callbackA, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	require.NotNil(t, callbackA)
 
@@ -1190,15 +1190,15 @@ func TestWaitForTransition_StalePubSubNotification(t *testing.T) {
 	callbackA(t.Context(), nil)
 
 	// Restore to Running so we can start a new transition.
-	_, err = storage.Update(t.Context(), sbx.TeamID, sbx.SandboxID, func(s sandbox.Sandbox) (sandbox.Sandbox, error) {
-		s.State = sandbox.StateRunning
+	_, err = storage.Update(t.Context(), sbx.TeamID, sbx.SandboxID, func(s sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
+		s.State = sandboxtypes.StateRunning
 
 		return s, nil
 	})
 	require.NoError(t, err)
 
 	// --- Transition B: pause again ---
-	_, _, callbackB, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, _, callbackB, err := storage.StartRemoving(t.Context(), sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	require.NotNil(t, callbackB)
 
@@ -1246,18 +1246,18 @@ func TestStartRemoving_CompletedTransitionAllowsNewTransition(t *testing.T) {
 	ctx := t.Context()
 
 	sbx := createTestSandbox("completed-allows-new")
-	sbx.State = sandbox.StateRunning
+	sbx.State = sandboxtypes.StateRunning
 	err := storage.Add(ctx, sbx)
 	require.NoError(t, err)
 
 	// Start and complete a pause transition
-	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionPause})
+	_, alreadyDone, callback, err := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionPause})
 	require.NoError(t, err)
 	assert.False(t, alreadyDone)
 	callback(ctx, nil)
 
 	// Immediately try to kill - should work since pause is completed
-	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandbox.RemoveOpts{Action: sandbox.StateActionKill})
+	_, alreadyDone2, callback2, err2 := storage.StartRemoving(ctx, sbx.TeamID, sbx.SandboxID, sandboxtypes.RemoveOpts{Action: sandboxtypes.StateActionKill})
 	require.NoError(t, err2)
 	assert.False(t, alreadyDone2)
 	require.NotNil(t, callback2)
@@ -1265,7 +1265,7 @@ func TestStartRemoving_CompletedTransitionAllowsNewTransition(t *testing.T) {
 	// Verify state is now Killing
 	updated, err := storage.Get(ctx, sbx.TeamID, sbx.SandboxID)
 	require.NoError(t, err)
-	assert.Equal(t, sandbox.StateKilling, updated.State)
+	assert.Equal(t, sandboxtypes.StateKilling, updated.State)
 
 	callback2(ctx, nil)
 }

--- a/packages/api/internal/sandbox/store.go
+++ b/packages/api/internal/sandbox/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox/sandboxtypes"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 )
@@ -27,35 +28,24 @@ type (
 	CreationCallback func(ctx context.Context, sbx Sandbox, meta CreationMetadata)
 )
 
-const (
-	StorageNameMemory        = "memory"
-	StorageNameRedis         = "redis"
-	StorageNamePopulateRedis = "populate_redis"
+const sbxRemoveTimeout = 10 * time.Second
 
-	sbxRemoveTimeout = 10 * time.Second
+// Storage names are re-exported from sandboxtypes for callers using this package.
+const (
+	StorageNameMemory        = sandboxtypes.StorageNameMemory
+	StorageNameRedis         = sandboxtypes.StorageNameRedis
+	StorageNamePopulateRedis = sandboxtypes.StorageNamePopulateRedis
 )
 
-type ReservationStorage interface {
-	Reserve(ctx context.Context, teamID uuid.UUID, sandboxID string, limit int) (finishStart func(Sandbox, error), waitForStart func(ctx context.Context) (Sandbox, error), err error)
-	Release(ctx context.Context, teamID uuid.UUID, sandboxID string) error
-}
-
-// TODO [ENG-3514]: Remove Name() and Sync() and nolint once migrated to Redis
-type Storage interface { //nolint: interfacebloat
-	Name() string
-	Add(ctx context.Context, sandbox Sandbox) error
-	Get(ctx context.Context, teamID uuid.UUID, sandboxID string) (Sandbox, error)
-	Remove(ctx context.Context, teamID uuid.UUID, sandboxID string) error
-
-	TeamItems(ctx context.Context, teamID uuid.UUID, states []State) ([]Sandbox, error)
-	ExpiredItems(ctx context.Context) ([]Sandbox, error)
-	TeamsWithSandboxCount(ctx context.Context) (map[uuid.UUID]int64, error)
-
-	Update(ctx context.Context, teamID uuid.UUID, sandboxID string, updateFunc func(sandbox Sandbox) (Sandbox, error)) (Sandbox, error)
-	StartRemoving(ctx context.Context, teamID uuid.UUID, sandboxID string, opts RemoveOpts) (Sandbox, bool, func(context.Context, error), error)
-	WaitForStateChange(ctx context.Context, teamID uuid.UUID, sandboxID string) error
-	Reconcile(ctx context.Context, sandboxes []Sandbox, nodeID string) []Sandbox
-}
+// Storage and ReservationStorage are re-exported from sandboxtypes so external
+// callers can continue to use sandbox.Storage / sandbox.ReservationStorage.
+// They live in sandboxtypes (a leaf package) so storage backends like
+// sandbox/storage/memory can implement them without creating an import cycle
+// back into package sandbox.
+type (
+	Storage            = sandboxtypes.Storage
+	ReservationStorage = sandboxtypes.ReservationStorage
+)
 
 type Callbacks struct {
 	// AddSandboxToRoutingTable should be called sync to prevent race conditions where we would know where to route the sandbox

--- a/packages/api/internal/sandbox/store_test.go
+++ b/packages/api/internal/sandbox/store_test.go
@@ -1,4 +1,4 @@
-package sandbox_test
+package sandbox
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/memory"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
@@ -25,8 +24,8 @@ import (
 // CallbackTracker tracks callback invocations with synchronization for async callbacks
 type CallbackTracker struct {
 	mu            sync.Mutex
-	calls         map[string][]sandbox.Sandbox
-	creationMeta  map[string][]sandbox.CreationMetadata
+	calls         map[string][]Sandbox
+	creationMeta  map[string][]CreationMetadata
 	expectedCalls int
 	actualCalls   atomic.Int32
 	done          chan struct{}
@@ -35,16 +34,16 @@ type CallbackTracker struct {
 
 func NewCallbackTracker(expectedCalls int) *CallbackTracker {
 	return &CallbackTracker{
-		calls:         make(map[string][]sandbox.Sandbox),
-		creationMeta:  make(map[string][]sandbox.CreationMetadata),
+		calls:         make(map[string][]Sandbox),
+		creationMeta:  make(map[string][]CreationMetadata),
 		expectedCalls: expectedCalls,
 		done:          make(chan struct{}),
 	}
 }
 
 // Track returns a callback function that tracks invocations
-func (ct *CallbackTracker) Track(name string) sandbox.InsertCallback {
-	return func(_ context.Context, sbx sandbox.Sandbox) {
+func (ct *CallbackTracker) Track(name string) InsertCallback {
+	return func(_ context.Context, sbx Sandbox) {
 		ct.mu.Lock()
 		ct.calls[name] = append(ct.calls[name], sbx)
 		ct.mu.Unlock()
@@ -58,8 +57,8 @@ func (ct *CallbackTracker) Track(name string) sandbox.InsertCallback {
 }
 
 // TrackCreation returns a CreationCallback that tracks invocations and per-call CreationMetadata.
-func (ct *CallbackTracker) TrackCreation(name string) sandbox.CreationCallback {
-	return func(_ context.Context, sbx sandbox.Sandbox, meta sandbox.CreationMetadata) {
+func (ct *CallbackTracker) TrackCreation(name string) CreationCallback {
+	return func(_ context.Context, sbx Sandbox, meta CreationMetadata) {
 		ct.mu.Lock()
 		ct.calls[name] = append(ct.calls[name], sbx)
 		ct.creationMeta[name] = append(ct.creationMeta[name], meta)
@@ -73,11 +72,11 @@ func (ct *CallbackTracker) TrackCreation(name string) sandbox.CreationCallback {
 	}
 }
 
-func (ct *CallbackTracker) GetCreationMeta(name string) []sandbox.CreationMetadata {
+func (ct *CallbackTracker) GetCreationMeta(name string) []CreationMetadata {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
 
-	return append([]sandbox.CreationMetadata{}, ct.creationMeta[name]...)
+	return append([]CreationMetadata{}, ct.creationMeta[name]...)
 }
 
 // WaitForCalls blocks until expected number of callbacks received or timeout
@@ -116,17 +115,17 @@ func (ct *CallbackTracker) AssertCallCount(t *testing.T, name string, count int)
 }
 
 // GetCalls returns all invocations for a callback
-func (ct *CallbackTracker) GetCalls(name string) []sandbox.Sandbox {
+func (ct *CallbackTracker) GetCalls(name string) []Sandbox {
 	ct.mu.Lock()
 	defer ct.mu.Unlock()
 
-	return append([]sandbox.Sandbox{}, ct.calls[name]...)
+	return append([]Sandbox{}, ct.calls[name]...)
 }
 
 // NoOpReservationStorage is a no-op implementation for testing
 type NoOpReservationStorage struct{}
 
-func (n *NoOpReservationStorage) Reserve(_ context.Context, _ uuid.UUID, _ string, _ int) (func(sandbox.Sandbox, error), func(ctx context.Context) (sandbox.Sandbox, error), error) {
+func (n *NoOpReservationStorage) Reserve(_ context.Context, _ uuid.UUID, _ string, _ int) (func(Sandbox, error), func(ctx context.Context) (Sandbox, error), error) {
 	return nil, nil, nil
 }
 
@@ -136,13 +135,13 @@ func (n *NoOpReservationStorage) Release(_ context.Context, _ uuid.UUID, _ strin
 
 // MockStorage wraps real storage and can inject errors
 type MockStorage struct {
-	sandbox.Storage
+	Storage
 
 	addError error
 	mu       sync.Mutex
 }
 
-func NewMockStorage(storage sandbox.Storage) *MockStorage {
+func NewMockStorage(storage Storage) *MockStorage {
 	return &MockStorage{
 		Storage: storage,
 	}
@@ -156,7 +155,7 @@ func (m *MockStorage) SetAddError(err error) {
 }
 
 // Add wraps Storage.Add() with error injection
-func (m *MockStorage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
+func (m *MockStorage) Add(ctx context.Context, sbx Sandbox) error {
 	m.mu.Lock()
 	err := m.addError
 	m.mu.Unlock()
@@ -169,8 +168,8 @@ func (m *MockStorage) Add(ctx context.Context, sbx sandbox.Sandbox) error {
 }
 
 // createTestSandbox creates a test sandbox with default values
-func createTestSandbox() sandbox.Sandbox {
-	return sandbox.NewSandbox(
+func createTestSandbox() Sandbox {
+	return NewSandbox(
 		"test-sandbox-"+uuid.New().String()[:8],
 		"test-template",
 		consts.ClientID,
@@ -217,16 +216,16 @@ func TestAdd_NewSandbox(t *testing.T) {
 		reservations := &NoOpReservationStorage{}
 
 		tracker := NewCallbackTracker(2) // Expect 2 callbacks
-		callbacks := sandbox.Callbacks{
+		callbacks := Callbacks{
 			AddSandboxToRoutingTable: tracker.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
 
-		store := sandbox.NewStore(storage, reservations, callbacks)
+		store := NewStore(storage, reservations, callbacks)
 		sbx := createTestSandbox()
 
 		// Execute
-		err := store.Add(ctx, sbx, &sandbox.CreationMetadata{})
+		err := store.Add(ctx, sbx, &CreationMetadata{})
 
 		// Wait for async callbacks
 		tracker.WaitForCalls(t, 2*time.Second)
@@ -256,27 +255,27 @@ func TestAdd_AlreadyInCache(t *testing.T) {
 
 		// First add with all 2 callbacks
 		tracker1 := NewCallbackTracker(2)
-		callbacks1 := sandbox.Callbacks{
+		callbacks1 := Callbacks{
 			AddSandboxToRoutingTable: tracker1.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker1.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store1 := sandbox.NewStore(storage, reservations, callbacks1)
+		store1 := NewStore(storage, reservations, callbacks1)
 		sbx := createTestSandbox()
 
-		err := store1.Add(ctx, sbx, &sandbox.CreationMetadata{})
+		err := store1.Add(ctx, sbx, &CreationMetadata{})
 		tracker1.WaitForCalls(t, 2*time.Second)
 		require.NoError(t, err)
 
 		// Second add with newlyCreated=true, only AsyncNewlyCreatedSandbox callback
 		// (AddSandboxToRoutingTable is NOT called because already in cache)
 		tracker2 := NewCallbackTracker(1)
-		callbacks2 := sandbox.Callbacks{
+		callbacks2 := Callbacks{
 			AddSandboxToRoutingTable: tracker2.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker2.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store2 := sandbox.NewStore(storage, reservations, callbacks2)
+		store2 := NewStore(storage, reservations, callbacks2)
 
-		err = store2.Add(ctx, sbx, &sandbox.CreationMetadata{})
+		err = store2.Add(ctx, sbx, &CreationMetadata{})
 		tracker2.WaitForCalls(t, 2*time.Second)
 
 		require.NoError(t, err)
@@ -293,25 +292,25 @@ func TestAdd_AlreadyInCache(t *testing.T) {
 
 		// First add with newlyCreated=true
 		tracker1 := NewCallbackTracker(2)
-		callbacks1 := sandbox.Callbacks{
+		callbacks1 := Callbacks{
 			AddSandboxToRoutingTable: tracker1.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker1.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store1 := sandbox.NewStore(storage, reservations, callbacks1)
+		store1 := NewStore(storage, reservations, callbacks1)
 		sbx := createTestSandbox()
 
-		err := store1.Add(ctx, sbx, &sandbox.CreationMetadata{})
+		err := store1.Add(ctx, sbx, &CreationMetadata{})
 		tracker1.WaitForCalls(t, 2*time.Second)
 		require.NoError(t, err)
 
 		// Second add with newlyCreated=false, no callbacks expected
 		// (No callbacks called because already in cache)
 		tracker2 := NewCallbackTracker(0)
-		callbacks2 := sandbox.Callbacks{
+		callbacks2 := Callbacks{
 			AddSandboxToRoutingTable: tracker2.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker2.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store2 := sandbox.NewStore(storage, reservations, callbacks2)
+		store2 := NewStore(storage, reservations, callbacks2)
 
 		err = store2.Add(ctx, sbx, nil)
 		require.NoError(t, err)
@@ -335,11 +334,11 @@ func TestAdd_NotNewlyCreated(t *testing.T) {
 
 		// Add with newlyCreated=false, expect 1 callback
 		tracker := NewCallbackTracker(1)
-		callbacks := sandbox.Callbacks{
+		callbacks := Callbacks{
 			AddSandboxToRoutingTable: tracker.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store := sandbox.NewStore(storage, reservations, callbacks)
+		store := NewStore(storage, reservations, callbacks)
 		sbx := createTestSandbox()
 
 		err := store.Add(ctx, sbx, nil)
@@ -359,11 +358,11 @@ func TestAdd_NotNewlyCreated(t *testing.T) {
 
 		// First add
 		tracker1 := NewCallbackTracker(1)
-		callbacks1 := sandbox.Callbacks{
+		callbacks1 := Callbacks{
 			AddSandboxToRoutingTable: tracker1.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker1.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store1 := sandbox.NewStore(storage, reservations, callbacks1)
+		store1 := NewStore(storage, reservations, callbacks1)
 		sbx := createTestSandbox()
 
 		err := store1.Add(ctx, sbx, nil)
@@ -372,11 +371,11 @@ func TestAdd_NotNewlyCreated(t *testing.T) {
 
 		// Second add with same sandbox, newlyCreated=false, no callbacks expected
 		tracker2 := NewCallbackTracker(0)
-		callbacks2 := sandbox.Callbacks{
+		callbacks2 := Callbacks{
 			AddSandboxToRoutingTable: tracker2.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker2.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store2 := sandbox.NewStore(storage, reservations, callbacks2)
+		store2 := NewStore(storage, reservations, callbacks2)
 
 		err = store2.Add(ctx, sbx, nil)
 		require.NoError(t, err)
@@ -404,14 +403,14 @@ func TestAdd_StorageErrors(t *testing.T) {
 
 		// Expect 0 callbacks since error should be returned immediately
 		tracker := NewCallbackTracker(1)
-		callbacks := sandbox.Callbacks{
+		callbacks := Callbacks{
 			AddSandboxToRoutingTable: tracker.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store := sandbox.NewStore(mockStorage, reservations, callbacks)
+		store := NewStore(mockStorage, reservations, callbacks)
 		sbx := createTestSandbox()
 
-		err := store.Add(ctx, sbx, &sandbox.CreationMetadata{})
+		err := store.Add(ctx, sbx, &CreationMetadata{})
 
 		// Error should be returned
 		require.Error(t, err)
@@ -438,11 +437,11 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 		numGoroutines := 100
 		tracker := NewCallbackTracker(numGoroutines * 2) // Each add calls 2 callbacks
 
-		callbacks := sandbox.Callbacks{
+		callbacks := Callbacks{
 			AddSandboxToRoutingTable: tracker.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store := sandbox.NewStore(storage, reservations, callbacks)
+		store := NewStore(storage, reservations, callbacks)
 
 		teamID := uuid.New()
 		var wg sync.WaitGroup
@@ -456,7 +455,7 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 				sbx := createTestSandbox()
 				sbx.SandboxID = fmt.Sprintf("concurrent-sandbox-%d", id)
 				sbx.TeamID = teamID
-				err := store.Add(ctx, sbx, &sandbox.CreationMetadata{})
+				err := store.Add(ctx, sbx, &CreationMetadata{})
 				if err != nil {
 					errorsChan <- err
 				}
@@ -503,11 +502,11 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 		// Total: 2 + 9 = 11 callbacks (AddSandboxToRoutingTable: 1, AsyncNewlyCreatedSandbox: 10)
 		tracker := NewCallbackTracker(1 + numGoroutines)
 
-		callbacks := sandbox.Callbacks{
+		callbacks := Callbacks{
 			AddSandboxToRoutingTable: tracker.Track("AddSandboxToRoutingTable"),
 			AsyncNewlyCreatedSandbox: tracker.TrackCreation("AsyncNewlyCreatedSandbox"),
 		}
-		store := sandbox.NewStore(storage, reservations, callbacks)
+		store := NewStore(storage, reservations, callbacks)
 
 		var wg sync.WaitGroup
 		successCount := atomic.Int32{}
@@ -515,7 +514,7 @@ func TestAdd_ConcurrentCalls(t *testing.T) {
 		// Launch concurrent adds for the same sandbox
 		for range numGoroutines {
 			wg.Go(func() {
-				err := store.Add(ctx, sbx, &sandbox.CreationMetadata{})
+				err := store.Add(ctx, sbx, &CreationMetadata{})
 				if err == nil {
 					successCount.Add(1)
 				}

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package smoketest_test
+package smoketest
 
 import (
 	"context"


### PR DESCRIPTION
Extract Sandbox, State, RemoveOpts, errors, Storage and
ReservationStorage interfaces, and related constants into a new
`sandboxtypes` leaf package. This breaks an import cycle that prevented
`store_test.go` from living in package `sandbox` alongside the code it
exercises.

Cycle being broken:

```text
sandbox (incl. _test.go files)
  -> sandbox/storage/memory       (used by tests as backing storage)
    -> sandbox                    (memory imports Sandbox, Storage, errors)
      ... CYCLE
````

Unlike the analogous fix for `nbd/testutils`, the back-edge here is not a
couple of helper functions but the entire memory (and redis) storage
implementations, which legitimately need the `Sandbox` struct, `State`
enum, error sentinels, and the `Storage` interface itself. Moving those
types into a leaf package is the cleanest break:

```text
sandboxtypes              (leaf: Sandbox, State, errors, Storage interface)
  ^         ^
  |         |
sandbox   sandbox/storage/{memory,redis,populate_redis}
sandbox   sandbox/reservations[/redis]
```

All arrows point at `sandboxtypes`; no cycle. Package `sandbox` keeps the
`Store` orchestrator, `Callbacks`, `CreationMetadata`, callback function
types, and now also re-exports every moved symbol via `aliases.go` so
external callers (handlers, orchestrator, utils, metrics, etc.)
continue to reference `sandbox.Sandbox`, `sandbox.ErrNotFound`,
`sandbox.StateRunning`, and so on without import churn.

### Files moved (renames)

```text
sandbox/sandbox.go  -> sandbox/sandboxtypes/sandbox.go
sandbox/states.go   -> sandbox/sandboxtypes/states.go
sandbox/errors.go   -> sandbox/sandboxtypes/errors.go
```

### New files

```text
sandbox/sandboxtypes/storage.go
  - Storage + ReservationStorage interfaces
  - StorageName* constants

sandbox/aliases.go
  - re-exports for backward compatibility
```

Storage backends and reservation packages now import `sandboxtypes`
directly. `store_test.go` is converted from `package sandbox_test` to
`package sandbox` now that the cycle is gone.

No behavior change. All sandbox tests pass; full `api` package builds
and vets cleanly.
