### PR TITLE
fix(iac): migrate moved terraform resources

### DIFF
--- a/iac/provider-aws/Makefile
+++ b/iac/provider-aws/Makefile
@@ -101,6 +101,7 @@ apply:
 .PHONY: state-migrate
 state-migrate:
 	@ printf "Running Terraform state migrations for env: $(ENV)\n\n"
+	@ $(tf_vars) $(TF) state mv 'module.nomad.random_password.volume_token_key' 'random_password.volume_token_key' || true
 
 .PHONY: apply-init
 apply-init:

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -133,6 +133,8 @@ state-migrate:
 	@ $(tf_vars) $(TF) state mv 'random_password.dashboard_api_admin_secret' 'module.init.random_password.dashboard_api_admin_secret' || true
 	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret.dashboard_api_admin_token' 'module.init.google_secret_manager_secret.dashboard_api_admin_token' || true
 	@ $(tf_vars) $(TF) state mv 'google_secret_manager_secret_version.dashboard_api_admin_token_value' 'module.init.google_secret_manager_secret_version.dashboard_api_admin_token_value' || true
+	@ $(tf_vars) $(TF) state mv 'module.nomad.random_password.clickhouse_password' 'random_password.clickhouse_password' || true
+	@ $(tf_vars) $(TF) state mv 'module.nomad.random_password.clickhouse_server_secret' 'random_password.clickhouse_server_secret' || true
 
 .PHONY: apply-init
 apply-init:


### PR DESCRIPTION
Adds state-migrate entries for Terraform moved resources so targeted applies/plans do not fail with `Moved resource instances excluded by targeting`.

Verification:
- `env -i PATH="$PATH" HOME="$HOME" make -n -C iac/provider-gcp state-migrate ENV=not-set`
- `env -i PATH="$PATH" HOME="$HOME" make -n -C iac/provider-aws state-migrate ENV=not-set`