### PR TITLE
perf(header): drop oversized temp set in newDiffHeader

### DIFF
--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -102,15 +102,20 @@ func newDiffHeader(metadata *Metadata, mapping []BuildMap, sourceBuilds map[uuid
 	}
 
 	if sourceBuilds != nil {
-		referenced := make(map[uuid.UUID]struct{}, len(h.Mapping))
+		// Walk mappings directly and dedupe by build ID using a set sized to
+		// the (small) source-builds map. Previously this used a set sized to
+		// len(h.Mapping) to dedupe before the sourceBuilds lookup; on
+		// snapshot-heavy nodes its buckets dominated live heap (each in-flight
+		// ToDiffHeader kept one alive for the duration of the call).
+		seen := make(map[uuid.UUID]struct{}, len(sourceBuilds))
+		h.Builds = make(map[uuid.UUID]BuildData, len(sourceBuilds))
 		for _, m := range h.Mapping {
-			referenced[m.BuildId] = struct{}{}
-		}
-
-		h.Builds = make(map[uuid.UUID]BuildData, len(referenced))
-		for id := range referenced {
-			if bd, ok := sourceBuilds[id]; ok {
-				h.Builds[id] = bd
+			if _, ok := seen[m.BuildId]; ok {
+				continue
+			}
+			seen[m.BuildId] = struct{}{}
+			if bd, ok := sourceBuilds[m.BuildId]; ok {
+				h.Builds[m.BuildId] = bd
 			}
 		}
 	}


### PR DESCRIPTION
On snapshot-heavy nodes the temp set in `newDiffHeader` (sized to `len(h.Mapping)` to dedupe build IDs before populating `h.Builds`) dominates live heap: each in-flight `ToDiffHeader` keeps one alive for the duration of the call.

Heap profile from a node right before OOM (126 GB total): `newDiffHeader` alone holds ~20 GB (~16%) — over-sized buckets that GC can't reclaim while many concurrent Pauses are running.

Walk mappings once and dedupe via a set sized to the (small) `sourceBuilds` map instead. Final `h.Builds` is identical.