### PR TITLE
feat(observability): include kill_reason in kill-path structured logs

### DIFF
--- a/packages/api/internal/handlers/admin_kill_team_sandboxes.go
+++ b/packages/api/internal/handlers/admin_kill_team_sandboxes.go
@@ -58,12 +58,14 @@ func (a *APIStore) PostAdminTeamsTeamIDSandboxesKill(c *gin.Context, teamID uuid
 				logger.L().Error(ctx, "Failed to kill sandbox",
 					logger.WithSandboxID(sbx.SandboxID),
 					logger.WithTeamID(teamID.String()),
+					zap.String("kill_reason", sandbox.KillReasonAdmin.String()),
 					zap.Error(err))
 				failedCount.Add(1)
 			} else {
 				logger.L().Debug(ctx, "Successfully killed sandbox",
 					logger.WithSandboxID(sbx.SandboxID),
-					logger.WithTeamID(teamID.String()))
+					logger.WithTeamID(teamID.String()),
+					zap.String("kill_reason", sandbox.KillReasonAdmin.String()))
 				killedCount.Add(1)
 			}
 

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -372,7 +372,11 @@ func (o *Orchestrator) CreateSandbox(
 				sandbox.KillReasonUnknown,
 			)
 			if killErr != nil {
-				logger.L().Error(ctx, "Error removing sandbox", zap.Error(killErr), logger.WithSandboxID(sbxToRemove.SandboxID))
+				logger.L().Error(ctx, "Error removing sandbox",
+					zap.Error(killErr),
+					logger.WithSandboxID(sbxToRemove.SandboxID),
+					zap.String("kill_reason", sandbox.KillReasonUnknown.String()),
+				)
 			}
 		}()
 

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -34,18 +34,28 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, teamID uuid.UUID, sand
 		switch opts.Action {
 		case sandbox.StateActionKill:
 			if errors.Is(err, sandbox.ErrNotFound) {
-				logger.L().Info(ctx, "Sandbox not found, already removed", logger.WithSandboxID(sandboxID))
+				logger.L().Info(ctx, "Sandbox not found, already removed",
+					logger.WithSandboxID(sandboxID),
+					zap.String("kill_reason", opts.Reason.String()),
+				)
 
 				return ErrSandboxNotFound
 			}
 
 			switch sbx.State {
 			case sandbox.StateKilling:
-				logger.L().Info(ctx, "Sandbox is already killed", logger.WithSandboxID(sandboxID))
+				logger.L().Info(ctx, "Sandbox is already killed",
+					logger.WithSandboxID(sandboxID),
+					zap.String("kill_reason", opts.Reason.String()),
+				)
 
 				return nil
 			default: // It shouldn't happen the sandbox ended in paused state
-				logger.L().Error(ctx, "Error killing sandbox", zap.Error(err), logger.WithSandboxID(sandboxID))
+				logger.L().Error(ctx, "Error killing sandbox",
+					zap.Error(err),
+					logger.WithSandboxID(sandboxID),
+					zap.String("kill_reason", opts.Reason.String()),
+				)
 
 				return ErrSandboxOperationFailed
 			}
@@ -96,11 +106,16 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, teamID uuid.UUID, sand
 	defer o.sandboxStore.Remove(context.WithoutCancel(ctx), teamID, sandboxID)
 	err = o.removeSandboxFromNode(ctx, sbx, opts.Action, opts.Reason)
 	if err != nil {
-		logger.L().Error(ctx, "Error removing sandbox",
+		fields := []zap.Field{
 			zap.String("state_action", opts.Action.Name),
 			zap.Error(err),
 			logger.WithSandboxID(sbx.SandboxID),
-		)
+		}
+		if opts.Action == sandbox.StateActionKill {
+			fields = append(fields, zap.String("kill_reason", opts.Reason.String()))
+		}
+
+		logger.L().Error(ctx, "Error removing sandbox", fields...)
 
 		return ErrSandboxOperationFailed
 	}
@@ -119,7 +134,14 @@ func (o *Orchestrator) removeSandboxFromNode(
 
 	node := o.getOrConnectNode(ctx, sbx.ClusterID, sbx.NodeID)
 	if node == nil {
-		logger.L().Error(ctx, "failed to get node", logger.WithNodeID(sbx.NodeID))
+		fields := []zap.Field{
+			logger.WithNodeID(sbx.NodeID),
+		}
+		if stateAction == sandbox.StateActionKill {
+			fields = append(fields, zap.String("kill_reason", reason.String()))
+		}
+
+		logger.L().Error(ctx, "failed to get node", fields...)
 
 		return fmt.Errorf("node '%s' not found", sbx.NodeID)
 	}
@@ -130,7 +152,15 @@ func (o *Orchestrator) removeSandboxFromNode(
 		// Remove the sandbox resources after the sandbox is deleted
 		err := o.routingCatalog.DeleteSandbox(ctx, sbx.SandboxID, sbx.ExecutionID)
 		if err != nil {
-			logger.L().Error(ctx, "error removing routing record from catalog", zap.Error(err), logger.WithSandboxID(sbx.SandboxID))
+			fields := []zap.Field{
+				zap.Error(err),
+				logger.WithSandboxID(sbx.SandboxID),
+			}
+			if stateAction == sandbox.StateActionKill {
+				fields = append(fields, zap.String("kill_reason", reason.String()))
+			}
+
+			logger.L().Error(ctx, "error removing routing record from catalog", fields...)
 		}
 	}
 
@@ -148,6 +178,7 @@ func (o *Orchestrator) removeSandboxFromNode(
 				logger.L().Error(ctx, "Pause failed due to missing base template, killed sandbox as fallback",
 					logger.WithSandboxID(sbx.SandboxID),
 					zap.String("base_template_id", sbx.BaseTemplateID),
+					zap.String("kill_reason", sandbox.KillReasonBaseTemplateMissing.String()),
 					zap.NamedError("pause_error", err),
 					zap.NamedError("kill_error", killErr),
 				)
@@ -172,6 +203,7 @@ func (o *Orchestrator) killOrphanSandbox(ctx context.Context, sbx sandbox.Sandbo
 		logger.L().Error(ctx, "Node not found for orphan sandbox kill",
 			logger.WithSandboxID(sbx.SandboxID),
 			logger.WithNodeID(sbx.NodeID),
+			zap.String("kill_reason", sandbox.KillReasonOrphaned.String()),
 		)
 
 		return
@@ -183,6 +215,7 @@ func (o *Orchestrator) killOrphanSandbox(ctx context.Context, sbx sandbox.Sandbo
 			zap.Error(err),
 			logger.WithSandboxID(sbx.SandboxID),
 			logger.WithNodeID(sbx.NodeID),
+			zap.String("kill_reason", sandbox.KillReasonOrphaned.String()),
 		)
 	}
 }
@@ -193,11 +226,7 @@ func (o *Orchestrator) killSandboxOnNode(
 	sbx sandbox.Sandbox,
 	reason sandbox.KillReason,
 ) error {
-	if reason == "" {
-		reason = sandbox.KillReasonUnknown
-	}
-
-	killReason := string(reason)
+	killReason := reason.String()
 	req := &orchestrator.SandboxDeleteRequest{
 		SandboxId:  sbx.SandboxID,
 		KillReason: &killReason,
@@ -207,7 +236,11 @@ func (o *Orchestrator) killSandboxOnNode(
 	_, err := client.Sandbox.Delete(ctx, req)
 	st, ok := status.FromError(err)
 	if ok && st.Code() == codes.NotFound {
-		logger.L().Info(ctx, "Sandbox not found during kill", logger.WithSandboxID(sbx.SandboxID), logger.WithNodeID(node.ID))
+		logger.L().Info(ctx, "Sandbox not found during kill",
+			logger.WithSandboxID(sbx.SandboxID),
+			logger.WithNodeID(node.ID),
+			zap.String("kill_reason", killReason),
+		)
 	} else if err != nil {
 		return fmt.Errorf("failed to delete sandbox: %w", err)
 	}

--- a/packages/api/internal/orchestrator/evictor/evict.go
+++ b/packages/api/internal/orchestrator/evictor/evict.go
@@ -175,6 +175,7 @@ func (e *Evictor) evictSandbox(ctx context.Context, sbx sandbox.Sandbox) {
 				zap.Error(err),
 				logger.WithSandboxID(sbx.SandboxID),
 				logger.WithTeamID(sbx.TeamID.String()),
+				zap.String("kill_reason", sandbox.KillReasonTimeout.String()),
 			)
 		}
 
@@ -184,7 +185,10 @@ func (e *Evictor) evictSandbox(ctx context.Context, sbx sandbox.Sandbox) {
 	}
 
 	if action != sandbox.StateActionPause {
-		logger.L().Debug(ctx, "Sandbox evicted", logger.WithSandboxID(sbx.SandboxID))
+		logger.L().Debug(ctx, "Sandbox evicted",
+			logger.WithSandboxID(sbx.SandboxID),
+			zap.String("kill_reason", sandbox.KillReasonTimeout.String()),
+		)
 	}
 }
 

--- a/packages/api/internal/sandbox/sandboxtypes/states.go
+++ b/packages/api/internal/sandbox/sandboxtypes/states.go
@@ -57,6 +57,16 @@ const (
 	KillReasonBaseTemplateMissing KillReason = "base_template_missing"
 )
 
+// String returns the reason as a string, normalizing the empty value to
+// "unknown". Keeps API-side log/metric fields consistent with the
+// orchestrator-side normalization in pkg/server/sandboxes.go.
+func (r KillReason) String() string {
+	if r == "" {
+		return string(KillReasonUnknown)
+	}
+	return string(r)
+}
+
 // RemoveOpts bundles the parameters that control sandbox removal.
 type RemoveOpts struct {
 	Action   StateAction

--- a/packages/api/internal/sandbox/sandboxtypes/states.go
+++ b/packages/api/internal/sandbox/sandboxtypes/states.go
@@ -64,6 +64,7 @@ func (r KillReason) String() string {
 	if r == "" {
 		return string(KillReasonUnknown)
 	}
+
 	return string(r)
 }
 

--- a/packages/api/internal/sandbox/sandboxtypes/states_test.go
+++ b/packages/api/internal/sandbox/sandboxtypes/states_test.go
@@ -18,3 +18,59 @@ func TestKillReasonValues(t *testing.T) {
 		}
 	}
 }
+
+func TestKillReasonString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   KillReason
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "unknown",
+		},
+		{
+			name: "unknown",
+			in:   KillReasonUnknown,
+			want: "unknown",
+		},
+		{
+			name: "request",
+			in:   KillReasonRequest,
+			want: "request",
+		},
+		{
+			name: "timeout",
+			in:   KillReasonTimeout,
+			want: "timeout",
+		},
+		{
+			name: "admin",
+			in:   KillReasonAdmin,
+			want: "admin",
+		},
+		{
+			name: "orphaned",
+			in:   KillReasonOrphaned,
+			want: "orphaned",
+		},
+		{
+			name: "base template missing",
+			in:   KillReasonBaseTemplateMissing,
+			want: "base_template_missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.in.String(); got != tt.want {
+				t.Errorf("(%q).String() = %q, want %q", string(tt.in), got, tt.want)
+			}
+		})
+	}
+}

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -441,7 +441,12 @@ func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 		return nil, status.Errorf(codes.Internal, "failed to delete sandbox '%s'", in.GetSandboxId())
 	}
 
-	sbxlogger.E(sbx).Info(ctx, "Killing sandbox")
+	killReason := in.GetKillReason()
+	if killReason == "" {
+		killReason = killReasonUnknown
+	}
+
+	sbxlogger.E(sbx).Info(ctx, "Killing sandbox", zap.String("kill_reason", killReason))
 
 	// Check health metrics before stopping the sandbox
 	sbx.Checks.Healthcheck(ctx, true)
@@ -451,7 +456,11 @@ func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	go func() {
 		err := sbx.Stop(context.WithoutCancel(ctx))
 		if err != nil {
-			sbxlogger.I(sbx).Error(ctx, "error stopping sandbox", logger.WithSandboxID(in.GetSandboxId()), zap.Error(err))
+			sbxlogger.I(sbx).Error(ctx, "error stopping sandbox",
+				logger.WithSandboxID(in.GetSandboxId()),
+				zap.String("kill_reason", killReason),
+				zap.Error(err),
+			)
 		}
 	}()
 
@@ -459,7 +468,6 @@ func (s *Server) Delete(ctxConn context.Context, in *orchestrator.SandboxDeleteR
 	if s.featureFlags.BoolFlag(ctx, featureflags.ExecutionMetricsOnWebhooksFlag) {
 		eventData[executionEventDataKey] = s.getSandboxExecutionData(sbx)
 	}
-	killReason := in.GetKillReason()
 	addKillReason(eventData, killReason)
 	recordSandboxKill(ctx, s.sandboxKilledCounter, killReason)
 


### PR DESCRIPTION
`kill_reason` already rides on the webhook event, the ClickHouse sandbox_events row, and the orchestrator.sandbox.killed counter. Adds it to the kill-path structured logs too, so log-only investigation in Loki has the same attribution.