### PR TITLE
chore: make pprof port configurable via PPROF_PORT

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -538,7 +538,7 @@ func run() int {
 	pprofServer := telemetry.NewPprofServer()
 
 	wg.Go(func() {
-		l.Info(ctx, "pprof server starting", zap.Int("port", telemetry.DefaultPprofPort))
+		l.Info(ctx, "pprof server starting", zap.Int("port", telemetry.PprofPort()))
 
 		if err := pprofServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			l.Error(ctx, "pprof server encountered error", zap.Error(err))

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -699,7 +699,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 	pprofServer := telemetry.NewPprofServer()
 	// We handle the pprof in a separate goroutine to prevent any interaction with the main server.
 	go func() {
-		logger.L().Info(ctx, "pprof server starting", zap.Int("port", telemetry.DefaultPprofPort))
+		logger.L().Info(ctx, "pprof server starting", zap.Int("port", telemetry.PprofPort()))
 
 		if err := pprofServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.L().Error(ctx, "pprof server encountered error", zap.Error(err))

--- a/packages/shared/pkg/telemetry/pprof.go
+++ b/packages/shared/pkg/telemetry/pprof.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"os"
+	"strconv"
 	"strings"
 )
 
@@ -29,10 +31,26 @@ func init() {
 // DefaultPprofPort is the default port that we should use to mount pprof endpoint.
 const DefaultPprofPort = 6060
 
+// pprofPortEnv overrides DefaultPprofPort so concurrent local instances don't
+// collide on the hardcoded port.
+const pprofPortEnv = "PPROF_PORT"
+
+// PprofPort returns the port the pprof server should bind to: the value of
+// PPROF_PORT when set to a valid port, otherwise DefaultPprofPort.
+func PprofPort() int {
+	if raw, ok := os.LookupEnv(pprofPortEnv); ok {
+		if port, err := strconv.Atoi(raw); err == nil && port > 0 && port <= 65535 {
+			return port
+		}
+	}
+
+	return DefaultPprofPort
+}
+
 func NewPprofServer() *http.Server {
 	return &http.Server{
 		// We mount only to the localhost to prevent accidental exposure.
-		Addr:    fmt.Sprintf("127.0.0.1:%d", DefaultPprofPort),
+		Addr:    fmt.Sprintf("127.0.0.1:%d", PprofPort()),
 		Handler: NewPprofMux(),
 	}
 }


### PR DESCRIPTION
Allows concurrent local instances to avoid colliding on the hardcoded 6060 port.