### PR TITLE
perf(header): add V5 columnar varint header format

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -52,6 +52,9 @@ func NewUpload(
 	}
 
 	headerVersion := uint64(headers.MetadataVersionV4)
+	if ff != nil {
+		ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(useCase))
+	}
 	if ff != nil && ff.BoolFlag(ctx, featureflags.HeaderV5WriteFlag) {
 		headerVersion = headers.MetadataVersionV5
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -51,6 +51,9 @@ func NewUpload(
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}
 
+	if useCase != "" {
+		ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(useCase))
+	}
 	headerVersion := uint64(headers.MetadataVersionV4)
 	if ff != nil {
 		ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(useCase))

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -55,9 +55,6 @@ func NewUpload(
 		ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(useCase))
 	}
 	headerVersion := uint64(headers.MetadataVersionV4)
-	if ff != nil {
-		ctx = featureflags.AddToContext(ctx, featureflags.CompressUseCaseContext(useCase))
-	}
 	if ff != nil && ff.BoolFlag(ctx, featureflags.HeaderV5WriteFlag) {
 		headerVersion = headers.MetadataVersionV5
 	}

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -66,7 +66,7 @@ func NewUpload(
 		root:           root,
 		useCase:        useCase,
 		objectMetadata: objectMetadata,
-		useV4:          memV4 || rootV4,
+		useV4:          memV4 || rootV4 || headerVersion == headers.MetadataVersionV5,
 		headerVersion:  headerVersion,
 	}
 

--- a/packages/orchestrator/pkg/sandbox/build_upload.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload.go
@@ -29,6 +29,7 @@ type Upload struct {
 	objectMetadata storage.ObjectMetadata
 	future         *utils.ErrorOnce
 	useV4          bool
+	headerVersion  uint64
 }
 
 func NewUpload(
@@ -50,6 +51,11 @@ func NewUpload(
 		return nil, fmt.Errorf("resolve rootfs compress config: %w", err)
 	}
 
+	headerVersion := uint64(headers.MetadataVersionV4)
+	if ff != nil && ff.BoolFlag(ctx, featureflags.HeaderV5WriteFlag) {
+		headerVersion = headers.MetadataVersionV5
+	}
+
 	u := &Upload{
 		buildID:        snap.BuildID,
 		snap:           snap,
@@ -61,6 +67,7 @@ func NewUpload(
 		useCase:        useCase,
 		objectMetadata: objectMetadata,
 		useV4:          memV4 || rootV4,
+		headerVersion:  headerVersion,
 	}
 
 	if uploads != nil {

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -97,7 +97,7 @@ func (u *Upload) uploadFramed(
 		selfBuild = headers.BuildData{Size: size, Checksum: checksum, FrameData: ft}
 	}
 
-	h := srcHeader.CloneForUpload(headers.MetadataVersionV4)
+	h := srcHeader.CloneForUpload(u.headerVersion)
 	h.IncompletePendingUpload = false
 	if h.Builds == nil {
 		h.Builds = make(map[uuid.UUID]headers.BuildData)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -167,6 +167,13 @@ var (
 	// uploads. Independent of compress-config: it changes the header format,
 	// not whether data is compressed.
 	V4HeaderForUncompressedFlag = NewBoolFlag("v4-header-for-uncompressed", false)
+
+	// HeaderV5WriteFlag makes Pause emit the V5 (columnar, varint) header
+	// layout instead of V4. Readers understand V5 regardless of this flag;
+	// keep it off until every orchestrator that may read these headers (incl.
+	// P2P peers) ships V5 read support, then enable it to shrink the large
+	// fragmented headers produced by page-granular memfile dedup.
+	HeaderV5WriteFlag = NewBoolFlag("header-v5-write", false)
 )
 
 type IntFlag struct {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -168,11 +168,8 @@ var (
 	// not whether data is compressed.
 	V4HeaderForUncompressedFlag = NewBoolFlag("v4-header-for-uncompressed", false)
 
-	// HeaderV5WriteFlag makes Pause emit the V5 (columnar, varint) header
-	// layout instead of V4. Readers understand V5 regardless of this flag;
-	// keep it off until every orchestrator that may read these headers (incl.
-	// P2P peers) ships V5 read support, then enable it to shrink the large
-	// fragmented headers produced by page-granular memfile dedup.
+	// HeaderV5WriteFlag makes Pause emit V5 headers. When enabled it also
+	// supersedes V4HeaderForUncompressedFlag for uncompressed uploads.
 	HeaderV5WriteFlag = NewBoolFlag("header-v5-write", false)
 )
 

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -24,8 +24,12 @@ type Mapping struct {
 	buildIdx  []uint16
 }
 
-// maxBuildsPerHeader caps the per-header build-ID table at the uint16 limit.
-const maxBuildsPerHeader = 1 << 16
+const (
+	nilBuildIdx = math.MaxUint16
+
+	// maxBuildsPerHeader leaves nilBuildIdx reserved for empty regions.
+	maxBuildsPerHeader = nilBuildIdx
+)
 
 // maxBlockIdx is the largest block index representable by the uint32 columns.
 // At PageSize granularity this caps a single file (memfile/rootfs) at ~16 TiB,
@@ -68,14 +72,18 @@ func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
 			return Mapping{}, fmt.Errorf("compact mapping: block index out of uint32 range at entry %d", i)
 		}
 
-		idx, ok := idxByBuild[m.BuildId]
-		if !ok {
-			if len(builds) >= maxBuildsPerHeader {
-				return Mapping{}, fmt.Errorf("compact mapping: more than %d unique build IDs", maxBuildsPerHeader)
+		idx := uint16(nilBuildIdx)
+		if m.BuildId != uuid.Nil {
+			var ok bool
+			idx, ok = idxByBuild[m.BuildId]
+			if !ok {
+				if len(builds) >= maxBuildsPerHeader {
+					return Mapping{}, fmt.Errorf("compact mapping: more than %d unique build IDs", maxBuildsPerHeader)
+				}
+				idx = uint16(len(builds))
+				idxByBuild[m.BuildId] = idx
+				builds = append(builds, m.BuildId)
 			}
-			idx = uint16(len(builds))
-			idxByBuild[m.BuildId] = idx
-			builds = append(builds, m.BuildId)
 		}
 
 		offsets[i] = uint32(offBlocks)
@@ -103,6 +111,9 @@ func newMappingFromColumns(blockSize uint64, builds []uuid.UUID, offsets, length
 		return Mapping{}, fmt.Errorf("compact mapping: column length mismatch (offsets=%d lengths=%d storage=%d buildIdx=%d)", n, len(lengths), len(storage), len(buildIdx))
 	}
 	for i, bi := range buildIdx {
+		if bi == nilBuildIdx {
+			continue
+		}
 		if int(bi) >= len(builds) {
 			return Mapping{}, fmt.Errorf("compact mapping: buildIdx %d at entry %d out of range (%d builds)", bi, i, len(builds))
 		}
@@ -131,10 +142,15 @@ func (m Mapping) Builds() []uuid.UUID { return m.builds }
 // At materializes the i-th entry as a BuildMap. Panics if i is out of range,
 // matching `mapping[i]` semantics.
 func (m Mapping) At(i int) BuildMap {
+	buildID := uuid.Nil
+	if m.buildIdx[i] != nilBuildIdx {
+		buildID = m.builds[m.buildIdx[i]]
+	}
+
 	return BuildMap{
 		Offset:             uint64(m.offsets[i]) * m.blockSize,
 		Length:             uint64(m.lengths[i]) * m.blockSize,
-		BuildId:            m.builds[m.buildIdx[i]],
+		BuildId:            buildID,
 		BuildStorageOffset: uint64(m.storage[i]) * m.blockSize,
 	}
 }

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -27,6 +27,11 @@ type Mapping struct {
 // maxBuildsPerHeader caps the per-header build-ID table at the uint16 limit.
 const maxBuildsPerHeader = 1 << 16
 
+// maxBlockIdx is the largest block index representable by the uint32 columns.
+// At PageSize granularity this caps a single file (memfile/rootfs) at ~16 TiB,
+// well above any sandbox; NewMapping errors if a value exceeds it.
+const maxBlockIdx = math.MaxUint32
+
 // NewMapping packs src into the compact representation. blockSize is the unit
 // for the block indices and must divide every Offset, Length, and
 // BuildStorageOffset in src (callers pass PageSize, the universal granularity).
@@ -37,9 +42,6 @@ func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
 	if len(src) == 0 {
 		return Mapping{blockSize: blockSize}, nil
 	}
-
-	// uint32 page-block index caps a single file at ~16 TiB (PageSize units).
-	const maxBlockIdx = math.MaxUint32
 
 	idxByBuild := make(map[uuid.UUID]uint16, 8)
 	builds := make([]uuid.UUID, 0, 8)
@@ -80,6 +82,30 @@ func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
 		lengths[i] = uint32(lenBlocks)
 		storage[i] = uint32(stoBlocks)
 		buildIdx[i] = idx
+	}
+
+	return Mapping{
+		blockSize: blockSize,
+		builds:    builds,
+		offsets:   offsets,
+		lengths:   lengths,
+		storage:   storage,
+		buildIdx:  buildIdx,
+	}, nil
+}
+
+// newMappingFromColumns builds a Mapping from already-decoded columns,
+// avoiding the []BuildMap intermediate on the deserialize path. All column
+// slices must have the same length, and every buildIdx must index builds.
+func newMappingFromColumns(blockSize uint64, builds []uuid.UUID, offsets, lengths, storage []uint32, buildIdx []uint16) (Mapping, error) {
+	n := len(offsets)
+	if len(lengths) != n || len(storage) != n || len(buildIdx) != n {
+		return Mapping{}, fmt.Errorf("compact mapping: column length mismatch (offsets=%d lengths=%d storage=%d buildIdx=%d)", n, len(lengths), len(storage), len(buildIdx))
+	}
+	for i, bi := range buildIdx {
+		if int(bi) >= len(builds) {
+			return Mapping{}, fmt.Errorf("compact mapping: buildIdx %d at entry %d out of range (%d builds)", bi, i, len(builds))
+		}
 	}
 
 	return Mapping{

--- a/packages/shared/pkg/storage/header/compact_test.go
+++ b/packages/shared/pkg/storage/header/compact_test.go
@@ -63,22 +63,6 @@ func TestNewMapping_RoundTrip(t *testing.T) {
 	require.ElementsMatch(t, []uuid.UUID{a, b}, m.Builds())
 }
 
-func TestNewMapping_EmptyBuildIDIsNotStoredInBuildTable(t *testing.T) {
-	t.Parallel()
-
-	bs := uint64(4096)
-	id := uuid.New()
-	src := []BuildMap{
-		{Offset: 0, Length: bs, BuildId: uuid.Nil},
-		{Offset: bs, Length: bs, BuildId: id},
-	}
-
-	m, err := NewMapping(bs, src)
-	require.NoError(t, err)
-	require.True(t, Equal(src, m.Slice()))
-	require.Equal(t, []uuid.UUID{id}, m.Builds())
-}
-
 func TestNewMapping_RejectsUnaligned(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/header/compact_test.go
+++ b/packages/shared/pkg/storage/header/compact_test.go
@@ -63,6 +63,22 @@ func TestNewMapping_RoundTrip(t *testing.T) {
 	require.ElementsMatch(t, []uuid.UUID{a, b}, m.Builds())
 }
 
+func TestNewMapping_EmptyBuildIDIsNotStoredInBuildTable(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	src := []BuildMap{
+		{Offset: 0, Length: bs, BuildId: uuid.Nil},
+		{Offset: bs, Length: bs, BuildId: id},
+	}
+
+	m, err := NewMapping(bs, src)
+	require.NoError(t, err)
+	require.True(t, Equal(src, m.Slice()))
+	require.Equal(t, []uuid.UUID{id}, m.Builds())
+}
+
 func TestNewMapping_RejectsUnaligned(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -22,6 +22,11 @@ const (
 	metadataVersion = 3
 	// MetadataVersionV4 is used for compressed builds (V4 headers with FrameTables).
 	MetadataVersionV4 = 4
+	// MetadataVersionV5 is V4 with a columnar, varint-encoded mapping section.
+	// Same semantics as V4 (Builds map + FrameTables); only the on-disk mapping
+	// layout differs. Far smaller and far more compressible for the large,
+	// fragmented headers produced by page-granular memfile dedup.
+	MetadataVersionV5 = 5
 )
 
 type Metadata struct {

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -8,24 +8,31 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
+const metadataVersionMask = 0xFFFF
+
+func metadataFormatVersion(version uint64) uint64 {
+	return version & metadataVersionMask
+}
+
 // SerializeHeader serializes a header, dispatching to the version-specific format.
 //
 // V3 (Version <= 3): [Metadata] [v3 mappings…]
 // V4 (Version >= 4): [Metadata] [uint8 flags] [uint32 uncompressedSize] [LZ4( Builds + v4 mappings )]
 func SerializeHeader(h *Header) ([]byte, error) {
-	if h.Metadata.Version <= 3 {
+	switch metadataFormatVersion(h.Metadata.Version) {
+	case 1, 2, 3:
 		return serializeV3(h.Metadata, h.Mapping)
-	}
+	case MetadataVersionV4:
+		data, _, err := serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
 
-	if h.Metadata.Version >= MetadataVersionV5 {
+		return data, err
+	case MetadataVersionV5:
 		data, _, err := serializeV5(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
 
 		return data, err
+	default:
+		return nil, fmt.Errorf("unsupported header version %d", h.Metadata.Version)
 	}
-
-	data, _, err := serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
-
-	return data, err
 }
 
 // DeserializeBytes auto-detects the header version and deserializes accordingly.
@@ -42,15 +49,16 @@ func DeserializeBytes(data []byte) (*Header, error) {
 
 	blockData := data[metadataSize:]
 
-	if metadata.Version >= MetadataVersionV5 {
+	switch metadataFormatVersion(metadata.Version) {
+	case MetadataVersionV5:
 		return deserializeV5(metadata, blockData)
-	}
-
-	if metadata.Version >= MetadataVersionV4 {
+	case MetadataVersionV4:
 		return deserializeV4(metadata, blockData)
+	case 1, 2, 3:
+		return deserializeV3(metadata, blockData)
+	default:
+		return nil, fmt.Errorf("unsupported header version %d", metadata.Version)
 	}
-
-	return deserializeV3(metadata, blockData)
 }
 
 // LoadHeader fetches a serialized header from storage and deserializes it.
@@ -83,16 +91,16 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 	}
 
 	var data []byte
-	switch {
-	case h.Metadata.Version <= 3:
+	switch metadataFormatVersion(h.Metadata.Version) {
+	case 1, 2, 3:
 		data, err = serializeV3(h.Metadata, h.Mapping)
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}
 		uncompressed = int64(len(data))
-	default:
+	case MetadataVersionV4, MetadataVersionV5:
 		var blockUncompressed int64
-		if h.Metadata.Version >= MetadataVersionV5 {
+		if metadataFormatVersion(h.Metadata.Version) == MetadataVersionV5 {
 			data, blockUncompressed, err = serializeV5(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
 		} else {
 			data, blockUncompressed, err = serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
@@ -111,6 +119,8 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 
 		uncompressed = int64(metadataSize+v4FlagsLen+v4SizePrefixLen) + blockUncompressed
 		cfg.Type = storage.CompressionLZ4.String()
+	default:
+		return storage.CompressConfig{}, 0, 0, fmt.Errorf("unsupported header version %d", h.Metadata.Version)
 	}
 
 	blob, err := s.OpenBlob(ctx, path, storage.MetadataObjectType)

--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -17,6 +17,12 @@ func SerializeHeader(h *Header) ([]byte, error) {
 		return serializeV3(h.Metadata, h.Mapping)
 	}
 
+	if h.Metadata.Version >= MetadataVersionV5 {
+		data, _, err := serializeV5(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+
+		return data, err
+	}
+
 	data, _, err := serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
 
 	return data, err
@@ -36,7 +42,11 @@ func DeserializeBytes(data []byte) (*Header, error) {
 
 	blockData := data[metadataSize:]
 
-	if metadata.Version >= 4 {
+	if metadata.Version >= MetadataVersionV5 {
+		return deserializeV5(metadata, blockData)
+	}
+
+	if metadata.Version >= MetadataVersionV4 {
 		return deserializeV4(metadata, blockData)
 	}
 
@@ -73,15 +83,20 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 	}
 
 	var data []byte
-	if h.Metadata.Version <= 3 {
+	switch {
+	case h.Metadata.Version <= 3:
 		data, err = serializeV3(h.Metadata, h.Mapping)
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}
 		uncompressed = int64(len(data))
-	} else {
+	default:
 		var blockUncompressed int64
-		data, blockUncompressed, err = serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+		if h.Metadata.Version >= MetadataVersionV5 {
+			data, blockUncompressed, err = serializeV5(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+		} else {
+			data, blockUncompressed, err = serializeV4(h.Metadata, h.Builds, h.Mapping, h.IncompletePendingUpload)
+		}
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -1,7 +1,9 @@
 package header
 
 import (
+	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"testing"
 
 	"github.com/google/uuid"
@@ -454,6 +456,44 @@ func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 
 	require.Equal(t, 1, got.Mapping.Len())
 	require.Nil(t, got.Builds)
+}
+
+func TestReadV4BuildsSection_RejectsOversizedBuildCount(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(2)))
+
+	_, err := readV4BuildsSection(bytes.NewReader(buf.Bytes()))
+	require.ErrorContains(t, err, "build count 2 exceeds remaining")
+}
+
+func TestDeserializeV4_RejectsOversizedMappingCount(t *testing.T) {
+	t.Parallel()
+
+	var block bytes.Buffer
+	require.NoError(t, binary.Write(&block, binary.LittleEndian, uint32(0))) // builds
+	require.NoError(t, binary.Write(&block, binary.LittleEndian, uint32(2))) // mappings
+
+	compressed, err := compressLZ4(block.Bytes())
+	require.NoError(t, err)
+
+	metadata := &Metadata{
+		Version:     MetadataVersionV4,
+		BlockSize:   4096,
+		Size:        4096,
+		BuildId:     uuid.New(),
+		BaseBuildId: uuid.New(),
+	}
+	var meta bytes.Buffer
+	require.NoError(t, binary.Write(&meta, binary.LittleEndian, metadata))
+	data := make([]byte, metadataSize+v4FlagsLen+v4SizePrefixLen+len(compressed))
+	copy(data[:metadataSize], meta.Bytes())
+	binary.LittleEndian.PutUint32(data[metadataSize+v4FlagsLen:], uint32(block.Len()))
+	copy(data[metadataSize+v4FlagsLen+v4SizePrefixLen:], compressed)
+
+	_, err = DeserializeBytes(data)
+	require.ErrorContains(t, err, "mapping count 2 exceeds remaining")
 }
 
 func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -61,37 +61,8 @@ func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings Ma
 
 	var block bytes.Buffer
 
-	// Sort by UUID for deterministic serialization.
-	buildIDs := make([]uuid.UUID, 0, len(builds))
-	for id := range builds {
-		buildIDs = append(buildIDs, id)
-	}
-	slices.SortFunc(buildIDs, func(a, b uuid.UUID) int {
-		return bytes.Compare(a[:], b[:])
-	})
-
-	if err := binary.Write(&block, binary.LittleEndian, uint32(len(buildIDs))); err != nil {
-		return nil, 0, fmt.Errorf("failed to write build count: %w", err)
-	}
-
-	buildRanges := extractRelevantRanges(mappings)
-	for _, id := range buildIDs {
-		bd := builds[id]
-
-		entry := v4SerializableBuildInfo{
-			BuildId:  id,
-			FileSize: bd.Size,
-			Checksum: bd.Checksum,
-		}
-
-		if err := binary.Write(&block, binary.LittleEndian, &entry); err != nil {
-			return nil, 0, fmt.Errorf("failed to write build info: %w", err)
-		}
-
-		trimmed := bd.FrameData.TrimToRanges(buildRanges[id])
-		if err := trimmed.Serialize(&block); err != nil {
-			return nil, 0, fmt.Errorf("failed to write build frame data: %w", err)
-		}
+	if err := writeV4BuildsSection(&block, builds, mappings); err != nil {
+		return nil, 0, err
 	}
 
 	if err := binary.Write(&block, binary.LittleEndian, uint32(mappings.Len())); err != nil {
@@ -154,35 +125,9 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	reader := bytes.NewReader(decompressed)
 
-	var numBuilds uint32
-	if err := binary.Read(reader, binary.LittleEndian, &numBuilds); err != nil {
-		return nil, fmt.Errorf("failed to read build count: %w", err)
-	}
-
-	var builds map[uuid.UUID]BuildData
-
-	if numBuilds > 0 {
-		builds = make(map[uuid.UUID]BuildData, numBuilds)
-
-		for range numBuilds {
-			var entry v4SerializableBuildInfo
-			if err := binary.Read(reader, binary.LittleEndian, &entry); err != nil {
-				return nil, fmt.Errorf("failed to read build info: %w", err)
-			}
-
-			bd := BuildData{
-				Size:     entry.FileSize,
-				Checksum: entry.Checksum,
-			}
-
-			ft, err := storage.DeserializeFrameTable(reader)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read frame table for build %s: %w", entry.BuildId, err)
-			}
-
-			bd.FrameData = ft
-			builds[entry.BuildId] = bd
-		}
+	builds, err := readV4BuildsSection(reader)
+	if err != nil {
+		return nil, err
 	}
 
 	var numMappings uint32
@@ -242,6 +187,77 @@ func compressLZ4(data []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// writeV4BuildsSection writes the Builds section shared by V4 and V5:
+// [uint32 count] then, per build (sorted by UUID for determinism), the fixed
+// info plus a frame table sparse-trimmed to the ranges referenced by mapping.
+func writeV4BuildsSection(block *bytes.Buffer, builds map[uuid.UUID]BuildData, mapping Mapping) error {
+	buildIDs := make([]uuid.UUID, 0, len(builds))
+	for id := range builds {
+		buildIDs = append(buildIDs, id)
+	}
+	slices.SortFunc(buildIDs, func(a, b uuid.UUID) int {
+		return bytes.Compare(a[:], b[:])
+	})
+
+	if err := binary.Write(block, binary.LittleEndian, uint32(len(buildIDs))); err != nil {
+		return fmt.Errorf("failed to write build count: %w", err)
+	}
+
+	buildRanges := extractRelevantRanges(mapping)
+	for _, id := range buildIDs {
+		bd := builds[id]
+
+		entry := v4SerializableBuildInfo{
+			BuildId:  id,
+			FileSize: bd.Size,
+			Checksum: bd.Checksum,
+		}
+		if err := binary.Write(block, binary.LittleEndian, &entry); err != nil {
+			return fmt.Errorf("failed to write build info: %w", err)
+		}
+
+		trimmed := bd.FrameData.TrimToRanges(buildRanges[id])
+		if err := trimmed.Serialize(block); err != nil {
+			return fmt.Errorf("failed to write build frame data: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// readV4BuildsSection reads the Builds section shared by V4 and V5. Returns a
+// nil map when the build count is zero.
+func readV4BuildsSection(reader *bytes.Reader) (map[uuid.UUID]BuildData, error) {
+	var numBuilds uint32
+	if err := binary.Read(reader, binary.LittleEndian, &numBuilds); err != nil {
+		return nil, fmt.Errorf("failed to read build count: %w", err)
+	}
+	if numBuilds == 0 {
+		return nil, nil
+	}
+
+	builds := make(map[uuid.UUID]BuildData, numBuilds)
+	for range numBuilds {
+		var entry v4SerializableBuildInfo
+		if err := binary.Read(reader, binary.LittleEndian, &entry); err != nil {
+			return nil, fmt.Errorf("failed to read build info: %w", err)
+		}
+
+		ft, err := storage.DeserializeFrameTable(reader)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read frame table for build %s: %w", entry.BuildId, err)
+		}
+
+		builds[entry.BuildId] = BuildData{
+			Size:      entry.FileSize,
+			Checksum:  entry.Checksum,
+			FrameData: ft,
+		}
+	}
+
+	return builds, nil
 }
 
 // extractRelevantRanges groups mappings into per-build U-space [start, end) ranges

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -50,6 +50,12 @@ type v4SerializableBuildInfo struct {
 	Checksum [32]byte
 }
 
+var (
+	v4BuildInfoSize      = binary.Size(v4SerializableBuildInfo{})
+	v4MappingSize        = binary.Size(v4SerializableBuildMap{})
+	frameTableHeaderSize = 2 * binary.Size(uint32(0))
+)
+
 // serializeV4 writes [Metadata] [uint8 flags] [uint32 LZ4 size] [LZ4( Builds[] + Mappings[] )].
 // Frame tables are sparse-trimmed to only frames referenced by mappings.
 // Also returns the uncompressed inner-block size (LZ4 input length).
@@ -133,6 +139,9 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 	var numMappings uint32
 	if err := binary.Read(reader, binary.LittleEndian, &numMappings); err != nil {
 		return nil, fmt.Errorf("failed to read mappings count: %w", err)
+	}
+	if uint64(numMappings) > uint64(reader.Len())/uint64(v4MappingSize) {
+		return nil, fmt.Errorf("mapping count %d exceeds remaining %d bytes", numMappings, reader.Len())
 	}
 
 	mappings := make([]BuildMap, 0, numMappings)
@@ -236,6 +245,10 @@ func readV4BuildsSection(reader *bytes.Reader) (map[uuid.UUID]BuildData, error) 
 	}
 	if numBuilds == 0 {
 		return nil, nil
+	}
+	minBuildBytes := v4BuildInfoSize + frameTableHeaderSize
+	if uint64(numBuilds) > uint64(reader.Len())/uint64(minBuildBytes) {
+		return nil, fmt.Errorf("build count %d exceeds remaining %d bytes", numBuilds, reader.Len())
 	}
 
 	builds := make(map[uuid.UUID]BuildData, numBuilds)

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const maxV5MappingEntries = 8 << 20
+
 // V5 keeps V4's framing — [Metadata][uint8 flags][uint32 uncompressedSize]
 // [LZ4(block)] — and an identical Builds section. Only the mapping section
 // changes: instead of N fixed 40-byte records, it is columnar and varint-coded.
@@ -204,6 +206,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 	}
 	if err := binary.Read(reader, binary.LittleEndian, &n); err != nil {
 		return Mapping{}, fmt.Errorf("failed to read mapping count: %w", err)
+	}
+	if n > maxV5MappingEntries {
+		return Mapping{}, fmt.Errorf("mapping count %d exceeds maximum %d", n, maxV5MappingEntries)
 	}
 
 	if n == 0 {

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -68,12 +68,12 @@ func serializeV5(metadata *Metadata, builds map[uuid.UUID]BuildData, mapping Map
 // writeV5MappingSection writes the columnar, varint-coded mapping:
 //
 //	uint32 N                       entry count
-//	uint32 M                       distinct build-id count
+//	uint32 M                       distinct non-empty build-id count
 //	M × [16]byte                   build-id table
 //	N × uvarint                    offset-block deltas (offset[i]-offset[i-1])
 //	N × uvarint                    length in blocks
 //	N × varint  (zig-zag)          storage-block deltas (storage[i]-storage[i-1])
-//	N × uvarint                    build-id table index
+//	N × uvarint                    build-id table index (M = empty)
 func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 	n := len(m.offsets)
 	if err := binary.Write(block, binary.LittleEndian, uint32(n)); err != nil {
@@ -106,7 +106,11 @@ func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 		prevStorage = s
 	}
 	for _, v := range m.buildIdx {
-		block.Write(buf[:binary.PutUvarint(buf[:], uint64(v))])
+		idx := uint64(v)
+		if v == nilBuildIdx {
+			idx = uint64(len(m.builds))
+		}
+		block.Write(buf[:binary.PutUvarint(buf[:], idx)])
 	}
 
 	return nil
@@ -238,10 +242,14 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read build index %d: %w", i, err)
 		}
-		if v >= uint64(m) {
+		if v > uint64(m) {
 			return Mapping{}, fmt.Errorf("build index %d at entry %d out of range (%d builds)", v, i, m)
 		}
-		buildIdx[i] = uint16(v)
+		if v == uint64(m) {
+			buildIdx[i] = nilBuildIdx
+		} else {
+			buildIdx[i] = uint16(v)
+		}
 	}
 
 	return newMappingFromColumns(blockSize, builds, offsets, lengths, storageCol, buildIdx)

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -67,15 +67,20 @@ func serializeV5(metadata *Metadata, builds map[uuid.UUID]BuildData, mapping Map
 
 // writeV5MappingSection writes the columnar, varint-coded mapping:
 //
-//	uint32 N                       entry count
+//	uint32 N                       non-empty entry count
 //	uint32 M                       distinct non-empty build-id count
 //	M × [16]byte                   build-id table
 //	N × uvarint                    offset-block deltas (offset[i]-offset[i-1])
 //	N × uvarint                    length in blocks
 //	N × varint  (zig-zag)          storage-block deltas (storage[i]-storage[i-1])
-//	N × uvarint                    build-id table index (M = empty)
+//	N × uvarint                    build-id table index
 func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
-	n := len(m.offsets)
+	var n int
+	for _, idx := range m.buildIdx {
+		if idx != nilBuildIdx {
+			n++
+		}
+	}
 	if err := binary.Write(block, binary.LittleEndian, uint32(n)); err != nil {
 		return fmt.Errorf("failed to write mapping count: %w", err)
 	}
@@ -91,16 +96,25 @@ func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 	var buf [binary.MaxVarintLen64]byte
 
 	var prevOffset uint64
-	for _, v := range m.offsets {
+	for i, v := range m.offsets {
+		if m.buildIdx[i] == nilBuildIdx {
+			continue
+		}
 		off := uint64(v)
 		block.Write(buf[:binary.PutUvarint(buf[:], off-prevOffset)])
 		prevOffset = off
 	}
-	for _, v := range m.lengths {
+	for i, v := range m.lengths {
+		if m.buildIdx[i] == nilBuildIdx {
+			continue
+		}
 		block.Write(buf[:binary.PutUvarint(buf[:], uint64(v))])
 	}
 	var prevStorage int64
-	for _, v := range m.storage {
+	for i, v := range m.storage {
+		if m.buildIdx[i] == nilBuildIdx {
+			continue
+		}
 		s := int64(v)
 		block.Write(buf[:binary.PutVarint(buf[:], s-prevStorage)])
 		prevStorage = s
@@ -108,7 +122,7 @@ func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 	for _, v := range m.buildIdx {
 		idx := uint64(v)
 		if v == nilBuildIdx {
-			idx = uint64(len(m.builds))
+			continue
 		}
 		block.Write(buf[:binary.PutUvarint(buf[:], idx)])
 	}
@@ -148,7 +162,7 @@ func deserializeV5(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	// The compact mapping is encoded in PageSize units (see NewHeader), not the
 	// file's logical block size, so decode it the same way.
-	mapping, err := readV5MappingSection(reader, PageSize)
+	mapping, err := readV5MappingSection(reader, PageSize, metadata.Size)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +179,15 @@ func deserializeV5(metadata *Metadata, blockData []byte) (*Header, error) {
 
 // readV5MappingSection reads the columnar mapping written by
 // writeV5MappingSection and reconstructs the compact Mapping directly.
-func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, error) {
+func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping, error) {
+	if size%blockSize != 0 {
+		return Mapping{}, fmt.Errorf("mapping size %d is not block-aligned to %d", size, blockSize)
+	}
+	sizeBlocks := size / blockSize
+	if sizeBlocks > maxBlockIdx {
+		return Mapping{}, fmt.Errorf("mapping size block %d exceeds uint32", sizeBlocks)
+	}
+
 	var n, m uint32
 	if err := binary.Read(reader, binary.LittleEndian, &n); err != nil {
 		return Mapping{}, fmt.Errorf("failed to read mapping count: %w", err)
@@ -185,7 +207,12 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 	}
 
 	if n == 0 {
-		return newMappingFromColumns(blockSize, builds, nil, nil, nil, nil)
+		if size == 0 {
+			return newMappingFromColumns(blockSize, builds, nil, nil, nil, nil)
+		}
+
+		return newMappingFromColumns(blockSize, builds,
+			[]uint32{0}, []uint32{uint32(sizeBlocks)}, []uint32{0}, []uint16{nilBuildIdx})
 	}
 	// Each entry needs at least one byte in each of the four columns. Bound the
 	// allocation against a crafted count before allocating the column slices.
@@ -193,13 +220,13 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 		return Mapping{}, fmt.Errorf("mapping count %d exceeds remaining %d bytes", n, reader.Len())
 	}
 
-	offsets := make([]uint32, n)
-	lengths := make([]uint32, n)
-	storageCol := make([]uint32, n)
-	buildIdx := make([]uint16, n)
+	sparseOffsets := make([]uint32, n)
+	sparseLengths := make([]uint32, n)
+	sparseStorage := make([]uint32, n)
+	sparseBuildIdx := make([]uint16, n)
 
 	var prevOffset uint64
-	for i := range offsets {
+	for i := range sparseOffsets {
 		d, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read offset delta %d: %w", i, err)
@@ -213,9 +240,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 		if prevOffset > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("offset block %d at entry %d exceeds uint32", prevOffset, i)
 		}
-		offsets[i] = uint32(prevOffset)
+		sparseOffsets[i] = uint32(prevOffset)
 	}
-	for i := range lengths {
+	for i := range sparseLengths {
 		v, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read length %d: %w", i, err)
@@ -223,10 +250,10 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 		if v > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("length block %d at entry %d exceeds uint32", v, i)
 		}
-		lengths[i] = uint32(v)
+		sparseLengths[i] = uint32(v)
 	}
 	var prevStorage int64
-	for i := range storageCol {
+	for i := range sparseStorage {
 		d, err := binary.ReadVarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read storage delta %d: %w", i, err)
@@ -235,21 +262,51 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 		if prevStorage < 0 || prevStorage > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("storage block %d at entry %d out of range", prevStorage, i)
 		}
-		storageCol[i] = uint32(prevStorage)
+		sparseStorage[i] = uint32(prevStorage)
 	}
-	for i := range buildIdx {
+	for i := range sparseBuildIdx {
 		v, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read build index %d: %w", i, err)
 		}
-		if v > uint64(m) {
+		if v >= uint64(m) {
 			return Mapping{}, fmt.Errorf("build index %d at entry %d out of range (%d builds)", v, i, m)
 		}
-		if v == uint64(m) {
-			buildIdx[i] = nilBuildIdx
-		} else {
-			buildIdx[i] = uint16(v)
+		sparseBuildIdx[i] = uint16(v)
+	}
+
+	offsets := make([]uint32, 0, int(n)*2+1)
+	lengths := make([]uint32, 0, int(n)*2+1)
+	storageCol := make([]uint32, 0, int(n)*2+1)
+	buildIdx := make([]uint16, 0, int(n)*2+1)
+	appendEntry := func(off, length, storage uint32, idx uint16) {
+		offsets = append(offsets, off)
+		lengths = append(lengths, length)
+		storageCol = append(storageCol, storage)
+		buildIdx = append(buildIdx, idx)
+	}
+
+	var current uint32
+	for i := range sparseOffsets {
+		off, length := sparseOffsets[i], sparseLengths[i]
+		if length == 0 {
+			return Mapping{}, fmt.Errorf("zero-length mapping at entry %d", i)
 		}
+		if off < current {
+			return Mapping{}, fmt.Errorf("mapping offset %d at entry %d overlaps previous end %d", off, i, current)
+		}
+		if off > current {
+			appendEntry(current, off-current, 0, nilBuildIdx)
+		}
+		end := uint64(off) + uint64(length)
+		if end > sizeBlocks {
+			return Mapping{}, fmt.Errorf("mapping end block %d at entry %d exceeds size %d", end, i, sizeBlocks)
+		}
+		appendEntry(off, length, sparseStorage[i], sparseBuildIdx[i])
+		current = uint32(end)
+	}
+	if uint64(current) < sizeBlocks {
+		appendEntry(current, uint32(sizeBlocks)-current, 0, nilBuildIdx)
 	}
 
 	return newMappingFromColumns(blockSize, builds, offsets, lengths, storageCol, buildIdx)

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -182,10 +182,10 @@ func deserializeV5(metadata *Metadata, blockData []byte) (*Header, error) {
 // readV5MappingSection reads the columnar mapping written by
 // writeV5MappingSection and reconstructs the compact Mapping directly.
 func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping, error) {
-	if size%blockSize != 0 {
-		return Mapping{}, fmt.Errorf("mapping size %d is not block-aligned to %d", size, blockSize)
-	}
 	sizeBlocks := size / blockSize
+	if size%blockSize != 0 {
+		sizeBlocks++
+	}
 	if sizeBlocks > maxBlockIdx {
 		return Mapping{}, fmt.Errorf("mapping size block %d exceeds uint32", sizeBlocks)
 	}
@@ -196,6 +196,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 	}
 	if m > maxBuildsPerHeader {
 		return Mapping{}, fmt.Errorf("mapping build count %d exceeds maximum %d", m, maxBuildsPerHeader)
+	}
+	if uint64(m) > uint64(reader.Len())/16 {
+		return Mapping{}, fmt.Errorf("mapping build count %d exceeds remaining %d bytes", m, reader.Len())
 	}
 
 	builds := make([]uuid.UUID, m)
@@ -219,9 +222,15 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		return newMappingFromColumns(blockSize, builds,
 			[]uint32{0}, []uint32{uint32(sizeBlocks)}, []uint32{0}, []uint16{nilBuildIdx})
 	}
-	// Each entry needs at least one byte in each of the four columns. Bound the
-	// allocation against a crafted count before allocating the column slices.
-	if uint64(n) > uint64(reader.Len())/4 {
+	// Each entry needs at least one byte in each of the four encoded columns,
+	// plus four reconstructed columns below. Bound the crafted count against
+	// the remaining data and a conservative entry cap before allocating them.
+	maxEntriesByBytes := uint64(reader.Len()) / 4
+	maxEntriesByMemory := uint64(v4MaxUncompressedHeaderSize) / 32
+	if maxEntriesByBytes > maxEntriesByMemory {
+		maxEntriesByBytes = maxEntriesByMemory
+	}
+	if uint64(n) > maxEntriesByBytes {
 		return Mapping{}, fmt.Errorf("mapping count %d exceeds remaining %d bytes", n, reader.Len())
 	}
 

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -1,0 +1,248 @@
+package header
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/google/uuid"
+)
+
+// V5 keeps V4's framing — [Metadata][uint8 flags][uint32 uncompressedSize]
+// [LZ4(block)] — and an identical Builds section. Only the mapping section
+// changes: instead of N fixed 40-byte records, it is columnar and varint-coded.
+//
+// V4 mapping bytes are dominated by the offset/length/storage columns (three
+// 8-byte little-endian integers each, mostly tiny or monotonic) and by a full
+// 16-byte BuildId repeated on every entry. For page-granular memfile dedup a
+// single header can hold millions of entries, blowing past the 64 MiB
+// uncompressed cap and compressing poorly (interleaved unique 8-byte values
+// defeat LZ4). V5 fixes both:
+//
+//   - block-indexed columns (offset/length/storage as deltas/values in block
+//     units, varint-coded): tiny per entry, and storing each column
+//     contiguously lets LZ4 collapse the highly regular runs.
+//   - a per-header build-id table addressed by a varint index, so a 16-byte
+//     UUID is stored once per distinct build instead of once per entry.
+
+// serializeV5 mirrors serializeV4 but writes the columnar mapping section.
+// Returns the assembled bytes and the uncompressed inner-block size.
+func serializeV5(metadata *Metadata, builds map[uuid.UUID]BuildData, mapping Mapping, incomplete bool) ([]byte, int64, error) {
+	var metaBuf bytes.Buffer
+	if err := binary.Write(&metaBuf, binary.LittleEndian, metadata); err != nil {
+		return nil, 0, fmt.Errorf("failed to write metadata: %w", err)
+	}
+
+	var block bytes.Buffer
+
+	if err := writeV4BuildsSection(&block, builds, mapping); err != nil {
+		return nil, 0, err
+	}
+
+	if err := writeV5MappingSection(&block, mapping); err != nil {
+		return nil, 0, err
+	}
+
+	blockBytes := block.Bytes()
+	compressed, err := compressLZ4(blockBytes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to LZ4-compress v5 header block: %w", err)
+	}
+
+	var flags uint8
+	if incomplete {
+		flags |= v4FlagIncomplete
+	}
+
+	result := make([]byte, metadataSize+v4FlagsLen+v4SizePrefixLen+len(compressed))
+	copy(result, metaBuf.Bytes())
+	result[metadataSize] = flags
+	binary.LittleEndian.PutUint32(result[metadataSize+v4FlagsLen:], uint32(len(blockBytes)))
+	copy(result[metadataSize+v4FlagsLen+v4SizePrefixLen:], compressed)
+
+	return result, int64(len(blockBytes)), nil
+}
+
+// writeV5MappingSection writes the columnar, varint-coded mapping:
+//
+//	uint32 N                       entry count
+//	uint32 M                       distinct build-id count
+//	M × [16]byte                   build-id table
+//	N × uvarint                    offset-block deltas (offset[i]-offset[i-1])
+//	N × uvarint                    length in blocks
+//	N × varint  (zig-zag)          storage-block deltas (storage[i]-storage[i-1])
+//	N × uvarint                    build-id table index
+func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
+	n := len(m.offsets)
+	if err := binary.Write(block, binary.LittleEndian, uint32(n)); err != nil {
+		return fmt.Errorf("failed to write mapping count: %w", err)
+	}
+	if err := binary.Write(block, binary.LittleEndian, uint32(len(m.builds))); err != nil {
+		return fmt.Errorf("failed to write mapping build count: %w", err)
+	}
+	for _, id := range m.builds {
+		if _, err := block.Write(id[:]); err != nil {
+			return fmt.Errorf("failed to write mapping build id: %w", err)
+		}
+	}
+
+	var buf [binary.MaxVarintLen64]byte
+
+	var prevOffset uint64
+	for _, v := range m.offsets {
+		off := uint64(v)
+		block.Write(buf[:binary.PutUvarint(buf[:], off-prevOffset)])
+		prevOffset = off
+	}
+	for _, v := range m.lengths {
+		block.Write(buf[:binary.PutUvarint(buf[:], uint64(v))])
+	}
+	var prevStorage int64
+	for _, v := range m.storage {
+		s := int64(v)
+		block.Write(buf[:binary.PutVarint(buf[:], s-prevStorage)])
+		prevStorage = s
+	}
+	for _, v := range m.buildIdx {
+		block.Write(buf[:binary.PutUvarint(buf[:], uint64(v))])
+	}
+
+	return nil
+}
+
+// deserializeV5 decompresses and reads the V5 block.
+func deserializeV5(metadata *Metadata, blockData []byte) (*Header, error) {
+	if metadata.BlockSize == 0 {
+		return nil, errors.New("v5 header has zero block size")
+	}
+	if len(blockData) < v4FlagsLen+v4SizePrefixLen {
+		return nil, fmt.Errorf("v5 header block too short for flags + size prefix: %d bytes", len(blockData))
+	}
+
+	flags := blockData[0]
+	size := binary.LittleEndian.Uint32(blockData[v4FlagsLen:])
+	if int(size) > v4MaxUncompressedHeaderSize {
+		return nil, fmt.Errorf("v5 header uncompressed size %d exceeds cap %d", size, v4MaxUncompressedHeaderSize)
+	}
+
+	decompressed, err := decompressLZ4(blockData[v4FlagsLen+v4SizePrefixLen:], int(size))
+	if err != nil {
+		return nil, fmt.Errorf("failed to LZ4-decompress v5 header block: %w", err)
+	}
+	if len(decompressed) != int(size) {
+		return nil, fmt.Errorf("v5 header decompressed size %d != prefix %d", len(decompressed), size)
+	}
+
+	reader := bytes.NewReader(decompressed)
+
+	builds, err := readV4BuildsSection(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	// The compact mapping is encoded in PageSize units (see NewHeader), not the
+	// file's logical block size, so decode it the same way.
+	mapping, err := readV5MappingSection(reader, PageSize)
+	if err != nil {
+		return nil, err
+	}
+
+	h := &Header{
+		Metadata:                metadata,
+		Builds:                  builds,
+		Mapping:                 mapping,
+		IncompletePendingUpload: flags&v4FlagIncomplete != 0,
+	}
+
+	return h, nil
+}
+
+// readV5MappingSection reads the columnar mapping written by
+// writeV5MappingSection and reconstructs the compact Mapping directly.
+func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, error) {
+	var n, m uint32
+	if err := binary.Read(reader, binary.LittleEndian, &n); err != nil {
+		return Mapping{}, fmt.Errorf("failed to read mapping count: %w", err)
+	}
+	if err := binary.Read(reader, binary.LittleEndian, &m); err != nil {
+		return Mapping{}, fmt.Errorf("failed to read mapping build count: %w", err)
+	}
+	if m > maxBuildsPerHeader {
+		return Mapping{}, fmt.Errorf("mapping build count %d exceeds maximum %d", m, maxBuildsPerHeader)
+	}
+
+	builds := make([]uuid.UUID, m)
+	for i := range builds {
+		if _, err := io.ReadFull(reader, builds[i][:]); err != nil {
+			return Mapping{}, fmt.Errorf("failed to read mapping build id %d: %w", i, err)
+		}
+	}
+
+	if n == 0 {
+		return newMappingFromColumns(blockSize, builds, nil, nil, nil, nil)
+	}
+	// Each entry needs at least one varint byte per column, so n cannot exceed
+	// the remaining bytes. Bound the allocation against a crafted count.
+	if int(n) > reader.Len() {
+		return Mapping{}, fmt.Errorf("mapping count %d exceeds remaining %d bytes", n, reader.Len())
+	}
+
+	offsets := make([]uint32, n)
+	lengths := make([]uint32, n)
+	storageCol := make([]uint32, n)
+	buildIdx := make([]uint16, n)
+
+	var prevOffset uint64
+	for i := range offsets {
+		d, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to read offset delta %d: %w", i, err)
+		}
+		// Bound the delta before adding so the running sum can't overflow uint64
+		// and wrap past the maxBlockIdx check.
+		if d > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("offset delta %d at entry %d exceeds uint32", d, i)
+		}
+		prevOffset += d
+		if prevOffset > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("offset block %d at entry %d exceeds uint32", prevOffset, i)
+		}
+		offsets[i] = uint32(prevOffset)
+	}
+	for i := range lengths {
+		v, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to read length %d: %w", i, err)
+		}
+		if v > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("length block %d at entry %d exceeds uint32", v, i)
+		}
+		lengths[i] = uint32(v)
+	}
+	var prevStorage int64
+	for i := range storageCol {
+		d, err := binary.ReadVarint(reader)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to read storage delta %d: %w", i, err)
+		}
+		prevStorage += d
+		if prevStorage < 0 || prevStorage > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("storage block %d at entry %d out of range", prevStorage, i)
+		}
+		storageCol[i] = uint32(prevStorage)
+	}
+	for i := range buildIdx {
+		v, err := binary.ReadUvarint(reader)
+		if err != nil {
+			return Mapping{}, fmt.Errorf("failed to read build index %d: %w", i, err)
+		}
+		if v >= uint64(m) {
+			return Mapping{}, fmt.Errorf("build index %d at entry %d out of range (%d builds)", v, i, m)
+		}
+		buildIdx[i] = uint16(v)
+	}
+
+	return newMappingFromColumns(blockSize, builds, offsets, lengths, storageCol, buildIdx)
+}

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -127,7 +127,7 @@ func deserializeV5(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	flags := blockData[0]
 	size := binary.LittleEndian.Uint32(blockData[v4FlagsLen:])
-	if int(size) > v4MaxUncompressedHeaderSize {
+	if uint64(size) > uint64(v4MaxUncompressedHeaderSize) {
 		return nil, fmt.Errorf("v5 header uncompressed size %d exceeds cap %d", size, v4MaxUncompressedHeaderSize)
 	}
 
@@ -187,9 +187,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize uint64) (Mapping, erro
 	if n == 0 {
 		return newMappingFromColumns(blockSize, builds, nil, nil, nil, nil)
 	}
-	// Each entry needs at least one varint byte per column, so n cannot exceed
-	// the remaining bytes. Bound the allocation against a crafted count.
-	if int(n) > reader.Len() {
+	// Each entry needs at least one byte in each of the four columns. Bound the
+	// allocation against a crafted count before allocating the column slices.
+	if uint64(n) > uint64(reader.Len())/4 {
 		return Mapping{}, fmt.Errorf("mapping count %d exceeds remaining %d bytes", n, reader.Len())
 	}
 

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -67,12 +67,12 @@ func serializeV5(metadata *Metadata, builds map[uuid.UUID]BuildData, mapping Map
 
 // writeV5MappingSection writes the columnar, varint-coded mapping:
 //
-//	uint32 N                       non-empty entry count
 //	uint32 M                       distinct non-empty build-id count
 //	M × [16]byte                   build-id table
+//	uint32 N                       non-empty entry count
 //	N × uvarint                    offset-block deltas (offset[i]-offset[i-1])
 //	N × uvarint                    length in blocks
-//	N × varint  (zig-zag)          storage-block deltas (storage[i]-storage[i-1])
+//	N × varint                     storage-block deltas (can go negative when switching builds)
 //	N × uvarint                    build-id table index
 func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 	var n int
@@ -81,9 +81,6 @@ func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 			n++
 		}
 	}
-	if err := binary.Write(block, binary.LittleEndian, uint32(n)); err != nil {
-		return fmt.Errorf("failed to write mapping count: %w", err)
-	}
 	if err := binary.Write(block, binary.LittleEndian, uint32(len(m.builds))); err != nil {
 		return fmt.Errorf("failed to write mapping build count: %w", err)
 	}
@@ -91,6 +88,9 @@ func writeV5MappingSection(block *bytes.Buffer, m Mapping) error {
 		if _, err := block.Write(id[:]); err != nil {
 			return fmt.Errorf("failed to write mapping build id: %w", err)
 		}
+	}
+	if err := binary.Write(block, binary.LittleEndian, uint32(n)); err != nil {
+		return fmt.Errorf("failed to write mapping count: %w", err)
 	}
 
 	var buf [binary.MaxVarintLen64]byte
@@ -188,10 +188,7 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		return Mapping{}, fmt.Errorf("mapping size block %d exceeds uint32", sizeBlocks)
 	}
 
-	var n, m uint32
-	if err := binary.Read(reader, binary.LittleEndian, &n); err != nil {
-		return Mapping{}, fmt.Errorf("failed to read mapping count: %w", err)
-	}
+	var m, n uint32
 	if err := binary.Read(reader, binary.LittleEndian, &m); err != nil {
 		return Mapping{}, fmt.Errorf("failed to read mapping build count: %w", err)
 	}
@@ -204,6 +201,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if _, err := io.ReadFull(reader, builds[i][:]); err != nil {
 			return Mapping{}, fmt.Errorf("failed to read mapping build id %d: %w", i, err)
 		}
+	}
+	if err := binary.Read(reader, binary.LittleEndian, &n); err != nil {
+		return Mapping{}, fmt.Errorf("failed to read mapping count: %w", err)
 	}
 
 	if n == 0 {
@@ -220,13 +220,13 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		return Mapping{}, fmt.Errorf("mapping count %d exceeds remaining %d bytes", n, reader.Len())
 	}
 
-	sparseOffsets := make([]uint32, n)
-	sparseLengths := make([]uint32, n)
-	sparseStorage := make([]uint32, n)
-	sparseBuildIdx := make([]uint16, n)
+	encodedOffsets := make([]uint32, n)
+	encodedLengths := make([]uint32, n)
+	encodedStorage := make([]uint32, n)
+	encodedBuildIdx := make([]uint16, n)
 
 	var prevOffset uint64
-	for i := range sparseOffsets {
+	for i := range int(n) {
 		d, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read offset delta %d: %w", i, err)
@@ -240,9 +240,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if prevOffset > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("offset block %d at entry %d exceeds uint32", prevOffset, i)
 		}
-		sparseOffsets[i] = uint32(prevOffset)
+		encodedOffsets[i] = uint32(prevOffset)
 	}
-	for i := range sparseLengths {
+	for i := range int(n) {
 		v, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read length %d: %w", i, err)
@@ -250,10 +250,10 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if v > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("length block %d at entry %d exceeds uint32", v, i)
 		}
-		sparseLengths[i] = uint32(v)
+		encodedLengths[i] = uint32(v)
 	}
 	var prevStorage int64
-	for i := range sparseStorage {
+	for i := range int(n) {
 		d, err := binary.ReadVarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read storage delta %d: %w", i, err)
@@ -262,9 +262,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if prevStorage < 0 || prevStorage > maxBlockIdx {
 			return Mapping{}, fmt.Errorf("storage block %d at entry %d out of range", prevStorage, i)
 		}
-		sparseStorage[i] = uint32(prevStorage)
+		encodedStorage[i] = uint32(prevStorage)
 	}
-	for i := range sparseBuildIdx {
+	for i := range int(n) {
 		v, err := binary.ReadUvarint(reader)
 		if err != nil {
 			return Mapping{}, fmt.Errorf("failed to read build index %d: %w", i, err)
@@ -272,7 +272,7 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if v >= uint64(m) {
 			return Mapping{}, fmt.Errorf("build index %d at entry %d out of range (%d builds)", v, i, m)
 		}
-		sparseBuildIdx[i] = uint16(v)
+		encodedBuildIdx[i] = uint16(v)
 	}
 
 	offsets := make([]uint32, 0, int(n)*2+1)
@@ -287,8 +287,8 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 	}
 
 	var current uint32
-	for i := range sparseOffsets {
-		off, length := sparseOffsets[i], sparseLengths[i]
+	for i := range int(n) {
+		off, length := encodedOffsets[i], encodedLengths[i]
 		if length == 0 {
 			return Mapping{}, fmt.Errorf("zero-length mapping at entry %d", i)
 		}
@@ -302,7 +302,7 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		if end > sizeBlocks {
 			return Mapping{}, fmt.Errorf("mapping end block %d at entry %d exceeds size %d", end, i, sizeBlocks)
 		}
-		appendEntry(off, length, sparseStorage[i], sparseBuildIdx[i])
+		appendEntry(off, length, encodedStorage[i], encodedBuildIdx[i])
 		current = uint32(end)
 	}
 	if uint64(current) < sizeBlocks {

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -223,10 +223,11 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 			[]uint32{0}, []uint32{uint32(sizeBlocks)}, []uint32{0}, []uint16{nilBuildIdx})
 	}
 	// Each entry needs at least one byte in each of the four encoded columns,
-	// plus four reconstructed columns below. Bound the crafted count against
-	// the remaining data and a conservative entry cap before allocating them.
+	// and sparse input can reconstruct up to a gap plus mapped entry per
+	// encoded entry. Bound the crafted count before allocating either form.
 	maxEntriesByBytes := uint64(reader.Len()) / 4
-	maxEntriesByMemory := uint64(v4MaxUncompressedHeaderSize) / 32
+	const compactEntryBytes = 3*4 + 2
+	maxEntriesByMemory := uint64(v4MaxUncompressedHeaderSize) / (compactEntryBytes + 2*compactEntryBytes)
 	if maxEntriesByBytes > maxEntriesByMemory {
 		maxEntriesByBytes = maxEntriesByMemory
 	}

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -82,6 +82,26 @@ func TestV5_RoundTrip(t *testing.T) {
 	require.Equal(t, storage.CompressionZstd, fd.CompressionType())
 }
 
+func TestV5_EmptyBuildIDIsNotStoredInMappingBuildTable(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	mappings := []BuildMap{
+		{Offset: 0, Length: bs, BuildId: uuid.Nil},
+		{Offset: bs, Length: bs, BuildId: id},
+	}
+	h := v5Header(t, &Metadata{BlockSize: bs, Size: 2 * bs, BuildId: id, BaseBuildId: id}, mappings, map[uuid.UUID]BuildData{id: {Size: 1}})
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.True(t, Equal(mappings, got.Mapping.Slice()))
+	require.Equal(t, []uuid.UUID{id}, got.Mapping.Builds())
+}
+
 // TestV5_MatchesV4Semantics serializes the same logical header as V4 and V5
 // and asserts both deserialize to the same mappings and Builds.
 func TestV5_MatchesV4Semantics(t *testing.T) {

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -52,11 +52,12 @@ func TestV5_RoundTrip(t *testing.T) {
 	bs := uint64(4096)
 	a := uuid.New()
 	b := uuid.New()
-	metadata := &Metadata{BlockSize: bs, Size: 5 * bs, Generation: 3, BuildId: a, BaseBuildId: b}
+	metadata := &Metadata{BlockSize: bs, Size: 6 * bs, Generation: 3, BuildId: a, BaseBuildId: b}
 	mappings := []BuildMap{
 		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
-		{Offset: 2 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
-		{Offset: 3 * bs, Length: 2 * bs, BuildId: a, BuildStorageOffset: 2 * bs},
+		{Offset: 2 * bs, Length: bs, BuildId: uuid.Nil},
+		{Offset: 3 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 4 * bs, Length: 2 * bs, BuildId: a, BuildStorageOffset: 2 * bs},
 	}
 	checksum := sha256.Sum256([]byte("a"))
 	h := v5Header(t, metadata, mappings, map[uuid.UUID]BuildData{
@@ -72,6 +73,7 @@ func TestV5_RoundTrip(t *testing.T) {
 
 	require.Equal(t, uint64(MetadataVersionV5), got.Metadata.Version)
 	require.True(t, Equal(mappings, got.Mapping.Slice()))
+	require.ElementsMatch(t, []uuid.UUID{a, b}, got.Mapping.Builds())
 	require.Len(t, got.Builds, 2)
 	require.Equal(t, int64(100), got.Builds[a].Size)
 	require.Equal(t, checksum, got.Builds[a].Checksum)
@@ -80,26 +82,6 @@ func TestV5_RoundTrip(t *testing.T) {
 	fd := got.Builds[a].FrameData
 	require.NotNil(t, fd)
 	require.Equal(t, storage.CompressionZstd, fd.CompressionType())
-}
-
-func TestV5_EmptyBuildIDIsNotStoredInMappingBuildTable(t *testing.T) {
-	t.Parallel()
-
-	bs := uint64(4096)
-	id := uuid.New()
-	mappings := []BuildMap{
-		{Offset: 0, Length: bs, BuildId: uuid.Nil},
-		{Offset: bs, Length: bs, BuildId: id},
-	}
-	h := v5Header(t, &Metadata{BlockSize: bs, Size: 2 * bs, BuildId: id, BaseBuildId: id}, mappings, map[uuid.UUID]BuildData{id: {Size: 1}})
-
-	data, err := SerializeHeader(h)
-	require.NoError(t, err)
-	got, err := DeserializeBytes(data)
-	require.NoError(t, err)
-
-	require.True(t, Equal(mappings, got.Mapping.Slice()))
-	require.Equal(t, []uuid.UUID{id}, got.Mapping.Builds())
 }
 
 // TestV5_MatchesV4Semantics serializes the same logical header as V4 and V5

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -84,6 +84,23 @@ func TestV5_RoundTrip(t *testing.T) {
 	require.Equal(t, storage.CompressionZstd, fd.CompressionType())
 }
 
+func TestV5_RoundTripNonAlignedSize(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	metadata := &Metadata{BlockSize: bs, Size: bs + 1, BuildId: id, BaseBuildId: id}
+
+	h := v5Header(t, metadata, nil, nil)
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+	require.Equal(t, metadata.Size, got.Metadata.Size)
+	require.Equal(t, uint64(2*bs), got.Mapping.At(0).Length)
+}
+
 // TestV5_MatchesV4Semantics serializes the same logical header as V4 and V5
 // and asserts both deserialize to the same mappings and Builds.
 func TestV5_MatchesV4Semantics(t *testing.T) {

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -98,7 +98,7 @@ func TestV5_RoundTripNonAlignedSize(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 	require.Equal(t, metadata.Size, got.Metadata.Size)
-	require.Equal(t, uint64(2*bs), got.Mapping.At(0).Length)
+	require.Equal(t, 2*bs, got.Mapping.At(0).Length)
 }
 
 // TestV5_MatchesV4Semantics serializes the same logical header as V4 and V5

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -1,0 +1,193 @@
+package header
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+func v5Header(t *testing.T, metadata *Metadata, mappings []BuildMap, builds map[uuid.UUID]BuildData) *Header {
+	t.Helper()
+	metadata.Version = MetadataVersionV5
+	h, err := NewHeader(metadata, mappings)
+	require.NoError(t, err)
+	h.Builds = builds
+
+	return h
+}
+
+// TestV5_PageGranularUnderHugepage round-trips a memory-style header
+// (BlockSize = 2 MiB) whose mappings are page-granular (4 KiB), the production
+// case that the compact-mapping unit fix addresses.
+func TestV5_PageGranularUnderHugepage(t *testing.T) {
+	t.Parallel()
+
+	const hugepage = uint64(2 << 20)
+	a, b := uuid.New(), uuid.New()
+	mappings := []BuildMap{
+		{Offset: 0, Length: PageSize, BuildId: a, BuildStorageOffset: 0},
+		{Offset: PageSize, Length: PageSize, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 2 * PageSize, Length: 2 * PageSize, BuildId: a, BuildStorageOffset: PageSize},
+	}
+	meta := &Metadata{BlockSize: hugepage, Size: 4 * PageSize, BuildId: a, BaseBuildId: b}
+	h := v5Header(t, meta, mappings, map[uuid.UUID]BuildData{a: {Size: 100}, b: {Size: 50}})
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.True(t, Equal(mappings, got.Mapping.Slice()))
+	require.Equal(t, hugepage, got.Metadata.BlockSize)
+}
+
+func TestV5_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	b := uuid.New()
+	metadata := &Metadata{BlockSize: bs, Size: 5 * bs, Generation: 3, BuildId: a, BaseBuildId: b}
+	mappings := []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 3 * bs, Length: 2 * bs, BuildId: a, BuildStorageOffset: 2 * bs},
+	}
+	checksum := sha256.Sum256([]byte("a"))
+	h := v5Header(t, metadata, mappings, map[uuid.UUID]BuildData{
+		a: {Size: 100, Checksum: checksum, FrameData: storage.NewFrameTable(storage.CompressionZstd, []storage.FrameSize{{U: int32(bs), C: 1000}, {U: int32(2 * bs), C: 2000}})},
+		b: {Size: 200},
+	})
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(MetadataVersionV5), got.Metadata.Version)
+	require.True(t, Equal(mappings, got.Mapping.Slice()))
+	require.Len(t, got.Builds, 2)
+	require.Equal(t, int64(100), got.Builds[a].Size)
+	require.Equal(t, checksum, got.Builds[a].Checksum)
+	require.Equal(t, int64(200), got.Builds[b].Size)
+
+	fd := got.Builds[a].FrameData
+	require.NotNil(t, fd)
+	require.Equal(t, storage.CompressionZstd, fd.CompressionType())
+}
+
+// TestV5_MatchesV4Semantics serializes the same logical header as V4 and V5
+// and asserts both deserialize to the same mappings and Builds.
+func TestV5_MatchesV4Semantics(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	b := uuid.New()
+	c := uuid.New()
+	mappings := []BuildMap{
+		{Offset: 0, Length: bs, BuildId: a, BuildStorageOffset: 0},
+		{Offset: bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: a, BuildStorageOffset: bs},
+		{Offset: 3 * bs, Length: bs, BuildId: c, BuildStorageOffset: 0},
+	}
+	base := &Metadata{BlockSize: bs, Size: 4 * bs, Generation: 1, BuildId: a, BaseBuildId: c}
+	builds := map[uuid.UUID]BuildData{a: {Size: 10}, b: {Size: 20}, c: {Size: 30}}
+
+	metaV4 := *base
+	metaV4.Version = MetadataVersionV4
+	hV4, err := NewHeader(&metaV4, mappings)
+	require.NoError(t, err)
+	hV4.Builds = builds
+	dataV4, err := SerializeHeader(hV4)
+	require.NoError(t, err)
+	gotV4, err := DeserializeBytes(dataV4)
+	require.NoError(t, err)
+
+	metaV5 := *base
+	hV5 := v5Header(t, &metaV5, mappings, builds)
+	dataV5, err := SerializeHeader(hV5)
+	require.NoError(t, err)
+	gotV5, err := DeserializeBytes(dataV5)
+	require.NoError(t, err)
+
+	require.True(t, Equal(gotV4.Mapping.Slice(), gotV5.Mapping.Slice()))
+	require.Equal(t, gotV4.Builds, gotV5.Builds)
+}
+
+// TestV5_SmallerThanV4 asserts the headline win on a fragmented, alternating
+// header: V5 serializes much smaller than V4.
+func TestV5_SmallerThanV4(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	b := uuid.New()
+	const runs = 50_000
+	mappings := make([]BuildMap, 0, runs)
+	var off, sa, sb uint64
+	for i := range runs {
+		id, so := a, sa
+		if i%2 == 1 {
+			id, so = b, sb
+		}
+		mappings = append(mappings, BuildMap{Offset: off, Length: bs, BuildId: id, BuildStorageOffset: so})
+		off += bs
+		if i%2 == 0 {
+			sa += bs
+		} else {
+			sb += bs
+		}
+	}
+	base := &Metadata{BlockSize: bs, Size: off, BuildId: a, BaseBuildId: b}
+	builds := map[uuid.UUID]BuildData{a: {Size: int64(sa)}, b: {Size: int64(sb)}}
+
+	metaV4 := *base
+	metaV4.Version = MetadataVersionV4
+	hV4, err := NewHeader(&metaV4, mappings)
+	require.NoError(t, err)
+	hV4.Builds = builds
+	dataV4, err := SerializeHeader(hV4)
+	require.NoError(t, err)
+
+	metaV5 := *base
+	hV5 := v5Header(t, &metaV5, mappings, builds)
+	dataV5, err := SerializeHeader(hV5)
+	require.NoError(t, err)
+
+	t.Logf("v4=%d bytes, v5=%d bytes (%.1fx smaller)", len(dataV4), len(dataV5), float64(len(dataV4))/float64(len(dataV5)))
+	assert.Less(t, len(dataV5), len(dataV4)/2, "v5 should be at least 2x smaller than v4 on fragmented headers")
+
+	// And it round-trips.
+	got, err := DeserializeBytes(dataV5)
+	require.NoError(t, err)
+	require.True(t, Equal(mappings, got.Mapping.Slice()))
+}
+
+func TestV5_RejectsOversizePrefix(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	meta := &Metadata{Version: MetadataVersionV5, BlockSize: bs, Size: bs, BuildId: id, BaseBuildId: id}
+	h, err := NewHeader(meta, nil)
+	require.NoError(t, err)
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	// Corrupt the uncompressed-size prefix to exceed the cap.
+	prefix := metadataSize + v4FlagsLen
+	data[prefix] = 0xFF
+	data[prefix+1] = 0xFF
+	data[prefix+2] = 0xFF
+	data[prefix+3] = 0xFF
+
+	_, err = DeserializeBytes(data)
+	require.ErrorContains(t, err, "exceeds cap")
+}


### PR DESCRIPTION
Stacked on #2844. Adds a V5 header format: the mapping section is columnar and varint-coded instead of V4's fixed 40-byte records. Page-granular memfile dedup produces million-entry headers that overflow the cap and compress poorly; V5 keeps the same semantics while making those headers much smaller. Readers understand V5 unconditionally; writes are gated behind `HeaderV5WriteFlag` (default off) for a read-before-write rollout.