### PR TITLE
Revert "Remove `no_cgroups` flag deprecated in Nomad 1.8+ (#2883)"

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -60,11 +60,6 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         attempts = 0
       }
 
-      resources {
-        memory     = 1024
-        memory_max = 1024 * 1024 # high memory to avoid OOM
-      }
-
       env {
         NODE_ID     = "$${node.unique.name}"
         NODE_IP     = "$${attr.unique.network.ip-address}"

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -89,7 +89,7 @@ job "template-manager" {
 
       resources {
         memory     = 1024
-        memory_max = 1024 * 1024 # high memory to avoid OOM
+        cpu        = 256
       }
 
       env {

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -243,6 +243,7 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
+    no_cgroups = true
   }
 }
 

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -217,6 +217,7 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
+    no_cgroups = true
   }
 }
 


### PR DESCRIPTION
This reverts commit 47627aa49f439096a3188fee4f27b3f91a7a64dd.