### PR TITLE
fix(orch): denormalize upload metric file type

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -36,7 +36,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), string(build.Memfile), finalizeV3(h))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), uploadFileMemfileHeader, finalizeV3(h))
 	})
 
 	eg.Go(func() error {
@@ -48,7 +48,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 			return nil
 		}
 
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), string(build.Rootfs), finalizeV3(h))
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), uploadFileRootfsHeader, finalizeV3(h))
 	})
 
 	meta := storage.WithMetadata(u.objectMetadata)
@@ -66,7 +66,7 @@ func (u *Upload) runV3(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		recordUploadCompression(egCtx, uploadArtifactData, string(build.Memfile), storage.CompressConfig{}, info.Size(), info.Size())
+		recordUploadCompression(egCtx, uploadFileMemfile, storage.CompressConfig{}, info.Size(), info.Size())
 
 		return nil
 	})
@@ -84,17 +84,17 @@ func (u *Upload) runV3(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		recordUploadCompression(egCtx, uploadArtifactData, string(build.Rootfs), storage.CompressConfig{}, info.Size(), info.Size())
+		recordUploadCompression(egCtx, uploadFileRootfs, storage.CompressConfig{}, info.Size(), info.Size())
 
 		return nil
 	})
 
 	eg.Go(func() error {
-		return storage.UploadBlob(egCtx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), meta)
+		return uploadBlobWithMetrics(egCtx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), uploadFileSnap, meta)
 	})
 
 	eg.Go(func() error {
-		return storage.UploadBlob(egCtx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), meta)
+		return uploadBlobWithMetrics(egCtx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
 	})
 
 	if err := eg.Wait(); err != nil {

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -93,7 +93,11 @@ func (u *Upload) uploadFramed(
 			compressedSize = size
 		}
 
-		recordUploadCompression(ctx, string(fileType), cfg, size, compressedSize)
+		dataFileType := uploadFileMemfile
+		if fileType == build.Rootfs {
+			dataFileType = uploadFileRootfs
+		}
+		recordUploadCompression(ctx, dataFileType, cfg, size, compressedSize)
 		selfBuild = headers.BuildData{Size: size, Checksum: checksum, FrameData: ft}
 	}
 

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -55,11 +55,11 @@ func (u *Upload) runV4(ctx context.Context) error {
 	meta := storage.WithMetadata(u.objectMetadata)
 
 	eg.Go(func() error {
-		return storage.UploadBlob(ctx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), meta)
+		return uploadBlobWithMetrics(ctx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), uploadFileSnap, meta)
 	})
 
 	eg.Go(func() error {
-		return storage.UploadBlob(ctx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), meta)
+		return uploadBlobWithMetrics(ctx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
 	})
 
 	return eg.Wait()
@@ -93,7 +93,7 @@ func (u *Upload) uploadFramed(
 			compressedSize = size
 		}
 
-		recordUploadCompression(ctx, uploadArtifactData, string(fileType), cfg, size, compressedSize)
+		recordUploadCompression(ctx, string(fileType), cfg, size, compressedSize)
 		selfBuild = headers.BuildData{Size: size, Checksum: checksum, FrameData: ft}
 	}
 
@@ -108,7 +108,11 @@ func (u *Upload) uploadFramed(
 	}
 	h.Builds[u.buildID] = selfBuild
 
-	if err := storeHeaderWithMetrics(ctx, u.store, u.paths.HeaderFile(string(fileType)), string(fileType), h); err != nil {
+	headerFileType := uploadFileMemfileHeader
+	if fileType == build.Rootfs {
+		headerFileType = uploadFileRootfsHeader
+	}
+	if err := storeHeaderWithMetrics(ctx, u.store, u.paths.HeaderFile(string(fileType)), headerFileType, h); err != nil {
 		return fmt.Errorf("store %s header: %w", fileType, err)
 	}
 

--- a/packages/orchestrator/pkg/sandbox/upload_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/upload_metrics.go
@@ -4,6 +4,8 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -15,8 +17,12 @@ import (
 )
 
 const (
-	uploadArtifactData   = "data"
-	uploadArtifactHeader = "header"
+	uploadFileMemfile       = "memfile"
+	uploadFileRootfs        = "rootfs"
+	uploadFileMemfileHeader = "memfile-header"
+	uploadFileRootfsHeader  = "rootfs-header"
+	uploadFileSnap          = "snap"
+	uploadFileMeta          = "meta"
 )
 
 var (
@@ -25,10 +31,9 @@ var (
 	uploadCompressionRatio  = utils.Must(telemetry.GetFloatHistogram(meter, telemetry.UploadCompressionRatio))
 )
 
-func recordUploadCompression(ctx context.Context, artifact, fileType string, cfg storage.CompressConfig, uncompressed, compressed int64) {
+func recordUploadCompression(ctx context.Context, fileType string, cfg storage.CompressConfig, uncompressed, compressed int64) {
 	attrs := metric.WithAttributes(
-		attribute.String("artifact", artifact),
-		attribute.String("file_type", uploadMetricFileType(fileType)),
+		attribute.String("file_type", fileType),
 		attribute.String("compression.type", cfg.CompressionType().String()),
 		attribute.Int("compression.level", cfg.Level),
 	)
@@ -54,7 +59,20 @@ func storeHeaderWithMetrics(ctx context.Context, store storage.StorageProvider, 
 		return err
 	}
 
-	recordUploadCompression(ctx, uploadArtifactHeader, fileType, cfg, uncompressed, stored)
+	recordUploadCompression(ctx, fileType, cfg, uncompressed, stored)
+
+	return nil
+}
+
+func uploadBlobWithMetrics(ctx context.Context, store storage.StorageProvider, path string, objectType storage.ObjectType, sourcePath, fileType string, opts ...storage.PutOption) error {
+	info, err := os.Stat(sourcePath)
+	if err != nil {
+		return fmt.Errorf("%s stat: %w", fileType, err)
+	}
+	if err := storage.UploadBlob(ctx, store, path, objectType, sourcePath, opts...); err != nil {
+		return err
+	}
+	recordUploadCompression(ctx, fileType, storage.CompressConfig{}, info.Size(), info.Size())
 
 	return nil
 }


### PR DESCRIPTION
## Summary
Use one denormalized `file_type` metric attribute for upload compression metrics (`memfile`, `memfile-header`, `rootfs`, `rootfs-header`, `snap`, `meta`) instead of splitting `artifact` and `file_type`.

## Test plan
- `cd packages/orchestrator && go test ./pkg/sandbox -run TestNonexistent`
- `cd packages/orchestrator && golangci-lint run ./pkg/sandbox/...`