### PR TITLE
Remove `no_cgroups` flag deprecated in Nomad 1.8+

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -61,9 +61,8 @@ job "orchestrator-${latest_orchestrator_job_id}" {
       }
 
       resources {
-        cpu        = 100 # there is no hard CPU cap, but its required value
         memory     = 1024
-        memory_max = -1 # no limit
+        memory_max = 1024 * 1024 # high memory to avoid OOM
       }
 
       env {

--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -60,6 +60,12 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         attempts = 0
       }
 
+      resources {
+        cpu        = 100 # there is no hard CPU cap, but its required value
+        memory     = 1024
+        memory_max = -1 # no limit
+      }
+
       env {
         NODE_ID     = "$${node.unique.name}"
         NODE_IP     = "$${attr.unique.network.ip-address}"

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -88,9 +88,8 @@ job "template-manager" {
       kill_signal  = "SIGTERM"
 
       resources {
-        cpu        = 100 # there is no hard CPU cap, but its required value
         memory     = 1024
-        memory_max = -1 # no limit
+        memory_max = 1024 * 1024 # high memory to avoid OOM
       }
 
       env {

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -88,8 +88,9 @@ job "template-manager" {
       kill_signal  = "SIGTERM"
 
       resources {
+        cpu        = 100 # there is no hard CPU cap, but its required value
         memory     = 1024
-        cpu        = 256
+        memory_max = -1 # no limit
       }
 
       env {

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -243,7 +243,6 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
-    no_cgroups = true
   }
 }
 

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -217,7 +217,6 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
-    no_cgroups = true
   }
 }
 


### PR DESCRIPTION
Removing `no_cgroups` requires explicit memory overprovisioning for the orchestrator and template builder jobs to preserve the previous behavior.

More details here:
- https://developer.hashicorp.com/nomad/docs/v1.8.x/job-specification/resources
- https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific#nomad-1-7-0
- https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific#nomad-1-8-0
