### PR TITLE
Add ClickHouse metric log toggle

### DIFF
--- a/iac/modules/job-clickhouse/configs/config.xml
+++ b/iac/modules/job-clickhouse/configs/config.xml
@@ -47,9 +47,13 @@
 
     <listen_host>0.0.0.0</listen_host>
 
+    %{ if enable_metric_logs }
     <asynchronous_metric_log>
         <ttl>event_date + INTERVAL 1 DAY</ttl>
     </asynchronous_metric_log>
+    %{ else }
+    <asynchronous_metric_log remove="1"/>
+    %{ endif }
 
     <trace_log remove="1"/>
 
@@ -69,9 +73,13 @@
         <ttl>event_date + INTERVAL 1 DAY</ttl>
     </query_views_log>
 
+    %{ if enable_metric_logs }
     <metric_log>
         <ttl>event_date + INTERVAL 1 DAY</ttl>
     </metric_log>
+    %{ else }
+    <metric_log remove="1"/>
+    %{ endif }
 
     <processors_profile_log remove="1"/>
 

--- a/iac/modules/job-clickhouse/main.tf
+++ b/iac/modules/job-clickhouse/main.tf
@@ -8,6 +8,8 @@ locals {
 
     username = var.clickhouse_username
     password = var.clickhouse_password
+
+    enable_metric_logs = var.enable_metric_logs
   })
 
   clickhouse_users_config = templatefile("${path.module}/configs/users.xml", {

--- a/iac/modules/job-clickhouse/variables.tf
+++ b/iac/modules/job-clickhouse/variables.tf
@@ -64,6 +64,12 @@ variable "clickhouse_metrics_port" {
   type = number
 }
 
+variable "enable_metric_logs" {
+  type        = bool
+  default     = true
+  description = "Whether to persist ClickHouse system.metric_log and system.asynchronous_metric_log tables."
+}
+
 variable "otel_exporter_endpoint" {
   type        = string
   description = "OTLP exporter endpoint (e.g. http://localhost:4317)"


### PR DESCRIPTION
## What changed

Adds an `enable_metric_logs` input to `iac/modules/job-clickhouse`, defaulting to `true` so existing consumers keep the current behavior.

When set to `false`, the generated ClickHouse config disables:

- `system.metric_log`
- `system.asynchronous_metric_log`

## Why

Some deployments already export ClickHouse metrics through Prometheus/OTel and do not need ClickHouse to persist duplicate internal metric history tables. Disabling these logs avoids background MergeTree merges for those internal tables on smaller/self-hosted deployments.

## Validation

- `git diff --check`
- Did not run Terraform.
