### PR TITLE
fix(header): guard header size cap on write and raise read cap to 256 MiB

### DIFF
--- a/packages/shared/pkg/storage/header/serialization.go
+++ b/packages/shared/pkg/storage/header/serialization.go
@@ -85,6 +85,15 @@ func StoreHeader(ctx context.Context, s storage.StorageProvider, path string, h 
 		if err != nil {
 			return storage.CompressConfig{}, 0, 0, fmt.Errorf("serialize header: %w", err)
 		}
+
+		// Guard the read-side cap on the write path. The cap is enforced in
+		// deserializeV4; without this symmetric check an oversize header would
+		// upload successfully and then fail every restore, permanently bricking
+		// the snapshot. Fail the Pause loudly instead.
+		if blockUncompressed > int64(v4MaxUncompressedHeaderSize) {
+			return storage.CompressConfig{}, 0, 0, fmt.Errorf("refusing to persist header for %s: uncompressed block %d exceeds cap %d", path, blockUncompressed, v4MaxUncompressedHeaderSize)
+		}
+
 		uncompressed = int64(metadataSize+v4FlagsLen+v4SizePrefixLen) + blockUncompressed
 		cfg.Type = storage.CompressionLZ4.String()
 	}

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -10,6 +10,71 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
+// fragmentedHeader builds a V4 header with n alternating-build mappings so its
+// uncompressed block is large and incompressible enough to exercise the cap.
+func fragmentedHeader(t *testing.T, n int) *Header {
+	t.Helper()
+	bs := uint64(4096)
+	a, b := uuid.New(), uuid.New()
+	mappings := make([]BuildMap, n)
+	var off, sa, sb uint64
+	for i := range mappings {
+		id, so := a, sa
+		if i%2 == 1 {
+			id, so = b, sb
+		}
+		mappings[i] = BuildMap{Offset: off, Length: bs, BuildId: id, BuildStorageOffset: so}
+		off += bs
+		if i%2 == 0 {
+			sa += bs
+		} else {
+			sb += bs
+		}
+	}
+	meta := &Metadata{Version: MetadataVersionV4, BlockSize: bs, Size: off, BuildId: a, BaseBuildId: b}
+	h, err := NewHeader(meta, mappings)
+	require.NoError(t, err)
+	h.Builds = map[uuid.UUID]BuildData{a: {Size: int64(sa)}, b: {Size: int64(sb)}}
+	return h
+}
+
+func TestStoreHeader_RejectsOversizeOnWrite(t *testing.T) {
+	// No t.Parallel: mutates the package-global cap, which parallel tests read.
+
+	orig := v4MaxUncompressedHeaderSize
+	v4MaxUncompressedHeaderSize = 1024
+	t.Cleanup(func() { v4MaxUncompressedHeaderSize = orig })
+
+	// The guard returns before the storage provider is used, so a nil provider
+	// is fine for the rejection path.
+	h := fragmentedHeader(t, 100)
+	_, _, _, err := StoreHeader(t.Context(), nil, "header", h)
+	require.ErrorContains(t, err, "exceeds cap")
+}
+
+func TestDeserialize_AboveOldCapRoundTrips(t *testing.T) {
+	// No t.Parallel: mutates the package-global cap, which parallel tests read.
+
+	// A header above a lowered cap is rejected on read; raising the cap lets it
+	// round-trip. Mirrors raising the production cap so already-uploaded large
+	// headers become resumable again.
+	orig := v4MaxUncompressedHeaderSize
+	v4MaxUncompressedHeaderSize = 4096
+	t.Cleanup(func() { v4MaxUncompressedHeaderSize = orig })
+
+	h := fragmentedHeader(t, 1000) // ~40 KiB uncompressed block, over the 4 KiB cap
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+
+	_, err = DeserializeBytes(data)
+	require.ErrorContains(t, err, "exceeds cap")
+
+	v4MaxUncompressedHeaderSize = orig
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+	require.Len(t, got.Mapping, 1000)
+}
+
 func TestSerializeDeserialize_V3_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/packages/shared/pkg/storage/header/serialization_test.go
+++ b/packages/shared/pkg/storage/header/serialization_test.go
@@ -35,12 +35,12 @@ func fragmentedHeader(t *testing.T, n int) *Header {
 	h, err := NewHeader(meta, mappings)
 	require.NoError(t, err)
 	h.Builds = map[uuid.UUID]BuildData{a: {Size: int64(sa)}, b: {Size: int64(sb)}}
+
 	return h
 }
 
+//nolint:paralleltest // mutates the package-global cap; must not run in parallel
 func TestStoreHeader_RejectsOversizeOnWrite(t *testing.T) {
-	// No t.Parallel: mutates the package-global cap, which parallel tests read.
-
 	orig := v4MaxUncompressedHeaderSize
 	v4MaxUncompressedHeaderSize = 1024
 	t.Cleanup(func() { v4MaxUncompressedHeaderSize = orig })
@@ -48,13 +48,12 @@ func TestStoreHeader_RejectsOversizeOnWrite(t *testing.T) {
 	// The guard returns before the storage provider is used, so a nil provider
 	// is fine for the rejection path.
 	h := fragmentedHeader(t, 100)
-	_, _, _, err := StoreHeader(t.Context(), nil, "header", h)
+	_, _, _, err := StoreHeader(t.Context(), nil, "header", h) //nolint:dogsled // only err matters
 	require.ErrorContains(t, err, "exceeds cap")
 }
 
+//nolint:paralleltest // mutates the package-global cap; must not run in parallel
 func TestDeserialize_AboveOldCapRoundTrips(t *testing.T) {
-	// No t.Parallel: mutates the package-global cap, which parallel tests read.
-
 	// A header above a lowered cap is rejected on read; raising the cap lets it
 	// round-trip. Mirrors raising the production cap so already-uploaded large
 	// headers become resumable again.

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -21,7 +21,13 @@ const v4SizePrefixLen = 4
 // v4FlagsLen is the length of the V4 flags byte. Bit 0 = IncompletePendingUpload.
 const v4FlagsLen = 1
 
-const v4MaxUncompressedHeaderSize = 64 << 20
+// v4MaxUncompressedHeaderSize caps the uncompressed V4 header block as an
+// anti-decompression-bomb guard (decompressLZ4 keeps the actual overrun bound).
+// Raised from 64 MiB to 256 MiB: a page-granular memfile diff can legitimately
+// produce a header above 64 MiB, and the old cap rejected such headers only on
+// read, permanently stranding already-uploaded snapshots whose data files are
+// intact. A var (not const) so tests can lower it cheaply.
+var v4MaxUncompressedHeaderSize = 256 << 20
 
 // v4FlagIncomplete is bit 0 of the V4 flags byte: when set, the header
 // describes a build whose upload has not yet finalized (an in-flight diff).
@@ -134,7 +140,7 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	flags := blockData[0]
 	size := binary.LittleEndian.Uint32(blockData[v4FlagsLen:])
-	if size > v4MaxUncompressedHeaderSize {
+	if int(size) > v4MaxUncompressedHeaderSize {
 		return nil, fmt.Errorf("v4 header uncompressed size %d exceeds cap %d", size, v4MaxUncompressedHeaderSize)
 	}
 

--- a/packages/shared/pkg/storage/header/serialization_v4.go
+++ b/packages/shared/pkg/storage/header/serialization_v4.go
@@ -140,7 +140,7 @@ func deserializeV4(metadata *Metadata, blockData []byte) (*Header, error) {
 
 	flags := blockData[0]
 	size := binary.LittleEndian.Uint32(blockData[v4FlagsLen:])
-	if int(size) > v4MaxUncompressedHeaderSize {
+	if uint64(size) > uint64(v4MaxUncompressedHeaderSize) {
 		return nil, fmt.Errorf("v4 header uncompressed size %d exceeds cap %d", size, v4MaxUncompressedHeaderSize)
 	}
 


### PR DESCRIPTION
The 64 MiB uncompressed-header cap was enforced only on read, so an oversize header (a page-granular memfile diff can exceed it) uploaded fine and then failed every restore, bricking the snapshot. Add a symmetric write-side guard in `StoreHeader` and raise the read cap to 256 MiB (keeping the `decompressLZ4` overrun bound) so already-uploaded large headers resume again.