### PR TITLE
feat(gcp): log sandbox routing headers

### DIFF
--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -670,6 +670,40 @@ resource "google_compute_security_policy_rule" "sandbox-throttling-host" {
   }
 }
 
+resource "google_compute_security_policy_rule" "sandbox-routing-headers-log" {
+  security_policy = google_compute_security_policy.default["session"].name
+  description     = "Log sandbox routing headers"
+
+  action   = "throttle"
+  priority = "250"
+  preview  = true
+  match {
+    expr {
+      expression = "has(request.headers['e2b-sandbox-id']) && has(request.headers['e2b-sandbox-port'])"
+    }
+  }
+
+  rate_limit_options {
+    conform_action = "allow"
+    exceed_action  = "deny(429)"
+
+    enforce_on_key_configs {
+      enforce_on_key_name = "E2b-Sandbox-Id"
+      enforce_on_key_type = "HTTP_HEADER"
+    }
+
+    enforce_on_key_configs {
+      enforce_on_key_name = "E2b-Sandbox-Port"
+      enforce_on_key_type = "HTTP_HEADER"
+    }
+
+    rate_limit_threshold {
+      count        = 1000000
+      interval_sec = 60
+    }
+  }
+}
+
 resource "google_compute_security_policy_rule" "sandbox-throttling-ip" {
   security_policy = google_compute_security_policy.default["session"].name
   action          = "throttle"

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -688,12 +688,12 @@ resource "google_compute_security_policy_rule" "sandbox-routing-headers-log" {
     exceed_action  = "deny(429)"
 
     enforce_on_key_configs {
-      enforce_on_key_name = "E2b-Sandbox-Id"
+      enforce_on_key_name = "e2b-sandbox-id"
       enforce_on_key_type = "HTTP_HEADER"
     }
 
     enforce_on_key_configs {
-      enforce_on_key_name = "E2b-Sandbox-Port"
+      enforce_on_key_name = "e2b-sandbox-port"
       enforce_on_key_type = "HTTP_HEADER"
     }
 


### PR DESCRIPTION
## Summary
- Add a preview-only Cloud Armor throttle rule on the sandbox session backend.
- Use E2b-Sandbox-Id and E2b-Sandbox-Port as rate-limit keys so values appear in http_load_balancer logs.

## Testing
- terraform fmt -check -diff iac/provider-gcp/nomad-cluster/network/main.tf
- terraform validate not run successfully: providers are not installed in this checkout; terraform init is required.