### PR TITLE
fix(uffd): dedupe deferred page faults

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -9,24 +9,30 @@ import "sync"
 type deferredFaults struct {
 	mu     sync.Mutex
 	pf     []*UffdPagefault
-	byAddr map[uint64]struct{}
+	byAddr map[uint64]*UffdPagefault
 }
 
 // push queues a deferred fault, skipping addresses already queued so a page
 // faulted by several threads is retried once instead of once per fault.
 // Fault addresses are already page-aligned by the kernel (UFFDIO_COPY rejects
-// unaligned dst), so the raw address keys per page.
+// unaligned dst), so the raw address keys per page. If the same page is faulted
+// as both read and write, the retained fault is upgraded to write so the retry
+// installs it dirty instead of leaving a later WP fault to catch it.
 func (d *deferredFaults) push(pf *UffdPagefault) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.byAddr == nil {
-		d.byAddr = make(map[uint64]struct{})
+		d.byAddr = make(map[uint64]*UffdPagefault)
 	}
 	addr := uint64(pf.address)
-	if _, ok := d.byAddr[addr]; ok {
+	if existing, ok := d.byAddr[addr]; ok {
+		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
+			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
+		}
+
 		return
 	}
-	d.byAddr[addr] = struct{}{}
+	d.byAddr[addr] = pf
 	d.pf = append(d.pf, pf)
 }
 

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -9,20 +9,27 @@ import "sync"
 type deferredFaults struct {
 	mu     sync.Mutex
 	pf     []*UffdPagefault
-	byAddr map[uint64]struct{}
+	byAddr map[uint64]*UffdPagefault
 }
 
+// push queues a deferred fault, deduping by address. If the same page is
+// faulted as both read and write, the retained fault is upgraded to write so
+// the retry installs it dirty instead of leaving a later WP fault to catch it.
 func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.byAddr == nil {
-		d.byAddr = make(map[uint64]struct{})
+		d.byAddr = make(map[uint64]*UffdPagefault)
 	}
 	addr := uint64(pf.address)
-	if _, ok := d.byAddr[addr]; ok {
+	if existing, ok := d.byAddr[addr]; ok {
+		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
+			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
+		}
+
 		return false
 	}
-	d.byAddr[addr] = struct{}{}
+	d.byAddr[addr] = pf
 	d.pf = append(d.pf, pf)
 
 	return true

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -7,36 +7,27 @@ import "sync"
 // deferredFaults collects pagefaults that returned EAGAIN so they get
 // retried on the next poll iteration. Safe for concurrent push.
 type deferredFaults struct {
-	mu       sync.Mutex
-	pf       []*UffdPagefault
-	byAddr   map[uint64]struct{}
-	pageSize uintptr
+	mu     sync.Mutex
+	pf     []*UffdPagefault
+	byAddr map[uint64]struct{}
 }
 
 // push queues a deferred fault, skipping addresses already queued so a page
 // faulted by several threads is retried once instead of once per fault.
+// Fault addresses are already page-aligned by the kernel (UFFDIO_COPY rejects
+// unaligned dst), so the raw address keys per page.
 func (d *deferredFaults) push(pf *UffdPagefault) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.byAddr == nil {
 		d.byAddr = make(map[uint64]struct{})
 	}
-	addr := d.key(uint64(pf.address))
+	addr := uint64(pf.address)
 	if _, ok := d.byAddr[addr]; ok {
 		return
 	}
 	d.byAddr[addr] = struct{}{}
 	d.pf = append(d.pf, pf)
-}
-
-func (d *deferredFaults) key(addr uint64) uint64 {
-	if d.pageSize == 0 {
-		return addr
-	}
-
-	pageSize := uint64(d.pageSize)
-
-	return addr & ^(pageSize - 1)
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -7,20 +7,31 @@ import "sync"
 // deferredFaults collects pagefaults that returned EAGAIN so they get
 // retried on the next poll iteration. Safe for concurrent push.
 type deferredFaults struct {
-	mu sync.Mutex
-	pf []*UffdPagefault
+	mu     sync.Mutex
+	pf     []*UffdPagefault
+	byAddr map[uint64]struct{}
 }
 
-func (d *deferredFaults) push(pf *UffdPagefault) {
+func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.byAddr == nil {
+		d.byAddr = make(map[uint64]struct{})
+	}
+	if _, ok := d.byAddr[pf.address]; ok {
+		return false
+	}
+	d.byAddr[pf.address] = struct{}{}
 	d.pf = append(d.pf, pf)
-	d.mu.Unlock()
+
+	return true
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {
 	d.mu.Lock()
 	out := d.pf
 	d.pf = nil
+	clear(d.byAddr)
 	d.mu.Unlock()
 
 	return out

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -9,30 +9,23 @@ import "sync"
 type deferredFaults struct {
 	mu     sync.Mutex
 	pf     []*UffdPagefault
-	byAddr map[uint64]*UffdPagefault
+	byAddr map[uint64]struct{}
 }
 
-// push queues a deferred fault, deduping by address. If the same page is
-// faulted as both read and write, the retained fault is upgraded to write so
-// the retry installs it dirty instead of leaving a later WP fault to catch it.
-func (d *deferredFaults) push(pf *UffdPagefault) bool {
+// push queues a deferred fault, skipping addresses already queued so a page
+// faulted by several threads is retried once instead of once per fault.
+func (d *deferredFaults) push(pf *UffdPagefault) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if d.byAddr == nil {
-		d.byAddr = make(map[uint64]*UffdPagefault)
+		d.byAddr = make(map[uint64]struct{})
 	}
 	addr := uint64(pf.address)
-	if existing, ok := d.byAddr[addr]; ok {
-		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
-			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
-		}
-
-		return false
+	if _, ok := d.byAddr[addr]; ok {
+		return
 	}
-	d.byAddr[addr] = pf
+	d.byAddr[addr] = struct{}{}
 	d.pf = append(d.pf, pf)
-
-	return true
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -7,9 +7,10 @@ import "sync"
 // deferredFaults collects pagefaults that returned EAGAIN so they get
 // retried on the next poll iteration. Safe for concurrent push.
 type deferredFaults struct {
-	mu     sync.Mutex
-	pf     []*UffdPagefault
-	byAddr map[uint64]*UffdPagefault
+	mu       sync.Mutex
+	pf       []*UffdPagefault
+	byAddr   map[uint64]*UffdPagefault
+	pageSize uintptr
 }
 
 // push queues a deferred fault, deduping by address. If the same page is
@@ -21,7 +22,7 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	if d.byAddr == nil {
 		d.byAddr = make(map[uint64]*UffdPagefault)
 	}
-	addr := uint64(pf.address)
+	addr := d.key(pf.address)
 	if existing, ok := d.byAddr[addr]; ok {
 		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
 			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
@@ -33,6 +34,14 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	d.pf = append(d.pf, pf)
 
 	return true
+}
+
+func (d *deferredFaults) key(addr uintptr) uint64 {
+	if d.pageSize == 0 {
+		return uint64(addr)
+	}
+
+	return uint64(addr & ^(d.pageSize - 1))
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -22,7 +22,7 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	if d.byAddr == nil {
 		d.byAddr = make(map[uint64]*UffdPagefault)
 	}
-	addr := d.key(pf.address)
+	addr := d.key(uint64(pf.address))
 	if existing, ok := d.byAddr[addr]; ok {
 		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
 			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
@@ -36,12 +36,14 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	return true
 }
 
-func (d *deferredFaults) key(addr uintptr) uint64 {
+func (d *deferredFaults) key(addr uint64) uint64 {
 	if d.pageSize == 0 {
-		return uint64(addr)
+		return addr
 	}
 
-	return uint64(addr & ^(d.pageSize - 1))
+	pageSize := uint64(d.pageSize)
+
+	return addr & ^(pageSize - 1)
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -39,7 +39,7 @@ func (d *deferredFaults) drain() []*UffdPagefault {
 	d.mu.Lock()
 	out := d.pf
 	d.pf = nil
-	clear(d.byAddr)
+	d.byAddr = nil
 	d.mu.Unlock()
 
 	return out

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -18,10 +18,11 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	if d.byAddr == nil {
 		d.byAddr = make(map[uint64]struct{})
 	}
-	if _, ok := d.byAddr[pf.address]; ok {
+	addr := uint64(pf.address)
+	if _, ok := d.byAddr[addr]; ok {
 		return false
 	}
-	d.byAddr[pf.address] = struct{}{}
+	d.byAddr[addr] = struct{}{}
 	d.pf = append(d.pf, pf)
 
 	return true

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred.go
@@ -7,10 +7,9 @@ import "sync"
 // deferredFaults collects pagefaults that returned EAGAIN so they get
 // retried on the next poll iteration. Safe for concurrent push.
 type deferredFaults struct {
-	mu       sync.Mutex
-	pf       []*UffdPagefault
-	byAddr   map[uint64]*UffdPagefault
-	pageSize uintptr
+	mu     sync.Mutex
+	pf     []*UffdPagefault
+	byAddr map[uint64]*UffdPagefault
 }
 
 // push queues a deferred fault, deduping by address. If the same page is
@@ -22,7 +21,7 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	if d.byAddr == nil {
 		d.byAddr = make(map[uint64]*UffdPagefault)
 	}
-	addr := d.key(pf.address)
+	addr := uint64(pf.address)
 	if existing, ok := d.byAddr[addr]; ok {
 		if pf.flags&UFFD_PAGEFAULT_FLAG_WRITE != 0 {
 			existing.flags |= UFFD_PAGEFAULT_FLAG_WRITE
@@ -34,14 +33,6 @@ func (d *deferredFaults) push(pf *UffdPagefault) bool {
 	d.pf = append(d.pf, pf)
 
 	return true
-}
-
-func (d *deferredFaults) key(addr uintptr) uint64 {
-	if d.pageSize == 0 {
-		return uint64(addr)
-	}
-
-	return uint64(addr & ^(d.pageSize - 1))
 }
 
 func (d *deferredFaults) drain() []*UffdPagefault {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -22,3 +22,15 @@ func TestDeferredFaultsDedupesByAddress(t *testing.T) {
 	require.True(t, d.push(&UffdPagefault{address: 42}))
 	require.Len(t, d.drain(), 1)
 }
+
+func TestDeferredFaultsUpgradesReadToWrite(t *testing.T) {
+	t.Parallel()
+
+	var d deferredFaults
+	require.True(t, d.push(&UffdPagefault{address: 42}))
+	require.False(t, d.push(&UffdPagefault{address: 42, flags: UFFD_PAGEFAULT_FLAG_WRITE}))
+
+	out := d.drain()
+	require.Len(t, out, 1)
+	require.NotZero(t, out[0].flags&UFFD_PAGEFAULT_FLAG_WRITE)
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeferredFaultsDedupesByAddress(t *testing.T) {
+func TestDeferredFaultsDedupesByPage(t *testing.T) {
 	t.Parallel()
 
-	var d deferredFaults
+	d := deferredFaults{pageSize: 4096}
 	require.True(t, d.push(&UffdPagefault{address: 42}))
-	require.False(t, d.push(&UffdPagefault{address: 42}))
-	require.True(t, d.push(&UffdPagefault{address: 43}))
+	require.False(t, d.push(&UffdPagefault{address: 43}))
+	require.True(t, d.push(&UffdPagefault{address: 4096}))
 
 	require.Len(t, d.drain(), 2)
 	require.Empty(t, d.drain())

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeferredFaultsDedupesByPage(t *testing.T) {
+func TestDeferredFaultsDedupesByAddress(t *testing.T) {
 	t.Parallel()
 
-	d := deferredFaults{pageSize: 4096}
+	var d deferredFaults
+	d.push(&UffdPagefault{address: 42})
 	d.push(&UffdPagefault{address: 42})
 	d.push(&UffdPagefault{address: 43})
-	d.push(&UffdPagefault{address: 4096})
 
 	require.Len(t, d.drain(), 2)
 	require.Empty(t, d.drain())

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -12,25 +12,13 @@ func TestDeferredFaultsDedupesByAddress(t *testing.T) {
 	t.Parallel()
 
 	var d deferredFaults
-	require.True(t, d.push(&UffdPagefault{address: 42}))
-	require.False(t, d.push(&UffdPagefault{address: 42}))
-	require.True(t, d.push(&UffdPagefault{address: 43}))
+	d.push(&UffdPagefault{address: 42})
+	d.push(&UffdPagefault{address: 42})
+	d.push(&UffdPagefault{address: 43})
 
 	require.Len(t, d.drain(), 2)
 	require.Empty(t, d.drain())
 
-	require.True(t, d.push(&UffdPagefault{address: 42}))
+	d.push(&UffdPagefault{address: 42})
 	require.Len(t, d.drain(), 1)
-}
-
-func TestDeferredFaultsUpgradesReadToWrite(t *testing.T) {
-	t.Parallel()
-
-	var d deferredFaults
-	require.True(t, d.push(&UffdPagefault{address: 42}))
-	require.False(t, d.push(&UffdPagefault{address: 42, flags: UFFD_PAGEFAULT_FLAG_WRITE}))
-
-	out := d.drain()
-	require.Len(t, out, 1)
-	require.NotZero(t, out[0].flags&UFFD_PAGEFAULT_FLAG_WRITE)
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -22,3 +22,15 @@ func TestDeferredFaultsDedupesByAddress(t *testing.T) {
 	d.push(&UffdPagefault{address: 42})
 	require.Len(t, d.drain(), 1)
 }
+
+func TestDeferredFaultsUpgradesReadToWrite(t *testing.T) {
+	t.Parallel()
+
+	var d deferredFaults
+	d.push(&UffdPagefault{address: 42})
+	d.push(&UffdPagefault{address: 42, flags: UFFD_PAGEFAULT_FLAG_WRITE})
+
+	out := d.drain()
+	require.Len(t, out, 1)
+	require.NotZero(t, out[0].flags&UFFD_PAGEFAULT_FLAG_WRITE)
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeferredFaultsDedupesByPage(t *testing.T) {
+func TestDeferredFaultsDedupesByAddress(t *testing.T) {
 	t.Parallel()
 
-	d := deferredFaults{pageSize: 4096}
+	var d deferredFaults
 	require.True(t, d.push(&UffdPagefault{address: 42}))
-	require.False(t, d.push(&UffdPagefault{address: 43}))
-	require.True(t, d.push(&UffdPagefault{address: 4096}))
+	require.False(t, d.push(&UffdPagefault{address: 42}))
+	require.True(t, d.push(&UffdPagefault{address: 43}))
 
 	require.Len(t, d.drain(), 2)
 	require.Empty(t, d.drain())

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/deferred_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeferredFaultsDedupesByAddress(t *testing.T) {
+	t.Parallel()
+
+	var d deferredFaults
+	require.True(t, d.push(&UffdPagefault{address: 42}))
+	require.False(t, d.push(&UffdPagefault{address: 42}))
+	require.True(t, d.push(&UffdPagefault{address: 43}))
+
+	require.Len(t, d.drain(), 2)
+	require.Empty(t, d.drain())
+
+	require.True(t, d.push(&UffdPagefault{address: 42}))
+	require.Len(t, d.drain(), 1)
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -261,7 +261,7 @@ func (u *Userfaultfd) Serve(
 		unix.POLLNVAL: "POLLNVAL",
 	}
 
-	deferred := deferredFaults{pageSize: u.pageSize}
+	var deferred deferredFaults
 
 	for {
 		if _, err := unix.Poll(

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -461,9 +461,8 @@ func (u *Userfaultfd) Serve(
 					}
 					u.prefetchTracker.Add(offset, accessType)
 				case faultDeferred:
-					if deferred.push(pf) {
-						u.signalWakeup()
-					}
+					deferred.push(pf)
+					u.signalWakeup()
 				case faultDiscarded:
 					// No install happened (ESRCH); retry would be pointless.
 				}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -261,7 +261,7 @@ func (u *Userfaultfd) Serve(
 		unix.POLLNVAL: "POLLNVAL",
 	}
 
-	var deferred deferredFaults
+	deferred := deferredFaults{pageSize: u.pageSize}
 
 	for {
 		if _, err := unix.Poll(

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -461,8 +461,9 @@ func (u *Userfaultfd) Serve(
 					}
 					u.prefetchTracker.Add(offset, accessType)
 				case faultDeferred:
-					deferred.push(pf)
-					u.signalWakeup()
+					if deferred.push(pf) {
+						u.signalWakeup()
+					}
 				case faultDiscarded:
 					// No install happened (ESRCH); retry would be pointless.
 				}


### PR DESCRIPTION
## Summary
Deduplicate deferred UFFD faults by address so repeated EAGAINs for the same page do not flood the retry queue or wake loop.

## Test plan
- Not run; Linux UFFD package depends on Linux cgo types and cannot execute on this macOS host.