### PR TITLE
feat(storage): write-through compressed templates to NFS on upload

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -75,6 +75,12 @@ func NewUpload(
 }
 
 func (u *Upload) Run(ctx context.Context) error {
+	// Attach the upload's use case ("build" for template builds, "pause" for
+	// snapshots) so downstream flag reads can target only one — e.g. the NFS
+	// write-through-on-write FF firing only for template builds. Matches the
+	// kind already wired into resolveCompressConfig.
+	ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(u.useCase))
+
 	if !u.mem.IsCompressionEnabled() && !u.root.IsCompressionEnabled() && !u.useV4 {
 		return u.runV3(ctx)
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -75,10 +75,7 @@ func NewUpload(
 }
 
 func (u *Upload) Run(ctx context.Context) error {
-	// Attach the upload's use case ("build" for template builds, "pause" for
-	// snapshots) so downstream flag reads can target only one — e.g. the NFS
-	// write-through-on-write FF firing only for template builds. Matches the
-	// kind already wired into resolveCompressConfig.
+	// Attach the upload use case so flag reads can target it (e.g. write-through only for builds).
 	ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(u.useCase))
 
 	if !u.mem.IsCompressionEnabled() && !u.root.IsCompressionEnabled() && !u.useV4 {

--- a/packages/shared/pkg/storage/compress_encode.go
+++ b/packages/shared/pkg/storage/compress_encode.go
@@ -113,7 +113,7 @@ func CompressBytes(ctx context.Context, data []byte, cfg CompressConfig) (*Frame
 	up := &memPartUploader{}
 
 	const compressBytesConcurrency = 1
-	ft, checksum, err := compressStream(ctx, bytes.NewReader(data), cfg, up, compressBytesConcurrency)
+	ft, checksum, err := compressStream(ctx, bytes.NewReader(data), cfg, up, compressBytesConcurrency, nil)
 	if err != nil {
 		return nil, nil, [32]byte{}, err
 	}

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -147,7 +147,7 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 			frameSizes = append(frameSizes, FrameSize{U: int32(f.uncompressedSize), C: int32(len(f.compressed))})
 			compressed = append(compressed, f.compressed)
 			if sink != nil {
-				sink(cOffset, f.compressed)
+				sink(ctx, cOffset, f.compressed)
 			}
 			cOffset += int64(len(f.compressed))
 		}

--- a/packages/shared/pkg/storage/compress_upload.go
+++ b/packages/shared/pkg/storage/compress_upload.go
@@ -104,7 +104,7 @@ func (p *part) addFrame(ctx context.Context, uncompressedData []byte, pool *sync
 	})
 }
 
-func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploader partUploader, maxUploadConcurrency int) (*FrameTable, [32]byte, error) {
+func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploader partUploader, maxUploadConcurrency int, sink FrameSink) (*FrameTable, [32]byte, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -132,6 +132,7 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 
 	// Upload loop.
 	var frameSizes []FrameSize
+	var cOffset int64
 	var loopErr error
 	for p := range q {
 		if err := p.compress.Wait(); err != nil {
@@ -145,6 +146,10 @@ func compressStream(ctx context.Context, in io.Reader, cfg CompressConfig, uploa
 		for _, f := range p.frames {
 			frameSizes = append(frameSizes, FrameSize{U: int32(f.uncompressedSize), C: int32(len(f.compressed))})
 			compressed = append(compressed, f.compressed)
+			if sink != nil {
+				sink(cOffset, f.compressed)
+			}
+			cOffset += int64(len(f.compressed))
 		}
 
 		pi := p.index

--- a/packages/shared/pkg/storage/compress_upload_test.go
+++ b/packages/shared/pkg/storage/compress_upload_test.go
@@ -166,6 +166,7 @@ func TestCompressStreamRoundTrip(t *testing.T) {
 				cfg,
 				up,
 				4,
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -203,7 +204,7 @@ func TestCompressStreamContextCancel(t *testing.T) {
 	up := &memPartUploader{}
 	cfg := defaultCfg(CompressionZstd, 4, 2*megabyte)
 
-	_, _, err := compressStream(ctx, bytes.NewReader(data), cfg, up, 4)
+	_, _, err := compressStream(ctx, bytes.NewReader(data), cfg, up, 4, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
 }
@@ -234,7 +235,7 @@ func TestCompressStreamPartSizeMinimum(t *testing.T) {
 			cfg := defaultCfg(CompressionZstd, 4, tc.frameSize)
 			cfg.MinPartSizeMB = tc.minPartSizeMB
 
-			_, _, err := compressStream(t.Context(), bytes.NewReader(data), cfg, up, 4)
+			_, _, err := compressStream(t.Context(), bytes.NewReader(data), cfg, up, 4, nil)
 			require.NoError(t, err)
 
 			// Verify: no non-final part is under 5 MiB.
@@ -290,7 +291,7 @@ func TestCompressStreamRace(t *testing.T) {
 				cfg.EncoderConcurrency = 4 // multi-threaded zstd encoders for more contention
 			}
 
-			ft, checksum, err := compressStream(ctx, bytes.NewReader(data), cfg, up, 4)
+			ft, checksum, err := compressStream(ctx, bytes.NewReader(data), cfg, up, 4, nil)
 			if err != nil {
 				return fmt.Errorf("stream %d: compress: %w", i, err)
 			}
@@ -357,6 +358,7 @@ func BenchmarkCompress(b *testing.B) {
 					bytes.NewReader(data),
 					compCfg,
 					up, 4,
+					nil,
 				)
 				if err != nil {
 					b.Fatal(err)

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -94,6 +94,7 @@ type (
 	ObjectMetadata = storageopts.ObjectMetadata
 	PutOptions     = storageopts.PutOptions
 	PutOption      = storageopts.PutOption
+	FrameSink      = storageopts.FrameSink
 )
 
 const ObjectMetadataTeamID = storageopts.ObjectMetadataTeamID
@@ -104,6 +105,8 @@ func WithMetadata(metadata ObjectMetadata) PutOption { return storageopts.WithMe
 // stored as `any` in storageopts to avoid importing storage from there;
 // backends use CompressConfigFromOpts to pull it back out.
 func WithCompressConfig(cfg CompressConfig) PutOption { return storageopts.WithCompression(cfg) }
+
+func WithFrameSink(s FrameSink) PutOption { return storageopts.WithFrameSink(s) }
 
 func WithChecksumSHA256() PutOption {
 	return func(o *PutOptions) { o.Checksum = true }

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -338,12 +338,28 @@ func (c *cachedSeekable) StoreFile(ctx context.Context, path string, opts ...Put
 	return c.inner.StoreFile(ctx, path, opts...)
 }
 
-// frameSink tees each compressed frame to a .frm file at its C-space offset,
-// matching the layout openReaderCompressed expects. Async; best-effort.
+// frameSink builds a FrameSink that writes each compressed frame to a .frm
+// file at its C-space offset, matching the layout openReaderCompressed expects.
+//
+// Fire-and-forget: writes are spawned via goCtx so they survive caller
+// cancellation, the upload doesn't wait. Concurrent NFS writes for this
+// upload are capped by MaxCacheWriterConcurrencyFlag, the same knob
+// createCacheBlocksFromFile reads for the uncompressed write-through path.
 func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
-	return func(cOffset int64, data []byte) {
-		framePath := makeFrameFilename(c.path, Range{Offset: cOffset, Length: len(data)})
+	maxConcurrency := c.flags.IntFlag(ctx, featureflags.MaxCacheWriterConcurrencyFlag)
+	if maxConcurrency <= 0 {
+		logger.L().Warn(ctx, "max cache writer concurrency is too low, falling back to 1",
+			zap.Int("max_concurrency", maxConcurrency))
+		maxConcurrency = 1
+	}
+	sem := make(chan struct{}, maxConcurrency)
+
+	return func(ctx context.Context, cOffset int64, data []byte) {
 		c.goCtx(ctx, func(ctx context.Context) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			framePath := makeFrameFilename(c.path, Range{Offset: cOffset, Length: len(data)})
 			if err := c.writeToCache(ctx, cOffset, framePath, data); err != nil {
 				recordCacheWriteError(ctx, cacheTypeSeekable, cacheOpWriteFromFileSystem, err)
 			}

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -377,6 +377,11 @@ func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
 	}
 }
 
+// goCtx runs fn on c.wg, detached from the caller's cancellation via
+// WithoutCancel so an in-flight cache write isn't aborted when the upload's
+// context is cancelled (it still inherits values for tracing/flags). Tracked
+// by c.wg so it can be awaited; pre-existing pattern from the uncompressed
+// write-through path.
 func (c *cachedSeekable) goCtx(ctx context.Context, fn func(context.Context)) {
 	c.wg.Go(func() {
 		fn(context.WithoutCancel(ctx))

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -338,13 +338,9 @@ func (c *cachedSeekable) StoreFile(ctx context.Context, path string, opts ...Put
 	return c.inner.StoreFile(ctx, path, opts...)
 }
 
-// frameSink builds a FrameSink that writes each compressed frame to a .frm
-// file at its C-space offset, matching the layout openReaderCompressed expects.
-//
-// Fire-and-forget: writes are spawned via goCtx so they survive caller
-// cancellation, the upload doesn't wait. Concurrent NFS writes for this
-// upload are capped by MaxCacheWriterConcurrencyFlag, the same knob
-// createCacheBlocksFromFile reads for the uncompressed write-through path.
+// frameSink writes each compressed frame to a .frm file at its C-space offset,
+// the layout openReaderCompressed expects. Writes are async (goCtx) and capped
+// by MaxCacheWriterConcurrencyFlag.
 func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
 	maxConcurrency := c.flags.IntFlag(ctx, featureflags.MaxCacheWriterConcurrencyFlag)
 	if maxConcurrency <= 0 {
@@ -355,11 +351,8 @@ func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
 	sem := make(chan struct{}, maxConcurrency)
 
 	return func(ctx context.Context, cOffset int64, data []byte) {
-		// Acquire BEFORE spawning so the goroutine count is bounded — otherwise
-		// every frame still spawns a goroutine that just blocks on sem, and
-		// large uploads with a low concurrency cap pile up thousands of live
-		// goroutines in wg. Pushes backpressure into the sink caller (the
-		// upload loop in compressStream), which is the right place to slow.
+		// Acquire before spawning so goroutine count stays bounded; this also
+		// backpressures the upload loop in compressStream.
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
@@ -377,11 +370,8 @@ func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
 	}
 }
 
-// goCtx runs fn on c.wg, detached from the caller's cancellation via
-// WithoutCancel so an in-flight cache write isn't aborted when the upload's
-// context is cancelled (it still inherits values for tracing/flags). Tracked
-// by c.wg so it can be awaited; pre-existing pattern from the uncompressed
-// write-through path.
+// goCtx runs fn on c.wg with WithoutCancel so an in-flight cache write isn't
+// aborted when the upload's context is cancelled.
 func (c *cachedSeekable) goCtx(ctx context.Context, fn func(context.Context)) {
 	c.wg.Go(func() {
 		fn(context.WithoutCancel(ctx))

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -306,11 +306,13 @@ func (c *cachedSeekable) StoreFile(ctx context.Context, path string, opts ...Put
 	}()
 
 	cfg := CompressConfigFromOpts(ApplyPutOptions(opts))
+	writeThrough := c.flags.BoolFlag(ctx, featureflags.EnableWriteThroughCacheFlag)
 
-	// write the file to the disk and the remote system at the same time.
-	// this opens the file twice, but the API makes it difficult to use a MultiWriter
+	if cfg.IsCompressionEnabled() && writeThrough {
+		opts = append(opts, WithFrameSink(c.frameSink(ctx)))
+	}
 
-	if !cfg.IsCompressionEnabled() && c.flags.BoolFlag(ctx, featureflags.EnableWriteThroughCacheFlag) {
+	if !cfg.IsCompressionEnabled() && writeThrough {
 		c.goCtx(ctx, func(ctx context.Context) {
 			ctx, span := c.tracer.Start(ctx, "write cache object from file system",
 				trace.WithAttributes(attribute.String("path", path)))
@@ -334,6 +336,19 @@ func (c *cachedSeekable) StoreFile(ctx context.Context, path string, opts ...Put
 	}
 
 	return c.inner.StoreFile(ctx, path, opts...)
+}
+
+// frameSink tees each compressed frame to a .frm file at its C-space offset,
+// matching the layout openReaderCompressed expects. Async; best-effort.
+func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
+	return func(cOffset int64, data []byte) {
+		framePath := makeFrameFilename(c.path, Range{Offset: cOffset, Length: len(data)})
+		c.goCtx(ctx, func(ctx context.Context) {
+			if err := c.writeToCache(ctx, cOffset, framePath, data); err != nil {
+				recordCacheWriteError(ctx, cacheTypeSeekable, cacheOpWriteFromFileSystem, err)
+			}
+		})
+	}
 }
 
 func (c *cachedSeekable) goCtx(ctx context.Context, fn func(context.Context)) {

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -355,8 +355,18 @@ func (c *cachedSeekable) frameSink(ctx context.Context) FrameSink {
 	sem := make(chan struct{}, maxConcurrency)
 
 	return func(ctx context.Context, cOffset int64, data []byte) {
+		// Acquire BEFORE spawning so the goroutine count is bounded — otherwise
+		// every frame still spawns a goroutine that just blocks on sem, and
+		// large uploads with a low concurrency cap pile up thousands of live
+		// goroutines in wg. Pushes backpressure into the sink caller (the
+		// upload loop in compressStream), which is the right place to slow.
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+
 		c.goCtx(ctx, func(ctx context.Context) {
-			sem <- struct{}{}
 			defer func() { <-sem }()
 
 			framePath := makeFrameFilename(c.path, Range{Offset: cOffset, Length: len(data)})

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -662,62 +662,6 @@ func TestCachedSeekable_StoreFile_Compressed_WriteThrough(t *testing.T) {
 	}
 }
 
-func TestCachedSeekable_StoreFile_Compressed_FlagOff_NoSink(t *testing.T) {
-	t.Parallel()
-
-	cfg := defaultCfg(CompressionZstd, 1, 64*1024)
-	tempDir := t.TempDir()
-	srcPath := filepath.Join(tempDir, "src.bin")
-	require.NoError(t, os.WriteFile(srcPath, []byte("x"), 0o644))
-
-	inner := NewMockSeekable(t)
-	inner.EXPECT().
-		StoreFile(mock.Anything, mock.Anything, mock.Anything).
-		RunAndReturn(func(_ context.Context, _ string, opts ...PutOption) (*FrameTable, [32]byte, error) {
-			po := ApplyPutOptions(opts)
-			assert.Nil(t, po.FrameSink, "FrameSink must NOT be attached when write-through flag is off")
-
-			return nil, [32]byte{}, nil
-		})
-
-	flags := NewMockFeatureFlagsClient(t)
-	flags.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(false)
-
-	c := cachedSeekable{path: t.TempDir(), inner: inner, chunkSize: 64 * 1024, flags: flags, tracer: noopTracer}
-
-	_, _, err := c.StoreFile(t.Context(), srcPath, WithCompressConfig(cfg))
-	require.NoError(t, err)
-	c.wg.Wait()
-}
-
-func TestCachedSeekable_FrameSinkPopulatesNFS(t *testing.T) {
-	t.Parallel()
-
-	const frameSize = 64 * 1024
-	data := generateSemiRandomData(3 * frameSize)
-
-	flags := NewMockFeatureFlagsClient(t)
-	flags.EXPECT().IntFlag(mock.Anything, mock.Anything).Return(4)
-	c := &cachedSeekable{path: t.TempDir(), flags: flags, tracer: noopTracer}
-	up := &memPartUploader{}
-	cfg := defaultCfg(CompressionZstd, 2, frameSize)
-
-	ft, _, err := compressStream(t.Context(), bytes.NewReader(data), cfg, up, 4, c.frameSink(t.Context()))
-	require.NoError(t, err)
-	c.wg.Wait()
-
-	require.Equal(t, 3, ft.NumFrames())
-	assembled := up.Assemble()
-
-	for i := range ft.NumFrames() {
-		_, _, startC, endC := ft.FrameAt(i)
-		framePath := makeFrameFilename(c.path, Range{Offset: startC, Length: int(endC - startC)})
-		onDisk, err := os.ReadFile(framePath)
-		require.NoError(t, err)
-		assert.Equal(t, assembled[startC:endC], onDisk)
-	}
-}
-
 func TestCacheWriteThroughReader(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -605,6 +605,89 @@ func TestCachedSeekable_OpenRangeReader(t *testing.T) {
 	})
 }
 
+func TestCachedSeekable_StoreFile_Compressed_WriteThrough(t *testing.T) {
+	t.Parallel()
+
+	const frameSize = 64 * 1024
+	cfg := defaultCfg(CompressionZstd, 2, frameSize)
+	data := generateSemiRandomData(3 * frameSize)
+
+	tempDir := t.TempDir()
+	cacheDir := filepath.Join(tempDir, "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, os.ModePerm))
+
+	srcPath := filepath.Join(tempDir, "src.bin")
+	require.NoError(t, os.WriteFile(srcPath, data, 0o644))
+
+	// Stub inner.StoreFile: open the file and run compressStream with the sink
+	// pulled from opts — mirrors what fs/GCS backends do for compressed puts.
+	up := &memPartUploader{}
+	var capturedFT *FrameTable
+	inner := NewMockSeekable(t)
+	inner.EXPECT().
+		StoreFile(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(ctx context.Context, path string, opts ...PutOption) (*FrameTable, [32]byte, error) {
+			po := ApplyPutOptions(opts)
+			require.NotNil(t, po.FrameSink, "cachedSeekable must attach a FrameSink for compressed+writeThrough")
+
+			f, err := os.Open(path)
+			require.NoError(t, err)
+			defer f.Close()
+
+			ft, sum, err := compressStream(ctx, f, cfg, up, 4, po.FrameSink)
+			capturedFT = ft
+			return ft, sum, err
+		})
+
+	flags := NewMockFeatureFlagsClient(t)
+	flags.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(true)
+	flags.EXPECT().IntFlag(mock.Anything, mock.Anything).Return(4)
+
+	c := cachedSeekable{path: cacheDir, inner: inner, chunkSize: frameSize, flags: flags, tracer: noopTracer}
+
+	_, _, err := c.StoreFile(t.Context(), srcPath, WithCompressConfig(cfg))
+	require.NoError(t, err)
+
+	c.wg.Wait()
+
+	require.Equal(t, 3, capturedFT.NumFrames())
+	assembled := up.Assemble()
+	for i := range capturedFT.NumFrames() {
+		_, _, startC, endC := capturedFT.FrameAt(i)
+		framePath := makeFrameFilename(c.path, Range{Offset: startC, Length: int(endC - startC)})
+		onDisk, err := os.ReadFile(framePath)
+		require.NoError(t, err)
+		assert.Equal(t, assembled[startC:endC], onDisk)
+	}
+}
+
+func TestCachedSeekable_StoreFile_Compressed_FlagOff_NoSink(t *testing.T) {
+	t.Parallel()
+
+	cfg := defaultCfg(CompressionZstd, 1, 64*1024)
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "src.bin")
+	require.NoError(t, os.WriteFile(srcPath, []byte("x"), 0o644))
+
+	inner := NewMockSeekable(t)
+	inner.EXPECT().
+		StoreFile(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, opts ...PutOption) (*FrameTable, [32]byte, error) {
+			po := ApplyPutOptions(opts)
+			assert.Nil(t, po.FrameSink, "FrameSink must NOT be attached when write-through flag is off")
+			return nil, [32]byte{}, nil
+		})
+
+	flags := NewMockFeatureFlagsClient(t)
+	flags.EXPECT().BoolFlag(mock.Anything, mock.Anything).Return(false)
+
+	c := cachedSeekable{path: t.TempDir(), inner: inner, chunkSize: 64 * 1024, flags: flags, tracer: noopTracer}
+
+	_, _, err := c.StoreFile(t.Context(), srcPath, WithCompressConfig(cfg))
+	require.NoError(t, err)
+	c.wg.Wait()
+}
+
 func TestCachedSeekable_FrameSinkPopulatesNFS(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -605,6 +605,32 @@ func TestCachedSeekable_OpenRangeReader(t *testing.T) {
 	})
 }
 
+func TestCachedSeekable_FrameSinkPopulatesNFS(t *testing.T) {
+	t.Parallel()
+
+	const frameSize = 64 * 1024
+	data := generateSemiRandomData(3 * frameSize)
+
+	c := &cachedSeekable{path: t.TempDir(), tracer: noopTracer}
+	up := &memPartUploader{}
+	cfg := defaultCfg(CompressionZstd, 2, frameSize)
+
+	ft, _, err := compressStream(t.Context(), bytes.NewReader(data), cfg, up, 4, c.frameSink(t.Context()))
+	require.NoError(t, err)
+	c.wg.Wait()
+
+	require.Equal(t, 3, ft.NumFrames())
+	assembled := up.Assemble()
+
+	for i := range ft.NumFrames() {
+		_, _, startC, endC := ft.FrameAt(i)
+		framePath := makeFrameFilename(c.path, Range{Offset: startC, Length: int(endC - startC)})
+		onDisk, err := os.ReadFile(framePath)
+		require.NoError(t, err)
+		assert.Equal(t, assembled[startC:endC], onDisk)
+	}
+}
+
 func TestCacheWriteThroughReader(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -611,7 +611,9 @@ func TestCachedSeekable_FrameSinkPopulatesNFS(t *testing.T) {
 	const frameSize = 64 * 1024
 	data := generateSemiRandomData(3 * frameSize)
 
-	c := &cachedSeekable{path: t.TempDir(), tracer: noopTracer}
+	flags := NewMockFeatureFlagsClient(t)
+	flags.EXPECT().IntFlag(mock.Anything, mock.Anything).Return(4)
+	c := &cachedSeekable{path: t.TempDir(), flags: flags, tracer: noopTracer}
 	up := &memPartUploader{}
 	cfg := defaultCfg(CompressionZstd, 2, frameSize)
 

--- a/packages/shared/pkg/storage/storage_cache_seekable_test.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_test.go
@@ -636,6 +636,7 @@ func TestCachedSeekable_StoreFile_Compressed_WriteThrough(t *testing.T) {
 
 			ft, sum, err := compressStream(ctx, f, cfg, up, 4, po.FrameSink)
 			capturedFT = ft
+
 			return ft, sum, err
 		})
 
@@ -675,6 +676,7 @@ func TestCachedSeekable_StoreFile_Compressed_FlagOff_NoSink(t *testing.T) {
 		RunAndReturn(func(_ context.Context, _ string, opts ...PutOption) (*FrameTable, [32]byte, error) {
 			po := ApplyPutOptions(opts)
 			assert.Nil(t, po.FrameSink, "FrameSink must NOT be attached when write-through flag is off")
+
 			return nil, [32]byte{}, nil
 		})
 

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -131,9 +131,10 @@ func (o *fsObject) Put(_ context.Context, data []byte, _ ...PutOption) error {
 }
 
 func (o *fsObject) StoreFile(ctx context.Context, path string, opts ...PutOption) (*FrameTable, [32]byte, error) {
-	cfg := CompressConfigFromOpts(ApplyPutOptions(opts))
+	putOpts := ApplyPutOptions(opts)
+	cfg := CompressConfigFromOpts(putOpts)
 	if cfg.IsCompressionEnabled() {
-		ft, checksum, err := o.storeFileCompressed(ctx, path, cfg)
+		ft, checksum, err := o.storeFileCompressed(ctx, path, cfg, putOpts.FrameSink)
 		if err == nil {
 			logger.L().Debug(ctx, "Stored file to filesystem",
 				zap.String("object", o.path),
@@ -173,7 +174,7 @@ func (o *fsObject) StoreFile(ctx context.Context, path string, opts ...PutOption
 	return nil, [32]byte{}, err
 }
 
-func (o *fsObject) storeFileCompressed(ctx context.Context, localPath string, cfg CompressConfig) (*FrameTable, [32]byte, error) {
+func (o *fsObject) storeFileCompressed(ctx context.Context, localPath string, cfg CompressConfig, sink FrameSink) (*FrameTable, [32]byte, error) {
 	file, err := os.Open(localPath)
 	if err != nil {
 		return nil, [32]byte{}, fmt.Errorf("failed to open local file %s: %w", localPath, err)
@@ -188,7 +189,7 @@ func (o *fsObject) storeFileCompressed(ctx context.Context, localPath string, cf
 	uploader := &fsPartUploader{fullPath: o.path}
 
 	const noConcurrencyForMemUploader = 1
-	ft, checksum, err := compressStream(ctx, file, cfg, uploader, noConcurrencyForMemUploader)
+	ft, checksum, err := compressStream(ctx, file, cfg, uploader, noConcurrencyForMemUploader, sink)
 	if err != nil {
 		return nil, [32]byte{}, err
 	}

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -576,7 +576,7 @@ func (o *gcpObject) storeFileCompressed(ctx context.Context, localPath string, c
 		return nil, [32]byte{}, fmt.Errorf("failed to create multipart uploader: %w", err)
 	}
 
-	return compressStream(ctx, file, cfg, uploader, maxConcurrency)
+	return compressStream(ctx, file, cfg, uploader, maxConcurrency, putOpts.FrameSink)
 }
 
 type gcpServiceToken struct {

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -8,14 +8,22 @@ type ObjectMetadata map[string]string
 
 const ObjectMetadataTeamID = "team_id"
 
+// FrameSink fires once per compressed frame produced by a compressed
+// StoreFile, with the frame's absolute C-space offset and bytes.
+// Best-effort, non-blocking.
+type FrameSink func(cOffset int64, compressed []byte)
+
 // PutOptions holds parameters for blob/seekable writes. Compression is held
 // as `any` so that storage.CompressConfig (which has heavy storage-internal
 // dependencies) doesn't have to be moved here. Backends type-assert it back.
 type PutOptions struct {
 	Metadata    ObjectMetadata
 	Compression any
+	FrameSink   FrameSink
 	Checksum    bool
 }
+
+func WithFrameSink(s FrameSink) PutOption { return func(o *PutOptions) { o.FrameSink = s } }
 
 type PutOption func(*PutOptions)
 

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -2,16 +2,20 @@
 // separate so generated mocks can reference them without an import cycle.
 package storageopts
 
-import "maps"
+import (
+	"context"
+	"maps"
+)
 
 type ObjectMetadata map[string]string
 
 const ObjectMetadataTeamID = "team_id"
 
 // FrameSink fires once per compressed frame produced by a compressed
-// StoreFile, with the frame's absolute C-space offset and bytes.
-// Best-effort, non-blocking.
-type FrameSink func(cOffset int64, compressed []byte)
+// StoreFile, with the frame's absolute C-space offset and bytes. Best-effort
+// and expected to return quickly — implementations should schedule any I/O
+// asynchronously and bound their own concurrency.
+type FrameSink func(ctx context.Context, cOffset int64, compressed []byte)
 
 // PutOptions holds parameters for blob/seekable writes. Compression is held
 // as `any` so that storage.CompressConfig (which has heavy storage-internal

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -11,10 +11,8 @@ type ObjectMetadata map[string]string
 
 const ObjectMetadataTeamID = "team_id"
 
-// FrameSink fires once per compressed frame produced by a compressed
-// StoreFile, with the frame's absolute C-space offset and bytes. Best-effort
-// and expected to return quickly — implementations should schedule any I/O
-// asynchronously and bound their own concurrency.
+// FrameSink fires once per compressed frame with its absolute C-space offset.
+// Best-effort; implementations should return quickly and bound their own I/O.
 type FrameSink func(ctx context.Context, cOffset int64, compressed []byte)
 
 // PutOptions holds parameters for blob/seekable writes. Compression is held


### PR DESCRIPTION
Compressed template uploads skipped the NFS write-through path, so the first read on every node refetched from GCS. Tee each compressed frame to a `.frm` file at its C-space offset during upload, matching the layout `openReaderCompressed` expects.

Gated by the existing `write-to-cache-on-writes` flag.