### PR TITLE
orchestrator: add read-only reconcile sweep command (diagnostics)

### DIFF
--- a/packages/orchestrator/cmd/reconcile/README.md
+++ b/packages/orchestrator/cmd/reconcile/README.md
@@ -31,11 +31,4 @@ Usage & Safety
 	remediation (deleting sockets, removing iptables rules, killing processes)
 	must be performed under an explicit, reviewed runbook.
 
-使用与安全说明（中文）
---------------------
 
-- 目的：生成只读诊断报告，列出 Firecracker 相关的主机遗留工件，并保存 `nat` 表输出以便调查。
-- 只读：该命令不会修改 iptables、网络设备或虚拟机。
-- 权限：通常需要 root 权限读取 iptables；如需使用请用 `sudo`。该工具仅调用 `iptables-save`，不做写操作。
-- 可测性：实现中支持注入 `ExecCommand`，测试时不会实际调用系统命令。
-- 运行建议：此工具用于检测与调查，不要用于自动清理。任何清理或回收必须通过独立且受审查的操作手册执行。

--- a/packages/orchestrator/cmd/reconcile/README.md
+++ b/packages/orchestrator/cmd/reconcile/README.md
@@ -1,0 +1,17 @@
+Reconcile sweep
+================
+
+This small command scans Firecracker artifacts and the nat iptables table and writes a report.
+
+Build:
+
+```bash
+cd packages/orchestrator
+go build ./cmd/reconcile
+```
+
+Run (requires root to read iptables and /data0/tmp):
+
+```bash
+sudo ./reconcile -out /tmp/reconcile-report.txt
+```

--- a/packages/orchestrator/cmd/reconcile/README.md
+++ b/packages/orchestrator/cmd/reconcile/README.md
@@ -15,3 +15,27 @@ Run (requires root to read iptables and /data0/tmp):
 ```bash
 sudo ./reconcile -out /tmp/reconcile-report.txt
 ```
+
+Usage & Safety
+--------------
+
+- Purpose: produce a read-only diagnostics report that lists Firecracker-related
+	host artifacts (API sockets, uffd sockets, fc-metrics FIFOs) and captures the
+	`nat` table via `iptables-save` for incident investigation.
+- Read-only: the command does not modify iptables, network devices, or VMs.
+- Privileges: reading the nat table usually requires root; run with `sudo` if
+	necessary. The tool only executes `iptables-save` (no writes).
+- Testability: the package exposes an injectable `ExecCommand` used by unit
+	tests to avoid invoking system commands in test environments.
+- Operational note: do not run this as an automated cleanup tool. Any
+	remediation (deleting sockets, removing iptables rules, killing processes)
+	must be performed under an explicit, reviewed runbook.
+
+使用与安全说明（中文）
+--------------------
+
+- 目的：生成只读诊断报告，列出 Firecracker 相关的主机遗留工件，并保存 `nat` 表输出以便调查。
+- 只读：该命令不会修改 iptables、网络设备或虚拟机。
+- 权限：通常需要 root 权限读取 iptables；如需使用请用 `sudo`。该工具仅调用 `iptables-save`，不做写操作。
+- 可测性：实现中支持注入 `ExecCommand`，测试时不会实际调用系统命令。
+- 运行建议：此工具用于检测与调查，不要用于自动清理。任何清理或回收必须通过独立且受审查的操作手册执行。

--- a/packages/orchestrator/cmd/reconcile/main.go
+++ b/packages/orchestrator/cmd/reconcile/main.go
@@ -1,0 +1,20 @@
+package reconcile
+package main
+
+import (
+    "flag"
+    "fmt"
+    "os"
+
+    "github.com/e2b-dev/infra/packages/orchestrator/pkg/reconcile"
+)
+
+func main() {
+    out := flag.String("out", "", "output report path (default /tmp/reconcile-report-<ts>.txt)")
+    flag.Parse()
+
+    if err := reconcile.RunReconcile(*out); err != nil {
+        fmt.Fprintf(os.Stderr, "reconcile error: %v\n", err)
+        os.Exit(2)
+    }
+}

--- a/packages/orchestrator/cmd/reconcile/main.go
+++ b/packages/orchestrator/cmd/reconcile/main.go
@@ -1,20 +1,19 @@
-package reconcile
 package main
 
 import (
-    "flag"
-    "fmt"
-    "os"
+	"flag"
+	"fmt"
+	"os"
 
-    "github.com/e2b-dev/infra/packages/orchestrator/pkg/reconcile"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/reconcile"
 )
 
 func main() {
-    out := flag.String("out", "", "output report path (default /tmp/reconcile-report-<ts>.txt)")
-    flag.Parse()
+	out := flag.String("out", "", "output report path (default /tmp/reconcile-report-<ts>.txt)")
+	flag.Parse()
 
-    if err := reconcile.RunReconcile(*out); err != nil {
-        fmt.Fprintf(os.Stderr, "reconcile error: %v\n", err)
-        os.Exit(2)
-    }
+	if err := reconcile.RunReconcile(*out); err != nil {
+		fmt.Fprintf(os.Stderr, "reconcile error: %v\n", err)
+		os.Exit(2)
+	}
 }

--- a/packages/orchestrator/pkg/reconcile/reconcile.go
+++ b/packages/orchestrator/pkg/reconcile/reconcile.go
@@ -1,0 +1,72 @@
+package reconcile
+package reconcile
+
+import (
+    "bytes"
+    "fmt"
+    "io/ioutil"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "time"
+)
+
+// RunReconcile scans common Firecracker artifact locations and iptables
+// and writes a plain-text report to stdout and to /tmp/reconcile-report-<ts>.txt.
+func RunReconcile(outPath string) error {
+    ts := time.Now().UTC().Format("20060102T150405Z")
+    if outPath == "" {
+        outPath = fmt.Sprintf("/tmp/reconcile-report-%s.txt", ts)
+    }
+
+    var buf bytes.Buffer
+    fmt.Fprintf(&buf, "Reconcile sweep report\nTimestamp: %s\n\n", ts)
+
+    // scan socket dirs
+    fmt.Fprintln(&buf, "==== Firecracker api sockets (/data0/tmp and /tmp) ====")
+    scanAndWrite(&buf, "/data0/tmp", "fc-*.sock")
+    scanAndWrite(&buf, "/tmp", "fc-*.sock")
+
+    fmt.Fprintln(&buf, "\n==== uffd sockets (/data0/tmp) ====")
+    scanAndWrite(&buf, "/data0/tmp", "uffd-*.sock")
+
+    fmt.Fprintln(&buf, "\n==== metrics FIFOs (/data0/tmp) ====")
+    scanAndWrite(&buf, "/data0/tmp", "fc-metrics-*")
+
+    fmt.Fprintln(&buf, "\n==== iptables (nat table) ====")
+    if out, err := exec.Command("iptables-save", "-t", "nat").CombinedOutput(); err != nil {
+        fmt.Fprintf(&buf, "iptables-save error: %v\n", err)
+    } else {
+        buf.Write(out)
+    }
+
+    // write report
+    if err := ioutil.WriteFile(outPath, buf.Bytes(), 0644); err != nil {
+        return fmt.Errorf("write report: %w", err)
+    }
+
+    // also echo to stdout
+    _, _ = os.Stdout.Write(buf.Bytes())
+    fmt.Fprintf(os.Stdout, "\nReport written to: %s\n", outPath)
+    return nil
+}
+
+func scanAndWrite(buf *bytes.Buffer, dir, pattern string) {
+    files, err := filepath.Glob(filepath.Join(dir, pattern))
+    if err != nil {
+        fmt.Fprintf(buf, "scan %s/%s error: %v\n", dir, pattern, err)
+        return
+    }
+    if len(files) == 0 {
+        fmt.Fprintf(buf, "(none found) %s/%s\n", dir, pattern)
+        return
+    }
+    for _, f := range files {
+        fi, err := os.Lstat(f)
+        if err != nil {
+            fmt.Fprintf(buf, "%s (stat error: %v)\n", f, err)
+            continue
+        }
+        fmt.Fprintf(buf, "%s  %s\n", f, fi.Mode().String())
+    }
+}

--- a/packages/orchestrator/pkg/reconcile/reconcile.go
+++ b/packages/orchestrator/pkg/reconcile/reconcile.go
@@ -1,18 +1,24 @@
 package reconcile
-package reconcile
 
 import (
-    "bytes"
-    "fmt"
-    "io/ioutil"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "time"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
 )
 
 // RunReconcile scans common Firecracker artifact locations and iptables
 // and writes a plain-text report to stdout and to /tmp/reconcile-report-<ts>.txt.
+// injectable vars to make the package testable
+var (
+    SocketDirs = []string{"/data0/tmp", "/tmp"}
+    MetricsDir = "/data0/tmp"
+    ExecCommand = exec.Command
+)
+
 func RunReconcile(outPath string) error {
     ts := time.Now().UTC().Format("20060102T150405Z")
     if outPath == "" {
@@ -23,18 +29,21 @@ func RunReconcile(outPath string) error {
     fmt.Fprintf(&buf, "Reconcile sweep report\nTimestamp: %s\n\n", ts)
 
     // scan socket dirs
-    fmt.Fprintln(&buf, "==== Firecracker api sockets (/data0/tmp and /tmp) ====")
-    scanAndWrite(&buf, "/data0/tmp", "fc-*.sock")
-    scanAndWrite(&buf, "/tmp", "fc-*.sock")
+    fmt.Fprintln(&buf, "==== Firecracker api sockets ====")
+    for _, d := range SocketDirs {
+        scanAndWrite(&buf, d, "fc-*.sock")
+    }
 
-    fmt.Fprintln(&buf, "\n==== uffd sockets (/data0/tmp) ====")
-    scanAndWrite(&buf, "/data0/tmp", "uffd-*.sock")
+    fmt.Fprintln(&buf, "\n==== uffd sockets ====")
+    for _, d := range SocketDirs {
+        scanAndWrite(&buf, d, "uffd-*.sock")
+    }
 
-    fmt.Fprintln(&buf, "\n==== metrics FIFOs (/data0/tmp) ====")
-    scanAndWrite(&buf, "/data0/tmp", "fc-metrics-*")
+    fmt.Fprintln(&buf, "\n==== metrics FIFOs ====")
+    scanAndWrite(&buf, MetricsDir, "fc-metrics-*")
 
     fmt.Fprintln(&buf, "\n==== iptables (nat table) ====")
-    if out, err := exec.Command("iptables-save", "-t", "nat").CombinedOutput(); err != nil {
+    if out, err := ExecCommand("iptables-save", "-t", "nat").CombinedOutput(); err != nil {
         fmt.Fprintf(&buf, "iptables-save error: %v\n", err)
     } else {
         buf.Write(out)

--- a/packages/orchestrator/pkg/reconcile/reconcile.go
+++ b/packages/orchestrator/pkg/reconcile/reconcile.go
@@ -14,68 +14,68 @@ import (
 // and writes a plain-text report to stdout and to /tmp/reconcile-report-<ts>.txt.
 // injectable vars to make the package testable
 var (
-    SocketDirs = []string{"/data0/tmp", "/tmp"}
-    MetricsDir = "/data0/tmp"
-    ExecCommand = exec.Command
+	SocketDirs  = []string{"/data0/tmp", "/tmp"}
+	MetricsDir  = "/data0/tmp"
+	ExecCommand = exec.Command
 )
 
 func RunReconcile(outPath string) error {
-    ts := time.Now().UTC().Format("20060102T150405Z")
-    if outPath == "" {
-        outPath = fmt.Sprintf("/tmp/reconcile-report-%s.txt", ts)
-    }
+	ts := time.Now().UTC().Format("20060102T150405Z")
+	if outPath == "" {
+		outPath = fmt.Sprintf("/tmp/reconcile-report-%s.txt", ts)
+	}
 
-    var buf bytes.Buffer
-    fmt.Fprintf(&buf, "Reconcile sweep report\nTimestamp: %s\n\n", ts)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Reconcile sweep report\nTimestamp: %s\n\n", ts)
 
-    // scan socket dirs
-    fmt.Fprintln(&buf, "==== Firecracker api sockets ====")
-    for _, d := range SocketDirs {
-        scanAndWrite(&buf, d, "fc-*.sock")
-    }
+	// scan socket dirs
+	fmt.Fprintln(&buf, "==== Firecracker api sockets ====")
+	for _, d := range SocketDirs {
+		scanAndWrite(&buf, d, "fc-*.sock")
+	}
 
-    fmt.Fprintln(&buf, "\n==== uffd sockets ====")
-    for _, d := range SocketDirs {
-        scanAndWrite(&buf, d, "uffd-*.sock")
-    }
+	fmt.Fprintln(&buf, "\n==== uffd sockets ====")
+	for _, d := range SocketDirs {
+		scanAndWrite(&buf, d, "uffd-*.sock")
+	}
 
-    fmt.Fprintln(&buf, "\n==== metrics FIFOs ====")
-    scanAndWrite(&buf, MetricsDir, "fc-metrics-*")
+	fmt.Fprintln(&buf, "\n==== metrics FIFOs ====")
+	scanAndWrite(&buf, MetricsDir, "fc-metrics-*")
 
-    fmt.Fprintln(&buf, "\n==== iptables (nat table) ====")
-    if out, err := ExecCommand("iptables-save", "-t", "nat").CombinedOutput(); err != nil {
-        fmt.Fprintf(&buf, "iptables-save error: %v\n", err)
-    } else {
-        buf.Write(out)
-    }
+	fmt.Fprintln(&buf, "\n==== iptables (nat table) ====")
+	if out, err := ExecCommand("iptables-save", "-t", "nat").CombinedOutput(); err != nil {
+		fmt.Fprintf(&buf, "iptables-save error: %v\n", err)
+	} else {
+		buf.Write(out)
+	}
 
-    // write report
-    if err := ioutil.WriteFile(outPath, buf.Bytes(), 0644); err != nil {
-        return fmt.Errorf("write report: %w", err)
-    }
+	// write report
+	if err := ioutil.WriteFile(outPath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
 
-    // also echo to stdout
-    _, _ = os.Stdout.Write(buf.Bytes())
-    fmt.Fprintf(os.Stdout, "\nReport written to: %s\n", outPath)
-    return nil
+	// also echo to stdout
+	_, _ = os.Stdout.Write(buf.Bytes())
+	fmt.Fprintf(os.Stdout, "\nReport written to: %s\n", outPath)
+	return nil
 }
 
 func scanAndWrite(buf *bytes.Buffer, dir, pattern string) {
-    files, err := filepath.Glob(filepath.Join(dir, pattern))
-    if err != nil {
-        fmt.Fprintf(buf, "scan %s/%s error: %v\n", dir, pattern, err)
-        return
-    }
-    if len(files) == 0 {
-        fmt.Fprintf(buf, "(none found) %s/%s\n", dir, pattern)
-        return
-    }
-    for _, f := range files {
-        fi, err := os.Lstat(f)
-        if err != nil {
-            fmt.Fprintf(buf, "%s (stat error: %v)\n", f, err)
-            continue
-        }
-        fmt.Fprintf(buf, "%s  %s\n", f, fi.Mode().String())
-    }
+	files, err := filepath.Glob(filepath.Join(dir, pattern))
+	if err != nil {
+		fmt.Fprintf(buf, "scan %s/%s error: %v\n", dir, pattern, err)
+		return
+	}
+	if len(files) == 0 {
+		fmt.Fprintf(buf, "(none found) %s/%s\n", dir, pattern)
+		return
+	}
+	for _, f := range files {
+		fi, err := os.Lstat(f)
+		if err != nil {
+			fmt.Fprintf(buf, "%s (stat error: %v)\n", f, err)
+			continue
+		}
+		fmt.Fprintf(buf, "%s  %s\n", f, fi.Mode().String())
+	}
 }

--- a/packages/orchestrator/pkg/reconcile/reconcile_test.go
+++ b/packages/orchestrator/pkg/reconcile/reconcile_test.go
@@ -10,56 +10,56 @@ import (
 )
 
 func TestRunReconcile_TempDirs(t *testing.T) {
-    tmp, err := ioutil.TempDir("", "reconcile-test")
-    if err != nil {
-        t.Fatal(err)
-    }
-    defer os.RemoveAll(tmp)
+	tmp, err := ioutil.TempDir("", "reconcile-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
 
-    data0 := filepath.Join(tmp, "data0", "tmp")
-    if err := os.MkdirAll(data0, 0755); err != nil {
-        t.Fatal(err)
-    }
-    localtmp := filepath.Join(tmp, "localtmp")
-    if err := os.MkdirAll(localtmp, 0755); err != nil {
-        t.Fatal(err)
-    }
+	data0 := filepath.Join(tmp, "data0", "tmp")
+	if err := os.MkdirAll(data0, 0755); err != nil {
+		t.Fatal(err)
+	}
+	localtmp := filepath.Join(tmp, "localtmp")
+	if err := os.MkdirAll(localtmp, 0755); err != nil {
+		t.Fatal(err)
+	}
 
-    // create sample socket and metric files
-    sock := filepath.Join(data0, "fc-test.sock")
-    if err := ioutil.WriteFile(sock, []byte(""), 0644); err != nil {
-        t.Fatal(err)
-    }
-    fifo := filepath.Join(data0, "fc-metrics-test.fifo")
-    if err := ioutil.WriteFile(fifo, []byte(""), 0644); err != nil {
-        t.Fatal(err)
-    }
+	// create sample socket and metric files
+	sock := filepath.Join(data0, "fc-test.sock")
+	if err := ioutil.WriteFile(sock, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(data0, "fc-metrics-test.fifo")
+	if err := ioutil.WriteFile(fifo, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-    // override dirs and ExecCommand to a stub that returns static output
-    SocketDirs = []string{data0, localtmp}
-    MetricsDir = data0
-    ExecCommand = func(name string, args ...string) *exec.Cmd {
-        return exec.Command("/bin/echo", "-n", "iptables: simulated")
-    }
+	// override dirs and ExecCommand to a stub that returns static output
+	SocketDirs = []string{data0, localtmp}
+	MetricsDir = data0
+	ExecCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("/bin/echo", "-n", "iptables: simulated")
+	}
 
-    outPath := filepath.Join(tmp, "report.txt")
-    if err := RunReconcile(outPath); err != nil {
-        t.Fatalf("RunReconcile failed: %v", err)
-    }
+	outPath := filepath.Join(tmp, "report.txt")
+	if err := RunReconcile(outPath); err != nil {
+		t.Fatalf("RunReconcile failed: %v", err)
+	}
 
-    // read report and validate contents
-    b, err := ioutil.ReadFile(outPath)
-    if err != nil {
-        t.Fatalf("read report: %v", err)
-    }
-    s := string(b)
-    if !strings.Contains(s, "fc-test.sock") {
-        t.Fatalf("report missing socket entry: %s", s)
-    }
-    if !strings.Contains(s, "fc-metrics-test.fifo") {
-        t.Fatalf("report missing metrics entry: %s", s)
-    }
-    if !strings.Contains(s, "iptables: simulated") {
-        t.Fatalf("report missing iptables simulated output: %s", s)
-    }
+	// read report and validate contents
+	b, err := ioutil.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read report: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "fc-test.sock") {
+		t.Fatalf("report missing socket entry: %s", s)
+	}
+	if !strings.Contains(s, "fc-metrics-test.fifo") {
+		t.Fatalf("report missing metrics entry: %s", s)
+	}
+	if !strings.Contains(s, "iptables: simulated") {
+		t.Fatalf("report missing iptables simulated output: %s", s)
+	}
 }

--- a/packages/orchestrator/pkg/reconcile/reconcile_test.go
+++ b/packages/orchestrator/pkg/reconcile/reconcile_test.go
@@ -1,0 +1,65 @@
+package reconcile
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunReconcile_TempDirs(t *testing.T) {
+    tmp, err := ioutil.TempDir("", "reconcile-test")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer os.RemoveAll(tmp)
+
+    data0 := filepath.Join(tmp, "data0", "tmp")
+    if err := os.MkdirAll(data0, 0755); err != nil {
+        t.Fatal(err)
+    }
+    localtmp := filepath.Join(tmp, "localtmp")
+    if err := os.MkdirAll(localtmp, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    // create sample socket and metric files
+    sock := filepath.Join(data0, "fc-test.sock")
+    if err := ioutil.WriteFile(sock, []byte(""), 0644); err != nil {
+        t.Fatal(err)
+    }
+    fifo := filepath.Join(data0, "fc-metrics-test.fifo")
+    if err := ioutil.WriteFile(fifo, []byte(""), 0644); err != nil {
+        t.Fatal(err)
+    }
+
+    // override dirs and ExecCommand to a stub that returns static output
+    SocketDirs = []string{data0, localtmp}
+    MetricsDir = data0
+    ExecCommand = func(name string, args ...string) *exec.Cmd {
+        return exec.Command("/bin/echo", "-n", "iptables: simulated")
+    }
+
+    outPath := filepath.Join(tmp, "report.txt")
+    if err := RunReconcile(outPath); err != nil {
+        t.Fatalf("RunReconcile failed: %v", err)
+    }
+
+    // read report and validate contents
+    b, err := ioutil.ReadFile(outPath)
+    if err != nil {
+        t.Fatalf("read report: %v", err)
+    }
+    s := string(b)
+    if !strings.Contains(s, "fc-test.sock") {
+        t.Fatalf("report missing socket entry: %s", s)
+    }
+    if !strings.Contains(s, "fc-metrics-test.fifo") {
+        t.Fatalf("report missing metrics entry: %s", s)
+    }
+    if !strings.Contains(s, "iptables: simulated") {
+        t.Fatalf("report missing iptables simulated output: %s", s)
+    }
+}

--- a/packages/orchestrator/scripts/detect_fc_leaks.sh
+++ b/packages/orchestrator/scripts/detect_fc_leaks.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -u
+STORAGE_DIR="${1:-/var/lib/e2b}"   # optional first arg override
+OUT="/tmp/fc-leak-report-$(date +%Y%m%dT%H%M%S).txt"
+
+echo "Firecracker leak quick-audit" > "$OUT"
+echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$OUT"
+echo "Storage dir: $STORAGE_DIR" >> "$OUT"
+echo "" >> "$OUT"
+
+# helper
+sep() { printf "\n==== %s ====" "$1" >> "$OUT"; printf "\n\n" >> "$OUT"; }
+
+sep "Firecracker processes"
+pgrep -af firecracker 2>/dev/null | tee -a "$OUT"
+echo "" >> "$OUT"
+echo "Count: $(pgrep -c firecracker 2>/dev/null || echo 0)" >> "$OUT"
+
+sep "Firecracker process details (ps + state + /proc/<pid>/cmdline summary)"
+if pids=$(pgrep -f firecracker 2>/dev/null); then
+  for p in $pids; do
+    printf "PID: %s\n" "$p" >> "$OUT"
+    ps -o pid,ppid,stat,etime,cmd -p "$p" 2>/dev/null | sed -n '1,1p' >> "$OUT"
+    ps -o pid,ppid,stat,etime,cmd -p "$p" 2>/dev/null | sed -n '2,2p' >> "$OUT"
+    if [ -r "/proc/$p/fd" ]; then
+      echo "Open files (first 20):" >> "$OUT"
+      ls -l /proc/$p/fd 2>/dev/null | head -n 20 >> "$OUT"
+    fi
+    echo "" >> "$OUT"
+  done
+else
+  echo "none" >> "$OUT"
+fi
+
+sep "Uninterruptible (D) state processes (possible stuck IO)"
+ps -eo pid,ppid,stat,cmd | awk '$3 ~ /D/ {print}' | tee -a "$OUT" || true
+
+sep "Network namespaces"
+ip netns list 2>/dev/null | tee -a "$OUT" || echo "(ip netns not available or none)" >> "$OUT"
+echo "" >> "$OUT"
+echo "Netns count: $(ip netns list 2>/dev/null | wc -l || echo 0)" >> "$OUT"
+
+sep "For each namespace: PIDs inside and top cmds"
+for ns in $(ip netns list 2>/dev/null | awk '{print $1}' 2>/dev/null || true); do
+  echo "Namespace: $ns" >> "$OUT"
+  ip netns pids "$ns" 2>/dev/null | tee -a "$OUT" || echo "(no pids or no permission)" >> "$OUT"
+  for pid in $(ip netns pids "$ns" 2>/dev/null || true); do
+    ps -o pid,ppid,stat,etime,cmd -p "$pid" 2>/dev/null | sed -n '2p' >> "$OUT"
+  done
+  echo "" >> "$OUT"
+done
+
+sep "Network devices (veth/tap/vpeer) and counts"
+ip link show 2>/dev/null | egrep -i 'veth|tap|vpeer' -n | tee -a "$OUT" || echo "(no veth/tap found)" >> "$OUT"
+echo "" >> "$OUT"
+echo "veth/tap count: $(ip link show 2>/dev/null | egrep -i 'veth|tap|vpeer' -c || echo 0)" >> "$OUT"
+
+sep "iptables rules mentioning veth/tap"
+if command -v iptables-save >/dev/null 2>&1; then
+  iptables-save 2>/dev/null | egrep -i 'veth|tap|vpeer' -n | tee -a "$OUT" || echo "(no iptables lines matched)" >> "$OUT"
+else
+  echo "iptables-save not available" >> "$OUT"
+fi
+
+sep "Metrics FIFOs / sockets / uffd in storage"
+find "$STORAGE_DIR" -xdev \( -type p -name '*metrics*' -o -name '*uffd*' -o -name '*fc*' -o -name '*sock*' \) -print 2>/dev/null | tee -a "$OUT" || echo "(no matches or permission denied)" >> "$OUT"
+echo "" >> "$OUT"
+
+sep "Unix domain sockets open by processes (ss -x)"
+if command -v ss >/dev/null 2>&1; then
+  ss -x -a -n -p 2>/dev/null | egrep -i 'firecracker|fc|nbd|uffd' -n | tee -a "$OUT" || echo "(no matching unix sockets)" >> "$OUT"
+else
+  echo "ss not installed" >> "$OUT"
+fi
+
+sep "Search for NBD-related files/sockets"
+find "$STORAGE_DIR" -xdev \( -type s -o -name '*nbd*' -o -name '*nbd.sock*' -o -name '*nbd*' \) -print 2>/dev/null | tee -a "$OUT" || true
+
+sep "NBD dispatch concurrent metric (if Prometheus available, not included here)"
+echo "Check metric: orchestrator.nbd.dispatch.read.concurrent if Prometheus is configured." >> "$OUT"
+
+sep "Orphan metrics FIFOs under /tmp and /var/run (common locations)"
+find /tmp /var/run -maxdepth 3 -type p -name '*metrics*' -o -name '*fc*' -print 2>/dev/null | tee -a "$OUT" || true
+
+sep "Summary counts"
+echo "firecracker_count: $(pgrep -c firecracker 2>/dev/null || echo 0)" >> "$OUT"
+echo "netns_count: $(ip netns list 2>/dev/null | wc -l || echo 0)" >> "$OUT"
+echo "veth_tap_count: $(ip link show 2>/dev/null | egrep -i 'veth|tap|vpeer' -c || echo 0)" >> "$OUT"
+echo "d_state_processes: $(ps -eo stat | egrep -c 'D' || echo 0)" >> "$OUT"
+
+echo "" >> "$OUT"
+echo "Tips:" >> "$OUT"
+echo "- Run as root (sudo) for full visibility (netns, iptables, lsof info)." >> "$OUT"
+echo "- If you find netns with PIDs inside, inspect those PIDs and their /proc/<pid>/fd to see held files." >> "$OUT"
+
+echo ""
+echo "Report generated: $OUT"
+echo "Preview (first 200 lines):"
+echo "----------------------------------------"
+sed -n '1,200p' "$OUT"


### PR DESCRIPTION
Summary: Add a read-only [reconcile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) sweep command to detect Firecracker-related host artifacts (API sockets, uffd sockets, fc-metrics FIFOs) and capture iptables-save (nat table) output for incident investigation. This is purely a diagnostic tool — it does not mutate firewall rules, networking, or VMs.
Files changed:
[main.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[reconcile.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[reconcile_test.go](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[detect_fc_leaks.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
How to verify:
Run locally (read-only):
go run ./packages/orchestrator/cmd/reconcile -out /tmp/reconcile-report.txt
Or build and run the binary then inspect /tmp/reconcile-report-*.txt
Unit test:
go test ./packages/orchestrator/pkg/reconcile -v
Risk & Safety:
Read-only by design. The only system command invoked is iptables-save -t nat, and the call is replaceable in tests via an injected [ExecCommand](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
This PR does not perform cleanup; any future “reclamation” behavior should be implemented in a separate, reviewed PR with strong safety checks.
CI notes:
Module-level tests for [pkg/reconcile](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) pass locally. Some other orchestrator tests failed in my environment due to external dependencies (NBD kernel module not loaded, Docker/container start errors, port conflicts); these failures are environment-dependent and unrelated to this change.
Patch file: [fix-reconcile-sweep.patch](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)