### PR TITLE
fix(shared): size v5 header mapping columns exactly on deserialize

### DIFF
--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -290,14 +290,9 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		encodedBuildIdx[i] = uint16(v)
 	}
 
-	// Pre-count the reconstructed entries (mapped entries plus the nil gaps
-	// inserted between them) so the columns are allocated exactly. The
-	// alternative — building into an n*2+1 buffer and trimming — does not help:
-	// the cached Mapping holds these slices for up to 25h, slices.Clip can't
-	// release an oversized backing array (it only lowers cap), and slices.Clone
-	// would add a transient full-header copy during a memory-pressured pause.
-	// A miscount on malformed input only costs a realloc; such input fails the
-	// validation below and the Mapping is discarded.
+	// Size the columns exactly: the Mapping is cached for ~25h, so an oversized
+	// buffer would stay resident (Clip keeps the backing array, Clone adds a
+	// transient copy). Count the mapped entries plus reconstructed nil gaps.
 	total := int(n)
 	var prevEnd uint64
 	for i := range int(n) {

--- a/packages/shared/pkg/storage/header/serialization_v5.go
+++ b/packages/shared/pkg/storage/header/serialization_v5.go
@@ -290,10 +290,30 @@ func readV5MappingSection(reader *bytes.Reader, blockSize, size uint64) (Mapping
 		encodedBuildIdx[i] = uint16(v)
 	}
 
-	offsets := make([]uint32, 0, int(n)*2+1)
-	lengths := make([]uint32, 0, int(n)*2+1)
-	storageCol := make([]uint32, 0, int(n)*2+1)
-	buildIdx := make([]uint16, 0, int(n)*2+1)
+	// Pre-count the reconstructed entries (mapped entries plus the nil gaps
+	// inserted between them) so the columns are allocated exactly. The
+	// alternative — building into an n*2+1 buffer and trimming — does not help:
+	// the cached Mapping holds these slices for up to 25h, slices.Clip can't
+	// release an oversized backing array (it only lowers cap), and slices.Clone
+	// would add a transient full-header copy during a memory-pressured pause.
+	// A miscount on malformed input only costs a realloc; such input fails the
+	// validation below and the Mapping is discarded.
+	total := int(n)
+	var prevEnd uint64
+	for i := range int(n) {
+		if uint64(encodedOffsets[i]) > prevEnd {
+			total++
+		}
+		prevEnd = uint64(encodedOffsets[i]) + uint64(encodedLengths[i])
+	}
+	if prevEnd < sizeBlocks {
+		total++
+	}
+
+	offsets := make([]uint32, 0, total)
+	lengths := make([]uint32, 0, total)
+	storageCol := make([]uint32, 0, total)
+	buildIdx := make([]uint16, 0, total)
 	appendEntry := func(off, length, storage uint32, idx uint16) {
 		offsets = append(offsets, off)
 		lengths = append(lengths, length)

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -189,42 +189,33 @@ func TestV5_SmallerThanV4(t *testing.T) {
 	require.True(t, Equal(mappings, got.Mapping.Slice()))
 }
 
-// TestV5_ReconstructedColumnsExactlySized guards the heap fix: a V5-deserialized
-// header is cached for up to 25h, so its mapping columns must not retain
-// over-allocated backing arrays. The reconstruction inserts nil gaps, so this
-// uses a header with gaps to exercise that path.
+// TestV5_ReconstructedColumnsExactlySized guards against cached headers
+// retaining over-allocated mapping columns. Alternating mapped/nil entries
+// force gap reconstruction, the path that previously over-allocated.
 func TestV5_ReconstructedColumnsExactlySized(t *testing.T) {
 	t.Parallel()
 
 	bs := uint64(4096)
 	a := uuid.New()
-	const mapped = 10_000
-	// Alternate a mapped page with a nil gap so the reader reconstructs a gap
-	// entry before every mapped entry (the maximal-fragmentation shape).
-	mappings := make([]BuildMap, 0, mapped*2)
-	var off, sa uint64
-	for range mapped {
-		mappings = append(mappings, BuildMap{Offset: off, Length: bs, BuildId: uuid.Nil})
-		off += bs
-		mappings = append(mappings, BuildMap{Offset: off, Length: bs, BuildId: a, BuildStorageOffset: sa})
-		off += bs
-		sa += bs
+	mappings := []BuildMap{
+		{Offset: 0, Length: bs, BuildId: uuid.Nil},
+		{Offset: bs, Length: bs, BuildId: a, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: uuid.Nil},
+		{Offset: 3 * bs, Length: bs, BuildId: a, BuildStorageOffset: bs},
 	}
-	meta := &Metadata{BlockSize: bs, Size: off, BuildId: a, BaseBuildId: a}
-	h := v5Header(t, meta, mappings, map[uuid.UUID]BuildData{a: {Size: int64(sa)}})
+	meta := &Metadata{BlockSize: bs, Size: 4 * bs, BuildId: a, BaseBuildId: a}
+	h := v5Header(t, meta, mappings, map[uuid.UUID]BuildData{a: {Size: int64(2 * bs)}})
 
 	data, err := SerializeHeader(h)
 	require.NoError(t, err)
 	got, err := DeserializeBytes(data)
 	require.NoError(t, err)
 
-	require.True(t, Equal(mappings, got.Mapping.Slice()))
-
 	m := got.Mapping
-	assert.Equal(t, len(m.offsets), cap(m.offsets), "offsets column carries slack")
-	assert.Equal(t, len(m.lengths), cap(m.lengths), "lengths column carries slack")
-	assert.Equal(t, len(m.storage), cap(m.storage), "storage column carries slack")
-	assert.Equal(t, len(m.buildIdx), cap(m.buildIdx), "buildIdx column carries slack")
+	assert.Equal(t, len(m.offsets), cap(m.offsets))
+	assert.Equal(t, len(m.lengths), cap(m.lengths))
+	assert.Equal(t, len(m.storage), cap(m.storage))
+	assert.Equal(t, len(m.buildIdx), cap(m.buildIdx))
 }
 
 func TestV5_RejectsOversizePrefix(t *testing.T) {

--- a/packages/shared/pkg/storage/header/serialization_v5_test.go
+++ b/packages/shared/pkg/storage/header/serialization_v5_test.go
@@ -189,6 +189,44 @@ func TestV5_SmallerThanV4(t *testing.T) {
 	require.True(t, Equal(mappings, got.Mapping.Slice()))
 }
 
+// TestV5_ReconstructedColumnsExactlySized guards the heap fix: a V5-deserialized
+// header is cached for up to 25h, so its mapping columns must not retain
+// over-allocated backing arrays. The reconstruction inserts nil gaps, so this
+// uses a header with gaps to exercise that path.
+func TestV5_ReconstructedColumnsExactlySized(t *testing.T) {
+	t.Parallel()
+
+	bs := uint64(4096)
+	a := uuid.New()
+	const mapped = 10_000
+	// Alternate a mapped page with a nil gap so the reader reconstructs a gap
+	// entry before every mapped entry (the maximal-fragmentation shape).
+	mappings := make([]BuildMap, 0, mapped*2)
+	var off, sa uint64
+	for range mapped {
+		mappings = append(mappings, BuildMap{Offset: off, Length: bs, BuildId: uuid.Nil})
+		off += bs
+		mappings = append(mappings, BuildMap{Offset: off, Length: bs, BuildId: a, BuildStorageOffset: sa})
+		off += bs
+		sa += bs
+	}
+	meta := &Metadata{BlockSize: bs, Size: off, BuildId: a, BaseBuildId: a}
+	h := v5Header(t, meta, mappings, map[uuid.UUID]BuildData{a: {Size: int64(sa)}})
+
+	data, err := SerializeHeader(h)
+	require.NoError(t, err)
+	got, err := DeserializeBytes(data)
+	require.NoError(t, err)
+
+	require.True(t, Equal(mappings, got.Mapping.Slice()))
+
+	m := got.Mapping
+	assert.Equal(t, len(m.offsets), cap(m.offsets), "offsets column carries slack")
+	assert.Equal(t, len(m.lengths), cap(m.lengths), "lengths column carries slack")
+	assert.Equal(t, len(m.storage), cap(m.storage), "storage column carries slack")
+	assert.Equal(t, len(m.buildIdx), cap(m.buildIdx), "buildIdx column carries slack")
+}
+
 func TestV5_RejectsOversizePrefix(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
`readV5MappingSection` reconstructed the compact mapping columns into an `n*2+1`-capacity buffer and stored them in the `Mapping` unchanged. The deserialized header is cached for up to 25h, so the over-allocated backing arrays stayed resident (up to ~2x the needed mapping bytes per cached header).

Now we pre-count the reconstructed entries (mapped entries + reconstructed nil gaps) and allocate the columns exactly, so the cached `Mapping` carries no slack.

## Why pre-count instead of clip/clone
- `slices.Clip` does **not** free anything — it only lowers `cap` on the same backing array.
- `slices.Clone` works but adds a transient full-header copy on the deserialize path (undesirable under pause-time memory pressure).
- Pre-counting allocates right-sized columns directly. A miscount on malformed input only costs a realloc, and such input fails the existing validation and is discarded.

V4 is unaffected: it goes through `NewHeader` -> `NewMapping`, which already allocates exact-size columns.

## Test
Added `TestV5_ReconstructedColumnsExactlySized`: round-trips a maximally fragmented (alternating mapped/nil) header and asserts `cap == len` on every reconstructed column. Full `storage/header` package tests pass.