### PR TITLE
perf(header): pack cached Header.Mapping into a compact form

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -131,7 +131,7 @@ func NewHeaderFromPath(ctx context.Context, from, headerPath string) (*header.He
 func getReferencedData(h *header.Header, dataFileName string) []string {
 	builds := make(map[uuid.UUID]struct{})
 
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		builds[mapping.BuildId] = struct{}{}
 	}
 

--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -105,7 +105,7 @@ func printUsage() {
 
 func printHeader(h *header.Header, source string) {
 	// Validate mappings
-	err := header.ValidateMappings(h.Mapping, h.Metadata.Size, h.Metadata.BlockSize)
+	err := h.Mapping.Validate(h.Metadata.Size, h.Metadata.BlockSize)
 	if err != nil {
 		fmt.Printf("\n⚠️  WARNING: Mapping validation failed!\n%s\n\n", err)
 	}
@@ -121,7 +121,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("Block size         %d B\n", h.Metadata.BlockSize)
 	fmt.Printf("Blocks             %d\n", (h.Metadata.Size+h.Metadata.BlockSize-1)/h.Metadata.BlockSize)
 
-	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(len(h.Mapping)) / 1024
+	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(h.Mapping.Len()) / 1024
 	var sizeMessage string
 	if totalSize == 0 {
 		sizeMessage = "<1 KiB"
@@ -129,10 +129,10 @@ func printHeader(h *header.Header, source string) {
 		sizeMessage = fmt.Sprintf("%d KiB", totalSize)
 	}
 
-	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", len(h.Mapping), sizeMessage)
+	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", h.Mapping.Len(), sizeMessage)
 	fmt.Printf("=======\n")
 
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		fmt.Println(mapping.Format(h.Metadata.BlockSize))
 	}
 
@@ -140,7 +140,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("===============\n")
 
 	builds := make(map[string]int64)
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		builds[mapping.BuildId.String()] += int64(mapping.Length)
 	}
 

--- a/packages/orchestrator/cmd/show-build-diff/main.go
+++ b/packages/orchestrator/cmd/show-build-diff/main.go
@@ -81,22 +81,24 @@ func main() {
 		log.Fatalf("failed to deserialize diff header: %s", err)
 	}
 
+	baseMapping := baseHeader.Mapping.Slice()
+
 	fmt.Printf("\nBASE METADATA\n")
 	fmt.Printf("Storage path       %s\n", baseSource)
 	fmt.Printf("========\n")
 
-	for _, mapping := range baseHeader.Mapping {
+	for _, mapping := range baseMapping {
 		fmt.Println(mapping.Format(baseHeader.Metadata.BlockSize))
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMapping)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")
 		fmt.Println(
 			header.Visualize(
-				baseHeader.Mapping,
+				baseMapping,
 				baseHeader.Metadata.Size,
 				baseHeader.Metadata.BlockSize,
 				128,
@@ -108,7 +110,7 @@ func main() {
 		)
 	}
 
-	if err := header.ValidateMappings(baseHeader.Mapping, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
+	if err := header.ValidateMappings(baseMapping, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
 		log.Fatalf("failed to validate base header: %s", err)
 	}
 
@@ -118,7 +120,7 @@ func main() {
 
 	onlyDiffMappings := make([]header.BuildMap, 0)
 
-	for _, mapping := range diffHeader.Mapping {
+	for _, mapping := range diffHeader.Mapping.All() {
 		if mapping.BuildId == diffHeader.Metadata.BuildId {
 			onlyDiffMappings = append(onlyDiffMappings, mapping)
 		}
@@ -142,7 +144,7 @@ func main() {
 		)
 	}
 
-	mergedHeader := header.MergeMappings(baseHeader.Mapping, onlyDiffMappings)
+	mergedHeader := header.MergeMappings(baseMapping, onlyDiffMappings)
 
 	fmt.Printf("\n\nMERGED METADATA\n")
 	fmt.Printf("========\n")
@@ -152,7 +154,7 @@ func main() {
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMapping)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -130,33 +130,29 @@ func (u *Upload) uploadFramed(
 func (u *Upload) appendAncestorBuilds(
 	ctx context.Context,
 	dst map[uuid.UUID]headers.BuildData,
-	mappings []headers.BuildMap,
+	mappings headers.Mapping,
 	fileType build.DiffType,
 ) error {
 	if u.uploads == nil {
 		return nil
 	}
 
-	seen := make(map[uuid.UUID]struct{}, len(mappings))
-	for _, m := range mappings {
-		if m.BuildId == u.buildID || m.BuildId == uuid.Nil {
+	// Mapping.Builds() is already deduplicated, so no local seen-set is needed.
+	for _, buildID := range mappings.Builds() {
+		if buildID == u.buildID || buildID == uuid.Nil {
 			continue
 		}
-		if _, dup := seen[m.BuildId]; dup {
-			continue
-		}
-		seen[m.BuildId] = struct{}{}
 
-		h, err := u.uploads.Wait(ctx, m.BuildId, fileType)
+		h, err := u.uploads.Wait(ctx, buildID, fileType)
 		if err != nil {
-			return fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
+			return fmt.Errorf("wait for ancestor %s/%s: %w", buildID, fileType, err)
 		}
 		if h == nil || dst == nil {
 			continue
 		}
 
-		if bd, ok := h.Builds[m.BuildId]; ok {
-			dst[m.BuildId] = bd
+		if bd, ok := h.Builds[buildID]; ok {
+			dst[buildID] = bd
 		}
 	}
 

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -1,0 +1,192 @@
+package header
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/uuid"
+)
+
+// Mapping is the compact in-memory representation of a Header's mapping list.
+// A merged Header is cached for up to 25h, so on snapshot-heavy nodes these
+// slices dominate host RAM. It shrinks each entry from 40 bytes (a BuildMap) to
+// 14 by encoding offset/length/storage as uint32 block indices, deduplicating
+// BuildId into a per-header table addressed by uint16, and storing the columns
+// as parallel slices. Immutable; read via At / All / Slice.
+type Mapping struct {
+	blockSize uint64
+	builds    []uuid.UUID
+	offsets   []uint32
+	lengths   []uint32
+	storage   []uint32
+	buildIdx  []uint16
+}
+
+// maxBuildsPerHeader caps the per-header build-ID table at the uint16 limit.
+const maxBuildsPerHeader = 1 << 16
+
+// NewMapping packs src into the compact representation. blockSize is the unit
+// for the block indices and must divide every Offset, Length, and
+// BuildStorageOffset in src (callers pass PageSize, the universal granularity).
+func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
+	if blockSize == 0 {
+		return Mapping{}, errors.New("compact mapping: block size cannot be zero")
+	}
+	if len(src) == 0 {
+		return Mapping{blockSize: blockSize}, nil
+	}
+
+	// uint32 page-block index caps a single file at ~16 TiB (PageSize units).
+	const maxBlockIdx = (1 << 32) - 1
+
+	idxByBuild := make(map[uuid.UUID]uint16, 8)
+	builds := make([]uuid.UUID, 0, 8)
+	offsets := make([]uint32, len(src))
+	lengths := make([]uint32, len(src))
+	storage := make([]uint32, len(src))
+	buildIdx := make([]uint16, len(src))
+
+	for i, m := range src {
+		if m.Offset%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: offset %d at index %d not block-aligned to %d", m.Offset, i, blockSize)
+		}
+		if m.Length%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: length %d at index %d not block-aligned to %d", m.Length, i, blockSize)
+		}
+		if m.BuildStorageOffset%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: build storage offset %d at index %d not block-aligned to %d", m.BuildStorageOffset, i, blockSize)
+		}
+
+		offBlocks := m.Offset / blockSize
+		lenBlocks := m.Length / blockSize
+		stoBlocks := m.BuildStorageOffset / blockSize
+		if offBlocks > maxBlockIdx || lenBlocks > maxBlockIdx || stoBlocks > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("compact mapping: block index out of uint32 range at entry %d", i)
+		}
+
+		idx, ok := idxByBuild[m.BuildId]
+		if !ok {
+			if len(builds) >= maxBuildsPerHeader {
+				return Mapping{}, fmt.Errorf("compact mapping: more than %d unique build IDs", maxBuildsPerHeader)
+			}
+			idx = uint16(len(builds))
+			idxByBuild[m.BuildId] = idx
+			builds = append(builds, m.BuildId)
+		}
+
+		offsets[i] = uint32(offBlocks)
+		lengths[i] = uint32(lenBlocks)
+		storage[i] = uint32(stoBlocks)
+		buildIdx[i] = idx
+	}
+
+	return Mapping{
+		blockSize: blockSize,
+		builds:    builds,
+		offsets:   offsets,
+		lengths:   lengths,
+		storage:   storage,
+		buildIdx:  buildIdx,
+	}, nil
+}
+
+// Len returns the number of entries.
+func (m Mapping) Len() int { return len(m.offsets) }
+
+// BlockSize returns the block size used for block<->byte conversions.
+func (m Mapping) BlockSize() uint64 { return m.blockSize }
+
+// Builds returns the deduplicated build IDs referenced by the mapping. The
+// returned slice is shared with the Mapping; callers must not mutate it.
+func (m Mapping) Builds() []uuid.UUID { return m.builds }
+
+// At materializes the i-th entry as a BuildMap. Panics if i is out of range,
+// matching `mapping[i]` semantics.
+func (m Mapping) At(i int) BuildMap {
+	return BuildMap{
+		Offset:             uint64(m.offsets[i]) * m.blockSize,
+		Length:             uint64(m.lengths[i]) * m.blockSize,
+		BuildId:            m.builds[m.buildIdx[i]],
+		BuildStorageOffset: uint64(m.storage[i]) * m.blockSize,
+	}
+}
+
+// All iterates the mapping, materializing each entry as a BuildMap. This is
+// the preferred read path for callers that don't need a backing []BuildMap.
+func (m Mapping) All() iter.Seq2[int, BuildMap] {
+	return func(yield func(int, BuildMap) bool) {
+		for i := range m.offsets {
+			if !yield(i, m.At(i)) {
+				return
+			}
+		}
+	}
+}
+
+// Slice materializes the full mapping as []BuildMap (~40 bytes/entry). Use
+// sparingly — for serialization fallbacks, CLI inspection, and tests. Hot
+// paths and the cached form should use At / All instead.
+func (m Mapping) Slice() []BuildMap {
+	out := make([]BuildMap, len(m.offsets))
+	for i := range m.offsets {
+		out[i] = m.At(i)
+	}
+
+	return out
+}
+
+// Validate checks that entries are contiguous, block-aligned to blockSize, and
+// cover exactly `size` bytes. It is the compact-form equivalent of
+// ValidateMappings(m.Slice(), size, blockSize) without the materialization.
+func (m Mapping) Validate(size, blockSize uint64) error {
+	if blockSize == 0 {
+		return errors.New("mapping validation failed: zero block size")
+	}
+	// The compact form stores in m.blockSize units; if those aren't a multiple
+	// of the requested validation blockSize, fall back to the slice path so we
+	// don't miss a misalignment.
+	if m.blockSize%blockSize != 0 {
+		return ValidateMappings(m.Slice(), size, blockSize)
+	}
+
+	var currentOffset uint64
+	for i := range m.offsets {
+		offset := uint64(m.offsets[i]) * m.blockSize
+		length := uint64(m.lengths[i]) * m.blockSize
+		if currentOffset != offset {
+			return fmt.Errorf("mapping validation failed at index %d: expected offset %d (block %d), got %d (block %d)", i, currentOffset, currentOffset/blockSize, offset, offset/blockSize)
+		}
+		if currentOffset+length > size {
+			return fmt.Errorf("mapping validation failed at index %d: %d (current offset) + %d (length) > %d (size)", i, currentOffset, length, size)
+		}
+		currentOffset += length
+	}
+	if currentOffset != size {
+		return fmt.Errorf("mapping validation failed: total %d != size %d", currentOffset, size)
+	}
+
+	return nil
+}
+
+// SearchOffset returns the first index i whose byte offset is strictly greater
+// than off, matching sort.Search semantics on Offset. It compares in block
+// units, so entries are never materialized: entry.OffsetBlocks*blockSize > off
+// iff entry.OffsetBlocks > off/blockSize (integer division).
+func (m Mapping) SearchOffset(off int64) int {
+	if off < 0 || len(m.offsets) == 0 {
+		return 0
+	}
+	target := uint64(off) / m.blockSize
+	lo, hi := 0, len(m.offsets)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if uint64(m.offsets[mid]) > target {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+
+	return lo
+}

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +39,7 @@ func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
 	}
 
 	// uint32 page-block index caps a single file at ~16 TiB (PageSize units).
-	const maxBlockIdx = (1 << 32) - 1
+	const maxBlockIdx = math.MaxUint32
 
 	idxByBuild := make(map[uuid.UUID]uint16, 8)
 	builds := make([]uuid.UUID, 0, 8)

--- a/packages/shared/pkg/storage/header/compact_test.go
+++ b/packages/shared/pkg/storage/header/compact_test.go
@@ -1,0 +1,137 @@
+package header
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewHeader_PageGranularMappingUnderHugepageBlockSize reproduces the
+// production case: a memory file has BlockSize = 2 MiB (hugepage) but its diff
+// mappings are page-granular (4 KiB), so the header carries 4 KiB-aligned
+// offsets under a 2 MiB block size. The compact mapping must encode in PageSize
+// units, not metadata.BlockSize, or header construction fails and bricks every
+// sandbox create/resume.
+func TestNewHeader_PageGranularMappingUnderHugepageBlockSize(t *testing.T) {
+	t.Parallel()
+
+	const hugepage = uint64(2 << 20) // 2 MiB memory block size
+	a := uuid.New()
+	b := uuid.New()
+
+	// Page-granular (4 KiB) mappings, NOT aligned to the 2 MiB block size.
+	mappings := []BuildMap{
+		{Offset: 0, Length: PageSize, BuildId: a, BuildStorageOffset: 0},
+		{Offset: PageSize, Length: PageSize, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 2 * PageSize, Length: 2 * PageSize, BuildId: a, BuildStorageOffset: PageSize},
+	}
+	meta := &Metadata{Version: MetadataVersionV4, BlockSize: hugepage, Size: 4 * PageSize, BuildId: a, BaseBuildId: b}
+
+	h, err := NewHeader(meta, mappings)
+	require.NoError(t, err, "page-granular mappings under a hugepage block size must be accepted")
+	require.True(t, Equal(mappings, h.Mapping.Slice()))
+
+	// And the offset lookup must resolve correctly at page granularity.
+	m, err := h.GetShiftedMapping(t.Context(), PageSize)
+	require.NoError(t, err)
+	require.Equal(t, b, m.BuildId)
+}
+
+func TestNewMapping_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	b := uuid.New()
+	src := []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 3 * bs, Length: bs, BuildId: a, BuildStorageOffset: 2 * bs},
+	}
+
+	m, err := NewMapping(bs, src)
+	require.NoError(t, err)
+	require.Equal(t, len(src), m.Len())
+
+	require.True(t, Equal(src, m.Slice()), "Slice must round-trip the input")
+	for i, want := range src {
+		require.Equal(t, want, m.At(i), "At(%d)", i)
+	}
+
+	// Builds deduplicated to {a, b}.
+	require.ElementsMatch(t, []uuid.UUID{a, b}, m.Builds())
+}
+
+func TestNewMapping_RejectsUnaligned(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+
+	_, err := NewMapping(bs, []BuildMap{{Offset: 123, Length: bs, BuildId: id}})
+	require.ErrorContains(t, err, "offset")
+
+	_, err = NewMapping(bs, []BuildMap{{Offset: 0, Length: 123, BuildId: id}})
+	require.ErrorContains(t, err, "length")
+
+	_, err = NewMapping(bs, []BuildMap{{Offset: 0, Length: bs, BuildId: id, BuildStorageOffset: 123}})
+	require.ErrorContains(t, err, "build storage offset")
+
+	_, err = NewMapping(0, []BuildMap{{Offset: 0, Length: bs, BuildId: id}})
+	require.ErrorContains(t, err, "block size")
+}
+
+func TestMapping_SearchOffset(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	src := []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: id},
+		{Offset: 2 * bs, Length: 2 * bs, BuildId: id, BuildStorageOffset: 2 * bs},
+		{Offset: 4 * bs, Length: bs, BuildId: id, BuildStorageOffset: 4 * bs},
+	}
+	m, err := NewMapping(bs, src)
+	require.NoError(t, err)
+
+	// SearchOffset must match sort.Search over the materialized offsets for
+	// every page within range, including non-block-aligned probes.
+	for off := int64(0); off < int64(5*bs); off += int64(PageSize) {
+		want := 0
+		for _, bm := range src {
+			if int64(bm.Offset) > off {
+				break
+			}
+			want++
+		}
+		require.Equal(t, want, m.SearchOffset(off), "off=%d", off)
+	}
+
+	require.Equal(t, 0, m.SearchOffset(-1))
+}
+
+func TestMapping_Validate(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	size := 4 * bs
+	m, err := NewMapping(bs, []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: id},
+		{Offset: 2 * bs, Length: 2 * bs, BuildId: id, BuildStorageOffset: 2 * bs},
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate(size, bs))
+
+	// Wrong size is rejected.
+	require.Error(t, m.Validate(size+bs, bs))
+
+	// A gap is rejected.
+	gap, err := NewMapping(bs, []BuildMap{
+		{Offset: 0, Length: bs, BuildId: id},
+		{Offset: 2 * bs, Length: bs, BuildId: id, BuildStorageOffset: 2 * bs},
+	})
+	require.NoError(t, err)
+	require.Error(t, gap.Validate(3*bs, bs))
+}

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -34,7 +33,10 @@ type Header struct {
 	// RPC and reads uncompressed data when nil.
 	Builds map[uuid.UUID]BuildData
 
-	Mapping []BuildMap
+	// Mapping is the per-block source map. Stored compactly (~14 B/entry vs 40
+	// for a BuildMap) so long-lived cached headers don't dominate orchestrator
+	// heap. Read via At / All / Slice / Len, not indexing.
+	Mapping Mapping
 
 	// IncompletePendingUpload is set on diff headers produced by ToDiffHeader and
 	// cleared on the finalized headers swapped in by the upload pipeline. It
@@ -81,17 +83,23 @@ func NewHeader(metadata *Metadata, mapping []BuildMap) (*Header, error) {
 	}
 
 	if len(mapping) == 0 {
+		length := (metadata.Size + PageSize - 1) / PageSize * PageSize
 		mapping = []BuildMap{{
 			Offset:             0,
-			Length:             metadata.Size,
+			Length:             length,
 			BuildId:            metadata.BuildId,
 			BuildStorageOffset: 0,
 		}}
 	}
 
+	compact, err := NewMapping(PageSize, mapping)
+	if err != nil {
+		return nil, fmt.Errorf("compact mapping: %w", err)
+	}
+
 	return &Header{
 		Metadata: metadata,
-		Mapping:  mapping,
+		Mapping:  compact,
 	}, nil
 }
 
@@ -102,13 +110,10 @@ func newDiffHeader(metadata *Metadata, mapping []BuildMap, sourceBuilds map[uuid
 	}
 
 	if sourceBuilds != nil {
-		referenced := make(map[uuid.UUID]struct{}, len(h.Mapping))
-		for _, m := range h.Mapping {
-			referenced[m.BuildId] = struct{}{}
-		}
-
-		h.Builds = make(map[uuid.UUID]BuildData, len(referenced))
-		for id := range referenced {
+		// h.Mapping.Builds() is already deduped at NewMapping construction;
+		// no need for an oversized temp set keyed by len(mapping).
+		h.Builds = make(map[uuid.UUID]BuildData, len(sourceBuilds))
+		for _, id := range h.Mapping.Builds() {
 			if bd, ok := sourceBuilds[id]; ok {
 				h.Builds[id] = bd
 			}
@@ -131,7 +136,7 @@ func (t *Header) String() string {
 		t.Metadata.BlockSize,
 		t.Metadata.Generation,
 		t.Metadata.BuildId.String(),
-		len(t.Mapping),
+		t.Mapping.Len(),
 	)
 }
 
@@ -183,10 +188,10 @@ func (t *Header) GetBuildFrameData(buildID uuid.UUID) *storage.FrameTable {
 	return t.Builds[buildID].FrameData
 }
 
-func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64, error) {
+func (t *Header) getMapping(ctx context.Context, offset int64) (BuildMap, int64, error) {
 	if offset < 0 || offset >= int64(t.Metadata.Size) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
 		}
 
 		logger.L().Warn(ctx, "offset is out of bounds, but normalize fix is not applied",
@@ -197,7 +202,7 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 	}
 	if offset%PageSize != 0 {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
 		}
 
 		logger.L().Warn(ctx, "offset is not aligned to page size, but normalize fix is not applied",
@@ -207,21 +212,18 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 		)
 	}
 
-	i := sort.Search(len(t.Mapping), func(i int) bool {
-		return int64(t.Mapping[i].Offset) > offset
-	})
-
+	i := t.Mapping.SearchOffset(offset)
 	if i == 0 {
-		return nil, 0, fmt.Errorf("no source found for offset %d", offset)
+		return BuildMap{}, 0, fmt.Errorf("no source found for offset %d", offset)
 	}
 
-	mapping := &t.Mapping[i-1]
+	mapping := t.Mapping.At(i - 1)
 	shift := offset - int64(mapping.Offset)
 
 	// Verify that the offset falls within this mapping's range
 	if shift >= int64(mapping.Length) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
+			return BuildMap{}, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
 				offset, mapping.Offset, mapping.Offset+mapping.Length)
 		}
 
@@ -254,12 +256,12 @@ func ValidateHeader(h *Header) error {
 	if h.Metadata.Size == 0 {
 		return errors.New("header has zero size")
 	}
-	if len(h.Mapping) == 0 {
+	if h.Mapping.Len() == 0 {
 		return errors.New("header has no mappings")
 	}
 
 	// Sort mappings by offset to check for gaps/overlaps
-	sortedMappings := slices.Clone(h.Mapping)
+	sortedMappings := h.Mapping.Slice()
 	slices.SortFunc(sortedMappings, func(a, b BuildMap) int {
 		return cmp.Compare(a.Offset, b.Offset)
 	})
@@ -300,7 +302,7 @@ func ValidateHeader(h *Header) error {
 	}
 
 	// Validate individual mapping bounds
-	for i, m := range h.Mapping {
+	for i, m := range h.Mapping.All() {
 		if m.Offset > h.Metadata.Size {
 			return fmt.Errorf("mapping[%d] has Offset %d beyond header size %d for buildId %s",
 				i, m.Offset, h.Metadata.Size, m.BuildId.String())

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -135,8 +135,12 @@ func (d *DiffMetadata) ToDiffHeader(
 
 	diffMapping := d.toDiffMapping(ctx, buildID)
 
+	// MergeMappings/NormalizeMappings operate on []BuildMap (transient).
+	// originalHeader.Mapping is the compact cached form; materialize it once
+	// here. The intermediate slice is short-lived (released after the new
+	// compact header is built below).
 	m := MergeMappings(
-		originalHeader.Mapping,
+		originalHeader.Mapping.Slice(),
 		diffMapping,
 	)
 	telemetry.ReportEvent(ctx, "merged mappings")
@@ -164,7 +168,7 @@ func (d *DiffMetadata) ToDiffHeader(
 	}
 
 	// Dedup emits PageSize-granular mappings; validate at PageSize.
-	err = ValidateMappings(header.Mapping, header.Metadata.Size, PageSize)
+	err = header.Mapping.Validate(header.Metadata.Size, PageSize)
 	if err != nil {
 		if header.IsNormalizeFixApplied() {
 			return nil, fmt.Errorf("invalid header mappings: %w", err)

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -71,7 +71,15 @@ func TestDeserialize_AboveOldCapRoundTrips(t *testing.T) {
 	v4MaxUncompressedHeaderSize = orig
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
-	require.Len(t, got.Mapping, 1000)
+	require.Equal(t, 1000, got.Mapping.Len())
+}
+
+func mustMapping(t *testing.T, blockSize uint64, src []BuildMap) Mapping {
+	t.Helper()
+	m, err := NewMapping(blockSize, src)
+	require.NoError(t, err)
+
+	return m
 }
 
 func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
@@ -99,27 +107,27 @@ func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 			Offset:             4096,
 			Length:             4096,
 			BuildId:            baseID,
-			BuildStorageOffset: 123,
+			BuildStorageOffset: 8192,
 		},
 	}
 
-	data, err := serializeV3(metadata, mappings)
+	data, err := serializeV3(metadata, mustMapping(t, metadata.BlockSize, mappings))
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
 	require.Equal(t, metadata, got.Metadata)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[0].Length)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, uint64(0), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(0).Length)
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, uint64(0), got.Mapping.At(0).BuildStorageOffset)
 
-	require.Equal(t, uint64(4096), got.Mapping[1].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[1].Length)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
-	require.Equal(t, uint64(123), got.Mapping[1].BuildStorageOffset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Length)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
+	require.Equal(t, uint64(8192), got.Mapping.At(1).BuildStorageOffset)
 
 	// V3 headers have no Builds
 	require.Nil(t, got.Builds)
@@ -145,17 +153,17 @@ func TestSerializeDeserialize_EmptyMappings_Defaults(t *testing.T) {
 		BaseBuildId: uuid.New(),
 	}
 
-	data, err := serializeV3(metadata, nil)
+	data, err := serializeV3(metadata, Mapping{})
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
 	// NewHeader creates a default mapping when none provided
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, metadata.Size, got.Mapping[0].Length)
-	require.Equal(t, metadata.BuildId, got.Mapping[0].BuildId)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, metadata.Size, got.Mapping.At(0).Length)
+	require.Equal(t, metadata.BuildId, got.Mapping.At(0).BuildId)
 }
 
 func TestDeserialize_BlockSizeZero(t *testing.T) {
@@ -170,7 +178,7 @@ func TestDeserialize_BlockSizeZero(t *testing.T) {
 		BaseBuildId: uuid.New(),
 	}
 
-	data, err := serializeV3(metadata, nil)
+	data, err := serializeV3(metadata, Mapping{})
 	require.NoError(t, err)
 
 	_, err = DeserializeBytes(data)
@@ -229,9 +237,9 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
 
 	// Builds round-trip
 	require.Len(t, got.Builds, 2)
@@ -300,8 +308,8 @@ func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(8192), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(8192), got.Mapping.At(0).BuildStorageOffset)
 
 	require.Len(t, got.Builds, 1)
 	fd := got.Builds[buildID].FrameData
@@ -353,7 +361,7 @@ func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 2)
+	require.Equal(t, 2, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -397,7 +405,7 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.NotNil(t, got.Builds)
 	fd := got.Builds[buildID].FrameData
 	require.NotNil(t, fd)
@@ -444,7 +452,7 @@ func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -508,7 +516,7 @@ func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 3)
+	require.Equal(t, 3, got.Mapping.Len())
 	require.Len(t, got.Builds, 2)
 
 	// Verify checksums round-trip.
@@ -842,7 +850,7 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 5)
+	require.Equal(t, 5, got.Mapping.Len())
 	require.Len(t, got.Builds, 3)
 
 	require.Nil(t, got.GetBuildFrameData(selfID))
@@ -858,11 +866,11 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	_, hasV3b := got.Builds[v3bID]
 	require.False(t, hasV3b)
 
-	require.Equal(t, selfID, got.Mapping[0].BuildId)
-	require.Equal(t, midID, got.Mapping[1].BuildId)
-	require.Equal(t, olderID, got.Mapping[2].BuildId)
-	require.Equal(t, v3aID, got.Mapping[3].BuildId)
-	require.Equal(t, v3bID, got.Mapping[4].BuildId)
+	require.Equal(t, selfID, got.Mapping.At(0).BuildId)
+	require.Equal(t, midID, got.Mapping.At(1).BuildId)
+	require.Equal(t, olderID, got.Mapping.At(2).BuildId)
+	require.Equal(t, v3aID, got.Mapping.At(3).BuildId)
+	require.Equal(t, v3bID, got.Mapping.At(4).BuildId)
 }
 
 // Layered chain with a compressed self entry:
@@ -972,7 +980,7 @@ func TestDeserialize_V3_StaysV3(t *testing.T) {
 	}
 	mappings := []BuildMap{{Offset: 0, Length: 4096, BuildId: buildID}}
 
-	data, err := serializeV3(metadata, mappings)
+	data, err := serializeV3(metadata, mustMapping(t, metadata.BlockSize, mappings))
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)

--- a/packages/shared/pkg/storage/header/serialization_v3.go
+++ b/packages/shared/pkg/storage/header/serialization_v3.go
@@ -16,14 +16,14 @@ type v3SerializableBuildMap struct {
 }
 
 // serializeV3 writes [Metadata] [v3 mappings…] with no length prefix.
-func serializeV3(metadata *Metadata, mappings []BuildMap) ([]byte, error) {
+func serializeV3(metadata *Metadata, mappings Mapping) ([]byte, error) {
 	var buf bytes.Buffer
 
 	if err := binary.Write(&buf, binary.LittleEndian, metadata); err != nil {
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	for _, mapping := range mappings {
+	for _, mapping := range mappings.All() {
 		v3 := &v3SerializableBuildMap{
 			Offset:             mapping.Offset,
 			Length:             mapping.Length,

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -53,7 +53,7 @@ type v4SerializableBuildInfo struct {
 // serializeV4 writes [Metadata] [uint8 flags] [uint32 LZ4 size] [LZ4( Builds[] + Mappings[] )].
 // Frame tables are sparse-trimmed to only frames referenced by mappings.
 // Also returns the uncompressed inner-block size (LZ4 input length).
-func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []BuildMap, incomplete bool) ([]byte, int64, error) {
+func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings Mapping, incomplete bool) ([]byte, int64, error) {
 	var metaBuf bytes.Buffer
 	if err := binary.Write(&metaBuf, binary.LittleEndian, metadata); err != nil {
 		return nil, 0, fmt.Errorf("failed to write metadata: %w", err)
@@ -94,11 +94,11 @@ func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []
 		}
 	}
 
-	if err := binary.Write(&block, binary.LittleEndian, uint32(len(mappings))); err != nil {
+	if err := binary.Write(&block, binary.LittleEndian, uint32(mappings.Len())); err != nil {
 		return nil, 0, fmt.Errorf("failed to write mappings count: %w", err)
 	}
 
-	for _, mapping := range mappings {
+	for _, mapping := range mappings.All() {
 		v4 := &v4SerializableBuildMap{
 			Offset:             mapping.Offset,
 			Length:             mapping.Length,
@@ -246,9 +246,9 @@ func compressLZ4(data []byte) ([]byte, error) {
 
 // extractRelevantRanges groups mappings into per-build U-space [start, end) ranges
 // for sparse frame table trimming during serialization.
-func extractRelevantRanges(mappings []BuildMap) map[uuid.UUID][]storage.Range {
+func extractRelevantRanges(mappings Mapping) map[uuid.UUID][]storage.Range {
 	ranges := make(map[uuid.UUID][]storage.Range)
-	for _, m := range mappings {
+	for _, m := range mappings.All() {
 		ranges[m.BuildId] = append(ranges[m.BuildId], storage.Range{
 			Offset: int64(m.BuildStorageOffset),
 			Length: int(m.Length),


### PR DESCRIPTION
Replace the cached `Header.Mapping` (`[]BuildMap`, 40 B/entry) with a struct-of-arrays compact form (~14 B/entry): offset/length/storage as uint32 page-block indices plus a deduplicated per-header build-ID table. On snapshot-heavy nodes the retained mapping slices dominate host RAM (heap profiles show ~80% inuse in `NormalizeMappings`). Mappings are encoded in PageSize units since a 2 MiB-hugepage memory file can carry page-granular diff mappings. In-memory only; the V3/V4 wire format is unchanged.