### PR TITLE
fix(api): stop evicting the local node during sync

### DIFF
--- a/packages/api/internal/orchestrator/cache.go
+++ b/packages/api/internal/orchestrator/cache.go
@@ -94,10 +94,17 @@ func (o *Orchestrator) syncNodes(ctx context.Context, store *sandbox.Store, skip
 			// cluster and local nodes needs to by synced differently,
 			// because each of them is taken from different source pool
 			var err error
-			if n.IsNomadManaged() {
-				err = o.syncNode(ctx, n, nomadNodes, store)
-			} else {
+			switch {
+			case !n.IsNomadManaged():
 				err = o.syncClusterNode(ctx, n, store)
+			case skipSyncingWithNomad:
+				// In local mode there is no Nomad discovery list to validate
+				// membership against, so sync the statically-connected node
+				// directly instead of evicting it every cycle. node.Sync still
+				// marks the node unhealthy if the orchestrator is unreachable.
+				n.Sync(ctx, store)
+			default:
+				err = o.syncNode(ctx, n, nomadNodes, store)
 			}
 			if err != nil {
 				logger.L().Error(ctx, "Error syncing node", zap.Error(err))


### PR DESCRIPTION
## Summary
In local/single-node mode the node sync loop runs with an empty Nomad discovery list (`skipSyncingWithNomad`). The statically-connected local orchestrator is registered with `NomadNodeShortID="local"`, so `IsNomadManaged()` is true and it was validated against that empty list in `syncNode` — failing the membership check and getting `Close`d + deregistered on every ~20s sync cycle.

Sandbox creates landing in the eviction/reconnect window (or racing the connection close) then fail placement with `500 "Failed to place sandbox"`. This is the most likely driver of the high integration-test flake rate (~42% on main) where unrelated tests intermittently get that 500 / a follow-up 502.

The fix syncs the local node directly when Nomad syncing is skipped, instead of evicting it against a list it can never appear in. Node health is still tracked by `node.Sync` (it is marked unhealthy if the orchestrator is unreachable), so a genuinely dead orchestrator is still handled.

## Test plan
- `go test ./packages/api/internal/orchestrator/...`
- Watch integration-test flake rate on `Failed to place sandbox`.