### PR TITLE
perf(orch): metrics for dirty page throttling

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -258,8 +258,14 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, mmapSlic
 		// Read in batches of max(blockSize, minReadBatchSize) to align notification
 		// granularity with the read size and minimize lock/notify overhead.
 		readEnd := min(totalRead+readBatch, s.chunkLen)
+		sw := c.metrics.WriteChunksTimerFactory.Begin()
 		n, readErr := io.ReadFull(reader, mmapSlice[totalRead:readEnd])
 		totalRead += int64(n)
+		if readErr == nil || totalRead >= s.chunkLen {
+			sw.RecordRaw(ctx, int64(n), writeSuccessAttr)
+		} else {
+			sw.RecordRaw(ctx, int64(n), writeFailureAttr)
+		}
 
 		if n > 0 {
 			// Dirty marking is deferred to runFetch after the full chunk is fetched.
@@ -327,6 +333,12 @@ func (c *Chunker) IsCached(_ context.Context, off, length int64) bool {
 func (c *Chunker) FileSize(ctx context.Context) (int64, error) {
 	return c.cache.FileSize(ctx)
 }
+
+// writeSuccessAttr and writeFailureAttr are pre-allocated result attributes for mmap write observations.
+var (
+	writeSuccessAttr = telemetry.PrecomputeAttrs(telemetry.Success)
+	writeFailureAttr = telemetry.PrecomputeAttrs(telemetry.Failure)
+)
 
 const (
 	compressedAttr = "compressed"

--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -66,7 +67,66 @@ var (
 	fcBlockRateLimiterEventCount = utils.Must(telemetry.GetHistogram(fcMeter, telemetry.SandboxFCBlockRateLimiterEventCount))
 	fcBlockIOEngineThrottled     = utils.Must(telemetry.GetHistogram(fcMeter, telemetry.SandboxFCBlockIOEngineThrottled))
 	fcBlockRemainingReqs         = utils.Must(telemetry.GetHistogram(fcMeter, telemetry.SandboxFCBlockRemainingReqs))
+
+	// Counter incremented by the stalled thread count at each 1 s poll.
+	// rate() of this counter shows throttle intensity in real-time and
+	// distinguishes dirty-page throttle (non-zero rate) from GCS cold cache
+	// (zero rate) without requiring a Tempo trace lookup.
+	balanceDirtyPageThreads = utils.Must(telemetry.GetCounter(fcMeter, telemetry.OrchestratorHostBalanceDirtyPagesThreads))
 )
+
+// dirtyPollInterval is how often monitorDirtyPageThrottle samples wchan entries.
+// 1 s gives adequate resolution for stall episodes that last several seconds,
+// and is consistent with other host-level pollers in pkg/metrics/host.go.
+const dirtyPollInterval = 1 * time.Second
+
+// balanceDirtyPagesWchan is the kernel wait-channel symbol written to
+// /proc/self/task/*/wchan when a thread is parked in balance_dirty_pages.
+// Fires for both per-BDI and global dirty-page throttle regardless of the
+// global dirty/MemTotal ratio, making it the only reliable userspace signal
+// for per-BDI throttle on large-RAM nodes.
+const balanceDirtyPagesWchan = "balance_dirty_pages"
+
+// countBalanceDirtyThreads returns the number of OS threads of the current
+// process currently stalled in balance_dirty_pages by reading
+// /proc/self/task/*/wchan. Returns 0 on any read error.
+func countBalanceDirtyThreads() int {
+	pid := os.Getpid()
+	entries, err := os.ReadDir(fmt.Sprintf("/proc/%d/task", pid))
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		data, err := os.ReadFile(fmt.Sprintf("/proc/%d/task/%s/wchan", pid, e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(data)) == balanceDirtyPagesWchan {
+			n++
+		}
+	}
+
+	return n
+}
+
+func init() {
+	go monitorDirtyPageThrottle()
+}
+
+// monitorDirtyPageThrottle runs for the lifetime of the process, sampling
+// balance_dirty_pages thread counts every dirtyPollInterval and incrementing
+// balanceDirtyPageThreads. rate() of the counter gives real-time throttle
+// intensity; 0 means no dirty-page stalls are occurring.
+func monitorDirtyPageThrottle() {
+	ticker := time.NewTicker(dirtyPollInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if n := countBalanceDirtyThreads(); n > 0 {
+			balanceDirtyPageThreads.Add(context.Background(), int64(n))
+		}
+	}
+}
 
 // firecrackerNetMetrics is a subset of Firecracker's NetDeviceMetrics we export via OTEL.
 // Full metric list: https://github.com/firecracker-microvm/firecracker/blob/main/docs/metrics.md

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -26,6 +26,10 @@ const (
 	TeamSandboxCreated CounterType = "e2b.team.sandbox.created"
 
 	EnvdInitCalls CounterType = "orchestrator.sandbox.envd.init.calls"
+	// Incremented by the balance_dirty_pages thread count at every 200 ms poll
+	// for the lifetime of the process. rate() shows dirty-page throttle
+	// intensity in real-time; 0 when no stalls are occurring.
+	OrchestratorHostBalanceDirtyPagesThreads CounterType = "orchestrator.host.balance_dirty_pages.threads"
 
 	OrchestratorSandboxKilledCounterName CounterType = "orchestrator.sandbox.killed"
 
@@ -162,16 +166,17 @@ const (
 )
 
 var counterDesc = map[CounterType]string{
-	SandboxCreateMeterName:               "Number of currently waiting requests to create a new sandbox",
-	ApiOrchestratorCreatedSandboxes:      "Number of successfully created sandboxes",
-	BuildResultCounterName:               "Number of template build results",
-	BuildCacheResultCounterName:          "Number of build cache results",
-	TeamSandboxCreated:                   "Counter of started sandboxes for the team in the interval",
-	EnvdInitCalls:                        "Number of envd initialization calls",
-	OrchestratorSandboxKilledCounterName: "Number of sandboxes killed, labeled by kill reason",
-	TCPFirewallConnectionsTotal:          "Total number of TCP firewall connections processed",
-	TCPFirewallErrorsTotal:               "Total number of TCP firewall errors",
-	TCPFirewallDecisionsTotal:            "Total number of TCP firewall allow/block decisions",
+	SandboxCreateMeterName:                   "Number of currently waiting requests to create a new sandbox",
+	ApiOrchestratorCreatedSandboxes:          "Number of successfully created sandboxes",
+	BuildResultCounterName:                   "Number of template build results",
+	BuildCacheResultCounterName:              "Number of build cache results",
+	TeamSandboxCreated:                       "Counter of started sandboxes for the team in the interval",
+	OrchestratorHostBalanceDirtyPagesThreads: "Cumulative stalled thread-polls during sandbox resume; rate() gives throttle intensity",
+	EnvdInitCalls:                            "Number of envd initialization calls",
+	OrchestratorSandboxKilledCounterName:     "Number of sandboxes killed, labeled by kill reason",
+	TCPFirewallConnectionsTotal:              "Total number of TCP firewall connections processed",
+	TCPFirewallErrorsTotal:                   "Total number of TCP firewall errors",
+	TCPFirewallDecisionsTotal:                "Total number of TCP firewall allow/block decisions",
 
 	IngressProxyConnectionsBlockedTotal: "Total number of ingress proxy connections blocked by connection limit",
 	CmuxErrorsTotal:                     "Total number of cmux connection multiplexer errors",
@@ -188,16 +193,17 @@ var counterDesc = map[CounterType]string{
 }
 
 var counterUnits = map[CounterType]string{
-	SandboxCreateMeterName:               "{sandbox}",
-	ApiOrchestratorCreatedSandboxes:      "{sandbox}",
-	BuildResultCounterName:               "{build}",
-	BuildCacheResultCounterName:          "{layer}",
-	TeamSandboxCreated:                   "{sandbox}",
-	EnvdInitCalls:                        "1",
-	OrchestratorSandboxKilledCounterName: "{sandbox}",
-	TCPFirewallConnectionsTotal:          "{connection}",
-	TCPFirewallErrorsTotal:               "{error}",
-	TCPFirewallDecisionsTotal:            "{decision}",
+	SandboxCreateMeterName:                   "{sandbox}",
+	ApiOrchestratorCreatedSandboxes:          "{sandbox}",
+	BuildResultCounterName:                   "{build}",
+	BuildCacheResultCounterName:              "{layer}",
+	TeamSandboxCreated:                       "{sandbox}",
+	OrchestratorHostBalanceDirtyPagesThreads: "{thread}",
+	EnvdInitCalls:                            "1",
+	OrchestratorSandboxKilledCounterName:     "{sandbox}",
+	TCPFirewallConnectionsTotal:              "{connection}",
+	TCPFirewallErrorsTotal:                   "{error}",
+	TCPFirewallDecisionsTotal:                "{decision}",
 
 	IngressProxyConnectionsBlockedTotal: "{connection}",
 	CmuxErrorsTotal:                     "{error}",


### PR DESCRIPTION
# Summary

## Problem

When resuming a sandbox with a large memory snapshot (e.g. 32 GB), the
orchestrator creates two mmap-backed caches backed by sparse files on the
host's NVMe RAID:

- a read-through cache that materialises memfile chunks fetched from
  remote storage as Firecracker takes page faults;
- a copy-on-write overlay cache that captures guest writes to the rootfs.

Writing tens of gigabytes of dirty pages into block-device-backed files
triggers Linux's per-BDI dirty-page throttle (`balance_dirty_pages`).
The kernel stalls the goroutines doing the writes until the writeback
daemon catches up, blocking the entire resume for ~64 s — roughly 4× longer than the
actual I/O work.

## What this PR adds

**Metrics** (always on, no flag required):

- `orchestrator.blocks.chunks.store` — native histogram of the time to
  fetch each batch of data from remote storage and write it into the
  local mmap cache. During a throttled resume the p99 spikes to
  300–600 ms while the p50 stays low; this ratio is the primary
  diagnostic signal.
- `orchestrator.host.balance_dirty_pages.threads` — counter of kernel
  dirty-page throttle polls observed by the process. A non-zero rate
  confirms the throttle is active; zero rules it out as the cause of
  slow resumes.