### PR TITLE
Run dedup page write phase asynchronously

### DIFF
--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -25,8 +25,8 @@ runs:
     - name: Build Sandbox Template
       env:
         TEMPLATE_ID: "2j6ly824owf4awgai1xo"
-        KERNEL_VERSION: "vmlinux-6.1.158"
-        FIRECRACKER_VERSION: "v1.14.1_458ca91"
+        KERNEL_VERSION: "vmlinux-6.1.158-c1a568c"
+        FIRECRACKER_VERSION: "v1.14.1_bd85e43"
         COMPRESS_ENABLED: ${{ inputs.compress_enabled }}
         COMPRESS_TYPE: ${{ inputs.compress_type }}
         COMPRESS_LEVEL: ${{ inputs.compress_level }}

--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Memfile dedup mode"
     required: false
     default: "default"
+  use_memfd:
+    description: "Run sandboxes with memfd-backed guest memory"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -134,6 +138,7 @@ runs:
         COMPRESS_LEVEL: ${{ inputs.compress_level }}
         COMPRESS_FRAME_ENCODE_WORKERS: ${{ inputs.compress_workers }}
         TESTS_MEMFILE_DIFF_DEDUP_MODE: ${{ inputs.dedup_mode }}
+        TESTS_USE_MEMFD: ${{ inputs.use_memfd }}
         E2B_DEBUG: "true"
       run: |
         mkdir -p $SHARED_CHUNK_CACHE_PATH

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,18 +26,21 @@ jobs:
             compress_level: ""
             compress_workers: ""
             dedup_mode: "default"
+            use_memfd: "false"
           - name: zstd1
             compress_enabled: "true"
             compress_type: "zstd"
             compress_level: "1"
             compress_workers: "8"
             dedup_mode: "best_effort"
+            use_memfd: "true"
           - name: lz4
             compress_enabled: "true"
             compress_type: "lz4"
             compress_level: "0"
             compress_workers: "8"
             dedup_mode: "direct_io"
+            use_memfd: "true"
     env:
       # Surfaced as env so upload steps can gate on presence (skipped on fork PRs).
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -68,6 +71,7 @@ jobs:
           compress_level: ${{ matrix.compress_level }}
           compress_workers: ${{ matrix.compress_workers }}
           dedup_mode: ${{ matrix.dedup_mode }}
+          use_memfd: ${{ matrix.use_memfd }}
 
       - name: Run Integration Tests
         env:

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -27,16 +27,16 @@ func main() {
 }
 
 func applyTestFlagOverrides() {
-	mode := os.Getenv("TESTS_MEMFILE_DIFF_DEDUP_MODE")
-	if mode == "" {
-		return
+	if mode := os.Getenv("TESTS_MEMFILE_DIFF_DEDUP_MODE"); mode != "" {
+		featureflags.OverrideJSONFlag(featureflags.MemfileDiffDedupFlag, ldvalue.FromJSONMarshal(map[string]any{
+			"enabled":    true,
+			"bestEffort": mode == "best_effort",
+			"directIO":   mode == "direct_io",
+		}))
 	}
-
-	featureflags.OverrideJSONFlag(featureflags.MemfileDiffDedupFlag, ldvalue.FromJSONMarshal(map[string]any{
-		"enabled":    true,
-		"bestEffort": mode == "best_effort",
-		"directIO":   mode == "direct_io",
-	}))
+	if os.Getenv("TESTS_USE_MEMFD") == "true" {
+		featureflags.OverrideBoolFlag(featureflags.UseMemFdFlag, true)
+	}
 }
 
 func defaultEgressFactory(_ context.Context, deps *factories.Deps) (*factories.EgressSetup, error) {

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -206,71 +206,48 @@ func (c *Cache) ExportToDiff(ctx context.Context, out *os.File) (*header.DiffMet
 	return diffMetadata, nil
 }
 
-// dedupPages writes src pages that differ from base, packed at PageSize,
-// to outPath. bestEffort skips uncached blocks; directIO uses O_DIRECT.
-func dedupPages(
+type dedupPlan struct {
+	pageDirty    *roaring.Bitmap
+	pageEmpty    *roaring.Bitmap
+	exportedSize int64
+}
+
+// dedupCompare classifies each dirty page against base into pageDirty or
+// pageEmpty. Per-page IsCached so a single uncached neighbour can't poison
+// cached pages of the same block when the parent header is page-granular.
+func dedupCompare(
 	ctx context.Context,
 	src func(absOff int64) ([]byte, error),
 	base ReadonlyDevice,
 	dirty *roaring.Bitmap,
 	blockSize int64,
-	outPath string,
 	bestEffort bool,
-	directIO bool,
-) (*Cache, *header.DiffMetadata, error) {
-	ctx, span := tracer.Start(ctx, "dedup-pages")
-	defer span.End()
-
-	openFlags := os.O_RDWR | os.O_CREATE
-	if directIO {
-		openFlags |= unix.O_DIRECT
-	}
-	f, err := os.OpenFile(outPath, openFlags, 0o644)
-	if err != nil {
-		return nil, nil, fmt.Errorf("open dedup cache: %w", err)
-	}
-	if directIO {
-		worst := int64(dirty.GetCardinality()) * blockSize
-		if fErr := unix.Fallocate(int(f.Fd()), 0, 0, worst); fErr != nil {
-			logger.L().Warn(ctx, "fallocate dedup cache; proceeding without preallocation", zap.Error(fErr))
-		}
-	}
-
+) (*dedupPlan, error) {
 	pageDirty := roaring.New()
 	pageEmpty := roaring.New()
 	var exportedSize int64
 
-	compareStart := time.Now()
+	baseHeader := base.Header()
+	peeker, _ := base.(CachePeeker)
+
 	for r := range BitsetRanges(dirty, blockSize) {
 		exportedSize += r.Size
 
 		for chunkOff := int64(0); chunkOff < r.Size; chunkOff += blockSize {
 			if err := ctx.Err(); err != nil {
-				return nil, nil, errors.Join(err, f.Close(), os.Remove(outPath))
+				return nil, err
 			}
 
 			absOff := r.Start + chunkOff
 			srcBuf, err := src(absOff)
 			if err != nil {
-				return nil, nil, errors.Join(err, f.Close(), os.Remove(outPath))
-			}
-
-			// Empty parent or best-effort cache miss: classify by IsZero alone.
-			skipBase := false
-			if h := base.Header(); h != nil {
-				if m, err := h.GetShiftedMapping(ctx, absOff); err == nil {
-					skipBase = m.BuildId == uuid.Nil && int64(m.Length) >= blockSize
-				}
-			}
-			if !skipBase && bestEffort {
-				if peeker, ok := base.(CachePeeker); ok && !peeker.IsCached(ctx, absOff, blockSize) {
-					skipBase = true
-				}
+				return nil, err
 			}
 
 			for i := int64(0); i < blockSize; i += header.PageSize {
 				srcPage := srcBuf[i : i+header.PageSize]
 				pageIdx := uint32((absOff + i) / header.PageSize)
+				pageOff := absOff + i
 
 				if header.IsZero(srcPage) {
 					pageEmpty.Add(pageIdx)
@@ -278,15 +255,26 @@ func dedupPages(
 					continue
 				}
 
-				if skipBase {
+				skip := false
+				if baseHeader != nil {
+					if m, err := baseHeader.GetShiftedMapping(ctx, pageOff); err == nil {
+						if m.BuildId == uuid.Nil && int64(m.Length) >= header.PageSize {
+							skip = true
+						}
+					}
+				}
+				if !skip && bestEffort && peeker != nil && !peeker.IsCached(ctx, pageOff, header.PageSize) {
+					skip = true
+				}
+				if skip {
 					pageDirty.Add(pageIdx)
 
 					continue
 				}
 
-				basePage, sErr := base.Slice(ctx, absOff+i, header.PageSize)
+				basePage, sErr := base.Slice(ctx, pageOff, header.PageSize)
 				if sErr != nil {
-					return nil, nil, errors.Join(fmt.Errorf("slice base at %d: %w", absOff+i, sErr), f.Close(), os.Remove(outPath))
+					return nil, fmt.Errorf("slice base at %d: %w", pageOff, sErr)
 				}
 				if bytes.Equal(srcPage, basePage) {
 					continue
@@ -296,33 +284,57 @@ func dedupPages(
 			}
 		}
 	}
-	compareDur := time.Since(compareStart)
 
-	writeStart := time.Now()
+	return &dedupPlan{pageDirty: pageDirty, pageEmpty: pageEmpty, exportedSize: exportedSize}, nil
+}
+
+// dedupDrain writes pageDirty pages from src to outPath packed at PageSize.
+func dedupDrain(
+	ctx context.Context,
+	src func(absOff int64) ([]byte, error),
+	pageDirty *roaring.Bitmap,
+	blockSize int64,
+	outPath string,
+	directIO bool,
+) (*Cache, error) {
+	openFlags := os.O_RDWR | os.O_CREATE
+	if directIO {
+		openFlags |= unix.O_DIRECT
+	}
+	f, err := os.OpenFile(outPath, openFlags, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open dedup cache: %w", err)
+	}
+	if want := int64(pageDirty.GetCardinality()) * header.PageSize; directIO && want > 0 {
+		if fErr := unix.Fallocate(int(f.Fd()), 0, 0, want); fErr != nil {
+			logger.L().Warn(ctx, "fallocate dedup cache; proceeding without preallocation", zap.Error(fErr))
+		}
+	}
+
 	fileOff, err := drainDirtyPages(ctx, int(f.Fd()), src, pageDirty, blockSize)
 	if err != nil {
-		return nil, nil, errors.Join(err, f.Close(), os.Remove(outPath))
+		return nil, errors.Join(err, f.Close(), os.Remove(outPath))
 	}
-	writeDur := time.Since(writeStart)
 
 	if directIO {
 		if err := f.Truncate(fileOff); err != nil {
-			return nil, nil, errors.Join(fmt.Errorf("truncate dedup cache: %w", err), f.Close(), os.Remove(outPath))
+			return nil, errors.Join(fmt.Errorf("truncate dedup cache: %w", err), f.Close(), os.Remove(outPath))
 		}
 	}
 	if err := f.Close(); err != nil {
-		return nil, nil, errors.Join(err, os.Remove(outPath))
+		return nil, errors.Join(err, os.Remove(outPath))
 	}
 
 	cache, err := NewCache(fileOff, header.PageSize, outPath, false)
 	if err != nil {
-		return nil, nil, errors.Join(err, os.Remove(outPath))
+		return nil, errors.Join(err, os.Remove(outPath))
 	}
 	cache.setIsCached(0, fileOff)
 
-	totalPages := exportedSize / header.PageSize
-	uniquePages := int64(pageDirty.GetCardinality())
-	emptyPages := int64(pageEmpty.GetCardinality())
+	return cache, nil
+}
+
+func recordDedupAttrs(ctx context.Context, totalPages, uniquePages, emptyPages int64, compareDur, writeDur time.Duration) {
 	dedupedPages := totalPages - uniquePages - emptyPages
 	ratio := 0.0
 	if totalPages > 0 {
@@ -337,68 +349,51 @@ func dedupPages(
 		attribute.Int64("dedup.compare_ms", compareDur.Milliseconds()),
 		attribute.Int64("dedup.write_ms", writeDur.Milliseconds()),
 	)
-
-	return cache, &header.DiffMetadata{
-		Dirty:     pageDirty,
-		Empty:     pageEmpty,
-		BlockSize: header.PageSize,
-	}, nil
 }
 
+// drainDirtyPages packs pageDirty pages from src into fd. Mirrors
+// Cache.copyProcessMemory: coalesce contiguous pages into ranges, carve at
+// source-block boundaries, pre-split over MAX_RW_COUNT, then drainIovs.
 func drainDirtyPages(ctx context.Context, fd int, src func(absOff int64) ([]byte, error), pageDirty *roaring.Bitmap, blockSize int64) (int64, error) {
-	maxBytes := getAlignedMaxRwCount(header.PageSize)
-	batch := make([][]byte, 0, IOV_MAX)
-	var batchBytes int64
-	var fileOff int64
-	flush := func() error {
-		if len(batch) == 0 {
+	var ranges []Range
+	for r := range BitsetRanges(pageDirty, header.PageSize) {
+		for off := r.Start; off < r.End(); {
+			blockOff := (off / blockSize) * blockSize
+			chunkEnd := min(r.End(), blockOff+blockSize)
+			ranges = append(ranges, Range{Start: off, Size: chunkEnd - off})
+			off = chunkEnd
+		}
+	}
+	ranges = splitOversizedRanges(ranges, getAlignedMaxRwCount(header.PageSize))
+
+	if err := drainIovs(ranges, func(r Range) int64 { return r.Size }, header.PageSize,
+		func(destOff int64, batch []Range, _ int64) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			iovs := make([][]byte, len(batch))
+			for i, r := range batch {
+				blockOff := (r.Start / blockSize) * blockSize
+				buf, srcErr := src(blockOff)
+				if srcErr != nil {
+					return fmt.Errorf("slice src at %d: %w", blockOff, srcErr)
+				}
+				iovs[i] = buf[r.Start-blockOff : r.Start-blockOff+r.Size]
+			}
+			if err := pwritevAll(fd, destOff, iovs); err != nil {
+				return fmt.Errorf("pwritev dedup pages: %w", err)
+			}
+
 			return nil
-		}
-		if err := pwritevAll(fd, fileOff, batch); err != nil {
-			return err
-		}
-
-		fileOff += batchBytes
-		batch = batch[:0]
-		batchBytes = 0
-
-		return nil
+		}); err != nil {
+		return 0, err
 	}
 
-	var curBlockOff int64 = -1
-	var curBuf []byte
-	it := pageDirty.Iterator()
-	for it.HasNext() {
-		if err := ctx.Err(); err != nil {
-			return 0, err
-		}
-		absOff := int64(it.Next()) * header.PageSize
-		blockOff := (absOff / blockSize) * blockSize
-		if blockOff != curBlockOff {
-			buf, err := src(blockOff)
-			if err != nil {
-				return 0, fmt.Errorf("slice src at %d: %w", blockOff, err)
-			}
-			curBuf = buf
-			curBlockOff = blockOff
-		}
-		inner := absOff - curBlockOff
-		if len(batch) >= IOV_MAX || batchBytes+header.PageSize > maxBytes {
-			if err := flush(); err != nil {
-				return 0, fmt.Errorf("drain dedup iovs: %w", err)
-			}
-		}
-		batch = append(batch, curBuf[inner:inner+header.PageSize])
-		batchBytes += header.PageSize
-	}
-	if err := flush(); err != nil {
-		return 0, fmt.Errorf("drain dedup iovs: %w", err)
-	}
-
-	return fileOff, nil
+	return GetSize(ranges), nil
 }
 
-// Dedup deduplicates c against base; see dedupPages.
+// Dedup writes pages from c that differ from base, packed at PageSize, to
+// outPath. bestEffort skips uncached blocks; directIO uses O_DIRECT.
 func (c *Cache) Dedup(
 	ctx context.Context,
 	base ReadonlyDevice,
@@ -408,6 +403,9 @@ func (c *Cache) Dedup(
 	bestEffort bool,
 	directIO bool,
 ) (*Cache, *header.DiffMetadata, error) {
+	ctx, span := tracer.Start(ctx, "dedup-pages")
+	defer span.End()
+
 	// c is packed in BitsetRanges order; map abs offset → packed offset.
 	packed := make(map[int64]int64, dirty.GetCardinality())
 	var cum int64
@@ -426,7 +424,30 @@ func (c *Cache) Dedup(
 		return c.Slice(idx, blockSize)
 	}
 
-	return dedupPages(ctx, src, base, dirty, blockSize, outPath, bestEffort, directIO)
+	compareStart := time.Now()
+	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
+	if err != nil {
+		return nil, nil, err
+	}
+	compareDur := time.Since(compareStart)
+
+	writeStart := time.Now()
+	cache, err := dedupDrain(ctx, src, plan.pageDirty, blockSize, outPath, directIO)
+	if err != nil {
+		return nil, nil, err
+	}
+	recordDedupAttrs(ctx,
+		plan.exportedSize/header.PageSize,
+		int64(plan.pageDirty.GetCardinality()),
+		int64(plan.pageEmpty.GetCardinality()),
+		compareDur, time.Since(writeStart),
+	)
+
+	return cache, &header.DiffMetadata{
+		Dirty:     plan.pageDirty,
+		Empty:     plan.pageEmpty,
+		BlockSize: header.PageSize,
+	}, nil
 }
 
 func (c *Cache) ReadAt(b []byte, off int64) (int, error) {

--- a/packages/orchestrator/pkg/sandbox/block/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache_test.go
@@ -1097,3 +1097,46 @@ func TestCacheDedup_BestEffortCachedMatchesNormalPath(t *testing.T) {
 	require.EqualValues(t, 1, meta.Dirty.GetCardinality(), "only the genuinely differing page is dirty")
 	require.EqualValues(t, 0, meta.Empty.GetCardinality())
 }
+
+type perPagePeeker struct {
+	fakeOriginalDevice
+
+	cachedPages map[uint32]bool
+}
+
+func (p *perPagePeeker) IsCached(_ context.Context, off, _ int64) bool {
+	return p.cachedPages[uint32(off/int64(header.PageSize))]
+}
+
+// Best-effort decides per page, not per block: when the parent has cached and
+// uncached pages inside the same dedup block, only the uncached ones get
+// written through. The earlier block-granular check gave up dedup on the
+// whole block as soon as any page inside it was uncached.
+func TestCacheDedup_BestEffortPerPageCacheCheck(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	blockSize := 4 * pageSize
+	size := blockSize
+
+	srcData := make([]byte, size)
+	_, err := rand.Read(srcData)
+	require.NoError(t, err)
+	baseData := make([]byte, size)
+	copy(baseData, srcData)
+
+	dirty := fullDirty(size, blockSize)
+	src := buildPackedSrcCache(t, srcData, dirty, blockSize)
+	base := &perPagePeeker{
+		fakeOriginalDevice: fakeOriginalDevice{data: baseData},
+		cachedPages:        map[uint32]bool{0: true, 1: false, 2: true, 3: false},
+	}
+
+	cache, meta, err := src.Dedup(t.Context(), base, dirty, blockSize, t.TempDir()+"/dedup", true, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	require.EqualValues(t, 2, meta.Dirty.GetCardinality())
+	require.True(t, meta.Dirty.Contains(1))
+	require.True(t, meta.Dirty.Contains(3))
+}

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,6 +17,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // Memfd wraps a memfd received from Firecracker. NewFromFd takes ownership of
@@ -121,11 +124,9 @@ func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roari
 // closes the memfd (releasing the hugetlb pages — potentially tens of GB)
 // and reads delegate to the embedded Cache.
 type MemfdCache struct {
-	cache *Cache
-
+	cache  *Cache
 	cancel context.CancelFunc
-	done   chan struct{} // closed by runCopy; happens-before for err
-	err    error
+	done   *utils.SetOnce[struct{}]
 }
 
 // NewCacheFromMemfdAsync starts the memfd→cache copy on a goroutine so
@@ -150,21 +151,19 @@ func NewCacheFromMemfdAsync(
 	if err != nil {
 		return nil, errors.Join(err, memfd.Close())
 	}
+	done := utils.NewSetOnce[struct{}]()
 	if dirty.IsEmpty() {
 		if closeErr := memfd.Close(); closeErr != nil {
 			return nil, errors.Join(fmt.Errorf("close memfd: %w", closeErr), cache.Close())
 		}
+		_ = done.SetValue(struct{}{})
 
-		return &MemfdCache{cache: cache}, nil
+		return &MemfdCache{cache: cache, done: done}, nil
 	}
 
 	// Detach from the request context so the copy outlives Pause.
 	copyCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	m := &MemfdCache{
-		cache:  cache,
-		cancel: cancel,
-		done:   make(chan struct{}),
-	}
+	m := &MemfdCache{cache: cache, cancel: cancel, done: done}
 
 	go m.runCopy(copyCtx, memfd, dirty, blockSize)
 
@@ -176,22 +175,14 @@ func (m *MemfdCache) runCopy(ctx context.Context, memfd *Memfd, dirty *roaring.B
 	if closeErr := memfd.Close(); closeErr != nil {
 		err = errors.Join(err, fmt.Errorf("close memfd: %w", closeErr))
 	}
-	m.err = err
-	close(m.done)
+	_ = m.done.SetResult(struct{}{}, err)
 }
 
 // Wait blocks until the background copy completes (or ctx is cancelled).
 func (m *MemfdCache) Wait(ctx context.Context) error {
-	if m.done == nil {
-		return nil
-	}
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-m.done:
-	}
+	_, err := m.done.WaitWithContext(ctx)
 
-	return m.err
+	return err
 }
 
 func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
@@ -213,7 +204,7 @@ func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
 func (m *MemfdCache) Close() error {
 	if m.cancel != nil {
 		m.cancel()
-		<-m.done
+		<-m.done.Done
 	}
 
 	return m.cache.Close()
@@ -238,8 +229,14 @@ func (m *MemfdCache) FileSize(ctx context.Context) (int64, error) {
 func (m *MemfdCache) BlockSize() int64     { return m.cache.BlockSize() }
 func (m *MemfdCache) Size() (int64, error) { return m.cache.Size() }
 
-// NewCacheFromMemfdDeduped deduplicates memfd contents against base; see
-// dedupPages. Consumes memfd.
+// DedupedMemfdCache is the dedup analogue of MemfdCache: compare runs
+// synchronously so the diff metadata is ready, drain runs on a goroutine.
+type DedupedMemfdCache struct {
+	outPath string
+	cancel  context.CancelFunc
+	done    *utils.SetOnce[*Cache]
+}
+
 func NewCacheFromMemfdDeduped(
 	ctx context.Context,
 	base ReadonlyDevice,
@@ -249,18 +246,127 @@ func NewCacheFromMemfdDeduped(
 	dirty *roaring.Bitmap,
 	bestEffort bool,
 	directIO bool,
-) (*Cache, *header.DiffMetadata, error) {
+) (*DedupedMemfdCache, *header.DiffMetadata, error) {
+	ctx, span := tracer.Start(ctx, "dedup-compare")
+	defer span.End()
+
 	src := func(absOff int64) ([]byte, error) { return memfd.Slice(absOff, blockSize) }
 
-	cache, meta, err := dedupPages(ctx, src, base, dirty, blockSize, outPath, bestEffort, directIO)
+	compareStart := time.Now()
+	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
 	if err != nil {
 		return nil, nil, errors.Join(err, memfd.Close())
 	}
-	if err := memfd.Close(); err != nil {
-		logger.L().Warn(ctx, "close memfd after dedup", zap.Error(err))
+	compareDur := time.Since(compareStart)
+
+	// Snapshot counts before exposing the bitmaps via meta; pauseProcessMemory
+	// mutates Empty after we return, which would race with recordDedupAttrs.
+	totalPages := plan.exportedSize / header.PageSize
+	uniquePages := int64(plan.pageDirty.GetCardinality())
+	emptyPages := int64(plan.pageEmpty.GetCardinality())
+
+	meta := &header.DiffMetadata{
+		Dirty:     plan.pageDirty,
+		Empty:     plan.pageEmpty,
+		BlockSize: header.PageSize,
 	}
 
-	return cache, meta, nil
+	drainCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	d := &DedupedMemfdCache{
+		outPath: outPath,
+		cancel:  cancel,
+		done:    utils.NewSetOnce[*Cache](),
+	}
+	go d.runDrain(drainCtx, src, memfd, plan.pageDirty, blockSize, directIO, compareDur, totalPages, uniquePages, emptyPages)
+
+	return d, meta, nil
+}
+
+func (d *DedupedMemfdCache) runDrain(
+	ctx context.Context,
+	src func(absOff int64) ([]byte, error),
+	memfd *Memfd,
+	pageDirty *roaring.Bitmap,
+	blockSize int64,
+	directIO bool,
+	compareDur time.Duration,
+	totalPages, uniquePages, emptyPages int64,
+) {
+	ctx, span := tracer.Start(ctx, "dedup-drain")
+	defer span.End()
+
+	writeStart := time.Now()
+	cache, err := dedupDrain(ctx, src, pageDirty, blockSize, d.outPath, directIO)
+	writeDur := time.Since(writeStart)
+
+	// Log only: a memfd close failure shouldn't fail in-flight Wait callers.
+	if closeErr := memfd.Close(); closeErr != nil {
+		logger.L().Warn(ctx, "close memfd after dedup drain", zap.Error(closeErr))
+	}
+
+	recordDedupAttrs(ctx, totalPages, uniquePages, emptyPages, compareDur, writeDur)
+	_ = d.done.SetResult(cache, err)
+}
+
+func (d *DedupedMemfdCache) Wait(ctx context.Context) (*Cache, error) {
+	return d.done.WaitWithContext(ctx)
+}
+
+func (d *DedupedMemfdCache) ReadAt(b []byte, off int64) (int, error) {
+	c, err := d.Wait(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	return c.ReadAt(b, off)
+}
+
+func (d *DedupedMemfdCache) Slice(off, length int64) ([]byte, error) {
+	c, err := d.Wait(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Slice(off, length)
+}
+
+func (d *DedupedMemfdCache) Close() error {
+	d.cancel()
+	c, _ := d.done.Wait()
+	if c != nil {
+		return c.Close()
+	}
+	_ = os.Remove(d.outPath)
+
+	return nil
+}
+
+func (d *DedupedMemfdCache) Path(ctx context.Context) (string, error) {
+	c, err := d.Wait(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return c.filePath, nil
+}
+
+func (d *DedupedMemfdCache) FileSize(ctx context.Context) (int64, error) {
+	c, err := d.Wait(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return c.FileSize(ctx)
+}
+
+func (d *DedupedMemfdCache) BlockSize() int64 { return header.PageSize }
+func (d *DedupedMemfdCache) Size() (int64, error) {
+	c, err := d.Wait(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	return c.Size()
 }
 
 // pwritevAll writes the iovecs at off, handling EINTR and short writes by

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -198,3 +198,47 @@ func TestNewCacheFromMemfdAsync_DetachesAndFlushes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, fromFile)
 }
+
+// Compare returns metadata synchronously while drain detaches; after Wait the
+// deduped cache contains only pages that differ from base.
+func TestNewCacheFromMemfdDeduped_DrainIsAsync(t *testing.T) {
+	t.Parallel()
+
+	pageSize := int64(header.PageSize)
+	numPages := uint32(8)
+	size := pageSize * int64(numPages)
+
+	memfd, srcData := newTestMemfd(t, size)
+	baseData := make([]byte, size)
+	copy(baseData, srcData)
+	for _, p := range []uint32{1, 4} {
+		off := int64(p) * pageSize
+		for i := range pageSize {
+			baseData[off+i] ^= 0xFF
+		}
+	}
+
+	dirty := roaring.New()
+	dirty.AddRange(0, uint64(numPages))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cachePath := t.TempDir() + "/dedup-async"
+	cache, meta, err := NewCacheFromMemfdDeduped(
+		ctx, &fakeOriginalDevice{data: baseData}, pageSize, cachePath, memfd, dirty, false, false,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cache.Close() })
+
+	require.Equal(t, uint64(2), meta.Dirty.GetCardinality())
+
+	cancel()
+	_, err = cache.Wait(t.Context())
+	require.NoError(t, err)
+
+	got := make([]byte, pageSize*2)
+	_, err = cache.ReadAt(got, 0)
+	require.NoError(t, err)
+	expected := append([]byte{}, srcData[pageSize:pageSize*2]...)
+	expected = append(expected, srcData[pageSize*4:pageSize*5]...)
+	require.Equal(t, expected, got)
+}

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -63,10 +63,11 @@ func (p *Process) exportMemoryFromFc(
 }
 
 // ExportMemory writes dirty guest memory to cachePath. If originalMemfile
-// is non-nil the result is deduplicated and DiffMetadata is non-nil;
-// mutually exclusive with bgCopy. When dedupBestEffort is true, blocks whose
+// is non-nil the result is deduplicated and DiffMetadata is non-nil; the
+// memfd dedup path detaches its drain to a goroutine (see
+// NewCacheFromMemfdDeduped). When dedupBestEffort is true, blocks whose
 // base data isn't already in the chunker's local cache are written through
-// as-is (see block.dedupPages).
+// as-is.
 func (p *Process) ExportMemory(
 	ctx context.Context,
 	include *roaring.Bitmap,

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -353,7 +353,7 @@ const (
 const (
 	DefaultFirecackerV1_10Version = "v1.10.1_30cbb07"
 	DefaultFirecackerV1_12Version = "v1.12.1_210cbac"
-	DefaultFirecackerV1_14Version = "v1.14.1_458ca91"
+	DefaultFirecackerV1_14Version = "v1.14.1_bd85e43"
 	DefaultFirecrackerVersion     = DefaultFirecackerV1_12Version
 )
 

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -223,7 +223,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, created_at, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 512, 1982, "vmlinux-6.1.102", "v1.14.1_458ca91", pkg.Version,
+				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_bd85e43", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version, build.createdAt)
 		} else {
 			err = db.TestsRawSQL(ctx, `
@@ -233,7 +233,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 512, 1982, "vmlinux-6.1.102", "v1.14.1_458ca91", pkg.Version,
+				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_bd85e43", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version)
 		}
 		if err != nil {


### PR DESCRIPTION
Memfd dedup ran the page write phase synchronously on the Pause RPC, ignoring the bgCopy detachment. Split `dedupPages` into a sync compare and an async drain wrapped in `DedupedMemfdCache` (mirrors `MemfdCache`); reads block via `SetOnce[*Cache].WaitWithContext`, the goroutine owns and closes the memfd. The diff metadata/header still comes back synchronously so `AddSnapshot`/`NewUpload` keep working unchanged. Also coalesces contiguous dirty pages in `drainDirtyPages` (mirrors `Cache.copyProcessMemory`) and moves the best-effort `IsCached`/`uuid.Nil` check to per-page granularity so a single uncached neighbour no longer poisons cached pages of the same block. Integration matrix wires `TESTS_USE_MEMFD` so two of the three variants exercise the new async path end-to-end.