### PR TITLE
perf(infra): slightly reduce client base hugepage reservation

### DIFF
--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -1,8 +1,12 @@
 # Server cluster instances are not currently automatically updated when you create a new
 # orchestrator image with Packer.
 locals {
-  build_base_hugepages_percentage  = 60
-  client_base_hugepages_percentage = 80
+  build_base_hugepages_percentage = 60
+  # Slightly below the previous 80% so a bit more host RAM stays in the
+  # overcommit pool (usable for the orchestrator heap) rather than being
+  # permanently locked as base hugepages. Override per-cluster via
+  # hugepages_percentage in *_clusters_config.
+  client_base_hugepages_percentage = 78
 
   nfs_mount_path   = "/orchestrator/shared-store"
   nfs_mount_subdir = "chunks-cache"


### PR DESCRIPTION
Lower the client base hugepage default from 80% to 78% so less host RAM is permanently locked as base hugepages and a bit more remains available for orchestrator heap headroom. This only changes the default; clusters can still override `hugepages_percentage`.