### PR TITLE
perf(orch): size-based eviction of idle templates from the template cache

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -131,7 +131,7 @@ func NewHeaderFromPath(ctx context.Context, from, headerPath string) (*header.He
 func getReferencedData(h *header.Header, dataFileName string) []string {
 	builds := make(map[uuid.UUID]struct{})
 
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		builds[mapping.BuildId] = struct{}{}
 	}
 

--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -105,7 +105,7 @@ func printUsage() {
 
 func printHeader(h *header.Header, source string) {
 	// Validate mappings
-	err := header.ValidateMappings(h.Mapping, h.Metadata.Size, h.Metadata.BlockSize)
+	err := h.Mapping.Validate(h.Metadata.Size, h.Metadata.BlockSize)
 	if err != nil {
 		fmt.Printf("\n⚠️  WARNING: Mapping validation failed!\n%s\n\n", err)
 	}
@@ -121,7 +121,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("Block size         %d B\n", h.Metadata.BlockSize)
 	fmt.Printf("Blocks             %d\n", (h.Metadata.Size+h.Metadata.BlockSize-1)/h.Metadata.BlockSize)
 
-	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(len(h.Mapping)) / 1024
+	totalSize := int64(unsafe.Sizeof(header.BuildMap{})) * int64(h.Mapping.Len()) / 1024
 	var sizeMessage string
 	if totalSize == 0 {
 		sizeMessage = "<1 KiB"
@@ -129,10 +129,10 @@ func printHeader(h *header.Header, source string) {
 		sizeMessage = fmt.Sprintf("%d KiB", totalSize)
 	}
 
-	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", len(h.Mapping), sizeMessage)
+	fmt.Printf("\nMAPPING (%d maps, uses %s in storage)\n", h.Mapping.Len(), sizeMessage)
 	fmt.Printf("=======\n")
 
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		fmt.Println(mapping.Format(h.Metadata.BlockSize))
 	}
 
@@ -140,7 +140,7 @@ func printHeader(h *header.Header, source string) {
 	fmt.Printf("===============\n")
 
 	builds := make(map[string]int64)
-	for _, mapping := range h.Mapping {
+	for _, mapping := range h.Mapping.All() {
 		builds[mapping.BuildId.String()] += int64(mapping.Length)
 	}
 

--- a/packages/orchestrator/cmd/show-build-diff/main.go
+++ b/packages/orchestrator/cmd/show-build-diff/main.go
@@ -81,22 +81,24 @@ func main() {
 		log.Fatalf("failed to deserialize diff header: %s", err)
 	}
 
+	baseMapping := baseHeader.Mapping.Slice()
+
 	fmt.Printf("\nBASE METADATA\n")
 	fmt.Printf("Storage path       %s\n", baseSource)
 	fmt.Printf("========\n")
 
-	for _, mapping := range baseHeader.Mapping {
+	for _, mapping := range baseMapping {
 		fmt.Println(mapping.Format(baseHeader.Metadata.BlockSize))
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMapping)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")
 		fmt.Println(
 			header.Visualize(
-				baseHeader.Mapping,
+				baseMapping,
 				baseHeader.Metadata.Size,
 				baseHeader.Metadata.BlockSize,
 				128,
@@ -108,7 +110,7 @@ func main() {
 		)
 	}
 
-	if err := header.ValidateMappings(baseHeader.Mapping, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
+	if err := header.ValidateMappings(baseMapping, baseHeader.Metadata.Size, baseHeader.Metadata.BlockSize); err != nil {
 		log.Fatalf("failed to validate base header: %s", err)
 	}
 
@@ -118,7 +120,7 @@ func main() {
 
 	onlyDiffMappings := make([]header.BuildMap, 0)
 
-	for _, mapping := range diffHeader.Mapping {
+	for _, mapping := range diffHeader.Mapping.All() {
 		if mapping.BuildId == diffHeader.Metadata.BuildId {
 			onlyDiffMappings = append(onlyDiffMappings, mapping)
 		}
@@ -142,7 +144,7 @@ func main() {
 		)
 	}
 
-	mergedHeader := header.MergeMappings(baseHeader.Mapping, onlyDiffMappings)
+	mergedHeader := header.MergeMappings(baseMapping, onlyDiffMappings)
 
 	fmt.Printf("\n\nMERGED METADATA\n")
 	fmt.Printf("========\n")
@@ -152,7 +154,7 @@ func main() {
 	}
 
 	if *visualize {
-		bottomLayers := header.Layers(baseHeader.Mapping)
+		bottomLayers := header.Layers(baseMapping)
 		delete(*bottomLayers, baseHeader.Metadata.BaseBuildId)
 
 		fmt.Println("")

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -130,33 +130,29 @@ func (u *Upload) uploadFramed(
 func (u *Upload) appendAncestorBuilds(
 	ctx context.Context,
 	dst map[uuid.UUID]headers.BuildData,
-	mappings []headers.BuildMap,
+	mappings headers.Mapping,
 	fileType build.DiffType,
 ) error {
 	if u.uploads == nil {
 		return nil
 	}
 
-	seen := make(map[uuid.UUID]struct{}, len(mappings))
-	for _, m := range mappings {
-		if m.BuildId == u.buildID || m.BuildId == uuid.Nil {
+	// Mapping.Builds() is already deduplicated, so no local seen-set is needed.
+	for _, buildID := range mappings.Builds() {
+		if buildID == u.buildID || buildID == uuid.Nil {
 			continue
 		}
-		if _, dup := seen[m.BuildId]; dup {
-			continue
-		}
-		seen[m.BuildId] = struct{}{}
 
-		h, err := u.uploads.Wait(ctx, m.BuildId, fileType)
+		h, err := u.uploads.Wait(ctx, buildID, fileType)
 		if err != nil {
-			return fmt.Errorf("wait for ancestor %s/%s: %w", m.BuildId, fileType, err)
+			return fmt.Errorf("wait for ancestor %s/%s: %w", buildID, fileType, err)
 		}
 		if h == nil || dst == nil {
 			continue
 		}
 
-		if bd, ok := h.Builds[m.BuildId]; ok {
-			dst[m.BuildId] = bd
+		if bd, ok := h.Builds[buildID]; ok {
+			dst[buildID] = bd
 		}
 	}
 

--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -69,26 +69,29 @@ func (m *Map) Count() int {
 	return m.live.Count()
 }
 
-// ProtectedBuildIDs returns the build IDs of every sandbox that may still read
-// its template's block devices: both the running (live) set and sandboxes that
-// have been marked stopping but not yet network-released (pause/checkpoint
-// still reads the template while the Firecracker process shuts down). The
-// template cache uses this to avoid evicting a template out from under an
-// active sandbox. The network map is a superset of live, but both are unioned
-// so the guard stays correct regardless of insertion ordering.
+// ProtectedBuildIDs returns template cache keys used by sandboxes that may
+// still read their template's block devices. It includes both Runtime.BuildID
+// and the attached template key; checkpoint resumes can differ.
 func (m *Map) ProtectedBuildIDs() map[string]struct{} {
 	live := m.live.Items()
 	network := m.network.Items()
 
 	ids := make(map[string]struct{}, len(network)+len(live))
 	for _, sbx := range live {
-		ids[sbx.Runtime.BuildID] = struct{}{}
+		addProtectedBuildIDs(ids, sbx)
 	}
 	for _, sbx := range network {
-		ids[sbx.Runtime.BuildID] = struct{}{}
+		addProtectedBuildIDs(ids, sbx)
 	}
 
 	return ids
+}
+
+func addProtectedBuildIDs(ids map[string]struct{}, sbx *Sandbox) {
+	ids[sbx.Runtime.BuildID] = struct{}{}
+	if sbx.Template != nil {
+		ids[sbx.Template.Files().CacheKey()] = struct{}{}
+	}
 }
 
 func (m *Map) Get(sandboxID string) (*Sandbox, bool) {

--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -69,6 +69,28 @@ func (m *Map) Count() int {
 	return m.live.Count()
 }
 
+// ProtectedBuildIDs returns the build IDs of every sandbox that may still read
+// its template's block devices: both the running (live) set and sandboxes that
+// have been marked stopping but not yet network-released (pause/checkpoint
+// still reads the template while the Firecracker process shuts down). The
+// template cache uses this to avoid evicting a template out from under an
+// active sandbox. The network map is a superset of live, but both are unioned
+// so the guard stays correct regardless of insertion ordering.
+func (m *Map) ProtectedBuildIDs() map[string]struct{} {
+	live := m.live.Items()
+	network := m.network.Items()
+
+	ids := make(map[string]struct{}, len(network)+len(live))
+	for _, sbx := range live {
+		ids[sbx.Runtime.BuildID] = struct{}{}
+	}
+	for _, sbx := range network {
+		ids[sbx.Runtime.BuildID] = struct{}{}
+	}
+
+	return ids
+}
+
 func (m *Map) Get(sandboxID string) (*Sandbox, bool) {
 	return m.live.Get(sandboxID)
 }

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -281,7 +281,8 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		if _, inUse := active[v]; inUse {
 			continue
 		}
-		if ts, ok := c.lastAccess.Load(v); ok && now.Sub(ts.(time.Time)) <= evictionGracePeriod {
+		ts, ok := c.lastAccess.Load(v)
+		if !ok || now.Sub(ts.(time.Time)) <= evictionGracePeriod {
 			continue
 		}
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -263,28 +263,7 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 	}
 
 	victims := selectEvictions(entries, (*activeFn)(), time.Now(), budget, total)
-	if len(victims) == 0 {
-		return
-	}
-
-	// Re-validate under extendMu before deleting: a concurrent GetTemplate/
-	// GetCachedTemplate (which record lastAccess under the same lock) can hand
-	// out a victim between sampling and Delete while the new sandbox is not yet
-	// in the active set. Holding the lock and re-checking the active set and
-	// grace window closes that window — a hand-out either happens-before (fresh
-	// lastAccess, skip) or after the entry is gone (refetch).
-	c.extendMu.Lock()
-	defer c.extendMu.Unlock()
-
-	active := (*activeFn)()
-	now := time.Now()
 	for _, v := range victims {
-		if _, inUse := active[v]; inUse {
-			continue
-		}
-		if ts, ok := c.lastAccess.Load(v); ok && now.Sub(ts.(time.Time)) <= evictionGracePeriod {
-			continue
-		}
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
 		logger.L().Info(ctx, "evicted idle template over memory budget",
@@ -309,6 +288,9 @@ type evictionEntry struct {
 func selectEvictions(entries []evictionEntry, active map[string]struct{}, now time.Time, budget, total int64) []string {
 	eligible := make([]evictionEntry, 0, len(entries))
 	for _, e := range entries {
+		if e.footprint == 0 {
+			continue
+		}
 		if _, inUse := active[e.key]; inUse {
 			continue
 		}
@@ -473,9 +455,6 @@ func (c *Cache) AddSnapshot(
 
 // GetCachedTemplate returns the template for buildID if it is currently in the cache.
 func (c *Cache) GetCachedTemplate(buildID string) (Template, bool) {
-	c.extendMu.Lock()
-	defer c.extendMu.Unlock()
-
 	item := c.cache.Get(buildID)
 	if item == nil {
 		return nil, false
@@ -555,10 +534,9 @@ func (c *Cache) getTemplateWithFetch(ctx context.Context, tmpl *storageTemplate,
 		// Another team with a shorter max length cached this entry; extend it.
 		c.cache.Set(key, t.Value(), ttl)
 	}
-	// Record under the lock so the eviction sweep's locked re-check observes a
-	// just-handed-out template as fresh and skips it.
-	c.lastAccess.Store(key, time.Now())
 	c.extendMu.Unlock()
+
+	c.lastAccess.Store(key, time.Now())
 
 	if !found {
 		missesMetric.Add(ctx, 1)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -89,6 +89,8 @@ type Cache struct {
 	// shield just-accessed templates from eviction during sandbox startup
 	// (before they appear in activeBuildIDs).
 	lastAccess sync.Map // key string -> time.Time
+
+	evicting sync.Map // key string -> chan struct{}
 }
 
 // SetActiveBuildIDs installs the in-use predicate used by size-based eviction.
@@ -96,6 +98,16 @@ type Cache struct {
 // must return the build IDs of all currently running sandboxes.
 func (c *Cache) SetActiveBuildIDs(fn func() map[string]struct{}) {
 	c.activeBuildIDs.Store(&fn)
+}
+
+func (c *Cache) waitEvicting(key string) {
+	for {
+		ch, ok := c.evicting.Load(key)
+		if !ok {
+			return
+		}
+		<-ch.(chan struct{})
+	}
 }
 
 // NewCache initializes a template new cache.
@@ -116,14 +128,10 @@ func NewCache(
 		peers.Purge(item.Key())
 
 		template := item.Value()
-		key := item.Key()
-
-		go func() {
-			err := template.Close(context.WithoutCancel(ctx))
-			if err != nil {
-				logger.L().Warn(ctx, "failed to cleanup template data", zap.String("item_key", key), zap.Error(err))
-			}
-		}()
+		err := template.Close(ctx)
+		if err != nil {
+			logger.L().Warn(ctx, "failed to cleanup template data", zap.String("item_key", item.Key()), zap.Error(err))
+		}
 	})
 
 	// Delete the old build cache directory content.
@@ -270,11 +278,11 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		return
 	}
 
-	// Re-check under extendMu so a concurrent template hand-out either marks
-	// lastAccess before deletion (skip) or happens after deletion (refetch).
+	// Re-check under extendMu and mark victims as evicting before releasing it.
+	// Same-key hand-outs wait for cleanup to finish; other keys are not blocked
+	// while Close waits on template files/devices.
+	toDelete := make([]string, 0, len(victims))
 	c.extendMu.Lock()
-	defer c.extendMu.Unlock()
-
 	active := (*activeFn)()
 	now := time.Now()
 	for _, v := range victims {
@@ -285,8 +293,20 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		if !ok || now.Sub(ts.(time.Time)) <= evictionGracePeriod {
 			continue
 		}
+		ch := make(chan struct{})
+		if _, loaded := c.evicting.LoadOrStore(v, ch); loaded {
+			continue
+		}
+		toDelete = append(toDelete, v)
+	}
+	c.extendMu.Unlock()
+
+	for _, v := range toDelete {
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
+		if ch, ok := c.evicting.LoadAndDelete(v); ok {
+			close(ch.(chan struct{}))
+		}
 		logger.L().Info(ctx, "evicted idle template over memory budget",
 			zap.String("build_id", v),
 			zap.Int64("budget_bytes", budget),
@@ -476,17 +496,28 @@ func (c *Cache) AddSnapshot(
 
 // GetCachedTemplate returns the template for buildID if it is currently in the cache.
 func (c *Cache) GetCachedTemplate(buildID string) (Template, bool) {
-	c.extendMu.Lock()
-	defer c.extendMu.Unlock()
+	for {
+		c.waitEvicting(buildID)
 
-	item := c.cache.Get(buildID)
-	if item == nil {
-		return nil, false
+		c.extendMu.Lock()
+		if _, ok := c.evicting.Load(buildID); ok {
+			c.extendMu.Unlock()
+
+			continue
+		}
+
+		item := c.cache.Get(buildID)
+		if item == nil {
+			c.extendMu.Unlock()
+
+			return nil, false
+		}
+
+		c.lastAccess.Store(buildID, time.Now())
+		c.extendMu.Unlock()
+
+		return item.Value(), true
 	}
-
-	c.lastAccess.Store(buildID, time.Now())
-
-	return item.Value(), true
 }
 
 // UpdateMetadata overwrites the local metadata file for a cached template so that
@@ -552,14 +583,27 @@ func (c *Cache) getTemplateWithFetch(ctx context.Context, tmpl *storageTemplate,
 
 	key := tmpl.Files().CacheKey()
 
-	c.extendMu.Lock()
-	t, found := c.cache.GetOrSet(key, tmpl, ttlcache.WithTTL[string, Template](ttl))
-	if found && t.TTL() < ttl {
-		// Another team with a shorter max length cached this entry; extend it.
-		c.cache.Set(key, t.Value(), ttl)
+	var t *ttlcache.Item[string, Template]
+	var found bool
+	for {
+		c.waitEvicting(key)
+
+		c.extendMu.Lock()
+		if _, ok := c.evicting.Load(key); ok {
+			c.extendMu.Unlock()
+
+			continue
+		}
+		t, found = c.cache.GetOrSet(key, tmpl, ttlcache.WithTTL[string, Template](ttl))
+		if found && t.TTL() < ttl {
+			// Another team with a shorter max length cached this entry; extend it.
+			c.cache.Set(key, t.Value(), ttl)
+		}
+		c.lastAccess.Store(key, time.Now())
+		c.extendMu.Unlock()
+
+		break
 	}
-	c.lastAccess.Store(key, time.Now())
-	c.extendMu.Unlock()
 
 	if !found {
 		missesMetric.Add(ctx, 1)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -91,6 +91,7 @@ type Cache struct {
 	lastAccess sync.Map // key string -> time.Time
 
 	evicting *sync.Map // key string -> chan struct{}
+	handouts sync.Map  // key string -> *atomic.Int64
 }
 
 // SetActiveBuildIDs installs the in-use predicate used by size-based eviction.
@@ -110,6 +111,18 @@ func (c *Cache) waitEvicting(key string) {
 		}
 		<-ch.(chan struct{})
 	}
+}
+
+func (c *Cache) protectHandout(ctx context.Context, key string) {
+	v, _ := c.handouts.LoadOrStore(key, &atomic.Int64{})
+	count := v.(*atomic.Int64)
+	count.Add(1)
+	go func() {
+		<-ctx.Done()
+		if count.Add(-1) == 0 {
+			c.handouts.Delete(key)
+		}
+	}()
 }
 
 // NewCache initializes a template new cache.
@@ -250,6 +263,13 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 	budget := int64(budgetMiB) << 20
 
 	items := c.cache.Items()
+	c.handouts.Range(func(k, _ any) bool {
+		if _, ok := items[k.(string)]; !ok {
+			c.handouts.Delete(k)
+		}
+
+		return true
+	})
 
 	// Drop last-access entries for keys no longer cached (TTL-evicted elsewhere).
 	c.lastAccess.Range(func(k, _ any) bool {
@@ -293,6 +313,11 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 
 		c.extendMu.Lock()
 		if _, inUse := active[v]; inUse {
+			c.extendMu.Unlock()
+
+			continue
+		}
+		if _, handedOut := c.handouts.Load(v); handedOut {
 			c.extendMu.Unlock()
 
 			continue
@@ -457,7 +482,10 @@ func (c *Cache) GetTemplate(
 		maxLen = opts[0].MaxSandboxLengthHours
 	}
 
-	return c.getTemplateWithFetch(ctx, storageTemplate, maxLen), nil
+	t := c.getTemplateWithFetch(ctx, storageTemplate, maxLen)
+	c.protectHandout(ctx, t.Files().CacheKey())
+
+	return t, nil
 }
 
 func resolvedHeader(h *header.Header) *utils.SetOnce[*header.Header] {

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -263,7 +263,24 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 	}
 
 	victims := selectEvictions(entries, (*activeFn)(), time.Now(), budget, total)
+	if len(victims) == 0 {
+		return
+	}
+
+	// Re-check under extendMu so a concurrent template hand-out either marks
+	// lastAccess before deletion (skip) or happens after deletion (refetch).
+	c.extendMu.Lock()
+	defer c.extendMu.Unlock()
+
+	active := (*activeFn)()
+	now := time.Now()
 	for _, v := range victims {
+		if _, inUse := active[v]; inUse {
+			continue
+		}
+		if ts, ok := c.lastAccess.Load(v); ok && now.Sub(ts.(time.Time)) <= evictionGracePeriod {
+			continue
+		}
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
 		logger.L().Info(ctx, "evicted idle template over memory budget",
@@ -455,6 +472,9 @@ func (c *Cache) AddSnapshot(
 
 // GetCachedTemplate returns the template for buildID if it is currently in the cache.
 func (c *Cache) GetCachedTemplate(buildID string) (Template, bool) {
+	c.extendMu.Lock()
+	defer c.extendMu.Unlock()
+
 	item := c.cache.Get(buildID)
 	if item == nil {
 		return nil, false
@@ -534,9 +554,8 @@ func (c *Cache) getTemplateWithFetch(ctx context.Context, tmpl *storageTemplate,
 		// Another team with a shorter max length cached this entry; extend it.
 		c.cache.Set(key, t.Value(), ttl)
 	}
-	c.extendMu.Unlock()
-
 	c.lastAccess.Store(key, time.Now())
+	c.extendMu.Unlock()
 
 	if !found {
 		missesMetric.Add(ctx, 1)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -94,8 +94,7 @@ type Cache struct {
 }
 
 // SetActiveBuildIDs installs the in-use predicate used by size-based eviction.
-// Must be called before Start. The function is consulted on every sweep and
-// must return the build IDs of all currently running sandboxes.
+// The function is consulted on every sweep and may be installed after Start.
 func (c *Cache) SetActiveBuildIDs(fn func() map[string]struct{}) {
 	c.activeBuildIDs.Store(&fn)
 }

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -278,30 +278,29 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		return
 	}
 
-	// Re-check under extendMu and mark victims as evicting before releasing it.
-	// Same-key hand-outs wait for cleanup to finish; other keys are not blocked
-	// while Close waits on template files/devices.
-	toDelete := make([]string, 0, len(victims))
-	c.extendMu.Lock()
-	active := (*activeFn)()
-	now := time.Now()
 	for _, v := range victims {
+		c.extendMu.Lock()
+		active := (*activeFn)()
+		now := time.Now()
 		if _, inUse := active[v]; inUse {
+			c.extendMu.Unlock()
+
 			continue
 		}
 		ts, ok := c.lastAccess.Load(v)
 		if !ok || now.Sub(ts.(time.Time)) <= evictionGracePeriod {
+			c.extendMu.Unlock()
+
 			continue
 		}
 		ch := make(chan struct{})
 		if _, loaded := c.evicting.LoadOrStore(v, ch); loaded {
+			c.extendMu.Unlock()
+
 			continue
 		}
-		toDelete = append(toDelete, v)
-	}
-	c.extendMu.Unlock()
+		c.extendMu.Unlock()
 
-	for _, v := range toDelete {
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
 		if ch, ok := c.evicting.LoadAndDelete(v); ok {

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	blockmetrics "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/metrics"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template/peerclient"
@@ -175,8 +176,13 @@ func (c *Cache) runEviction(ctx context.Context) {
 
 // mappingFootprint estimates the retained header-mapping memory of a cached
 // template. Only storage-backed templates carry the long-lived merged headers
-// that drive cache memory; other kinds report 0. Headers not yet resolved
-// (fetch in flight) are skipped via the non-blocking SetOnce result.
+// that drive cache memory; other kinds report 0.
+//
+// The header is read from the resolved device rather than memfileHeader/
+// rootfsHeader: on the GetTemplate path those SetOnces are pre-resolved to nil
+// and the real header is loaded later inside NewStorage during Fetch, so only
+// the device carries it. Devices not yet resolved (fetch in flight) report 0
+// via the non-blocking SetOnce result.
 func mappingFootprint(t Template) int64 {
 	st, ok := t.(*storageTemplate)
 	if !ok {
@@ -184,11 +190,19 @@ func mappingFootprint(t Template) int64 {
 	}
 
 	var bytes int64
-	for _, h := range []*utils.SetOnce[*header.Header]{st.memfileHeader, st.rootfsHeader} {
-		if h == nil {
+	for _, dev := range []*utils.SetOnce[block.ReadonlyDevice]{st.memfile, st.rootfs} {
+		if dev == nil {
 			continue
 		}
-		if hdr, err := h.Result(); err == nil && hdr != nil {
+		d, err := dev.Result()
+		if err != nil || d == nil {
+			continue
+		}
+		s, ok := d.(*Storage)
+		if !ok {
+			continue
+		}
+		if hdr := s.Header(); hdr != nil {
 			bytes += int64(hdr.Mapping.Len()) * approxBuildMapBytes
 		}
 	}

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -116,11 +116,14 @@ func NewCache(
 		peers.Purge(item.Key())
 
 		template := item.Value()
+		key := item.Key()
 
-		err := template.Close(ctx)
-		if err != nil {
-			logger.L().Warn(ctx, "failed to cleanup template data", zap.String("item_key", item.Key()), zap.Error(err))
-		}
+		go func() {
+			err := template.Close(context.WithoutCancel(ctx))
+			if err != nil {
+				logger.L().Warn(ctx, "failed to cleanup template data", zap.String("item_key", key), zap.Error(err))
+			}
+		}()
 	})
 
 	// Delete the old build cache directory content.

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -90,7 +90,7 @@ type Cache struct {
 	// (before they appear in activeBuildIDs).
 	lastAccess sync.Map // key string -> time.Time
 
-	evicting sync.Map // key string -> chan struct{}
+	evicting *sync.Map // key string -> chan struct{}
 }
 
 // SetActiveBuildIDs installs the in-use predicate used by size-based eviction.
@@ -101,6 +101,9 @@ func (c *Cache) SetActiveBuildIDs(fn func() map[string]struct{}) {
 }
 
 func (c *Cache) waitEvicting(key string) {
+	if c.evicting == nil {
+		return
+	}
 	for {
 		ch, ok := c.evicting.Load(key)
 		if !ok {
@@ -124,8 +127,14 @@ func NewCache(
 		ttlcache.WithTTL[string, Template](templateExpiration),
 	)
 
+	evicting := &sync.Map{}
 	cache.OnEviction(func(ctx context.Context, _ ttlcache.EvictionReason, item *ttlcache.Item[string, Template]) {
 		peers.Purge(item.Key())
+		defer func() {
+			if ch, ok := evicting.LoadAndDelete(item.Key()); ok {
+				close(ch.(chan struct{}))
+			}
+		}()
 
 		template := item.Value()
 		err := template.Close(ctx)
@@ -160,6 +169,7 @@ func NewCache(
 		flags:         flags,
 		rootCachePath: config.BuilderConfig.SharedChunkCacheDir,
 		peers:         peers,
+		evicting:      evicting,
 	}, nil
 }
 
@@ -294,6 +304,9 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 			continue
 		}
 		ch := make(chan struct{})
+		if c.evicting == nil {
+			c.evicting = &sync.Map{}
+		}
 		if _, loaded := c.evicting.LoadOrStore(v, ch); loaded {
 			c.extendMu.Unlock()
 
@@ -303,9 +316,6 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
-		if ch, ok := c.evicting.LoadAndDelete(v); ok {
-			close(ch.(chan struct{}))
-		}
 		logger.L().Info(ctx, "evicted idle template over memory budget",
 			zap.String("build_id", v),
 			zap.Int64("budget_bytes", budget),

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -114,13 +114,39 @@ func (c *Cache) waitEvicting(key string) {
 }
 
 func (c *Cache) protectHandout(ctx context.Context, key string) {
-	v, _ := c.handouts.LoadOrStore(key, &atomic.Int64{})
-	count := v.(*atomic.Int64)
-	count.Add(1)
+	var count *atomic.Int64
+	for count == nil {
+		v, _ := c.handouts.LoadOrStore(key, &atomic.Int64{})
+		candidate := v.(*atomic.Int64)
+		for {
+			n := candidate.Load()
+			if n < 0 {
+				c.handouts.CompareAndDelete(key, candidate)
+
+				break
+			}
+			if candidate.CompareAndSwap(n, n+1) {
+				count = candidate
+
+				break
+			}
+		}
+	}
+
 	go func() {
 		<-ctx.Done()
-		if count.Add(-1) == 0 {
-			c.handouts.Delete(key)
+		for {
+			n := count.Load()
+			if n <= 0 {
+				return
+			}
+			if count.CompareAndSwap(n, n-1) {
+				if n == 1 && count.CompareAndSwap(0, -1) {
+					c.handouts.CompareAndDelete(key, count)
+				}
+
+				return
+			}
 		}
 	}()
 }

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -37,6 +38,21 @@ const (
 
 	buildCacheTTL           = time.Hour * 25
 	buildCacheDelayEviction = time.Second * 60
+
+	// evictionSweepInterval is how often the size-based sweeper runs.
+	evictionSweepInterval = time.Second * 30
+
+	// evictionGracePeriod protects templates accessed very recently from
+	// size-based eviction, covering the window between GetTemplate and a
+	// sandbox entering the running set (MarkRunning). Comfortably larger than
+	// sandbox start time.
+	evictionGracePeriod = time.Minute * 5
+
+	// approxBuildMapBytes is the per-entry cost used to estimate a cached
+	// header's retained mapping memory. The compact in-memory Mapping is
+	// ~14 bytes/entry; the estimate is intentionally coarse (it only needs to
+	// rank entries and compare against a budget).
+	approxBuildMapBytes = 14
 )
 
 var (
@@ -58,6 +74,24 @@ type Cache struct {
 	rootCachePath string
 	peers         peerclient.Resolver
 	extendMu      sync.Mutex
+
+	// activeBuildIDs reports the set of build IDs currently backing a running
+	// sandbox. Size-based eviction never closes a template in this set, since a
+	// running sandbox reads through its block devices. nil disables size-based
+	// eviction (the safe default until the server wires it in).
+	activeBuildIDs func() map[string]struct{}
+
+	// lastAccess records when each cached build ID was last handed out, used to
+	// shield just-accessed templates from eviction during sandbox startup
+	// (before they appear in activeBuildIDs).
+	lastAccess sync.Map // key string -> time.Time
+}
+
+// SetActiveBuildIDs installs the in-use predicate used by size-based eviction.
+// Must be called before Start. The function is consulted on every sweep and
+// must return the build IDs of all currently running sandboxes.
+func (c *Cache) SetActiveBuildIDs(fn func() map[string]struct{}) {
+	c.activeBuildIDs = fn
 }
 
 // NewCache initializes a template new cache.
@@ -118,6 +152,148 @@ func (c *Cache) Start(ctx context.Context) {
 	c.buildStore.Start(ctx)
 
 	go c.cache.Start()
+	go c.runEviction(ctx)
+}
+
+// runEviction periodically enforces the size-based memory budget, evicting
+// idle templates oldest-first. Each tick is a no-op while the budget flag is 0
+// or the in-use predicate has not been installed (the predicate may be set
+// after Start, so the check is per-tick rather than once up front).
+func (c *Cache) runEviction(ctx context.Context) {
+	ticker := time.NewTicker(evictionSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.evictOverBudget(ctx)
+		}
+	}
+}
+
+// mappingFootprint estimates the retained header-mapping memory of a cached
+// template. Only storage-backed templates carry the long-lived merged headers
+// that drive cache memory; other kinds report 0. Headers not yet resolved
+// (fetch in flight) are skipped via the non-blocking SetOnce result.
+func mappingFootprint(t Template) int64 {
+	st, ok := t.(*storageTemplate)
+	if !ok {
+		return 0
+	}
+
+	var bytes int64
+	for _, h := range []*utils.SetOnce[*header.Header]{st.memfileHeader, st.rootfsHeader} {
+		if h == nil {
+			continue
+		}
+		if hdr, err := h.Result(); err == nil && hdr != nil {
+			bytes += int64(hdr.Mapping.Len()) * approxBuildMapBytes
+		}
+	}
+
+	return bytes
+}
+
+// evictOverBudget evicts idle templates (no running sandbox) oldest-first until
+// the estimated retained mapping memory is under the configured budget. A
+// running sandbox reads through its template's block devices, so in-use
+// templates are never evicted regardless of size or age.
+func (c *Cache) evictOverBudget(ctx context.Context) {
+	if c.activeBuildIDs == nil {
+		return
+	}
+
+	budgetMiB := c.flags.IntFlag(ctx, featureflags.TemplateCacheMaxMappingMiBFlag)
+	if budgetMiB <= 0 {
+		return
+	}
+	budget := int64(budgetMiB) << 20
+
+	items := c.cache.Items()
+
+	// Drop last-access entries for keys no longer cached (TTL-evicted elsewhere).
+	c.lastAccess.Range(func(k, _ any) bool {
+		if _, ok := items[k.(string)]; !ok {
+			c.lastAccess.Delete(k)
+		}
+
+		return true
+	})
+
+	entries := make([]evictionEntry, 0, len(items))
+	var total int64
+	for key, item := range items {
+		fp := mappingFootprint(item.Value())
+		total += fp
+
+		var lastAccess time.Time
+		if ts, ok := c.lastAccess.Load(key); ok {
+			lastAccess = ts.(time.Time)
+		}
+
+		entries = append(entries, evictionEntry{
+			key:        key,
+			footprint:  fp,
+			expiresAt:  item.ExpiresAt(),
+			lastAccess: lastAccess,
+		})
+	}
+	if total <= budget {
+		return
+	}
+
+	victims := selectEvictions(entries, c.activeBuildIDs(), time.Now(), budget, total)
+	for _, v := range victims {
+		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
+		c.lastAccess.Delete(v)
+		logger.L().Info(ctx, "evicted idle template over memory budget",
+			zap.String("build_id", v),
+			zap.Int64("budget_bytes", budget),
+		)
+	}
+}
+
+type evictionEntry struct {
+	key        string
+	footprint  int64
+	expiresAt  time.Time
+	lastAccess time.Time
+}
+
+// selectEvictions returns the build IDs to evict, oldest-first, until the
+// running total drops to budget. An entry is eligible only when it is not in
+// the active set (no running sandbox reads it) and was last accessed before the
+// grace window (shielding sandboxes still starting up). Pure function: no I/O,
+// so the in-use/grace correctness rules are unit-testable.
+func selectEvictions(entries []evictionEntry, active map[string]struct{}, now time.Time, budget, total int64) []string {
+	eligible := make([]evictionEntry, 0, len(entries))
+	for _, e := range entries {
+		if _, inUse := active[e.key]; inUse {
+			continue
+		}
+		if e.lastAccess.IsZero() || now.Sub(e.lastAccess) <= evictionGracePeriod {
+			continue
+		}
+		eligible = append(eligible, e)
+	}
+
+	// Oldest-first: smallest TTL = least-recently set or extended.
+	slices.SortFunc(eligible, func(a, b evictionEntry) int {
+		return a.expiresAt.Compare(b.expiresAt)
+	})
+
+	var victims []string
+	for _, e := range eligible {
+		if total <= budget {
+			break
+		}
+		victims = append(victims, e.key)
+		total -= e.footprint
+	}
+
+	return victims
 }
 
 func (c *Cache) Stop() {
@@ -263,6 +439,8 @@ func (c *Cache) GetCachedTemplate(buildID string) (Template, bool) {
 		return nil, false
 	}
 
+	c.lastAccess.Store(buildID, time.Now())
+
 	return item.Value(), true
 }
 
@@ -336,6 +514,8 @@ func (c *Cache) getTemplateWithFetch(ctx context.Context, tmpl *storageTemplate,
 		c.cache.Set(key, t.Value(), ttl)
 	}
 	c.extendMu.Unlock()
+
+	c.lastAccess.Store(key, time.Now())
 
 	if !found {
 		missesMetric.Add(ctx, 1)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -531,9 +531,10 @@ func (c *Cache) getTemplateWithFetch(ctx context.Context, tmpl *storageTemplate,
 		// Another team with a shorter max length cached this entry; extend it.
 		c.cache.Set(key, t.Value(), ttl)
 	}
-	c.extendMu.Unlock()
-
+	// Record under the lock so the eviction sweep's locked re-check observes a
+	// just-handed-out template as fresh and skips it.
 	c.lastAccess.Store(key, time.Now())
+	c.extendMu.Unlock()
 
 	if !found {
 		missesMetric.Add(ctx, 1)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -263,7 +263,28 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 	}
 
 	victims := selectEvictions(entries, (*activeFn)(), time.Now(), budget, total)
+	if len(victims) == 0 {
+		return
+	}
+
+	// Re-validate under extendMu before deleting: a concurrent GetTemplate/
+	// GetCachedTemplate (which record lastAccess under the same lock) can hand
+	// out a victim between sampling and Delete while the new sandbox is not yet
+	// in the active set. Holding the lock and re-checking the active set and
+	// grace window closes that window — a hand-out either happens-before (fresh
+	// lastAccess, skip) or after the entry is gone (refetch).
+	c.extendMu.Lock()
+	defer c.extendMu.Unlock()
+
+	active := (*activeFn)()
+	now := time.Now()
 	for _, v := range victims {
+		if _, inUse := active[v]; inUse {
+			continue
+		}
+		if ts, ok := c.lastAccess.Load(v); ok && now.Sub(ts.(time.Time)) <= evictionGracePeriod {
+			continue
+		}
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)
 		logger.L().Info(ctx, "evicted idle template over memory budget",
@@ -452,6 +473,9 @@ func (c *Cache) AddSnapshot(
 
 // GetCachedTemplate returns the template for buildID if it is currently in the cache.
 func (c *Cache) GetCachedTemplate(buildID string) (Template, bool) {
+	c.extendMu.Lock()
+	defer c.extendMu.Unlock()
+
 	item := c.cache.Get(buildID)
 	if item == nil {
 		return nil, false

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
@@ -79,8 +80,10 @@ type Cache struct {
 	// activeBuildIDs reports the set of build IDs currently backing a running
 	// sandbox. Size-based eviction never closes a template in this set, since a
 	// running sandbox reads through its block devices. nil disables size-based
-	// eviction (the safe default until the server wires it in).
-	activeBuildIDs func() map[string]struct{}
+	// eviction (the safe default until the server wires it in). Stored
+	// atomically: the eviction goroutine (started by Start) reads it while the
+	// server may install it later via SetActiveBuildIDs.
+	activeBuildIDs atomic.Pointer[func() map[string]struct{}]
 
 	// lastAccess records when each cached build ID was last handed out, used to
 	// shield just-accessed templates from eviction during sandbox startup
@@ -92,7 +95,7 @@ type Cache struct {
 // Must be called before Start. The function is consulted on every sweep and
 // must return the build IDs of all currently running sandboxes.
 func (c *Cache) SetActiveBuildIDs(fn func() map[string]struct{}) {
-	c.activeBuildIDs = fn
+	c.activeBuildIDs.Store(&fn)
 }
 
 // NewCache initializes a template new cache.
@@ -215,7 +218,8 @@ func mappingFootprint(t Template) int64 {
 // running sandbox reads through its template's block devices, so in-use
 // templates are never evicted regardless of size or age.
 func (c *Cache) evictOverBudget(ctx context.Context) {
-	if c.activeBuildIDs == nil {
+	activeFn := c.activeBuildIDs.Load()
+	if activeFn == nil {
 		return
 	}
 
@@ -258,7 +262,7 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		return
 	}
 
-	victims := selectEvictions(entries, c.activeBuildIDs(), time.Now(), budget, total)
+	victims := selectEvictions(entries, (*activeFn)(), time.Now(), budget, total)
 	for _, v := range victims {
 		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
 		c.lastAccess.Delete(v)

--- a/packages/orchestrator/pkg/sandbox/template/cache.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache.go
@@ -289,9 +289,10 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 	}
 
 	for _, v := range victims {
-		c.extendMu.Lock()
 		active := (*activeFn)()
 		now := time.Now()
+
+		c.extendMu.Lock()
 		if _, inUse := active[v]; inUse {
 			c.extendMu.Unlock()
 
@@ -314,7 +315,12 @@ func (c *Cache) evictOverBudget(ctx context.Context) {
 		}
 		c.extendMu.Unlock()
 
-		c.cache.Delete(v) // triggers OnEviction: peer purge + template Close
+		_, deleted := c.cache.GetAndDelete(v) // triggers OnEviction: peer purge + template Close
+		if !deleted {
+			if ch, ok := c.evicting.LoadAndDelete(v); ok {
+				close(ch.(chan struct{}))
+			}
+		}
 		c.lastAccess.Delete(v)
 		logger.L().Info(ctx, "evicted idle template over memory budget",
 			zap.String("build_id", v),

--- a/packages/orchestrator/pkg/sandbox/template/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache_test.go
@@ -128,3 +128,65 @@ func TestWithoutExtend_EntryEvictedEarly(t *testing.T) {
 	item := c.cache.Get(key)
 	assert.Nil(t, item, "without TTL extension, the entry should be evicted after the default TTL")
 }
+
+func TestSelectEvictions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	stale := now.Add(-time.Hour)   // outside grace window
+	fresh := now.Add(-time.Second) // inside grace window
+	mib := int64(1) << 20
+
+	entry := func(key string, fpMiB int64, exp, last time.Time) evictionEntry {
+		return evictionEntry{key: key, footprint: fpMiB * mib, expiresAt: exp, lastAccess: last}
+	}
+
+	t.Run("under budget evicts nothing", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{entry("a", 5, now.Add(time.Hour), stale)}
+		got := selectEvictions(entries, nil, now, 10*mib, 5*mib)
+		assert.Empty(t, got)
+	})
+
+	t.Run("evicts oldest-first until under budget", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{
+			entry("new", 10, now.Add(3*time.Hour), stale),
+			entry("old", 10, now.Add(time.Hour), stale),
+			entry("mid", 10, now.Add(2*time.Hour), stale),
+		}
+		// total 30 MiB, budget 15 MiB -> must free >=15, evicting 2 oldest.
+		got := selectEvictions(entries, nil, now, 15*mib, 30*mib)
+		assert.Equal(t, []string{"old", "mid"}, got)
+	})
+
+	t.Run("never evicts in-use templates", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{
+			entry("running", 100, now.Add(time.Hour), stale),
+			entry("idle", 10, now.Add(2*time.Hour), stale),
+		}
+		active := map[string]struct{}{"running": {}}
+		got := selectEvictions(entries, active, now, 5*mib, 110*mib)
+		// running is skipped even though it is the largest and oldest; only idle
+		// is eligible (and still over budget, but nothing else can be freed).
+		assert.Equal(t, []string{"idle"}, got)
+	})
+
+	t.Run("never evicts within grace window", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{
+			entry("starting", 100, now.Add(time.Hour), fresh),
+			entry("idle", 10, now.Add(2*time.Hour), stale),
+		}
+		got := selectEvictions(entries, nil, now, 5*mib, 110*mib)
+		assert.Equal(t, []string{"idle"}, got)
+	})
+
+	t.Run("never evicts entries with no recorded access", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{entry("unknown", 100, now.Add(time.Hour), time.Time{})}
+		got := selectEvictions(entries, nil, now, 5*mib, 100*mib)
+		assert.Empty(t, got)
+	})
+}

--- a/packages/orchestrator/pkg/sandbox/template/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/cache_test.go
@@ -189,4 +189,14 @@ func TestSelectEvictions(t *testing.T) {
 		got := selectEvictions(entries, nil, now, 5*mib, 100*mib)
 		assert.Empty(t, got)
 	})
+
+	t.Run("never evicts zero-footprint entries", func(t *testing.T) {
+		t.Parallel()
+		entries := []evictionEntry{
+			entry("fetching", 0, now.Add(time.Hour), stale),
+			entry("idle", 10, now.Add(2*time.Hour), stale),
+		}
+		got := selectEvictions(entries, nil, now, 5*mib, 10*mib)
+		assert.Equal(t, []string{"idle"}, got)
+	})
 }

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
@@ -46,10 +46,10 @@ type nopResolver struct{}
 func (nopResolver) resolve(context.Context, string) (attribute.KeyValue, resolveResult) {
 	return attrResolveNoPeer, resolveResult{}
 }
-func (nopResolver) IsActive(string) bool                 { return false }
-func (nopResolver) ActiveBuildIDs() map[string]struct{}  { return nil }
-func (nopResolver) Purge(string)                         {}
-func (nopResolver) Close()                               {}
+func (nopResolver) IsActive(string) bool                { return false }
+func (nopResolver) ActiveBuildIDs() map[string]struct{} { return nil }
+func (nopResolver) Purge(string)                        {}
+func (nopResolver) Close()                              {}
 
 // peerResolver is the real implementation that looks up peers via the Registry.
 type peerResolver struct {

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
@@ -27,7 +27,7 @@ const peerConnectTimeout = 5 * time.Second
 type Resolver interface {
 	resolve(ctx context.Context, buildID string) (attribute.KeyValue, resolveResult)
 	IsActive(buildID string) bool
-	ActiveBuildIDs() map[string]struct{}
+	ActiveBuildIDs(ctx context.Context) map[string]struct{}
 	Purge(buildID string)
 	Close()
 }
@@ -46,10 +46,12 @@ type nopResolver struct{}
 func (nopResolver) resolve(context.Context, string) (attribute.KeyValue, resolveResult) {
 	return attrResolveNoPeer, resolveResult{}
 }
-func (nopResolver) IsActive(string) bool                { return false }
-func (nopResolver) ActiveBuildIDs() map[string]struct{} { return nil }
-func (nopResolver) Purge(string)                        {}
-func (nopResolver) Close()                              {}
+func (nopResolver) IsActive(string) bool { return false }
+func (nopResolver) ActiveBuildIDs(context.Context) map[string]struct{} {
+	return nil
+}
+func (nopResolver) Purge(string) {}
+func (nopResolver) Close()       {}
 
 // peerResolver is the real implementation that looks up peers via the Registry.
 type peerResolver struct {
@@ -185,12 +187,22 @@ func (r *peerResolver) IsActive(buildID string) bool {
 	return ok && !v.(*atomic.Bool).Load()
 }
 
-func (r *peerResolver) ActiveBuildIDs() map[string]struct{} {
+func (r *peerResolver) ActiveBuildIDs(ctx context.Context) map[string]struct{} {
 	ids := make(map[string]struct{})
 	r.uploadedBuilds.Range(func(key, value any) bool {
-		if !value.(*atomic.Bool).Load() {
-			ids[key.(string)] = struct{}{}
+		uploaded := value.(*atomic.Bool)
+		if uploaded.Load() {
+			return true
 		}
+
+		buildID := key.(string)
+		addr, found, err := r.readPeerAddress(ctx, buildID)
+		if err == nil && (!found || r.isSelfAddress(addr)) {
+			uploaded.Store(true)
+
+			return true
+		}
+		ids[buildID] = struct{}{}
 
 		return true
 	})

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/resolver.go
@@ -27,6 +27,7 @@ const peerConnectTimeout = 5 * time.Second
 type Resolver interface {
 	resolve(ctx context.Context, buildID string) (attribute.KeyValue, resolveResult)
 	IsActive(buildID string) bool
+	ActiveBuildIDs() map[string]struct{}
 	Purge(buildID string)
 	Close()
 }
@@ -45,9 +46,10 @@ type nopResolver struct{}
 func (nopResolver) resolve(context.Context, string) (attribute.KeyValue, resolveResult) {
 	return attrResolveNoPeer, resolveResult{}
 }
-func (nopResolver) IsActive(string) bool { return false }
-func (nopResolver) Purge(string)         {}
-func (nopResolver) Close()               {}
+func (nopResolver) IsActive(string) bool                 { return false }
+func (nopResolver) ActiveBuildIDs() map[string]struct{}  { return nil }
+func (nopResolver) Purge(string)                         {}
+func (nopResolver) Close()                               {}
 
 // peerResolver is the real implementation that looks up peers via the Registry.
 type peerResolver struct {
@@ -181,6 +183,19 @@ func (r *peerResolver) IsActive(buildID string) bool {
 	v, ok := r.uploadedBuilds.Load(buildID)
 
 	return ok && !v.(*atomic.Bool).Load()
+}
+
+func (r *peerResolver) ActiveBuildIDs() map[string]struct{} {
+	ids := make(map[string]struct{})
+	r.uploadedBuilds.Range(func(key, value any) bool {
+		if !value.(*atomic.Bool).Load() {
+			ids[key.(string)] = struct{}{}
+		}
+
+		return true
+	})
+
+	return ids
 }
 
 func (r *peerResolver) Close() {

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -114,9 +114,9 @@ func (u *Uploads) InFlightBuildIDs() map[string]struct{} {
 	return ids
 }
 
-func (u *Uploads) ProtectedBuildIDs() map[string]struct{} {
+func (u *Uploads) ProtectedBuildIDs(ctx context.Context) map[string]struct{} {
 	ids := u.InFlightBuildIDs()
-	for id := range u.p2p.ActiveBuildIDs() {
+	for id := range u.p2p.ActiveBuildIDs(ctx) {
 		ids[id] = struct{}{}
 	}
 

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -114,6 +114,15 @@ func (u *Uploads) InFlightBuildIDs() map[string]struct{} {
 	return ids
 }
 
+func (u *Uploads) ProtectedBuildIDs() map[string]struct{} {
+	ids := u.InFlightBuildIDs()
+	for id := range u.p2p.ActiveBuildIDs() {
+		ids[id] = struct{}{}
+	}
+
+	return ids
+}
+
 // Wait returns the parent's post-upload header, or (nil, nil) when the
 // ancestor was never opened locally and no peer is mid-upload — the caller
 // already carries its BuildData through srcHeader.Builds.

--- a/packages/orchestrator/pkg/sandbox/uploads.go
+++ b/packages/orchestrator/pkg/sandbox/uploads.go
@@ -97,6 +97,23 @@ func (u *Uploads) Start(buildID uuid.UUID) (*utils.ErrorOnce, error) {
 	return fut, nil
 }
 
+// InFlightBuildIDs returns the build IDs whose upload has not yet finished.
+// Their snapshot data may only exist locally and still be served to peers, so
+// the template cache must not evict (and close) them mid-upload.
+func (u *Uploads) InFlightBuildIDs() map[string]struct{} {
+	items := u.futures.Items()
+	ids := make(map[string]struct{}, len(items))
+	for id, item := range items {
+		select {
+		case <-item.Value().Done():
+		default:
+			ids[id.String()] = struct{}{}
+		}
+	}
+
+	return ids
+}
+
 // Wait returns the parent's post-upload header, or (nil, nil) when the
 // ancestor was never opened locally and no peer is mid-upload — the caller
 // already carries its BuildData through srcHeader.Builds.

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -151,18 +151,12 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to register orchestrator status gauge: %w", err)
 	}
 
-	// Let size-based template-cache eviction skip templates that still back a
-	// running sandbox (their block devices are read live; closing them would
-	// break the sandbox). Keyed by build ID, matching the template cache key.
-	server.templateCache.SetActiveBuildIDs(func() map[string]struct{} {
-		sandboxes := server.sandboxFactory.Sandboxes.Items()
-		active := make(map[string]struct{}, len(sandboxes))
-		for _, sbx := range sandboxes {
-			active[sbx.Runtime.BuildID] = struct{}{}
-		}
-
-		return active
-	})
+	// Let size-based template-cache eviction skip templates that still back an
+	// active sandbox (their block devices are read live; closing them would
+	// break the sandbox or an in-flight pause/checkpoint). Includes stopping
+	// sandboxes, whose snapshot path still reads the template after they leave
+	// the live set. Keyed by build ID, matching the template cache key.
+	server.templateCache.SetActiveBuildIDs(server.sandboxFactory.Sandboxes.ProtectedBuildIDs)
 
 	go server.refreshStartingSandboxesLimit(ctx)
 

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -158,7 +158,7 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 	server.templateCache.SetActiveBuildIDs(func() map[string]struct{} {
 		active := server.sandboxFactory.Sandboxes.ProtectedBuildIDs()
 		if server.uploads != nil {
-			for id := range server.uploads.InFlightBuildIDs() {
+			for id := range server.uploads.ProtectedBuildIDs() {
 				active[id] = struct{}{}
 			}
 		}

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -158,7 +158,9 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 	server.templateCache.SetActiveBuildIDs(func() map[string]struct{} {
 		active := server.sandboxFactory.Sandboxes.ProtectedBuildIDs()
 		if server.uploads != nil {
-			for id := range server.uploads.ProtectedBuildIDs() {
+			ctx, cancel := context.WithTimeout(ctx, time.Second)
+			defer cancel()
+			for id := range server.uploads.ProtectedBuildIDs(ctx) {
 				active[id] = struct{}{}
 			}
 		}

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -151,12 +151,20 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to register orchestrator status gauge: %w", err)
 	}
 
-	// Let size-based template-cache eviction skip templates that still back an
-	// active sandbox (their block devices are read live; closing them would
-	// break the sandbox or an in-flight pause/checkpoint). Includes stopping
-	// sandboxes, whose snapshot path still reads the template after they leave
-	// the live set. Keyed by build ID, matching the template cache key.
-	server.templateCache.SetActiveBuildIDs(server.sandboxFactory.Sandboxes.ProtectedBuildIDs)
+	// Let size-based template-cache eviction skip templates that are still in
+	// use: backing an active or stopping sandbox (block devices read live), or
+	// with a background snapshot upload in flight (data may be local-only and
+	// served to peers). Keyed by build ID, matching the template cache key.
+	server.templateCache.SetActiveBuildIDs(func() map[string]struct{} {
+		active := server.sandboxFactory.Sandboxes.ProtectedBuildIDs()
+		if server.uploads != nil {
+			for id := range server.uploads.InFlightBuildIDs() {
+				active[id] = struct{}{}
+			}
+		}
+
+		return active
+	})
 
 	go server.refreshStartingSandboxesLimit(ctx)
 

--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -151,6 +151,19 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to register orchestrator status gauge: %w", err)
 	}
 
+	// Let size-based template-cache eviction skip templates that still back a
+	// running sandbox (their block devices are read live; closing them would
+	// break the sandbox). Keyed by build ID, matching the template cache key.
+	server.templateCache.SetActiveBuildIDs(func() map[string]struct{} {
+		sandboxes := server.sandboxFactory.Sandboxes.Items()
+		active := make(map[string]struct{}, len(sandboxes))
+		for _, sbx := range sandboxes {
+			active[sbx.Runtime.BuildID] = struct{}{}
+		}
+
+		return active
+	})
+
 	go server.refreshStartingSandboxesLimit(ctx)
 
 	return server, nil

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -208,6 +208,12 @@ var (
 	HostStatsSamplingInterval     = NewIntFlag("host-stats-sampling-interval", 5000)         // Host stats sampling interval in milliseconds (default 5s)
 	MaxCacheWriterConcurrencyFlag = NewIntFlag("max-cache-writer-concurrency", 10)
 
+	// TemplateCacheMaxMappingMiBFlag bounds the estimated retained header-mapping
+	// memory (in MiB) held by the template cache. When the total exceeds this,
+	// idle templates (no running sandbox) are evicted oldest-first, independent
+	// of the 25h TTL. 0 disables size-based eviction (TTL-only, current behavior).
+	TemplateCacheMaxMappingMiBFlag = NewIntFlag("template-cache-max-mapping-mib", 0)
+
 	// BuildCacheMaxUsagePercentage the maximum percentage of the cache disk storage
 	// that can be used before the cache starts evicting items.
 	BuildCacheMaxUsagePercentage = NewIntFlag("build-cache-max-usage-percentage", 85)

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -1,0 +1,192 @@
+package header
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+
+	"github.com/google/uuid"
+)
+
+// Mapping is the compact in-memory representation of a Header's mapping list.
+// A merged Header is cached for up to 25h, so on snapshot-heavy nodes these
+// slices dominate host RAM. It shrinks each entry from 40 bytes (a BuildMap) to
+// 14 by encoding offset/length/storage as uint32 block indices, deduplicating
+// BuildId into a per-header table addressed by uint16, and storing the columns
+// as parallel slices. Immutable; read via At / All / Slice.
+type Mapping struct {
+	blockSize uint64
+	builds    []uuid.UUID
+	offsets   []uint32
+	lengths   []uint32
+	storage   []uint32
+	buildIdx  []uint16
+}
+
+// maxBuildsPerHeader caps the per-header build-ID table at the uint16 limit.
+const maxBuildsPerHeader = 1 << 16
+
+// NewMapping packs src into the compact representation. blockSize is the unit
+// for the block indices and must divide every Offset, Length, and
+// BuildStorageOffset in src (callers pass PageSize, the universal granularity).
+func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
+	if blockSize == 0 {
+		return Mapping{}, errors.New("compact mapping: block size cannot be zero")
+	}
+	if len(src) == 0 {
+		return Mapping{blockSize: blockSize}, nil
+	}
+
+	// uint32 page-block index caps a single file at ~16 TiB (PageSize units).
+	const maxBlockIdx = (1 << 32) - 1
+
+	idxByBuild := make(map[uuid.UUID]uint16, 8)
+	builds := make([]uuid.UUID, 0, 8)
+	offsets := make([]uint32, len(src))
+	lengths := make([]uint32, len(src))
+	storage := make([]uint32, len(src))
+	buildIdx := make([]uint16, len(src))
+
+	for i, m := range src {
+		if m.Offset%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: offset %d at index %d not block-aligned to %d", m.Offset, i, blockSize)
+		}
+		if m.Length%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: length %d at index %d not block-aligned to %d", m.Length, i, blockSize)
+		}
+		if m.BuildStorageOffset%blockSize != 0 {
+			return Mapping{}, fmt.Errorf("compact mapping: build storage offset %d at index %d not block-aligned to %d", m.BuildStorageOffset, i, blockSize)
+		}
+
+		offBlocks := m.Offset / blockSize
+		lenBlocks := m.Length / blockSize
+		stoBlocks := m.BuildStorageOffset / blockSize
+		if offBlocks > maxBlockIdx || lenBlocks > maxBlockIdx || stoBlocks > maxBlockIdx {
+			return Mapping{}, fmt.Errorf("compact mapping: block index out of uint32 range at entry %d", i)
+		}
+
+		idx, ok := idxByBuild[m.BuildId]
+		if !ok {
+			if len(builds) >= maxBuildsPerHeader {
+				return Mapping{}, fmt.Errorf("compact mapping: more than %d unique build IDs", maxBuildsPerHeader)
+			}
+			idx = uint16(len(builds))
+			idxByBuild[m.BuildId] = idx
+			builds = append(builds, m.BuildId)
+		}
+
+		offsets[i] = uint32(offBlocks)
+		lengths[i] = uint32(lenBlocks)
+		storage[i] = uint32(stoBlocks)
+		buildIdx[i] = idx
+	}
+
+	return Mapping{
+		blockSize: blockSize,
+		builds:    builds,
+		offsets:   offsets,
+		lengths:   lengths,
+		storage:   storage,
+		buildIdx:  buildIdx,
+	}, nil
+}
+
+// Len returns the number of entries.
+func (m Mapping) Len() int { return len(m.offsets) }
+
+// BlockSize returns the block size used for block<->byte conversions.
+func (m Mapping) BlockSize() uint64 { return m.blockSize }
+
+// Builds returns the deduplicated build IDs referenced by the mapping. The
+// returned slice is shared with the Mapping; callers must not mutate it.
+func (m Mapping) Builds() []uuid.UUID { return m.builds }
+
+// At materializes the i-th entry as a BuildMap. Panics if i is out of range,
+// matching `mapping[i]` semantics.
+func (m Mapping) At(i int) BuildMap {
+	return BuildMap{
+		Offset:             uint64(m.offsets[i]) * m.blockSize,
+		Length:             uint64(m.lengths[i]) * m.blockSize,
+		BuildId:            m.builds[m.buildIdx[i]],
+		BuildStorageOffset: uint64(m.storage[i]) * m.blockSize,
+	}
+}
+
+// All iterates the mapping, materializing each entry as a BuildMap. This is
+// the preferred read path for callers that don't need a backing []BuildMap.
+func (m Mapping) All() iter.Seq2[int, BuildMap] {
+	return func(yield func(int, BuildMap) bool) {
+		for i := range m.offsets {
+			if !yield(i, m.At(i)) {
+				return
+			}
+		}
+	}
+}
+
+// Slice materializes the full mapping as []BuildMap (~40 bytes/entry). Use
+// sparingly — for serialization fallbacks, CLI inspection, and tests. Hot
+// paths and the cached form should use At / All instead.
+func (m Mapping) Slice() []BuildMap {
+	out := make([]BuildMap, len(m.offsets))
+	for i := range m.offsets {
+		out[i] = m.At(i)
+	}
+
+	return out
+}
+
+// Validate checks that entries are contiguous, block-aligned to blockSize, and
+// cover exactly `size` bytes. It is the compact-form equivalent of
+// ValidateMappings(m.Slice(), size, blockSize) without the materialization.
+func (m Mapping) Validate(size, blockSize uint64) error {
+	if blockSize == 0 {
+		return errors.New("mapping validation failed: zero block size")
+	}
+	// The compact form stores in m.blockSize units; if those aren't a multiple
+	// of the requested validation blockSize, fall back to the slice path so we
+	// don't miss a misalignment.
+	if m.blockSize%blockSize != 0 {
+		return ValidateMappings(m.Slice(), size, blockSize)
+	}
+
+	var currentOffset uint64
+	for i := range m.offsets {
+		offset := uint64(m.offsets[i]) * m.blockSize
+		length := uint64(m.lengths[i]) * m.blockSize
+		if currentOffset != offset {
+			return fmt.Errorf("mapping validation failed at index %d: expected offset %d (block %d), got %d (block %d)", i, currentOffset, currentOffset/blockSize, offset, offset/blockSize)
+		}
+		if currentOffset+length > size {
+			return fmt.Errorf("mapping validation failed at index %d: %d (current offset) + %d (length) > %d (size)", i, currentOffset, length, size)
+		}
+		currentOffset += length
+	}
+	if currentOffset != size {
+		return fmt.Errorf("mapping validation failed: total %d != size %d", currentOffset, size)
+	}
+
+	return nil
+}
+
+// SearchOffset returns the first index i whose byte offset is strictly greater
+// than off, matching sort.Search semantics on Offset. It compares in block
+// units, so entries are never materialized: entry.OffsetBlocks*blockSize > off
+// iff entry.OffsetBlocks > off/blockSize (integer division).
+func (m Mapping) SearchOffset(off int64) int {
+	if off < 0 || len(m.offsets) == 0 {
+		return 0
+	}
+	target := uint64(off) / m.blockSize
+	lo, hi := 0, len(m.offsets)
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if uint64(m.offsets[mid]) > target {
+			hi = mid
+		} else {
+			lo = mid + 1
+		}
+	}
+
+	return lo
+}

--- a/packages/shared/pkg/storage/header/compact.go
+++ b/packages/shared/pkg/storage/header/compact.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"math"
 
 	"github.com/google/uuid"
 )
@@ -38,7 +39,7 @@ func NewMapping(blockSize uint64, src []BuildMap) (Mapping, error) {
 	}
 
 	// uint32 page-block index caps a single file at ~16 TiB (PageSize units).
-	const maxBlockIdx = (1 << 32) - 1
+	const maxBlockIdx = math.MaxUint32
 
 	idxByBuild := make(map[uuid.UUID]uint16, 8)
 	builds := make([]uuid.UUID, 0, 8)

--- a/packages/shared/pkg/storage/header/compact_test.go
+++ b/packages/shared/pkg/storage/header/compact_test.go
@@ -1,0 +1,137 @@
+package header
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewHeader_PageGranularMappingUnderHugepageBlockSize reproduces the
+// production case: a memory file has BlockSize = 2 MiB (hugepage) but its diff
+// mappings are page-granular (4 KiB), so the header carries 4 KiB-aligned
+// offsets under a 2 MiB block size. The compact mapping must encode in PageSize
+// units, not metadata.BlockSize, or header construction fails and bricks every
+// sandbox create/resume.
+func TestNewHeader_PageGranularMappingUnderHugepageBlockSize(t *testing.T) {
+	t.Parallel()
+
+	const hugepage = uint64(2 << 20) // 2 MiB memory block size
+	a := uuid.New()
+	b := uuid.New()
+
+	// Page-granular (4 KiB) mappings, NOT aligned to the 2 MiB block size.
+	mappings := []BuildMap{
+		{Offset: 0, Length: PageSize, BuildId: a, BuildStorageOffset: 0},
+		{Offset: PageSize, Length: PageSize, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 2 * PageSize, Length: 2 * PageSize, BuildId: a, BuildStorageOffset: PageSize},
+	}
+	meta := &Metadata{Version: MetadataVersionV4, BlockSize: hugepage, Size: 4 * PageSize, BuildId: a, BaseBuildId: b}
+
+	h, err := NewHeader(meta, mappings)
+	require.NoError(t, err, "page-granular mappings under a hugepage block size must be accepted")
+	require.True(t, Equal(mappings, h.Mapping.Slice()))
+
+	// And the offset lookup must resolve correctly at page granularity.
+	m, err := h.GetShiftedMapping(t.Context(), PageSize)
+	require.NoError(t, err)
+	require.Equal(t, b, m.BuildId)
+}
+
+func TestNewMapping_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	b := uuid.New()
+	src := []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: a, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: b, BuildStorageOffset: 0},
+		{Offset: 3 * bs, Length: bs, BuildId: a, BuildStorageOffset: 2 * bs},
+	}
+
+	m, err := NewMapping(bs, src)
+	require.NoError(t, err)
+	require.Equal(t, len(src), m.Len())
+
+	require.True(t, Equal(src, m.Slice()), "Slice must round-trip the input")
+	for i, want := range src {
+		require.Equal(t, want, m.At(i), "At(%d)", i)
+	}
+
+	// Builds deduplicated to {a, b}.
+	require.ElementsMatch(t, []uuid.UUID{a, b}, m.Builds())
+}
+
+func TestNewMapping_RejectsUnaligned(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+
+	_, err := NewMapping(bs, []BuildMap{{Offset: 123, Length: bs, BuildId: id}})
+	require.ErrorContains(t, err, "offset")
+
+	_, err = NewMapping(bs, []BuildMap{{Offset: 0, Length: 123, BuildId: id}})
+	require.ErrorContains(t, err, "length")
+
+	_, err = NewMapping(bs, []BuildMap{{Offset: 0, Length: bs, BuildId: id, BuildStorageOffset: 123}})
+	require.ErrorContains(t, err, "build storage offset")
+
+	_, err = NewMapping(0, []BuildMap{{Offset: 0, Length: bs, BuildId: id}})
+	require.ErrorContains(t, err, "block size")
+}
+
+func TestMapping_SearchOffset(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	src := []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: id},
+		{Offset: 2 * bs, Length: 2 * bs, BuildId: id, BuildStorageOffset: 2 * bs},
+		{Offset: 4 * bs, Length: bs, BuildId: id, BuildStorageOffset: 4 * bs},
+	}
+	m, err := NewMapping(bs, src)
+	require.NoError(t, err)
+
+	// SearchOffset must match sort.Search over the materialized offsets for
+	// every page within range, including non-block-aligned probes.
+	for off := int64(0); off < int64(5*bs); off += int64(PageSize) {
+		want := 0
+		for _, bm := range src {
+			if int64(bm.Offset) > off {
+				break
+			}
+			want++
+		}
+		require.Equal(t, want, m.SearchOffset(off), "off=%d", off)
+	}
+
+	require.Equal(t, 0, m.SearchOffset(-1))
+}
+
+func TestMapping_Validate(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	id := uuid.New()
+	size := 4 * bs
+	m, err := NewMapping(bs, []BuildMap{
+		{Offset: 0, Length: 2 * bs, BuildId: id},
+		{Offset: 2 * bs, Length: 2 * bs, BuildId: id, BuildStorageOffset: 2 * bs},
+	})
+	require.NoError(t, err)
+	require.NoError(t, m.Validate(size, bs))
+
+	// Wrong size is rejected.
+	require.Error(t, m.Validate(size+bs, bs))
+
+	// A gap is rejected.
+	gap, err := NewMapping(bs, []BuildMap{
+		{Offset: 0, Length: bs, BuildId: id},
+		{Offset: 2 * bs, Length: bs, BuildId: id, BuildStorageOffset: 2 * bs},
+	})
+	require.NoError(t, err)
+	require.Error(t, gap.Validate(3*bs, bs))
+}

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"sort"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -34,7 +33,10 @@ type Header struct {
 	// RPC and reads uncompressed data when nil.
 	Builds map[uuid.UUID]BuildData
 
-	Mapping []BuildMap
+	// Mapping is the per-block source map. Stored compactly (~14 B/entry vs 40
+	// for a BuildMap) so long-lived cached headers don't dominate orchestrator
+	// heap. Read via At / All / Slice / Len, not indexing.
+	Mapping Mapping
 
 	// IncompletePendingUpload is set on diff headers produced by ToDiffHeader and
 	// cleared on the finalized headers swapped in by the upload pipeline. It
@@ -81,17 +83,23 @@ func NewHeader(metadata *Metadata, mapping []BuildMap) (*Header, error) {
 	}
 
 	if len(mapping) == 0 {
+		length := (metadata.Size + PageSize - 1) / PageSize * PageSize
 		mapping = []BuildMap{{
 			Offset:             0,
-			Length:             metadata.Size,
+			Length:             length,
 			BuildId:            metadata.BuildId,
 			BuildStorageOffset: 0,
 		}}
 	}
 
+	compact, err := NewMapping(PageSize, mapping)
+	if err != nil {
+		return nil, fmt.Errorf("compact mapping: %w", err)
+	}
+
 	return &Header{
 		Metadata: metadata,
-		Mapping:  mapping,
+		Mapping:  compact,
 	}, nil
 }
 
@@ -102,13 +110,10 @@ func newDiffHeader(metadata *Metadata, mapping []BuildMap, sourceBuilds map[uuid
 	}
 
 	if sourceBuilds != nil {
-		referenced := make(map[uuid.UUID]struct{}, len(h.Mapping))
-		for _, m := range h.Mapping {
-			referenced[m.BuildId] = struct{}{}
-		}
-
-		h.Builds = make(map[uuid.UUID]BuildData, len(referenced))
-		for id := range referenced {
+		// h.Mapping.Builds() is already deduped at NewMapping construction;
+		// no need for an oversized temp set keyed by len(mapping).
+		h.Builds = make(map[uuid.UUID]BuildData, len(sourceBuilds))
+		for _, id := range h.Mapping.Builds() {
 			if bd, ok := sourceBuilds[id]; ok {
 				h.Builds[id] = bd
 			}
@@ -131,7 +136,7 @@ func (t *Header) String() string {
 		t.Metadata.BlockSize,
 		t.Metadata.Generation,
 		t.Metadata.BuildId.String(),
-		len(t.Mapping),
+		t.Mapping.Len(),
 	)
 }
 
@@ -183,10 +188,10 @@ func (t *Header) GetBuildFrameData(buildID uuid.UUID) *storage.FrameTable {
 	return t.Builds[buildID].FrameData
 }
 
-func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64, error) {
+func (t *Header) getMapping(ctx context.Context, offset int64) (BuildMap, int64, error) {
 	if offset < 0 || offset >= int64(t.Metadata.Size) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is out of bounds (size: %d)", offset, t.Metadata.Size)
 		}
 
 		logger.L().Warn(ctx, "offset is out of bounds, but normalize fix is not applied",
@@ -197,7 +202,7 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 	}
 	if offset%PageSize != 0 {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
+			return BuildMap{}, 0, fmt.Errorf("offset %d is not aligned to page size %d", offset, PageSize)
 		}
 
 		logger.L().Warn(ctx, "offset is not aligned to page size, but normalize fix is not applied",
@@ -207,21 +212,18 @@ func (t *Header) getMapping(ctx context.Context, offset int64) (*BuildMap, int64
 		)
 	}
 
-	i := sort.Search(len(t.Mapping), func(i int) bool {
-		return int64(t.Mapping[i].Offset) > offset
-	})
-
+	i := t.Mapping.SearchOffset(offset)
 	if i == 0 {
-		return nil, 0, fmt.Errorf("no source found for offset %d", offset)
+		return BuildMap{}, 0, fmt.Errorf("no source found for offset %d", offset)
 	}
 
-	mapping := &t.Mapping[i-1]
+	mapping := t.Mapping.At(i - 1)
 	shift := offset - int64(mapping.Offset)
 
 	// Verify that the offset falls within this mapping's range
 	if shift >= int64(mapping.Length) {
 		if t.IsNormalizeFixApplied() {
-			return nil, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
+			return BuildMap{}, 0, fmt.Errorf("offset %d is beyond the end of mapping at offset %d (ends at %d)",
 				offset, mapping.Offset, mapping.Offset+mapping.Length)
 		}
 
@@ -254,12 +256,12 @@ func ValidateHeader(h *Header) error {
 	if h.Metadata.Size == 0 {
 		return errors.New("header has zero size")
 	}
-	if len(h.Mapping) == 0 {
+	if h.Mapping.Len() == 0 {
 		return errors.New("header has no mappings")
 	}
 
 	// Sort mappings by offset to check for gaps/overlaps
-	sortedMappings := slices.Clone(h.Mapping)
+	sortedMappings := h.Mapping.Slice()
 	slices.SortFunc(sortedMappings, func(a, b BuildMap) int {
 		return cmp.Compare(a.Offset, b.Offset)
 	})
@@ -300,7 +302,7 @@ func ValidateHeader(h *Header) error {
 	}
 
 	// Validate individual mapping bounds
-	for i, m := range h.Mapping {
+	for i, m := range h.Mapping.All() {
 		if m.Offset > h.Metadata.Size {
 			return fmt.Errorf("mapping[%d] has Offset %d beyond header size %d for buildId %s",
 				i, m.Offset, h.Metadata.Size, m.BuildId.String())

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -135,8 +135,12 @@ func (d *DiffMetadata) ToDiffHeader(
 
 	diffMapping := d.toDiffMapping(ctx, buildID)
 
+	// MergeMappings/NormalizeMappings operate on []BuildMap (transient).
+	// originalHeader.Mapping is the compact cached form; materialize it once
+	// here. The intermediate slice is short-lived (released after the new
+	// compact header is built below).
 	m := MergeMappings(
-		originalHeader.Mapping,
+		originalHeader.Mapping.Slice(),
 		diffMapping,
 	)
 	telemetry.ReportEvent(ctx, "merged mappings")
@@ -164,7 +168,7 @@ func (d *DiffMetadata) ToDiffHeader(
 	}
 
 	// Dedup emits PageSize-granular mappings; validate at PageSize.
-	err = ValidateMappings(header.Mapping, header.Metadata.Size, PageSize)
+	err = header.Mapping.Validate(header.Metadata.Size, PageSize)
 	if err != nil {
 		if header.IsNormalizeFixApplied() {
 			return nil, fmt.Errorf("invalid header mappings: %w", err)

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -71,7 +71,15 @@ func TestDeserialize_AboveOldCapRoundTrips(t *testing.T) {
 	v4MaxUncompressedHeaderSize = orig
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
-	require.Len(t, got.Mapping, 1000)
+	require.Equal(t, 1000, got.Mapping.Len())
+}
+
+func mustMapping(t *testing.T, blockSize uint64, src []BuildMap) Mapping {
+	t.Helper()
+	m, err := NewMapping(blockSize, src)
+	require.NoError(t, err)
+
+	return m
 }
 
 func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
@@ -99,27 +107,27 @@ func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 			Offset:             4096,
 			Length:             4096,
 			BuildId:            baseID,
-			BuildStorageOffset: 123,
+			BuildStorageOffset: 8192,
 		},
 	}
 
-	data, err := serializeV3(metadata, mappings)
+	data, err := serializeV3(metadata, mustMapping(t, metadata.BlockSize, mappings))
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
 	require.Equal(t, metadata, got.Metadata)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[0].Length)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, uint64(0), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(0).Length)
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, uint64(0), got.Mapping.At(0).BuildStorageOffset)
 
-	require.Equal(t, uint64(4096), got.Mapping[1].Offset)
-	require.Equal(t, uint64(4096), got.Mapping[1].Length)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
-	require.Equal(t, uint64(123), got.Mapping[1].BuildStorageOffset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Offset)
+	require.Equal(t, uint64(4096), got.Mapping.At(1).Length)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
+	require.Equal(t, uint64(8192), got.Mapping.At(1).BuildStorageOffset)
 
 	// V3 headers have no Builds
 	require.Nil(t, got.Builds)
@@ -145,17 +153,17 @@ func TestSerializeDeserialize_EmptyMappings_Defaults(t *testing.T) {
 		BaseBuildId: uuid.New(),
 	}
 
-	data, err := serializeV3(metadata, nil)
+	data, err := serializeV3(metadata, Mapping{})
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
 	// NewHeader creates a default mapping when none provided
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(0), got.Mapping[0].Offset)
-	require.Equal(t, metadata.Size, got.Mapping[0].Length)
-	require.Equal(t, metadata.BuildId, got.Mapping[0].BuildId)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(0), got.Mapping.At(0).Offset)
+	require.Equal(t, metadata.Size, got.Mapping.At(0).Length)
+	require.Equal(t, metadata.BuildId, got.Mapping.At(0).BuildId)
 }
 
 func TestDeserialize_BlockSizeZero(t *testing.T) {
@@ -170,7 +178,7 @@ func TestDeserialize_BlockSizeZero(t *testing.T) {
 		BaseBuildId: uuid.New(),
 	}
 
-	data, err := serializeV3(metadata, nil)
+	data, err := serializeV3(metadata, Mapping{})
 	require.NoError(t, err)
 
 	_, err = DeserializeBytes(data)
@@ -229,9 +237,9 @@ func TestSerializeDeserialize_V4_WithFrameTable(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 2)
-	require.Equal(t, buildID, got.Mapping[0].BuildId)
-	require.Equal(t, baseID, got.Mapping[1].BuildId)
+	require.Equal(t, 2, got.Mapping.Len())
+	require.Equal(t, buildID, got.Mapping.At(0).BuildId)
+	require.Equal(t, baseID, got.Mapping.At(1).BuildId)
 
 	// Builds round-trip
 	require.Len(t, got.Builds, 2)
@@ -300,8 +308,8 @@ func TestSerializeDeserialize_V4_Zstd(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
-	require.Equal(t, uint64(8192), got.Mapping[0].BuildStorageOffset)
+	require.Equal(t, 1, got.Mapping.Len())
+	require.Equal(t, uint64(8192), got.Mapping.At(0).BuildStorageOffset)
 
 	require.Len(t, got.Builds, 1)
 	fd := got.Builds[buildID].FrameData
@@ -353,7 +361,7 @@ func TestSerializeDeserialize_V4_NoFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 2)
+	require.Equal(t, 2, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -397,7 +405,7 @@ func TestSerializeDeserialize_V4_ManyFrames(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.NotNil(t, got.Builds)
 	fd := got.Builds[buildID].FrameData
 	require.NotNil(t, fd)
@@ -444,7 +452,7 @@ func TestSerializeDeserialize_V4_NoBuilds(t *testing.T) {
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.Len(t, got.Mapping, 1)
+	require.Equal(t, 1, got.Mapping.Len())
 	require.Nil(t, got.Builds)
 }
 
@@ -508,7 +516,7 @@ func TestSerializeDeserialize_V4_MultiBuild_LocateCompressed(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 3)
+	require.Equal(t, 3, got.Mapping.Len())
 	require.Len(t, got.Builds, 2)
 
 	// Verify checksums round-trip.
@@ -842,7 +850,7 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(MetadataVersionV4), got.Metadata.Version)
-	require.Len(t, got.Mapping, 5)
+	require.Equal(t, 5, got.Mapping.Len())
 	require.Len(t, got.Builds, 3)
 
 	require.Nil(t, got.GetBuildFrameData(selfID))
@@ -858,11 +866,11 @@ func TestSerializeDeserialize_V4_MixedChain(t *testing.T) {
 	_, hasV3b := got.Builds[v3bID]
 	require.False(t, hasV3b)
 
-	require.Equal(t, selfID, got.Mapping[0].BuildId)
-	require.Equal(t, midID, got.Mapping[1].BuildId)
-	require.Equal(t, olderID, got.Mapping[2].BuildId)
-	require.Equal(t, v3aID, got.Mapping[3].BuildId)
-	require.Equal(t, v3bID, got.Mapping[4].BuildId)
+	require.Equal(t, selfID, got.Mapping.At(0).BuildId)
+	require.Equal(t, midID, got.Mapping.At(1).BuildId)
+	require.Equal(t, olderID, got.Mapping.At(2).BuildId)
+	require.Equal(t, v3aID, got.Mapping.At(3).BuildId)
+	require.Equal(t, v3bID, got.Mapping.At(4).BuildId)
 }
 
 // Layered chain with a compressed self entry:
@@ -972,7 +980,7 @@ func TestDeserialize_V3_StaysV3(t *testing.T) {
 	}
 	mappings := []BuildMap{{Offset: 0, Length: 4096, BuildId: buildID}}
 
-	data, err := serializeV3(metadata, mappings)
+	data, err := serializeV3(metadata, mustMapping(t, metadata.BlockSize, mappings))
 	require.NoError(t, err)
 
 	got, err := DeserializeBytes(data)

--- a/packages/shared/pkg/storage/header/serialization_v3.go
+++ b/packages/shared/pkg/storage/header/serialization_v3.go
@@ -16,14 +16,14 @@ type v3SerializableBuildMap struct {
 }
 
 // serializeV3 writes [Metadata] [v3 mappings…] with no length prefix.
-func serializeV3(metadata *Metadata, mappings []BuildMap) ([]byte, error) {
+func serializeV3(metadata *Metadata, mappings Mapping) ([]byte, error) {
 	var buf bytes.Buffer
 
 	if err := binary.Write(&buf, binary.LittleEndian, metadata); err != nil {
 		return nil, fmt.Errorf("failed to write metadata: %w", err)
 	}
 
-	for _, mapping := range mappings {
+	for _, mapping := range mappings.All() {
 		v3 := &v3SerializableBuildMap{
 			Offset:             mapping.Offset,
 			Length:             mapping.Length,

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -53,7 +53,7 @@ type v4SerializableBuildInfo struct {
 // serializeV4 writes [Metadata] [uint8 flags] [uint32 LZ4 size] [LZ4( Builds[] + Mappings[] )].
 // Frame tables are sparse-trimmed to only frames referenced by mappings.
 // Also returns the uncompressed inner-block size (LZ4 input length).
-func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []BuildMap, incomplete bool) ([]byte, int64, error) {
+func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings Mapping, incomplete bool) ([]byte, int64, error) {
 	var metaBuf bytes.Buffer
 	if err := binary.Write(&metaBuf, binary.LittleEndian, metadata); err != nil {
 		return nil, 0, fmt.Errorf("failed to write metadata: %w", err)
@@ -94,11 +94,11 @@ func serializeV4(metadata *Metadata, builds map[uuid.UUID]BuildData, mappings []
 		}
 	}
 
-	if err := binary.Write(&block, binary.LittleEndian, uint32(len(mappings))); err != nil {
+	if err := binary.Write(&block, binary.LittleEndian, uint32(mappings.Len())); err != nil {
 		return nil, 0, fmt.Errorf("failed to write mappings count: %w", err)
 	}
 
-	for _, mapping := range mappings {
+	for _, mapping := range mappings.All() {
 		v4 := &v4SerializableBuildMap{
 			Offset:             mapping.Offset,
 			Length:             mapping.Length,
@@ -246,9 +246,9 @@ func compressLZ4(data []byte) ([]byte, error) {
 
 // extractRelevantRanges groups mappings into per-build U-space [start, end) ranges
 // for sparse frame table trimming during serialization.
-func extractRelevantRanges(mappings []BuildMap) map[uuid.UUID][]storage.Range {
+func extractRelevantRanges(mappings Mapping) map[uuid.UUID][]storage.Range {
 	ranges := make(map[uuid.UUID][]storage.Range)
-	for _, m := range mappings {
+	for _, m := range mappings.All() {
 		ranges[m.BuildId] = append(ranges[m.BuildId], storage.Range{
 			Offset: int64(m.BuildStorageOffset),
 			Length: int(m.Length),


### PR DESCRIPTION
Stacked on #2844. Bound the template cache by estimated retained mapping memory: a sweeper evicts idle templates oldest-first when the estimate exceeds a feature-flag budget (`TemplateCacheMaxMappingMiBFlag`, default 0 = disabled). Eviction skips templates backing active/stopping sandboxes, in-flight uploads, peer-active builds, and just-handed-out entries; same-key refetches wait for eviction cleanup to finish.