### PR TITLE
fix(block): rephrase misleading error message in pwritevAll

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -288,7 +288,7 @@ func pwritevAll(fd int, off int64, iovs [][]byte) error {
 			return err
 		}
 		if n == 0 {
-			return fmt.Errorf("pwritev: EOF with %d iovec(s) remaining", len(iovs))
+			return fmt.Errorf("pwritev: no progress, %d iovec(s) remaining", len(iovs))
 		}
 
 		off += int64(n)


### PR DESCRIPTION
The n == 0 safety net guard in pwritevAll breaks out of the retry loop if pwritev(2) returns zero bytes written with no error, which would otherwise spin forever. The old message called this "EOF", but pwritev() on a regular file has no write-side EOF concept.

Rename to "no progress" which describes what actually happened: the syscall succeeded but transferred nothing.