### PR TITLE
perf(header): allocate NormalizeMappings result at exact size

### DIFF
--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -206,11 +206,12 @@ func MergeMappings(
 
 // NormalizeMappings joins adjacent mappings that have the same buildId.
 //
-// The returned slice has cap == len so the merged header can be cached
-// without retaining unused trailing capacity from the pre-merge input
-// (which can be 10–100x larger than the normalized result on
-// snapshot-heavy workloads). The intermediate oversized slice is freed
-// once the clone is returned.
+// The merge loop preallocates cap == len(input) to stay single-alloc,
+// but the merged Header lives in the 25h template cache and on
+// snapshot-heavy workloads the input is 10–100x larger than the
+// normalized output. Clone the result so the oversized intermediate
+// drops to GC instead of being retained for a day. slices.Clip is not
+// enough — it only retightens the cap header on the same backing array.
 func NormalizeMappings(mappings []BuildMap) []BuildMap {
 	if len(mappings) == 0 {
 		return nil

--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -204,12 +204,26 @@ func MergeMappings(
 }
 
 // NormalizeMappings joins adjacent mappings that have the same buildId.
+//
+// The returned slice is allocated with cap == len so the merged header
+// can be cached without retaining unused trailing capacity from the
+// pre-merge input (which can be 10–100x larger than the normalized
+// result on snapshot-heavy workloads).
 func NormalizeMappings(mappings []BuildMap) []BuildMap {
 	if len(mappings) == 0 {
 		return nil
 	}
 
-	result := make([]BuildMap, 0, len(mappings))
+	// First pass: count distinct adjacent runs so the result slice can
+	// be allocated at exactly the final length.
+	runs := 1
+	for i := 1; i < len(mappings); i++ {
+		if mappings[i].BuildId != mappings[i-1].BuildId {
+			runs++
+		}
+	}
+
+	result := make([]BuildMap, 0, runs)
 
 	current := mappings[0]
 

--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -206,12 +206,9 @@ func MergeMappings(
 
 // NormalizeMappings joins adjacent mappings that have the same buildId.
 //
-// The merge loop preallocates cap == len(input) to stay single-alloc,
-// but the merged Header lives in the 25h template cache and on
-// snapshot-heavy workloads the input is 10–100x larger than the
-// normalized output. Clone the result so the oversized intermediate
-// drops to GC instead of being retained for a day. slices.Clip is not
-// enough — it only retightens the cap header on the same backing array.
+// Clone the result so the oversized intermediate (cap == len(input)) is
+// released; the merged Header is cached for up to 25h. slices.Clip will
+// not do — it only retightens cap on the same backing array.
 func NormalizeMappings(mappings []BuildMap) []BuildMap {
 	if len(mappings) == 0 {
 		return nil

--- a/packages/shared/pkg/storage/header/mapping.go
+++ b/packages/shared/pkg/storage/header/mapping.go
@@ -3,6 +3,7 @@ package header
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"github.com/RoaringBitmap/roaring/v2"
 	"github.com/google/uuid"
@@ -205,25 +206,17 @@ func MergeMappings(
 
 // NormalizeMappings joins adjacent mappings that have the same buildId.
 //
-// The returned slice is allocated with cap == len so the merged header
-// can be cached without retaining unused trailing capacity from the
-// pre-merge input (which can be 10–100x larger than the normalized
-// result on snapshot-heavy workloads).
+// The returned slice has cap == len so the merged header can be cached
+// without retaining unused trailing capacity from the pre-merge input
+// (which can be 10–100x larger than the normalized result on
+// snapshot-heavy workloads). The intermediate oversized slice is freed
+// once the clone is returned.
 func NormalizeMappings(mappings []BuildMap) []BuildMap {
 	if len(mappings) == 0 {
 		return nil
 	}
 
-	// First pass: count distinct adjacent runs so the result slice can
-	// be allocated at exactly the final length.
-	runs := 1
-	for i := 1; i < len(mappings); i++ {
-		if mappings[i].BuildId != mappings[i-1].BuildId {
-			runs++
-		}
-	}
-
-	result := make([]BuildMap, 0, runs)
+	result := make([]BuildMap, 0, len(mappings))
 
 	current := mappings[0]
 
@@ -239,5 +232,5 @@ func NormalizeMappings(mappings []BuildMap) []BuildMap {
 
 	result = append(result, current)
 
-	return result
+	return slices.Clone(result)
 }

--- a/packages/shared/pkg/storage/header/mapping_test.go
+++ b/packages/shared/pkg/storage/header/mapping_test.go
@@ -657,41 +657,6 @@ func TestNormalizeMappingsZeroLengthMapping(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func BenchmarkNormalizeMappingsHeavyMerge(b *testing.B) {
-	// Worst case for the old preallocation: many short input runs that
-	// collapse to very few output runs. Each cached header used to retain
-	// the full input-sized backing array.
-	id1 := uuid.New()
-	id2 := uuid.New()
-	input := make([]BuildMap, 0, 10_000)
-	for i := 0; i < 5_000; i++ {
-		input = append(input,
-			BuildMap{Offset: uint64(i * 2), Length: 1, BuildId: id1},
-			BuildMap{Offset: uint64(i*2 + 1), Length: 1, BuildId: id1},
-		)
-	}
-	input[len(input)/2].BuildId = id2
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = NormalizeMappings(input)
-	}
-}
-
-func BenchmarkNormalizeMappingsNoMerge(b *testing.B) {
-	// Worst case for the new two-pass: every entry has a distinct buildId
-	// so the second pass cannot collapse anything.
-	input := make([]BuildMap, 10_000)
-	for i := range input {
-		input[i] = BuildMap{Offset: uint64(i), Length: 1, BuildId: uuid.New()}
-	}
-
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		_ = NormalizeMappings(input)
-	}
-}
-
 func TestNormalizeMappingsDoesNotModifyInput(t *testing.T) {
 	t.Parallel()
 	input := []BuildMap{

--- a/packages/shared/pkg/storage/header/mapping_test.go
+++ b/packages/shared/pkg/storage/header/mapping_test.go
@@ -657,6 +657,41 @@ func TestNormalizeMappingsZeroLengthMapping(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func BenchmarkNormalizeMappingsHeavyMerge(b *testing.B) {
+	// Worst case for the old preallocation: many short input runs that
+	// collapse to very few output runs. Each cached header used to retain
+	// the full input-sized backing array.
+	id1 := uuid.New()
+	id2 := uuid.New()
+	input := make([]BuildMap, 0, 10_000)
+	for i := 0; i < 5_000; i++ {
+		input = append(input,
+			BuildMap{Offset: uint64(i * 2), Length: 1, BuildId: id1},
+			BuildMap{Offset: uint64(i*2 + 1), Length: 1, BuildId: id1},
+		)
+	}
+	input[len(input)/2].BuildId = id2
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = NormalizeMappings(input)
+	}
+}
+
+func BenchmarkNormalizeMappingsNoMerge(b *testing.B) {
+	// Worst case for the new two-pass: every entry has a distinct buildId
+	// so the second pass cannot collapse anything.
+	input := make([]BuildMap, 10_000)
+	for i := range input {
+		input[i] = BuildMap{Offset: uint64(i), Length: 1, BuildId: uuid.New()}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = NormalizeMappings(input)
+	}
+}
+
 func TestNormalizeMappingsDoesNotModifyInput(t *testing.T) {
 	t.Parallel()
 	input := []BuildMap{


### PR DESCRIPTION
`NormalizeMappings` returns its working slice (`cap == len(input)`), and the merged `Header` is held in the orchestrator template cache for up to 25h. On snapshot-heavy nodes that unused trailing capacity is what's dominating retained heap. Clone before returning so only the exact-size copy survives.