### PR TITLE
fix(api): bound ResourceExhausted retries in sandbox placement

### DIFF
--- a/packages/api/internal/orchestrator/placement/config.go
+++ b/packages/api/internal/orchestrator/placement/config.go
@@ -1,6 +1,16 @@
 package placement
 
+import "time"
+
 const (
 	maxRetries                  = 3
 	maxStartingInstancesPerNode = 3
+
+	// Bound placement retries when nodes report ResourceExhausted so a saturated
+	// fleet can't make PlaceSandbox spin until the request deadline. The backoff
+	// grows exponentially from base to max (with jitter) to avoid hammering the
+	// fleet under sustained capacity pressure.
+	maxResourceExhaustedRetries     = 8
+	resourceExhaustedBackoffBase    = 250 * time.Millisecond
+	resourceExhaustedBackoffMaxWait = 5 * time.Second
 )

--- a/packages/api/internal/orchestrator/placement/config.go
+++ b/packages/api/internal/orchestrator/placement/config.go
@@ -6,11 +6,11 @@ const (
 	maxRetries                  = 3
 	maxStartingInstancesPerNode = 3
 
-	// Bound placement retries when nodes report ResourceExhausted so a saturated
-	// fleet can't make PlaceSandbox spin until the request deadline. The backoff
-	// grows exponentially from base to max (with jitter) to avoid hammering the
-	// fleet under sustained capacity pressure.
-	maxResourceExhaustedRetries     = 8
+	// When every node reports ResourceExhausted, PlaceSandbox keeps retrying
+	// until the request deadline (capacity is usually transient), but waits a
+	// jittered backoff after each full pass over the nodes so a saturated fleet
+	// can't make it spin in a tight loop. The backoff grows exponentially from
+	// base to max.
 	resourceExhaustedBackoffBase    = 250 * time.Millisecond
 	resourceExhaustedBackoffMaxWait = 5 * time.Second
 )

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -75,20 +75,18 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 			node, err = algorithm.chooseNode(ctx, clusterNodes, skip, nodemanager.SandboxResources{CPUs: sbxRequest.GetSandbox().GetVcpu(), MiBMemory: sbxRequest.GetSandbox().GetRamMb()}, buildMachineInfo, labelFilteringEnabled, requiredLabels)
 			if err != nil {
 				// No selectable node. If exhausted nodes are the only blocker,
-				// back off (bounded) and retry them; otherwise give up.
+				// back off and retry them until the request deadline (capacity is
+				// usually transient); otherwise give up.
 				if len(nodesExhausted) == 0 {
 					return nil, err
 				}
 
 				exhaustedRetries++
-				if exhaustedRetries >= maxResourceExhaustedRetries {
-					logger.L().Warn(ctx, "Placement failed, all nodes exhausted", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()), logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()), zap.Int("exhausted_retries", exhaustedRetries))
-
-					return nil, errSandboxCreateFailed
-				}
 
 				select {
 				case <-ctx.Done():
+					logger.L().Warn(ctx, "Placement failed, all nodes exhausted", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()), logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()), zap.Int("exhausted_retries", exhaustedRetries))
+
 					return nil, fmt.Errorf("request timed out after %d exhausted retries", exhaustedRetries)
 				case <-time.After(exhaustedBackoff(exhaustedRetries)):
 				}
@@ -161,9 +159,13 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 // exhaustedBackoff returns a jittered, exponentially growing wait for the n-th
 // (1-based) ResourceExhausted retry, capped at resourceExhaustedBackoffMaxWait.
 func exhaustedBackoff(n int) time.Duration {
-	wait := resourceExhaustedBackoffBase << (n - 1)
-	if wait <= 0 || wait > resourceExhaustedBackoffMaxWait {
-		wait = resourceExhaustedBackoffMaxWait
+	wait := resourceExhaustedBackoffMaxWait
+	// Cap the shift to avoid overflow once n grows large; the wait is capped at
+	// the max anyway.
+	if n >= 1 && n <= 16 {
+		if w := resourceExhaustedBackoffBase << (n - 1); w > 0 && w < wait {
+			wait = w
+		}
 	}
 
 	return time.Duration(rand.Int63n(int64(wait)) + 1)

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -143,7 +143,14 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 		default:
 			nodesExcluded[failedNode.ID] = struct{}{}
 			failedNode.PlacementMetrics.Fail(sbxRequest.GetSandbox().GetSandboxId())
-			logger.L().Error(ctx, "Failed to create sandbox", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID), logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()), logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()), zap.Int("attempt", attempt+1), zap.Error(utils.UnwrapGRPCError(err)))
+			logger.L().Error(ctx, "Failed to create sandbox",
+				logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()),
+				logger.WithNodeID(failedNode.ID),
+				logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()),
+				logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()),
+				zap.Int("attempt", attempt+1),
+				zap.Error(utils.UnwrapGRPCError(err)),
+			)
 			attempt++
 		}
 	}

--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
@@ -33,7 +35,11 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 	ctx, span := tracer.Start(ctx, "place-sandbox")
 	defer span.End()
 
+	// nodesExcluded: nodes that hard-failed and must not be retried.
+	// nodesExhausted: nodes that reported ResourceExhausted; skipped so other
+	// nodes are tried first, then retried after a bounded backoff.
 	nodesExcluded := make(map[string]struct{})
+	nodesExhausted := make(map[string]struct{})
 	var err error
 
 	var node *nodemanager.Node
@@ -42,6 +48,7 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 	}
 
 	attempt := 0
+	exhaustedRetries := 0
 	for attempt < maxRetries {
 		select {
 		case <-ctx.Done():
@@ -57,9 +64,38 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 				return nil, errors.New("no nodes available")
 			}
 
-			node, err = algorithm.chooseNode(ctx, clusterNodes, nodesExcluded, nodemanager.SandboxResources{CPUs: sbxRequest.GetSandbox().GetVcpu(), MiBMemory: sbxRequest.GetSandbox().GetRamMb()}, buildMachineInfo, labelFilteringEnabled, requiredLabels)
+			skip := make(map[string]struct{}, len(nodesExcluded)+len(nodesExhausted))
+			for id := range nodesExcluded {
+				skip[id] = struct{}{}
+			}
+			for id := range nodesExhausted {
+				skip[id] = struct{}{}
+			}
+
+			node, err = algorithm.chooseNode(ctx, clusterNodes, skip, nodemanager.SandboxResources{CPUs: sbxRequest.GetSandbox().GetVcpu(), MiBMemory: sbxRequest.GetSandbox().GetRamMb()}, buildMachineInfo, labelFilteringEnabled, requiredLabels)
 			if err != nil {
-				return nil, err
+				// No selectable node. If exhausted nodes are the only blocker,
+				// back off (bounded) and retry them; otherwise give up.
+				if len(nodesExhausted) == 0 {
+					return nil, err
+				}
+
+				exhaustedRetries++
+				if exhaustedRetries >= maxResourceExhaustedRetries {
+					logger.L().Warn(ctx, "Placement failed, all nodes exhausted", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()), logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()), zap.Int("exhausted_retries", exhaustedRetries))
+
+					return nil, errSandboxCreateFailed
+				}
+
+				select {
+				case <-ctx.Done():
+					return nil, fmt.Errorf("request timed out after %d exhausted retries", exhaustedRetries)
+				case <-time.After(exhaustedBackoff(exhaustedRetries)):
+				}
+
+				nodesExhausted = make(map[string]struct{})
+
+				continue
 			}
 
 			telemetry.ReportEvent(ctx, "Placing sandbox on the node", telemetry.WithNodeID(node.ID))
@@ -103,14 +139,25 @@ func PlaceSandbox(ctx context.Context, algorithm Algorithm, clusterNodes []*node
 		switch statusCode {
 		case codes.ResourceExhausted:
 			failedNode.PlacementMetrics.Skip(sbxRequest.GetSandbox().GetSandboxId())
-			logger.L().Warn(ctx, "Node exhausted, trying another node", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID))
+			nodesExhausted[failedNode.ID] = struct{}{}
 		default:
 			nodesExcluded[failedNode.ID] = struct{}{}
 			failedNode.PlacementMetrics.Fail(sbxRequest.GetSandbox().GetSandboxId())
-			logger.L().Error(ctx, "Failed to create sandbox", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID), zap.Int("attempt", attempt+1), zap.Error(utils.UnwrapGRPCError(err)))
+			logger.L().Error(ctx, "Failed to create sandbox", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID), logger.WithTemplateID(sbxRequest.GetSandbox().GetTemplateId()), logger.WithBuildID(sbxRequest.GetSandbox().GetBuildId()), zap.Int("attempt", attempt+1), zap.Error(utils.UnwrapGRPCError(err)))
 			attempt++
 		}
 	}
 
 	return nil, errSandboxCreateFailed
+}
+
+// exhaustedBackoff returns a jittered, exponentially growing wait for the n-th
+// (1-based) ResourceExhausted retry, capped at resourceExhaustedBackoffMaxWait.
+func exhaustedBackoff(n int) time.Duration {
+	wait := resourceExhaustedBackoffBase << (n - 1)
+	if wait <= 0 || wait > resourceExhaustedBackoffMaxWait {
+		wait = resourceExhaustedBackoffMaxWait
+	}
+
+	return time.Duration(rand.Int63n(int64(wait)) + 1)
 }


### PR DESCRIPTION
## What

When all nodes report `ResourceExhausted`, keep retrying placement until the request deadline (as before), but wait a jittered, exponentially-growing backoff (capped) after each full pass over the nodes instead of spinning in a tight loop. Exhausted nodes are skipped within a pass so other nodes are tried first. Also log the give-up once (on deadline) instead of per attempt, and add `template_id`/`build_id` to placement failure logs.

## Why

When every node was at its starting-instance limit, the loop retried with no backoff, spinning until the request deadline. A few stuck creates amplified into thousands of log lines/sec and a ~390x allocation-rate spike on the API. Capacity exhaustion is usually transient, so this keeps the original "retry until deadline" behavior (avoiding spurious placement failures) while the backoff caps the work/log volume per request. The build/template id makes the offending build identifiable from logs.