### PR TITLE
fix(orchestrator): anchor rsync CWD to root in template file copy

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/oci/oci.go
+++ b/packages/orchestrator/pkg/template/build/core/oci/oci.go
@@ -372,6 +372,13 @@ func copyFiles(ctx context.Context, src, dest string) error {
 	// --whole-file: Copy files without using the delta algorithm, which is faster for local copies
 	// --inplace: Update destination files in place, no need to create temporary files
 	cmd := exec.CommandContext(ctx, "rsync", "-aH", "--whole-file", "--inplace", src+"/", dest)
+	// Pin rsync's working directory to root. When template-manager is exec'd
+	// via `nsenter -t 1 -m -u -i -n -w/` into PID 1's namespaces, a child
+	// process's inherited CWD can land on a directory that has been unmounted
+	// in another mount namespace, causing rsync's receiver to abort at
+	// startup with `getcwd(): No such file or directory (2)`. `/` is always
+	// present in the host mount namespace, so anchoring there is safe.
+	cmd.Dir = "/"
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("while copying files from %s to %s: %w: %s", src, dest, err, string(out))
 	}


### PR DESCRIPTION
When template-manager runs inside PID 1's mount namespace via nsenter, a child process can inherit a working directory that has since been unmounted in another mount namespace. That makes rsync's receiver fail immediately with `getcwd(): No such file or directory (2)` before it ever touches the source or destination paths.

Explicitly set rsync's working directory to `/`, which is guaranteed to exist in the host mount namespace, so the copy step no longer depends on whatever CWD happened to be inherited from the parent process.