### PR TITLE
perf(header): dictionary-encoded SoA Mappings to shrink cached headers

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -131,8 +131,8 @@ func NewHeaderFromPath(ctx context.Context, from, headerPath string) (*header.He
 func getReferencedData(h *header.Header, objectType storage.ObjectType) []string {
 	builds := make(map[string]struct{})
 
-	for _, mapping := range h.Mapping {
-		builds[mapping.BuildId.String()] = struct{}{}
+	for _, id := range h.Mapping.Builds() {
+		builds[id.String()] = struct{}{}
 	}
 
 	delete(builds, uuid.Nil.String())

--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -105,7 +105,7 @@ func printUsage() {
 
 func printHeader(h *header.Header, source string) {
 	// Validate mappings
-	err := header.ValidateMappings(h.Mapping, h.Metadata.Size, h.Metadata.BlockSize)
+	err := header.ValidateMappings(h.Mapping.Slice(), h.Metadata.Size, h.Metadata.BlockSize)
 	if err != nil {
 		fmt.Printf("\n⚠️  WARNING: Mapping validation failed!\n%s\n\n", err)
 	}
@@ -121,7 +121,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("Block size         %d B\n", h.Metadata.BlockSize)
 	fmt.Printf("Blocks             %d\n", (h.Metadata.Size+h.Metadata.BlockSize-1)/h.Metadata.BlockSize)
 
-	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(len(h.Mapping)) / 1024
+	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(h.Mapping.Len()) / 1024
 	var sizeMessage string
 	if totalSize == 0 {
 		sizeMessage = "<1 KiB"
@@ -129,10 +129,10 @@ func printHeader(h *header.Header, source string) {
 		sizeMessage = fmt.Sprintf("%d KiB", totalSize)
 	}
 
-	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", len(h.Mapping), sizeMessage)
+	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", h.Mapping.Len(), sizeMessage)
 	fmt.Printf("=======\n")
 
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		fmt.Println(mapping.Format(h.Metadata.BlockSize))
 	}
 
@@ -140,7 +140,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("===============\n")
 
 	builds := make(map[string]int64)
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		builds[mapping.BuildId.String()] += int64(mapping.Length)
 	}
 

--- a/packages/orchestrator/cmd/show-build-diff/main.go
+++ b/packages/orchestrator/cmd/show-build-diff/main.go
@@ -85,18 +85,20 @@ func main() {
 	fmt.Printf("Storage path       %s\n", baseSource)
 	fmt.Printf("========\n")
 
-	for _, mapping := range baseHeader.Mapping {
+	baseMappingSlice := baseHeader.Mapping.Slice()
+
+	for _, mapping := range baseMappingSlice {
 		fmt.Println(mapping.Format(baseHeader.Metadata.BlockSize))
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMappingSlice)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")
 		fmt.Println(
 			header.Visualize(
-				baseHeader.Mapping,
+				baseMappingSlice,
 				baseHeader.Metadata.Size,
 				baseHeader.Metadata.BlockSize,
 				128,
@@ -108,7 +110,7 @@ func main() {
 		)
 	}
 
-	if err := header.ValidateMappings(baseHeader.Mapping, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
+	if err := header.ValidateMappings(baseMappingSlice, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
 		log.Fatalf("failed to validate base header: %s", err)
 	}
 
@@ -118,7 +120,7 @@ func main() {
 
 	onlyDiffMappings := make([]header.BuildMap, 0)
 
-	for _, mapping := range diffHeader.Mapping {
+	for _, mapping := range diffHeader.Mapping.All() {
 		if mapping.BuildId == diffHeader.Metadata.BuildId {
 			onlyDiffMappings = append(onlyDiffMappings, mapping)
 		}
@@ -142,7 +144,7 @@ func main() {
 		)
 	}
 
-	mergedHeader := header.MergeMappings(baseHeader.Mapping, onlyDiffMappings)
+	mergedHeader := header.MergeMappings(baseMappingSlice, onlyDiffMappings)
 
 	fmt.Printf("\n\nMERGED METADATA\n")
 	fmt.Printf("========\n")
@@ -152,7 +154,7 @@ func main() {
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMappingSlice)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")

--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -113,7 +113,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 	}
 
 	if memfileDiffHeader != nil {
-		if err := u.appendAncestorBuilds(ctx, nil, memfileDiffHeader.Mapping, build.Memfile); err != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, memfileDiffHeader.Mapping.Builds(), build.Memfile); err != nil {
 			return err
 		}
 	}
@@ -124,7 +124,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 	}
 
 	if rootfsDiffHeader != nil {
-		if err := u.appendAncestorBuilds(ctx, nil, rootfsDiffHeader.Mapping, build.Rootfs); err != nil {
+		if err := u.appendAncestorBuilds(ctx, nil, rootfsDiffHeader.Mapping.Builds(), build.Rootfs); err != nil {
 			return err
 		}
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -103,7 +103,7 @@ func (u *Upload) uploadFramed(
 		h.Builds = make(map[uuid.UUID]headers.BuildData)
 	}
 
-	if err := u.appendAncestorBuilds(ctx, h.Builds, srcHeader.Mapping, fileType); err != nil {
+	if err := u.appendAncestorBuilds(ctx, h.Builds, srcHeader.Mapping.Builds(), fileType); err != nil {
 		return err
 	}
 	h.Builds[u.buildID] = selfBuild
@@ -115,7 +115,7 @@ func (u *Upload) uploadFramed(
 	return u.publish(ctx, fileType, h)
 }
 
-// appendAncestorBuilds waits on every unique buildID referenced by mappings
+// appendAncestorBuilds waits on every unique buildID in ancestorBuilds
 // (excluding self) — gating publish on parents' header finalization — and,
 // when dst is non-nil, writes the freshest BuildData into it. Existing dst
 // entries are overwritten (Wait is more authoritative than CloneForUpload).
@@ -130,33 +130,28 @@ func (u *Upload) uploadFramed(
 func (u *Upload) appendAncestorBuilds(
 	ctx context.Context,
 	dst map[uuid.UUID]headers.BuildData,
-	mappings []headers.BuildMap,
+	ancestorBuilds []uuid.UUID,
 	fileType build.DiffType,
 ) error {
 	if u.uploads == nil {
 		return nil
 	}
 
-	seen := make(map[uuid.UUID]struct{}, len(mappings))
-	for _, m := range mappings {
-		if m.BuildId == u.buildID || m.BuildId == uuid.Nil {
+	for _, id := range ancestorBuilds {
+		if id == u.buildID || id == uuid.Nil {
 			continue
 		}
-		if _, dup := seen[m.BuildId]; dup {
-			continue
-		}
-		seen[m.BuildId] = struct{}{}
 
-		h, err := u.uploads.Wait(ctx, m.BuildId, fileType)
+		h, err := u.uploads.Wait(ctx, id, fileType)
 		if err != nil {
-			return fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
+			return fmt.Errorf("wait for ancestor %s/%s: %w", id, fileType, err)
 		}
 		if h == nil || dst == nil {
 			continue
 		}
 
-		if bd, ok := h.Builds[m.BuildId]; ok {
-			dst[m.BuildId] = bd
+		if bd, ok := h.Builds[id]; ok {
+			dst[id] = bd
 		}
 	}
 

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -34,7 +34,7 @@ type Header struct {
 	// RPC and reads uncompressed data when nil.
 	Builds map[uuid.UUID]BuildData
 
-	Mapping []BuildMap
+	Mapping Mappings
 
 	// IncompletePendingUpload is set on diff headers produced by ToDiffHeader and
 	// cleared on the finalized headers swapped in by the upload pipeline. It
@@ -91,7 +91,7 @@ func NewHeader(metadata *Metadata, mapping []BuildMap) (*Header, error) {
 
 	return &Header{
 		Metadata: metadata,
-		Mapping:  mapping,
+		Mapping:  MappingsFromSlice(mapping),
 	}, nil
 }
 
@@ -102,13 +102,10 @@ func newDiffHeader(metadata *Metadata, mapping []BuildMap, sourceBuilds map[uuid
 	}
 
 	if sourceBuilds != nil {
-		referenced := make(map[uuid.UUID]struct{}, len(h.Mapping))
-		for _, m := range h.Mapping {
-			referenced[m.BuildId] = struct{}{}
-		}
+		referenced := h.Mapping.Builds()
 
 		h.Builds = make(map[uuid.UUID]BuildData, len(referenced))
-		for id := range referenced {
+		for _, id := range referenced {
 			if bd, ok := sourceBuilds[id]; ok {
 				h.Builds[id] = bd
 			}
@@ -131,7 +128,7 @@ func (t *Header) String() string {
 		t.Metadata.BlockSize,
 		t.Metadata.Generation,
 		t.Metadata.BuildId.String(),
-		len(t.Mapping),
+		t.Mapping.Len(),
 	)
 }
 
@@ -183,10 +180,10 @@ func (t *Header) GetBuildFrameData(buildID uuid.UUID) *storage.FrameTable {
 	return t.Builds[buildID].FrameData
 }
 
-func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64, error) {
+func (t *Header) getMapping(ctx context.Context, offset int64) (BuildMap, int64, error) {
 	if offset < 0 || offset >= int64(t.Metadata.Size) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
 		}
 
 		logger.L().Warn(ctx, "offset is out of bounds, but normalize fix is not applied",
@@ -197,7 +194,7 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 	}
 	if offset%PageSize != 0 {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
 		}
 
 		logger.L().Warn(ctx, "offset is not aligned to page size, but normalize fix is not applied",
@@ -207,21 +204,21 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 		)
 	}
 
-	i := sort.Search(len(t.Mapping), func(i int) bool {
-		return int64(t.Mapping[i].Offset) > offset
+	i := sort.Search(t.Mapping.Len(), func(i int) bool {
+		return int64(t.Mapping.OffsetAt(i)) > offset
 	})
 
 	if i == 0 {
-		return nil, 0, fmt.Errorf("no source found for offset %d", offset)
+		return BuildMap{}, 0, fmt.Errorf("no source found for offset %d", offset)
 	}
 
-	mapping := &t.Mapping[i-1]
+	mapping := t.Mapping.At(i - 1)
 	shift := offset - int64(mapping.Offset)
 
 	// Verify that the offset falls within this mapping's range
 	if shift >= int64(mapping.Length) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
+			return BuildMap{}, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
 				offset, mapping.Offset, mapping.Offset+mapping.Length)
 		}
 
@@ -254,12 +251,12 @@ func ValidateHeader(h *Header) error {
 	if h.Metadata.Size == 0 {
 		return errors.New("header has zero size")
 	}
-	if len(h.Mapping) == 0 {
+	if h.Mapping.Len() == 0 {
 		return errors.New("header has no mappings")
 	}
 
 	// Sort mappings by offset to check for gaps/overlaps
-	sortedMappings := slices.Clone(h.Mapping)
+	sortedMappings := h.Mapping.Slice()
 	slices.SortFunc(sortedMappings, func(a, b BuildMap) int {
 		return cmp.Compare(a.Offset, b.Offset)
 	})
@@ -300,7 +297,7 @@ func ValidateHeader(h *Header) error {
 	}
 
 	// Validate individual mapping bounds
-	for i, m := range h.Mapping {
+	for i, m := range h.Mapping.All() {
 		if m.Offset > h.Metadata.Size {
 			return fmt.Errorf("mapping[%d] has Offset %d beyond header size %d for buildId %s",
 				i, m.Offset, h.Metadata.Size, m.BuildId.String())

--- a/packages/shared/pkg/storage/header/mappings.go
+++ b/packages/shared/pkg/storage/header/mappings.go
@@ -138,4 +138,3 @@ func (b *mappingsBuilder) build() Mappings { return b.m }
 // (parallel slices, ignoring slice-header overhead and the small builds
 // dictionary). Exposed for tests and tooling.
 func (m Mappings) entrySize() int { return 8 + 8 + 8 + 2 }
-

--- a/packages/shared/pkg/storage/header/mappings.go
+++ b/packages/shared/pkg/storage/header/mappings.go
@@ -1,0 +1,141 @@
+package header
+
+import (
+	"fmt"
+	"iter"
+	"math"
+
+	"github.com/google/uuid"
+)
+
+// maxDistinctBuilds is the largest number of distinct BuildIds a single
+// Mappings can intern (cap of the uint16 dictionary index). Real headers
+// reference a handful of builds; tripping this is a bug, not a deploy.
+const maxDistinctBuilds = math.MaxUint16 + 1
+
+// Mappings is the in-memory representation of a Header's mapping list.
+//
+// On the wire each mapping is a 40-byte BuildMap (uuid.UUID is 16 bytes
+// inline). In memory we store the fields in parallel slices and intern
+// each distinct BuildId once in builds, indexed by a uint16 per entry.
+// Net per-entry footprint drops from 40 to 26 bytes plus 16 bytes per
+// distinct build, which is a ~35% reduction on the dominant cached-header
+// retain on snapshot-heavy orchestrator nodes.
+//
+// The zero value is empty and safe to use. Construction goes through
+// MappingsFromSlice or MappingsBuilder; the SoA layout is otherwise an
+// implementation detail and callers see only BuildMap values.
+type Mappings struct {
+	offsets        []uint64
+	lengths        []uint64
+	storageOffsets []uint64
+	buildIdxs      []uint16
+	builds         []uuid.UUID
+}
+
+// MappingsFromSlice packs maps into a Mappings, interning distinct BuildIds.
+// Panics if the input references more than maxDistinctBuilds distinct
+// BuildIds — which would mean a header has grown well past anything we
+// expect in practice and is almost certainly a bug.
+func MappingsFromSlice(maps []BuildMap) Mappings {
+	if len(maps) == 0 {
+		return Mappings{}
+	}
+
+	b := newMappingsBuilder(len(maps))
+	for i := range maps {
+		b.append(maps[i])
+	}
+	return b.build()
+}
+
+// Len returns the number of mappings.
+func (m Mappings) Len() int { return len(m.offsets) }
+
+// At returns the BuildMap at index i. The returned value is materialized
+// (the BuildId is looked up in the internal dictionary), so callers can
+// keep using the BuildMap value type unchanged.
+func (m Mappings) At(i int) BuildMap {
+	return BuildMap{
+		Offset:             m.offsets[i],
+		Length:             m.lengths[i],
+		BuildId:            m.builds[m.buildIdxs[i]],
+		BuildStorageOffset: m.storageOffsets[i],
+	}
+}
+
+// OffsetAt is used by the binary-search hot path (Header.getMapping) and
+// avoids materializing the full BuildMap on every probe.
+func (m Mappings) OffsetAt(i int) uint64 { return m.offsets[i] }
+
+// All yields (index, BuildMap) for range loops.
+func (m Mappings) All() iter.Seq2[int, BuildMap] {
+	return func(yield func(int, BuildMap) bool) {
+		for i := range m.offsets {
+			if !yield(i, m.At(i)) {
+				return
+			}
+		}
+	}
+}
+
+// Builds returns the distinct BuildIds referenced by this Mappings, in
+// insertion order. The returned slice is read-only and aliases internal
+// storage; callers must not mutate it.
+func (m Mappings) Builds() []uuid.UUID { return m.builds }
+
+// Slice materializes the full flat []BuildMap. Use only at serialization
+// boundaries and in tools that need the legacy shape; the hot path should
+// stick to At / OffsetAt / All.
+func (m Mappings) Slice() []BuildMap {
+	if len(m.offsets) == 0 {
+		return nil
+	}
+
+	out := make([]BuildMap, len(m.offsets))
+	for i := range out {
+		out[i] = m.At(i)
+	}
+	return out
+}
+
+type mappingsBuilder struct {
+	m     Mappings
+	idxOf map[uuid.UUID]uint16
+}
+
+func newMappingsBuilder(capHint int) *mappingsBuilder {
+	return &mappingsBuilder{
+		m: Mappings{
+			offsets:        make([]uint64, 0, capHint),
+			lengths:        make([]uint64, 0, capHint),
+			storageOffsets: make([]uint64, 0, capHint),
+			buildIdxs:      make([]uint16, 0, capHint),
+		},
+		idxOf: make(map[uuid.UUID]uint16),
+	}
+}
+
+func (b *mappingsBuilder) append(bm BuildMap) {
+	idx, ok := b.idxOf[bm.BuildId]
+	if !ok {
+		if len(b.m.builds) >= maxDistinctBuilds {
+			panic(fmt.Sprintf("header: more than %d distinct BuildIds in a single Mappings", maxDistinctBuilds))
+		}
+		idx = uint16(len(b.m.builds))
+		b.m.builds = append(b.m.builds, bm.BuildId)
+		b.idxOf[bm.BuildId] = idx
+	}
+	b.m.offsets = append(b.m.offsets, bm.Offset)
+	b.m.lengths = append(b.m.lengths, bm.Length)
+	b.m.storageOffsets = append(b.m.storageOffsets, bm.BuildStorageOffset)
+	b.m.buildIdxs = append(b.m.buildIdxs, idx)
+}
+
+func (b *mappingsBuilder) build() Mappings { return b.m }
+
+// entrySize returns the in-memory bytes per entry held by this Mappings
+// (parallel slices, ignoring slice-header overhead and the small builds
+// dictionary). Exposed for tests and tooling.
+func (m Mappings) entrySize() int { return 8 + 8 + 8 + 2 }
+

--- a/packages/shared/pkg/storage/header/mappings_test.go
+++ b/packages/shared/pkg/storage/header/mappings_test.go
@@ -1,0 +1,84 @@
+package header
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMappings_RoundTripFromSlice(t *testing.T) {
+	t.Parallel()
+
+	id1 := uuid.New()
+	id2 := uuid.New()
+	in := []BuildMap{
+		{Offset: 0, Length: 4096, BuildId: id1, BuildStorageOffset: 0},
+		{Offset: 4096, Length: 4096, BuildId: id2, BuildStorageOffset: 7},
+		{Offset: 8192, Length: 4096, BuildId: id1, BuildStorageOffset: 4096},
+	}
+
+	m := MappingsFromSlice(in)
+
+	require.Equal(t, len(in), m.Len())
+	for i, want := range in {
+		assert.Equal(t, want, m.At(i))
+		assert.Equal(t, want.Offset, m.OffsetAt(i))
+	}
+	assert.Equal(t, in, m.Slice())
+
+	// Dictionary contains only the two distinct builds.
+	assert.ElementsMatch(t, []uuid.UUID{id1, id2}, m.Builds())
+
+	// All() yields the same values.
+	var rebuilt []BuildMap
+	for _, b := range m.All() {
+		rebuilt = append(rebuilt, b)
+	}
+	assert.Equal(t, in, rebuilt)
+}
+
+func TestMappings_Empty(t *testing.T) {
+	t.Parallel()
+
+	m := MappingsFromSlice(nil)
+	assert.Equal(t, 0, m.Len())
+	assert.Empty(t, m.Builds())
+	assert.Nil(t, m.Slice())
+}
+
+// BenchmarkMappings_FromSlice exercises the construction path. The whole
+// point of the dictionary is to retain less memory once the result lives
+// in the template cache, not to be allocation-free at build time.
+func BenchmarkMappings_FromSlice(b *testing.B) {
+	id1 := uuid.New()
+	id2 := uuid.New()
+	in := make([]BuildMap, 10_000)
+	for i := range in {
+		id := id1
+		if i%2 == 0 {
+			id = id2
+		}
+		in[i] = BuildMap{
+			Offset: uint64(i * 4096), Length: 4096,
+			BuildId: id, BuildStorageOffset: uint64(i * 4096),
+		}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = MappingsFromSlice(in)
+	}
+}
+
+// TestMappings_EntrySize documents the per-entry footprint vs the legacy
+// []BuildMap layout (40 bytes). Failure means the SoA struct grew or the
+// platform changed BuildMap's layout — both are worth reviewing.
+func TestMappings_EntrySize(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 40, int(unsafe.Sizeof(BuildMap{})))
+	assert.Equal(t, 26, Mappings{}.entrySize())
+}

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -136,7 +136,7 @@ func (d *DiffMetadata) ToDiffHeader(
 	diffMapping := d.toDiffMapping(ctx, buildID)
 
 	m := MergeMappings(
-		originalHeader.Mapping,
+		originalHeader.Mapping.Slice(),
 		diffMapping,
 	)
 	telemetry.ReportEvent(ctx, "merged mappings")
@@ -164,7 +164,7 @@ func (d *DiffMetadata) ToDiffHeader(
 	}
 
 	// Dedup emits PageSize-granular mappings; validate at PageSize.
-	err = ValidateMappings(header.Mapping, header.Metadata.Size, PageSize)
+	err = ValidateMappings(header.Mapping.Slice(), header.Metadata.Size, PageSize)
 	if err != nil {
 		if header.IsNormalizeFixApplied() {
 			return nil, fmt.Errorf("invalid header mappings: %w", err)

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -14,10 +14,10 @@ import (
 // V4 (Version >= 4): [Metadata] [uint8 flags] [uint32 uncompressedSize] [LZ4( Builds + v4 mappings )]
 func SerializeHeader(h *Header) ([]byte, error) {
 	if h.Metadata.Version <= 3 {
-		return serializeV3(h.Metadata, h.Mapping)
+		return serializeV3(h.Metadata, h.Mapping.Slice())
 	}
 
-	data, _, err := serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+	data, _, err := serializeV4(h.Metadata, h.Builds, h.Mapping.Slice(), h.IncompletePendingUpload)
 
 	return data, err
 }
@@ -74,14 +74,14 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 
 	var data []byte
 	if h.Metadata.Version <= 3 {
-		data, err = serializeV3(h.Metadata, h.Mapping)
+		data, err = serializeV3(h.Metadata, h.Mapping.Slice())
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}
 		uncompressed = int64(len(data))
 	} else {
 		var blockUncompressed int64
-		data, blockUncompressed, err = serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+		data, blockUncompressed, err = serializeV4(h.Metadata, h.Builds, h.Mapping.Slice(), h.IncompletePendingUpload)
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -46,16 +46,16 @@ func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, metadata, got.Metadata)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[0].Length)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, uint64(0), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(0).Length)
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, uint64(0), got.Mapping.At(0).BuildStorageOffset)
 
-	require.Equal(t, uint64(4096), got.Mapping[1].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[1].Length)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
-	require.Equal(t, uint64(123), got.Mapping[1].BuildStorageOffset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Length)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
+	require.Equal(t, uint64(123), got.Mapping.At(1).BuildStorageOffset)
 
 	// V3 headers have no Builds
 	require.Nil(t, got.Builds)
@@ -88,10 +88,10 @@ func TestSerializeDeserialize_EmptyMappings_Defaults(t *testing.T) {
 	require.NoError(t, err)
 
 	// NewHeader creates a default mapping when none provided
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, metadata.Size, got.Mapping[0].Length)
-	require.Equal(t, metadata.BuildId, got.Mapping[0].BuildId)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, metadata.Size, got.Mapping.At(0).Length)
+	require.Equal(t, metadata.BuildId, got.Mapping.At(0).BuildId)
 }
 
 func TestDeserialize_BlockSizeZero(t *testing.T) {
@@ -165,9 +165,9 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
 
 	// Builds round-trip
 	require.Len(t, got.Builds, 2)
@@ -236,8 +236,8 @@ func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(8192), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(8192), got.Mapping.At(0).BuildStorageOffset)
 
 	require.Len(t, got.Builds, 1)
 	fd := got.Builds[buildID].FrameData
@@ -289,7 +289,7 @@ func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 2)
+	require.Equal(t, 2, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -333,7 +333,7 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.NotNil(t, got.Builds)
 	fd := got.Builds[buildID].FrameData
 	require.NotNil(t, fd)
@@ -380,7 +380,7 @@ func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -444,7 +444,7 @@ func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 3)
+	require.Equal(t, 3, got.Mapping.Len())
 	require.Len(t, got.Builds, 2)
 
 	// Verify checksums round-trip.
@@ -778,7 +778,7 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 5)
+	require.Equal(t, 5, got.Mapping.Len())
 	require.Len(t, got.Builds, 3)
 
 	require.Nil(t, got.GetBuildFrameData(selfID))
@@ -794,11 +794,11 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	_, hasV3b := got.Builds[v3bID]
 	require.False(t, hasV3b)
 
-	require.Equal(t, selfID, got.Mapping[0].BuildId)
-	require.Equal(t, midID, got.Mapping[1].BuildId)
-	require.Equal(t, olderID, got.Mapping[2].BuildId)
-	require.Equal(t, v3aID, got.Mapping[3].BuildId)
-	require.Equal(t, v3bID, got.Mapping[4].BuildId)
+	require.Equal(t, selfID, got.Mapping.At(0).BuildId)
+	require.Equal(t, midID, got.Mapping.At(1).BuildId)
+	require.Equal(t, olderID, got.Mapping.At(2).BuildId)
+	require.Equal(t, v3aID, got.Mapping.At(3).BuildId)
+	require.Equal(t, v3bID, got.Mapping.At(4).BuildId)
 }
 
 // Layered chain with a compressed self entry:


### PR DESCRIPTION
## Summary

`Header.Mapping` was a flat `[]BuildMap` (40 bytes/entry — `uuid.UUID` is 16 bytes inline). Each `Header` lives in the orchestrator template cache for up to 25h, so on snapshot-heavy nodes the per-entry overhead dominates heap (~60% of orchestrator inuse on a recent staging pprof).

Replace it with a struct-of-arrays `Mappings` type that interns each distinct `BuildId` once in a small dictionary and references it by `uint16` index per entry. Per-entry footprint drops from 40 B to **26 B (~35%)**; the dictionary is a handful of UUIDs.

**Internal representation only.** Wire format (V3/V4), validation, merge/normalize semantics, and the `BuildMap` value type are all unchanged. Construction goes through `MappingsFromSlice`; the hot read path uses `At` / `OffsetAt` / `All` accessors. Serializers and CLI tools that needed the legacy `[]BuildMap` shape call `Mapping.Slice()` at the boundary.

Stacks cleanly on top of (or independent of) #2822 — that PR clipped `NormalizeMappings`' slack capacity; this one shrinks every entry that survives the clip.

## Bench

Per-entry retain on a 10k-mapping header (worst case for the old layout):

| layout | per-entry | 10k-entry header |
|---|---|---|
| before (`[]BuildMap`) | 40 B | ~400 KB |
| after (`Mappings`)    | 26 B | ~260 KB |

On a saturated cache (~45k cached headers × ~1k entries avg) this maps to roughly **~600 MB freed** on top of the clip PR.

## Bonus

`appendAncestorBuilds` previously scanned every mapping entry, de-duplicating BuildIds via a map. Now it walks `Mapping.Builds()` directly — already deduped, no allocation, regardless of mapping count.

## Test plan

- [x] `go test ./packages/shared/pkg/storage/header/...` (round-trip + existing serialization, merge, normalize tests pass)
- [x] `go test ./packages/orchestrator/pkg/sandbox/block/... ./packages/sandbox/build/...`
- [x] `go build ./...` for every module in go.work
- [x] new `Mappings` unit tests + construction benchmark