### PR TITLE
perf(iac): tune NFS caching and RPC parallelism for persistent volumes

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -81,8 +81,13 @@ locals {
     "local_lock=none", // all locks are network locks
 
     // caching
-    "noac",             // disable attribute caching. slower, but more reliable
-    "lookupcache=none", // disable lookup caching
+    // Bound cross-host staleness to ~1s while avoiding a Filestore RPC on every
+    // metadata op. Sandboxes mounting the same volume on different hosts still see
+    // peer writes within the attribute timer; strict coherency for shared mutable
+    // state should use NLM locks (already enabled via lock,local_lock=none) or an
+    // out-of-band signal.
+    "actimeo=1",            // cap all attribute caches at 1 second
+    "lookupcache=positive", // cache hits; negative lookups still hit the server so new files appear promptly
 
     // security
     "noacl",   // do not use an acl

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -83,6 +83,19 @@ echo "$SWAPFILE none swap sw 0 0" | tee -a /etc/fstab
 sysctl vm.swappiness=10
 sysctl vm.vfs_cache_pressure=50
 
+# Increase RPC slot table so nconnect can actually parallelize. Default of 2 in-flight
+# RPCs per TCP connection bottlenecks metadata-heavy NFS workloads (uncached lookups,
+# many concurrent sandboxes). Modprobe options apply when sunrpc loads (first NFS mount);
+# the runtime sysctl handles the case where the module is already loaded.
+mkdir -p /etc/modprobe.d
+cat <<'EOF' >/etc/modprobe.d/sunrpc.conf
+options sunrpc tcp_slot_table_entries=128 tcp_max_slot_table_entries=128
+EOF
+if [ -d /proc/sys/sunrpc ]; then
+  sysctl -w sunrpc.tcp_slot_table_entries=128 || true
+  sysctl -w sunrpc.tcp_max_slot_table_entries=128 || true
+fi
+
 # TODO: Optimize the mount more according to https://cloud.google.com/filestore/docs/mounting-fileshares
 %{ if USE_FILESTORE_CACHE }
 # Configure NFS read ahead

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -92,8 +92,8 @@ cat <<'EOF' >/etc/modprobe.d/sunrpc.conf
 options sunrpc tcp_slot_table_entries=128 tcp_max_slot_table_entries=128
 EOF
 if [ -d /proc/sys/sunrpc ]; then
-  sysctl -w sunrpc.tcp_slot_table_entries=128 || true
-  sysctl -w sunrpc.tcp_max_slot_table_entries=128 || true
+  sysctl -w sunrpc.tcp_slot_table_entries=128
+  sysctl -w sunrpc.tcp_max_slot_table_entries=128
 fi
 
 # TODO: Optimize the mount more according to https://cloud.google.com/filestore/docs/mounting-fileshares


### PR DESCRIPTION
## Summary

Two changes targeting NFS-volume read latency for sandboxes mounting persistent volumes:

- **Relax `default_persistent_volume_type_nfs_mount_options`**: replace `noac, lookupcache=none` with `actimeo=1, lookupcache=positive`. The current options force every `stat()`/`lookup()` to round-trip to Filestore, which dominates metadata-heavy workloads. `actimeo=1` bounds cross-host attribute staleness to ~1s — below the VM-side NFS client's own cache floor — while eliminating the bulk of redundant `GETATTR` RPCs. Negative lookups stay uncached so new files created by peer sandboxes still appear promptly. Per-`volume_type` `mount_options` overrides remain available for workloads that explicitly need stricter coherency.
- **Raise `sunrpc.tcp_slot_table_entries` to 128** (default `2`) via `/etc/modprobe.d/sunrpc.conf` on client nodes. With `nconnect=7`, the host opens 7 TCP connections to Filestore, but the default 2 in-flight RPCs per connection caps total in-flight RPCs at 14 — far too low for many concurrent sandboxes generating uncached metadata RPCs. `cmd/simulate-nfs-traffic` already validated this experimentally; this wires it into the production startup script. A runtime `sysctl -w` covers the case where the module is already loaded.

## Rationale on the cache change

The previous `noac, lookupcache=none` defaults were inherited from the original chunks-cache mount options (commit `a56c28d`, Sep 2025), with the inline comment `// disable attribute caching. slower, but more reliable`. That mount was later flipped to caching in #1429 (Nov 2025). The persistent-volumes path added in #1893 (Mar 2026, "Add files API") reused the pre-#1429 conservative options without re-evaluating them for the new use case.

In the multi-mount case (N sandboxes attaching the same volume across multiple hosts), `noac` does bound host-side staleness — but the VM-side NFS client has its own attribute cache that the orchestrator cannot control. Real cross-sandbox staleness is bounded by the VM cache, not the host cache, so removing `noac` does not meaningfully degrade observable consistency. It does eliminate a Filestore RPC on every metadata op.

`lookupcache=positive` (not `none`) preserves prompt discovery of newly-created files from peer sandboxes — important for shared-state coordination workloads — while still caching successful lookups for hot paths.

## Why this matters

Sandbox volume reads currently traverse: VM kernel NFSv3 → orchestrator go-nfs proxy → host kernel NFSv3 → Filestore. With `noac, lookupcache=none`, every `ls`, `stat`, `open(path)`, and directory walk on the hot path is a Filestore round-trip (~1–3ms in-zone). For metadata-heavy workloads this dominates end-to-end latency.

## Test plan

- [ ] Apply Terraform plan to staging; confirm the diff only touches mount options and the start-client script template
- [ ] Roll a fresh client node in staging and verify `cat /sys/module/sunrpc/parameters/tcp_slot_table_entries` reports 128
- [ ] Verify `mount | grep persistent-volume-types` on a staging client shows `actimeo=1` and `lookupcache=pos` in the active mount options
- [ ] Run `cmd/simulate-nfs-traffic` against a staging persistent volume; compare p50/p99 read latency before/after for metadata-heavy scenarios
- [ ] Sanity-check that a multi-sandbox coordination test (write file from one sandbox, poll for it from another on a different host) still observes the new file within seconds
- [ ] Watch `orchestrator.chroot.request.latency` and Filestore-side metrics over 24h post-rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)