### PR TITLE
fix(nfsproxy): only increment unmounts counter on successful chroot close

### DIFF
--- a/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
+++ b/packages/orchestrator/pkg/nfsproxy/chroot/nfs.go
@@ -109,7 +109,10 @@ func (h *NFSHandler) OnNetworkRelease(ctx context.Context, sbx *sandbox.Sandbox)
 				zap.String("path", chroot.Root()),
 				zap.Error(err),
 			)
+
+			continue
 		}
+
 		h.chrootUnmountsCounter.Add(ctx, 1)
 	}
 }

--- a/packages/orchestrator/pkg/nfsproxy/chroot/nfs_test.go
+++ b/packages/orchestrator/pkg/nfsproxy/chroot/nfs_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package chroot
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/chrooted"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
+)
+
+// makeSandbox creates a minimal *sandbox.Sandbox with a unique lifecycleID.
+func makeSandbox(lifecycleID string) *sandbox.Sandbox {
+	return &sandbox.Sandbox{
+		LifecycleID: lifecycleID,
+		Metadata: &sandbox.Metadata{
+			Runtime: sandbox.RuntimeMetadata{
+				SandboxID: uuid.NewString(),
+			},
+		},
+		Resources: &sandbox.Resources{
+			Slot: &network.Slot{HostIP: net.IPv4(127, 0, 0, 1)},
+		},
+	}
+}
+
+// countingCounter embeds noop.Int64Counter to satisfy the full metric.Int64Counter
+// interface (including the embedded private marker), and overrides Add to record calls.
+type countingCounter struct {
+	noop.Int64Counter
+	total atomic.Int64
+}
+
+func (c *countingCounter) Add(_ context.Context, incr int64, _ ...metric.AddOption) {
+	c.total.Add(incr)
+}
+
+// TestOnNetworkRelease_CounterOnlyIncrementedOnSuccess verifies that
+// chrootUnmountsCounter is NOT incremented when Close() returns an error,
+// so that mounts-unmounts accurately reflects leaked mount namespaces.
+func TestOnNetworkRelease_CounterOnlyIncrementedOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("requires pivot_root, skipping in short mode")
+	}
+
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	// goodChroot: will close successfully.
+	goodChroot, err := chrooted.Chroot(ctx, dir)
+	require.NoError(t, err)
+
+	// badChroot: pre-close it so the second Close() returns an error,
+	// simulating a mount namespace that is already gone.
+	badChroot, err := chrooted.Chroot(ctx, dir)
+	require.NoError(t, err)
+	require.NoError(t, badChroot.Close())
+
+	lifecycleID := "lifecycle-abc"
+
+	unmounts := &countingCounter{}
+	mounts := &countingCounter{}
+
+	h := &NFSHandler{
+		chrootsByLifecycleID:  map[string][]*chrooted.Chrooted{lifecycleID: {goodChroot, badChroot}},
+		chrootUnmountsCounter: unmounts,
+		chrootMountsCounter:   mounts,
+	}
+
+	h.OnNetworkRelease(ctx, makeSandbox(lifecycleID))
+
+	// goodChroot closed OK → counter == 1.
+	// badChroot.Close() failed → counter must NOT be incremented.
+	assert.Equal(t, int64(1), unmounts.total.Load(),
+		"unmounts counter must only increment on successful Close()")
+
+	// The lifecycle entry must be removed regardless of Close() errors.
+	h.mu.Lock()
+	_, exists := h.chrootsByLifecycleID[lifecycleID]
+	h.mu.Unlock()
+	assert.False(t, exists, "lifecycle entry must be removed from map after OnNetworkRelease")
+}

--- a/packages/orchestrator/pkg/nfsproxy/chroot/nfs_test.go
+++ b/packages/orchestrator/pkg/nfsproxy/chroot/nfs_test.go
@@ -5,6 +5,7 @@ package chroot
 import (
 	"context"
 	"net"
+	"os"
 	"sync/atomic"
 	"testing"
 
@@ -51,8 +52,8 @@ func (c *countingCounter) Add(_ context.Context, incr int64, _ ...metric.AddOpti
 func TestOnNetworkRelease_CounterOnlyIncrementedOnSuccess(t *testing.T) {
 	t.Parallel()
 
-	if testing.Short() {
-		t.Skip("requires pivot_root, skipping in short mode")
+	if os.Geteuid() != 0 {
+		t.Skip("skipping test because it requires root privileges")
 	}
 
 	dir := t.TempDir()


### PR DESCRIPTION
OnNetworkRelease incremented [nfs.chroot.unmounts] unconditionally, even when [chroot.Close()] returned an error. This meant the difference between [nfs.chroot.mounts] and [nfs.chroot.unmounts] — which is supposed to reflect the number of active mount namespaces — was silently understated whenever a close failed, masking mount namespace leaks in metrics and alerting.

Fix by skipping the counter increment via continue when Close() returns an error. The warning log and map cleanup are unaffected.

A unit test is added to nfs_test.go that injects one successful and one failing Close() call and asserts the counter is incremented exactly once.
/cc @jakubno @dobrac @ValentaTomas Would appreciate your review on this change, thanks!