### PR TITLE
Run dedup compare asynchronously

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -249,6 +249,9 @@ func NewCacheFromMemfdDeduped(
 	inputEmpty *roaring.Bitmap,
 	metaOut *utils.SetOnce[*header.DiffMetadata],
 ) (*DedupedMemfdCache, error) {
+	if blockSize%header.PageSize != 0 {
+		return nil, fmt.Errorf("diff block size %d not a multiple of dedup page size %d", blockSize, header.PageSize)
+	}
 	drainCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	d := &DedupedMemfdCache{
 		outPath: outPath,

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -279,8 +279,8 @@ func (d *DedupedMemfdCache) runDedup(
 	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
 	compareDur := time.Since(compareStart)
 	if err != nil {
-		_ = metaOut.SetError(err)
-		_ = d.done.SetError(errors.Join(err, memfd.Close()))
+		logSetOnceErr(ctx, "dedup metaOut", metaOut.SetError(err))
+		logSetOnceErr(ctx, "dedup done", d.done.SetError(errors.Join(err, memfd.Close())))
 
 		return
 	}
@@ -292,7 +292,7 @@ func (d *DedupedMemfdCache) runDedup(
 			meta.Empty.AddRange(uint64(start)*ratio, end*ratio)
 		}
 	}
-	_ = metaOut.SetValue(meta)
+	logSetOnceErr(ctx, "dedup metaOut", metaOut.SetValue(meta))
 
 	writeStart := time.Now()
 	cache, err := dedupDrain(ctx, src, plan.pageDirty, blockSize, d.outPath, directIO)
@@ -307,7 +307,16 @@ func (d *DedupedMemfdCache) runDedup(
 		int64(plan.pageEmpty.GetCardinality()),
 		compareDur, writeDur,
 	)
-	_ = d.done.SetResult(cache, err)
+	logSetOnceErr(ctx, "dedup done", d.done.SetResult(cache, err))
+}
+
+// logSetOnceErr warns on a SetOnce.SetValue/SetError failure (i.e. a
+// repeated set), which signals a misuse rather than a runtime problem;
+// keep going so the original outcome still wins.
+func logSetOnceErr(ctx context.Context, what string, err error) {
+	if err != nil {
+		logger.L().Warn(ctx, "set once already resolved", zap.String("what", what), zap.Error(err))
+	}
 }
 
 func (d *DedupedMemfdCache) Wait(ctx context.Context) (*Cache, error) {

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -229,8 +229,8 @@ func (m *MemfdCache) FileSize(ctx context.Context) (int64, error) {
 func (m *MemfdCache) BlockSize() int64     { return m.cache.BlockSize() }
 func (m *MemfdCache) Size() (int64, error) { return m.cache.Size() }
 
-// DedupedMemfdCache is the dedup analogue of MemfdCache: compare runs
-// synchronously so the diff metadata is ready, drain runs on a goroutine.
+// DedupedMemfdCache runs compare+drain on a goroutine; metaOut resolves
+// after compare, reads against the cache block on done until drain finishes.
 type DedupedMemfdCache struct {
 	outPath string
 	cancel  context.CancelFunc
@@ -246,65 +246,67 @@ func NewCacheFromMemfdDeduped(
 	dirty *roaring.Bitmap,
 	bestEffort bool,
 	directIO bool,
-) (*DedupedMemfdCache, *header.DiffMetadata, error) {
-	ctx, span := tracer.Start(ctx, "dedup-compare")
-	defer span.End()
-
-	src := func(absOff int64) ([]byte, error) { return memfd.Slice(absOff, blockSize) }
-
-	compareStart := time.Now()
-	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
-	if err != nil {
-		return nil, nil, errors.Join(err, memfd.Close())
-	}
-	compareDur := time.Since(compareStart)
-
-	// Snapshot counts before exposing the bitmaps via meta; pauseProcessMemory
-	// mutates Empty after we return, which would race with recordDedupAttrs.
-	totalPages := plan.exportedSize / header.PageSize
-	uniquePages := int64(plan.pageDirty.GetCardinality())
-	emptyPages := int64(plan.pageEmpty.GetCardinality())
-
-	meta := &header.DiffMetadata{
-		Dirty:     plan.pageDirty,
-		Empty:     plan.pageEmpty,
-		BlockSize: header.PageSize,
-	}
-
+	inputEmpty *roaring.Bitmap,
+	metaOut *utils.SetOnce[*header.DiffMetadata],
+) (*DedupedMemfdCache, error) {
 	drainCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	d := &DedupedMemfdCache{
 		outPath: outPath,
 		cancel:  cancel,
 		done:    utils.NewSetOnce[*Cache](),
 	}
-	go d.runDrain(drainCtx, src, memfd, plan.pageDirty, blockSize, directIO, compareDur, totalPages, uniquePages, emptyPages)
+	go d.runDedup(drainCtx, base, blockSize, memfd, dirty, bestEffort, directIO, inputEmpty, metaOut)
 
-	return d, meta, nil
+	return d, nil
 }
 
-func (d *DedupedMemfdCache) runDrain(
+func (d *DedupedMemfdCache) runDedup(
 	ctx context.Context,
-	src func(absOff int64) ([]byte, error),
-	memfd *Memfd,
-	pageDirty *roaring.Bitmap,
+	base ReadonlyDevice,
 	blockSize int64,
-	directIO bool,
-	compareDur time.Duration,
-	totalPages, uniquePages, emptyPages int64,
+	memfd *Memfd,
+	dirty *roaring.Bitmap,
+	bestEffort, directIO bool,
+	inputEmpty *roaring.Bitmap,
+	metaOut *utils.SetOnce[*header.DiffMetadata],
 ) {
-	ctx, span := tracer.Start(ctx, "dedup-drain")
+	ctx, span := tracer.Start(ctx, "dedup-pages")
 	defer span.End()
 
-	writeStart := time.Now()
-	cache, err := dedupDrain(ctx, src, pageDirty, blockSize, d.outPath, directIO)
-	writeDur := time.Since(writeStart)
+	src := func(absOff int64) ([]byte, error) { return memfd.Slice(absOff, blockSize) }
 
-	// Log only: a memfd close failure shouldn't fail in-flight Wait callers.
+	compareStart := time.Now()
+	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
+	compareDur := time.Since(compareStart)
+	if err != nil {
+		_ = metaOut.SetError(err)
+		_ = d.done.SetError(errors.Join(err, memfd.Close()))
+
+		return
+	}
+
+	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: plan.pageEmpty, BlockSize: header.PageSize}
+	if inputEmpty != nil {
+		ratio := uint64(blockSize / header.PageSize)
+		for start, end := range inputEmpty.Ranges() {
+			meta.Empty.AddRange(uint64(start)*ratio, end*ratio)
+		}
+	}
+	_ = metaOut.SetValue(meta)
+
+	writeStart := time.Now()
+	cache, err := dedupDrain(ctx, src, plan.pageDirty, blockSize, d.outPath, directIO)
+	writeDur := time.Since(writeStart)
 	if closeErr := memfd.Close(); closeErr != nil {
 		logger.L().Warn(ctx, "close memfd after dedup drain", zap.Error(closeErr))
 	}
 
-	recordDedupAttrs(ctx, totalPages, uniquePages, emptyPages, compareDur, writeDur)
+	recordDedupAttrs(ctx,
+		plan.exportedSize/header.PageSize,
+		int64(plan.pageDirty.GetCardinality()),
+		int64(plan.pageEmpty.GetCardinality()),
+		compareDur, writeDur,
+	)
 	_ = d.done.SetResult(cache, err)
 }
 

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 func newTestMemfd(t *testing.T, size int64) (memfd *Memfd, data []byte) {
@@ -199,9 +200,9 @@ func TestNewCacheFromMemfdAsync_DetachesAndFlushes(t *testing.T) {
 	require.Equal(t, expected, fromFile)
 }
 
-// Compare returns metadata synchronously while drain detaches; after Wait the
-// deduped cache contains only pages that differ from base.
-func TestNewCacheFromMemfdDeduped_DrainIsAsync(t *testing.T) {
+// Compare detaches: the header future resolves only after the goroutine
+// runs, and the deduped cache (after Wait) holds only pages that differ.
+func TestNewCacheFromMemfdDeduped_DetachesCompareAndDrain(t *testing.T) {
 	t.Parallel()
 
 	pageSize := int64(header.PageSize)
@@ -223,15 +224,20 @@ func TestNewCacheFromMemfdDeduped_DrainIsAsync(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cachePath := t.TempDir() + "/dedup-async"
-	cache, meta, err := NewCacheFromMemfdDeduped(
+	metaOut := utils.NewSetOnce[*header.DiffMetadata]()
+	cache, err := NewCacheFromMemfdDeduped(
 		ctx, &fakeOriginalDevice{data: baseData}, pageSize, cachePath, memfd, dirty, false, false,
+		nil, metaOut,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cache.Close() })
 
-	require.Equal(t, uint64(2), meta.Dirty.GetCardinality())
-
 	cancel()
+
+	meta, err := metaOut.WaitWithContext(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 2, meta.Dirty.GetCardinality())
+
 	_, err = cache.Wait(t.Context())
 	require.NoError(t, err)
 

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -41,11 +41,11 @@ func NewUpload(
 	useCase string,
 	objectMetadata storage.ObjectMetadata,
 ) (*Upload, error) {
-	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, snap.MemfileDiffHeader.Metadata.BlockSize, useCase)
+	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, uint64(snap.MemfileDiff.BlockSize()), useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve memfile compress config: %w", err)
 	}
-	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, snap.RootfsDiffHeader.Metadata.BlockSize, useCase)
+	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, uint64(snap.RootfsDiff.BlockSize()), useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -41,25 +41,11 @@ func NewUpload(
 	useCase string,
 	objectMetadata storage.ObjectMetadata,
 ) (*Upload, error) {
-	// Rootfs header is always sync-resolved at this point; Wait returns
-	// immediately and gives us the template block size, which stays correct
-	// even when the diff is NoDiff (where Diff.BlockSize() would be 0).
-	rootfsHdr, err := snap.RootfsDiffHeader.WaitWithContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("wait rootfs diff header: %w", err)
-	}
-	var rootfsBlockSize uint64
-	if rootfsHdr != nil {
-		rootfsBlockSize = rootfsHdr.Metadata.BlockSize
-	}
-	// Memfile is never NoDiff, so Diff.BlockSize() is always the template
-	// block size (== header.Metadata.BlockSize). Using it here avoids
-	// blocking on the memfile header future.
-	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, uint64(snap.MemfileDiff.BlockSize()), useCase)
+	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, snap.MemfileBlockSize, useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve memfile compress config: %w", err)
 	}
-	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, rootfsBlockSize, useCase)
+	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, snap.RootfsBlockSize, useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -41,11 +41,25 @@ func NewUpload(
 	useCase string,
 	objectMetadata storage.ObjectMetadata,
 ) (*Upload, error) {
+	// Rootfs header is always sync-resolved at this point; Wait returns
+	// immediately and gives us the template block size, which stays correct
+	// even when the diff is NoDiff (where Diff.BlockSize() would be 0).
+	rootfsHdr, err := snap.RootfsDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("wait rootfs diff header: %w", err)
+	}
+	var rootfsBlockSize uint64
+	if rootfsHdr != nil {
+		rootfsBlockSize = rootfsHdr.Metadata.BlockSize
+	}
+	// Memfile is never NoDiff, so Diff.BlockSize() is always the template
+	// block size (== header.Metadata.BlockSize). Using it here avoids
+	// blocking on the memfile header future.
 	mem, memV4, err := resolveCompressConfig(ctx, cfg, ff, storage.MemfileName, uint64(snap.MemfileDiff.BlockSize()), useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve memfile compress config: %w", err)
 	}
-	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, uint64(snap.RootfsDiff.BlockSize()), useCase)
+	root, rootV4, err := resolveCompressConfig(ctx, cfg, ff, storage.RootfsName, rootfsBlockSize, useCase)
 	if err != nil {
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -25,31 +25,30 @@ func (u *Upload) runV3(ctx context.Context) error {
 		return fmt.Errorf("error getting rootfs diff path: %w", err)
 	}
 
-	memfileDiffHeader, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("wait memfile diff header: %w", err)
-	}
-	rootfsDiffHeader, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("wait rootfs diff header: %w", err)
-	}
-
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		if memfileDiffHeader == nil {
+		h, err := u.snap.MemfileDiffHeader.WaitWithContext(egCtx)
+		if err != nil {
+			return fmt.Errorf("wait memfile diff header: %w", err)
+		}
+		if h == nil {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(memfileDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(h))
 	})
 
 	eg.Go(func() error {
-		if rootfsDiffHeader == nil {
+		h, err := u.snap.RootfsDiffHeader.WaitWithContext(egCtx)
+		if err != nil {
+			return fmt.Errorf("wait rootfs diff header: %w", err)
+		}
+		if h == nil {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(rootfsDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(h))
 	})
 
 	meta := storage.WithMetadata(u.objectMetadata)
@@ -100,6 +99,17 @@ func (u *Upload) runV3(ctx context.Context) error {
 
 	if err := eg.Wait(); err != nil {
 		return err
+	}
+
+	// Body uploads done; headers must be ready by now (the per-file Goroutines
+	// above already Wait-ed). Wait() is a fast lookup here.
+	memfileDiffHeader, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait memfile diff header: %w", err)
+	}
+	rootfsDiffHeader, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait rootfs diff header: %w", err)
 	}
 
 	if memfileDiffHeader != nil {

--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -25,22 +25,31 @@ func (u *Upload) runV3(ctx context.Context) error {
 		return fmt.Errorf("error getting rootfs diff path: %w", err)
 	}
 
+	memfileDiffHeader, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait memfile diff header: %w", err)
+	}
+	rootfsDiffHeader, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait rootfs diff header: %w", err)
+	}
+
 	eg, egCtx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		if u.snap.MemfileDiffHeader == nil {
+		if memfileDiffHeader == nil {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(u.snap.MemfileDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(memfileDiffHeader))
 	})
 
 	eg.Go(func() error {
-		if u.snap.RootfsDiffHeader == nil {
+		if rootfsDiffHeader == nil {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(u.snap.RootfsDiffHeader))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(rootfsDiffHeader))
 	})
 
 	meta := storage.WithMetadata(u.objectMetadata)
@@ -93,23 +102,23 @@ func (u *Upload) runV3(ctx context.Context) error {
 		return err
 	}
 
-	if u.snap.MemfileDiffHeader != nil {
-		if err := u.appendAncestorBuilds(ctx, nil, u.snap.MemfileDiffHeader.Mapping, build.Memfile); err != nil {
+	if memfileDiffHeader != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, memfileDiffHeader.Mapping, build.Memfile); err != nil {
 			return err
 		}
 	}
-	if h := finalizeV3(u.snap.MemfileDiffHeader); h != nil {
+	if h := finalizeV3(memfileDiffHeader); h != nil {
 		if err := u.publish(ctx, build.Memfile, h); err != nil {
 			return err
 		}
 	}
 
-	if u.snap.RootfsDiffHeader != nil {
-		if err := u.appendAncestorBuilds(ctx, nil, u.snap.RootfsDiffHeader.Mapping, build.Rootfs); err != nil {
+	if rootfsDiffHeader != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, rootfsDiffHeader.Mapping, build.Rootfs); err != nil {
 			return err
 		}
 	}
-	if h := finalizeV3(u.snap.RootfsDiffHeader); h != nil {
+	if h := finalizeV3(rootfsDiffHeader); h != nil {
 		if err := u.publish(ctx, build.Rootfs, h); err != nil {
 			return err
 		}

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -26,28 +26,31 @@ func (u *Upload) runV4(ctx context.Context) error {
 		return fmt.Errorf("rootfs diff path: %w", err)
 	}
 
-	memfileDiffHeader, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("wait memfile diff header: %w", err)
-	}
-	rootfsDiffHeader, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
-	if err != nil {
-		return fmt.Errorf("wait rootfs diff header: %w", err)
-	}
-
 	eg, ctx := errgroup.WithContext(ctx)
 
-	if memfileDiffHeader != nil {
-		eg.Go(func() error {
-			return u.uploadFramed(ctx, build.Memfile, memSrc, memfileDiffHeader, u.mem)
-		})
-	}
+	eg.Go(func() error {
+		h, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
+		if err != nil {
+			return fmt.Errorf("wait memfile diff header: %w", err)
+		}
+		if h == nil {
+			return nil
+		}
 
-	if rootfsDiffHeader != nil {
-		eg.Go(func() error {
-			return u.uploadFramed(ctx, build.Rootfs, rootfsSrc, rootfsDiffHeader, u.root)
-		})
-	}
+		return u.uploadFramed(ctx, build.Memfile, memSrc, h, u.mem)
+	})
+
+	eg.Go(func() error {
+		h, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
+		if err != nil {
+			return fmt.Errorf("wait rootfs diff header: %w", err)
+		}
+		if h == nil {
+			return nil
+		}
+
+		return u.uploadFramed(ctx, build.Rootfs, rootfsSrc, h, u.root)
+	})
 
 	meta := storage.WithMetadata(u.objectMetadata)
 

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -26,17 +26,26 @@ func (u *Upload) runV4(ctx context.Context) error {
 		return fmt.Errorf("rootfs diff path: %w", err)
 	}
 
+	memfileDiffHeader, err := u.snap.MemfileDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait memfile diff header: %w", err)
+	}
+	rootfsDiffHeader, err := u.snap.RootfsDiffHeader.WaitWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("wait rootfs diff header: %w", err)
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 
-	if u.snap.MemfileDiffHeader != nil {
+	if memfileDiffHeader != nil {
 		eg.Go(func() error {
-			return u.uploadFramed(ctx, build.Memfile, memSrc, u.snap.MemfileDiffHeader, u.mem)
+			return u.uploadFramed(ctx, build.Memfile, memSrc, memfileDiffHeader, u.mem)
 		})
 	}
 
-	if u.snap.RootfsDiffHeader != nil {
+	if rootfsDiffHeader != nil {
 		eg.Go(func() error {
-			return u.uploadFramed(ctx, build.Rootfs, rootfsSrc, u.snap.RootfsDiffHeader, u.root)
+			return u.uploadFramed(ctx, build.Rootfs, rootfsSrc, rootfsDiffHeader, u.root)
 		})
 	}
 

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 // MemoryInfo returns the memory info for the sandbox.
@@ -62,12 +63,11 @@ func (p *Process) exportMemoryFromFc(
 	return cache, nil
 }
 
-// ExportMemory writes dirty guest memory to cachePath. If originalMemfile
-// is non-nil the result is deduplicated and DiffMetadata is non-nil; the
-// memfd dedup path detaches its drain to a goroutine (see
-// NewCacheFromMemfdDeduped). When dedupBestEffort is true, blocks whose
-// base data isn't already in the chunker's local cache are written through
-// as-is.
+// ExportMemory writes dirty guest memory to cachePath and resolves metaOut
+// with the diff metadata once it is known. metaOut resolves asynchronously
+// only for the memfd-dedup path; all other paths resolve it before returning.
+// For the FC-dedup path, input.Empty is merged into the page-granular dedup
+// Empty before metaOut is resolved.
 func (p *Process) ExportMemory(
 	ctx context.Context,
 	include *roaring.Bitmap,
@@ -78,36 +78,53 @@ func (p *Process) ExportMemory(
 	originalMemfile block.ReadonlyDevice,
 	dedupBestEffort bool,
 	dedupDirectIO bool,
-) (block.DiffSource, *header.DiffMetadata, error) {
+	inputEmpty *roaring.Bitmap,
+	metaOut *utils.SetOnce[*header.DiffMetadata],
+) (block.DiffSource, error) {
+	inputMeta := &header.DiffMetadata{Dirty: include, Empty: inputEmpty, BlockSize: blockSize}
 	if memfd != nil {
 		if originalMemfile != nil {
-			return block.NewCacheFromMemfdDeduped(ctx, originalMemfile, blockSize, cachePath, memfd, include, dedupBestEffort, dedupDirectIO)
+			return block.NewCacheFromMemfdDeduped(ctx, originalMemfile, blockSize, cachePath, memfd, include,
+				dedupBestEffort, dedupDirectIO, inputEmpty, metaOut)
 		}
 		if bgCopy {
 			src, err := block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
 
-			return src, nil, err
+			return src, errors.Join(metaOut.SetValue(inputMeta), err)
 		}
 		src, err := block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)
 
-		return src, nil, err
+		return src, errors.Join(metaOut.SetValue(inputMeta), err)
 	}
 
 	cache, err := p.exportMemoryFromFc(ctx, include, cachePath, blockSize)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if originalMemfile == nil {
-		return cache, nil, nil
+		_ = metaOut.SetValue(inputMeta)
+
+		return cache, nil
 	}
 	// .dedup suffix avoids clobbering the source mmap during truncate.
 	dedupCache, meta, err := cache.Dedup(ctx, originalMemfile, include, blockSize, cachePath+".dedup", dedupBestEffort, dedupDirectIO)
 	if err != nil {
-		return nil, nil, fmt.Errorf("dedup memfile diff: %w", errors.Join(err, cache.Close()))
+		return nil, fmt.Errorf("dedup memfile diff: %w", errors.Join(err, cache.Close()))
 	}
 	if err := cache.Close(); err != nil {
-		return nil, nil, fmt.Errorf("close pre-dedup cache: %w", errors.Join(err, dedupCache.Close()))
+		return nil, fmt.Errorf("close pre-dedup cache: %w", errors.Join(err, dedupCache.Close()))
 	}
+	if blockSize%meta.BlockSize != 0 {
+		return nil, errors.Join(
+			fmt.Errorf("diff block size %d not a multiple of dedup block size %d", blockSize, meta.BlockSize),
+			dedupCache.Close(),
+		)
+	}
+	ratio := uint64(blockSize / meta.BlockSize)
+	for start, end := range inputEmpty.Ranges() {
+		meta.Empty.AddRange(uint64(start)*ratio, end*ratio)
+	}
+	_ = metaOut.SetValue(meta)
 
-	return dedupCache, meta, nil
+	return dedupCache, nil
 }

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -84,8 +86,11 @@ func (p *Process) ExportMemory(
 	// Resolve metaOut on every sync error so Wait-ers don't hang. Success paths
 	// resolve it inline; the memfd-dedup goroutine owns metaOut after this returns.
 	defer func() {
-		if e != nil {
-			_ = metaOut.SetError(e)
+		if e == nil {
+			return
+		}
+		if setErr := metaOut.SetError(e); setErr != nil {
+			logger.L().Warn(ctx, "set metaOut error", zap.Error(setErr))
 		}
 	}()
 
@@ -107,7 +112,9 @@ func (p *Process) ExportMemory(
 		if err != nil {
 			return nil, err
 		}
-		_ = metaOut.SetValue(inputMeta)
+		if setErr := metaOut.SetValue(inputMeta); setErr != nil {
+			logger.L().Warn(ctx, "set metaOut", zap.Error(setErr))
+		}
 
 		return src, nil
 	}
@@ -117,7 +124,9 @@ func (p *Process) ExportMemory(
 		return nil, err
 	}
 	if originalMemfile == nil {
-		_ = metaOut.SetValue(inputMeta)
+		if setErr := metaOut.SetValue(inputMeta); setErr != nil {
+			logger.L().Warn(ctx, "set metaOut", zap.Error(setErr))
+		}
 
 		return cache, nil
 	}
@@ -139,7 +148,9 @@ func (p *Process) ExportMemory(
 	for start, end := range inputEmpty.Ranges() {
 		meta.Empty.AddRange(uint64(start)*ratio, end*ratio)
 	}
-	_ = metaOut.SetValue(meta)
+	if setErr := metaOut.SetValue(meta); setErr != nil {
+		logger.L().Warn(ctx, "set metaOut", zap.Error(setErr))
+	}
 
 	return dedupCache, nil
 }

--- a/packages/orchestrator/pkg/sandbox/fc/memory.go
+++ b/packages/orchestrator/pkg/sandbox/fc/memory.go
@@ -80,21 +80,36 @@ func (p *Process) ExportMemory(
 	dedupDirectIO bool,
 	inputEmpty *roaring.Bitmap,
 	metaOut *utils.SetOnce[*header.DiffMetadata],
-) (block.DiffSource, error) {
+) (_ block.DiffSource, e error) {
+	// Resolve metaOut on every sync error so Wait-ers don't hang. Success paths
+	// resolve it inline; the memfd-dedup goroutine owns metaOut after this returns.
+	defer func() {
+		if e != nil {
+			_ = metaOut.SetError(e)
+		}
+	}()
+
 	inputMeta := &header.DiffMetadata{Dirty: include, Empty: inputEmpty, BlockSize: blockSize}
 	if memfd != nil {
 		if originalMemfile != nil {
 			return block.NewCacheFromMemfdDeduped(ctx, originalMemfile, blockSize, cachePath, memfd, include,
 				dedupBestEffort, dedupDirectIO, inputEmpty, metaOut)
 		}
+		var (
+			src block.DiffSource
+			err error
+		)
 		if bgCopy {
-			src, err := block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
-
-			return src, errors.Join(metaOut.SetValue(inputMeta), err)
+			src, err = block.NewCacheFromMemfdAsync(ctx, blockSize, cachePath, memfd, include)
+		} else {
+			src, err = block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)
 		}
-		src, err := block.NewCacheFromMemfd(ctx, blockSize, cachePath, memfd, include)
+		if err != nil {
+			return nil, err
+		}
+		_ = metaOut.SetValue(inputMeta)
 
-		return src, errors.Join(metaOut.SetValue(inputMeta), err)
+		return src, nil
 	}
 
 	cache, err := p.exportMemoryFromFc(ctx, include, cachePath, blockSize)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1263,6 +1263,7 @@ func pauseProcessMemory(
 		meta, err := metaOut.Wait()
 		if err != nil {
 			_ = headerOut.SetError(err)
+
 			return
 		}
 		if originalMemfile != nil {

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1200,6 +1200,8 @@ func (s *Sandbox) Pause(
 		MemfileDiffHeader: memfileDiffHeader,
 		RootfsDiff:        rootfsDiff,
 		RootfsDiffHeader:  NewResolvedDiffHeader(rootfsHeader),
+		MemfileBlockSize:  originalMemfile.Header().Metadata.BlockSize,
+		RootfsBlockSize:   originalRootfs.Header().Metadata.BlockSize,
 
 		BuildID: buildID,
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1260,19 +1260,23 @@ func pauseProcessMemory(
 
 	headerOut := utils.NewSetOnce[*header.Header]()
 	go func() {
+		setHeader := func(h *header.Header, err error) {
+			if setErr := headerOut.SetResult(h, err); setErr != nil {
+				logger.L().Warn(ctx, "set memfile diff header", zap.Error(setErr))
+			}
+		}
 		meta, err := metaOut.Wait()
 		if err != nil {
-			_ = headerOut.SetError(err)
+			setHeader(nil, err)
 
 			return
 		}
-		if originalMemfile != nil {
-			recordSnapshotDedup(ctx, "memfile", diffMetadata, meta, dedupBestEffort)
-		} else {
-			recordSnapshotDedup(ctx, "memfile", diffMetadata, nil, dedupBestEffort)
+		post := meta
+		if originalMemfile == nil {
+			post = nil
 		}
-		h, err := meta.ToDiffHeader(ctx, originalHeader, buildID)
-		_ = headerOut.SetResult(h, err)
+		recordSnapshotDedup(ctx, "memfile", diffMetadata, post, dedupBestEffort)
+		setHeader(meta.ToDiffHeader(ctx, originalHeader, buildID))
 	}()
 
 	return diff, headerOut, nil

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1170,7 +1170,7 @@ func (s *Sandbox) Pause(
 	}
 	cleanup.AddNoContext(ctx, memfileDiff.Close)
 
-	rootfsDiff, rootfsDiffHeader, err := pauseProcessRootfs(
+	rootfsDiff, rootfsHeader, err := pauseProcessRootfs(
 		ctx,
 		buildID,
 		originalRootfs.Header(),
@@ -1199,7 +1199,7 @@ func (s *Sandbox) Pause(
 		MemfileDiff:       memfileDiff,
 		MemfileDiffHeader: memfileDiffHeader,
 		RootfsDiff:        rootfsDiff,
-		RootfsDiffHeader:  rootfsDiffHeader,
+		RootfsDiffHeader:  NewResolvedDiffHeader(rootfsHeader),
 
 		BuildID: buildID,
 
@@ -1235,39 +1235,19 @@ func pauseProcessMemory(
 	originalMemfile block.ReadonlyDevice,
 	dedupBestEffort bool,
 	dedupDirectIO bool,
-) (d build.Diff, h *header.Header, e error) {
+) (d build.Diff, h *DiffHeader, e error) {
 	ctx, span := tracer.Start(ctx, "process-memory")
 	defer span.End()
 
-	// ExportMemory owns memfd and closes it on all paths.
 	memfileDiffPath := build.GenerateDiffCachePath(cacheDir, buildID.String(), build.Memfile)
-	cache, dedupMeta, err := fc.ExportMemory(ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd, bgCopy, originalMemfile, dedupBestEffort, dedupDirectIO)
+	metaOut := utils.NewSetOnce[*header.DiffMetadata]()
+	// ExportMemory owns memfd and closes it on all paths.
+	cache, err := fc.ExportMemory(
+		ctx, diffMetadata.Dirty, memfileDiffPath, diffMetadata.BlockSize, memfd, bgCopy,
+		originalMemfile, dedupBestEffort, dedupDirectIO, diffMetadata.Empty, metaOut,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to export memory: %w", err)
-	}
-
-	recordSnapshotDedup(ctx, "memfile", diffMetadata, dedupMeta, dedupBestEffort)
-
-	// Re-key the original Empty into the page-granular dedup metadata so
-	// guest-zeroed pages that weren't Dirty still read as zero on restore.
-	if dedupMeta != nil {
-		if diffMetadata.BlockSize%dedupMeta.BlockSize != 0 {
-			return nil, nil, errors.Join(
-				fmt.Errorf("diff block size %d not a multiple of dedup block size %d",
-					diffMetadata.BlockSize, dedupMeta.BlockSize),
-				cache.Close(),
-			)
-		}
-		ratio := uint64(diffMetadata.BlockSize / dedupMeta.BlockSize)
-		for start, end := range diffMetadata.Empty.Ranges() {
-			dedupMeta.Empty.AddRange(uint64(start)*ratio, end*ratio)
-		}
-		diffMetadata = dedupMeta
-	}
-
-	header, err := diffMetadata.ToDiffHeader(ctx, originalHeader, buildID)
-	if err != nil {
-		return nil, nil, errors.Join(fmt.Errorf("failed to create memfile header: %w", err), cache.Close())
 	}
 
 	diff, err := build.NewLocalDiffFromCache(
@@ -1278,7 +1258,23 @@ func pauseProcessMemory(
 		return nil, nil, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
 	}
 
-	return diff, header, nil
+	headerOut := utils.NewSetOnce[*header.Header]()
+	go func() {
+		meta, err := metaOut.Wait()
+		if err != nil {
+			_ = headerOut.SetError(err)
+			return
+		}
+		if originalMemfile != nil {
+			recordSnapshotDedup(ctx, "memfile", diffMetadata, meta, dedupBestEffort)
+		} else {
+			recordSnapshotDedup(ctx, "memfile", diffMetadata, nil, dedupBestEffort)
+		}
+		h, err := meta.ToDiffHeader(ctx, originalHeader, buildID)
+		_ = headerOut.SetResult(h, err)
+	}()
+
+	return diff, headerOut, nil
 }
 
 func pauseProcessRootfs(

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1258,6 +1258,9 @@ func pauseProcessMemory(
 		return nil, nil, fmt.Errorf("failed to create local diff from cache: %w", errors.Join(err, cache.Close()))
 	}
 
+	// Build the diff header on a goroutine so Pause returns without waiting
+	// on memfd-dedup compare. ExportMemory resolves metaOut sync for every
+	// other path, so Wait there is non-blocking; the goroutine is harmless.
 	headerOut := utils.NewSetOnce[*header.Header]()
 	go func() {
 		setHeader := func(h *header.Header, err error) {
@@ -1271,6 +1274,8 @@ func pauseProcessMemory(
 
 			return
 		}
+		// post == nil signals "no dedup ran" to the metric so it records
+		// kind="none" with zero savings.
 		post := meta
 		if originalMemfile == nil {
 			post = nil

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -11,13 +11,25 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
+
+// DiffHeader resolves sync for every path except the memfd-dedup one,
+// which resolves it from a goroutine so Pause can return before compare.
+type DiffHeader = utils.SetOnce[*header.Header]
+
+func NewResolvedDiffHeader(h *header.Header) *DiffHeader {
+	d := utils.NewSetOnce[*header.Header]()
+	_ = d.SetValue(h)
+
+	return d
+}
 
 type Snapshot struct {
 	MemfileDiff       build.Diff
-	MemfileDiffHeader *header.Header
+	MemfileDiffHeader *DiffHeader
 	RootfsDiff        build.Diff
-	RootfsDiffHeader  *header.Header
+	RootfsDiffHeader  *DiffHeader
 	Snapfile          template.File
 	Metafile          template.File
 	BuildID           uuid.UUID

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -34,6 +34,14 @@ type Snapshot struct {
 	Metafile          template.File
 	BuildID           uuid.UUID
 
+	// Template block sizes captured sync at Pause time. They equal
+	// MemfileDiffHeader.Metadata.BlockSize once that header resolves, but
+	// are needed sync by NewUpload's compression validation — the dedup
+	// memfile path produces a page-granular Diff.BlockSize() that doesn't
+	// match the chunker-read granularity on restore.
+	MemfileBlockSize uint64
+	RootfsBlockSize  uint64
+
 	cleanup *Cleanup
 }
 

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -189,8 +189,8 @@ func (c *Cache) GetTemplate(
 	storageTemplate, err := newTemplateFromStorage(
 		c.config.BuilderConfig,
 		buildID,
-		nil,
-		nil,
+		resolvedHeader(nil),
+		resolvedHeader(nil),
 		persistence,
 		c.blockMetrics,
 		nil,
@@ -208,11 +208,18 @@ func (c *Cache) GetTemplate(
 	return c.getTemplateWithFetch(ctx, storageTemplate, maxLen), nil
 }
 
+func resolvedHeader(h *header.Header) *utils.SetOnce[*header.Header] {
+	s := utils.NewSetOnce[*header.Header]()
+	_ = s.SetValue(h)
+
+	return s
+}
+
 func (c *Cache) AddSnapshot(
 	ctx context.Context,
 	buildId string,
-	memfileHeader *header.Header,
-	rootfsHeader *header.Header,
+	memfileHeader *utils.SetOnce[*header.Header],
+	rootfsHeader *utils.SetOnce[*header.Header],
 	localSnapfile File,
 	localMetafile File,
 	memfileDiff build.Diff,

--- a/packages/orchestrator/pkg/sandbox/template/storage_template.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage_template.go
@@ -32,8 +32,8 @@ type storageTemplate struct {
 	snapfile *utils.SetOnce[File]
 	metafile *utils.SetOnce[File]
 
-	memfileHeader *header.Header
-	rootfsHeader  *header.Header
+	memfileHeader *utils.SetOnce[*header.Header]
+	rootfsHeader  *utils.SetOnce[*header.Header]
 	localSnapfile File
 	localMetafile File
 
@@ -44,8 +44,8 @@ type storageTemplate struct {
 func newTemplateFromStorage(
 	config cfg.BuilderConfig,
 	buildId string,
-	memfileHeader *header.Header,
-	rootfsHeader *header.Header,
+	memfileHeader *utils.SetOnce[*header.Header],
+	rootfsHeader *utils.SetOnce[*header.Header],
 	persistence storage.StorageProvider,
 	metrics blockmetrics.Metrics,
 	localSnapfile File,
@@ -174,12 +174,22 @@ func (t *storageTemplate) Fetch(ctx context.Context, buildStore *build.DiffStore
 	})
 
 	wg.Go(func() error {
+		memHdr, hdrErr := t.memfileHeader.WaitWithContext(ctx)
+		if hdrErr != nil {
+			errMsg := fmt.Errorf("failed to resolve memfile header: %w", hdrErr)
+			if err := t.memfile.SetError(errMsg); err != nil {
+				return fmt.Errorf("failed to set memfile error: %w", errors.Join(errMsg, err))
+			}
+
+			return nil
+		}
+
 		memfileStorage, memfileErr := NewStorage(
 			ctx,
 			buildStore,
 			t.paths.BuildID,
 			build.Memfile,
-			t.memfileHeader,
+			memHdr,
 			t.persistence,
 			t.metrics,
 		)
@@ -202,12 +212,22 @@ func (t *storageTemplate) Fetch(ctx context.Context, buildStore *build.DiffStore
 	})
 
 	wg.Go(func() error {
+		rootHdr, hdrErr := t.rootfsHeader.WaitWithContext(ctx)
+		if hdrErr != nil {
+			errMsg := fmt.Errorf("failed to resolve rootfs header: %w", hdrErr)
+			if err := t.rootfs.SetError(errMsg); err != nil {
+				return fmt.Errorf("failed to set rootfs error: %w", errors.Join(errMsg, err))
+			}
+
+			return nil
+		}
+
 		rootfsStorage, rootfsErr := NewStorage(
 			ctx,
 			buildStore,
 			t.paths.BuildID,
 			build.Rootfs,
-			t.rootfsHeader,
+			rootHdr,
 			t.persistence,
 			t.metrics,
 		)


### PR DESCRIPTION
#2814 detached only the dedup drain; the page-by-page compare and the diff header build still ran synchronously on the Pause RPC, so deduped pauses still scaled with dirty-page count and base-layer fetch latency.

Wrap `Snapshot.{Memfile,Rootfs}DiffHeader` in a `*utils.SetOnce[*header.Header]`. The memfd-dedup goroutine now resolves the header after compare; all other paths resolve it sync before returning. `storageTemplate.Fetch` and the upload paths Wait on the future, so the Pause RPC returns before compare/drain finishes.