### PR TITLE
refactor(iac): lift client-proxy env vars

### DIFF
--- a/iac/modules/job-api/variables.tf
+++ b/iac/modules/job-api/variables.tf
@@ -45,11 +45,13 @@ variable "db_migrator_docker_image" {
 }
 
 variable "job_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "db_migrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }

--- a/iac/modules/job-client-proxy/jobs/client-proxy.hcl
+++ b/iac/modules/job-client-proxy/jobs/client-proxy.hcl
@@ -104,34 +104,9 @@ job "client-proxy" {
         HEALTH_PORT = "$${NOMAD_PORT_health}"
         PROXY_PORT  = "$${NOMAD_PORT_proxy}"
 
-        ENVIRONMENT = "${environment}"
-
-        OTEL_COLLECTOR_GRPC_ENDPOINT = "${otel_collector_grpc_endpoint}"
-        LOGS_COLLECTOR_ADDRESS       = "${logs_collector_address}"
-
-        REDIS_POOL_SIZE          = "${redis_pool_size}"
-        REDIS_CLUSTER_URL        = "${redis_cluster_url}"
-        REDIS_TLS_CA_BASE64      = "${redis_tls_ca_base64}"
-        REDIS_URL                = "${redis_url}"
-
-        %{ if api_internal_grpc_address != "" }
-        # used by in-cluster client-proxy to call API ResumeSandbox over gRPC
-        API_INTERNAL_GRPC_ADDRESS = "${api_internal_grpc_address}"
-        %{ endif }
-
-        %{ if api_edge_grpc_address != "" }
-        # used by external client-proxy to call edge API ResumeSandbox over gRPC
-        API_EDGE_GRPC_ADDRESS             = "${api_edge_grpc_address}"
-        %{ if api_edge_grpc_oauth_client_id != "" }
-        API_EDGE_GRPC_OAUTH_CLIENT_ID     = "${api_edge_grpc_oauth_client_id}"
-        API_EDGE_GRPC_OAUTH_CLIENT_SECRET = "${api_edge_grpc_oauth_client_secret}"
-        API_EDGE_GRPC_OAUTH_TOKEN_URL     = "${api_edge_grpc_oauth_token_url}"
-        %{ endif }
-        %{ endif }
-
-        %{ if launch_darkly_api_key != "" }
-        LAUNCH_DARKLY_API_KEY         = "${launch_darkly_api_key}"
-        %{ endif }
+%{ for key, value in job_env_vars ~}
+        ${key} = "${value}"
+%{ endfor ~}
       }
 
       config {

--- a/iac/modules/job-client-proxy/main.tf
+++ b/iac/modules/job-client-proxy/main.tf
@@ -1,6 +1,8 @@
 locals {
-  api_internal_grpc_address = trimspace(var.api_internal_grpc_address)
-  api_edge_grpc_address     = trimspace(var.api_edge_grpc_address)
+  job_env_vars = {
+    for key, value in var.job_env_vars : key => trimspace(value)
+    if try(trimspace(value), "") != ""
+  }
 
   # Convert exposure_type to Traefik entrypoints
   entrypoints = (
@@ -18,29 +20,13 @@ resource "nomad_job" "client_proxy" {
     memory_mb           = var.client_proxy_memory_mb
     update_max_parallel = var.client_proxy_update_max_parallel
 
-    node_pool   = var.node_pool
-    environment = var.environment
+    node_pool = var.node_pool
 
     proxy_port  = var.proxy_port
     health_port = var.health_port
 
-    redis_url           = var.redis_url
-    redis_cluster_url   = var.redis_cluster_url
-    redis_tls_ca_base64 = var.redis_tls_ca_base64
-    redis_pool_size     = var.redis_pool_size
-
-    image                     = var.image
-    api_internal_grpc_address = local.api_internal_grpc_address
-    api_edge_grpc_address     = local.api_edge_grpc_address
-
-    api_edge_grpc_oauth_client_id     = trimspace(var.api_edge_grpc_oauth_client_id)
-    api_edge_grpc_oauth_client_secret = trimspace(var.api_edge_grpc_oauth_client_secret)
-    api_edge_grpc_oauth_token_url     = trimspace(var.api_edge_grpc_oauth_token_url)
-
-    otel_collector_grpc_endpoint = var.otel_collector_grpc_endpoint
-    logs_collector_address       = var.logs_collector_address
-    launch_darkly_api_key        = trimspace(var.launch_darkly_api_key)
-
-    entrypoints = local.entrypoints
+    image        = var.image
+    job_env_vars = local.job_env_vars
+    entrypoints  = local.entrypoints
   })
 }

--- a/iac/modules/job-client-proxy/variables.tf
+++ b/iac/modules/job-client-proxy/variables.tf
@@ -25,10 +25,6 @@ variable "node_pool" {
   type = string
 }
 
-variable "environment" {
-  type = string
-}
-
 variable "proxy_port" {
   type    = number
   default = 3002
@@ -39,70 +35,8 @@ variable "health_port" {
   default = 3001
 }
 
-variable "redis_url" {
-  type      = string
-  sensitive = true
-}
-
-variable "redis_cluster_url" {
-  type      = string
-  sensitive = true
-}
-
-variable "redis_tls_ca_base64" {
-  type      = string
-  sensitive = true
-}
-
-variable "redis_pool_size" {
-  type    = number
-  default = 40
-}
-
 variable "image" {
   type = string
-}
-
-variable "api_internal_grpc_address" {
-  type    = string
-  default = ""
-}
-
-variable "api_edge_grpc_address" {
-  type    = string
-  default = ""
-}
-
-variable "api_edge_grpc_oauth_client_id" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
-variable "api_edge_grpc_oauth_client_secret" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
-variable "api_edge_grpc_oauth_token_url" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
-variable "otel_collector_grpc_endpoint" {
-  type = string
-}
-
-variable "logs_collector_address" {
-  type = string
-}
-
-variable "launch_darkly_api_key" {
-  type      = string
-  default   = ""
-  sensitive = true
 }
 
 variable "exposure_type" {
@@ -113,4 +47,9 @@ variable "exposure_type" {
     condition     = contains(["public", "private", "both"], var.exposure_type)
     error_message = "Must be: public, private, or both"
   }
+}
+
+variable "job_env_vars" {
+  type    = map(string)
+  default = {}
 }

--- a/iac/modules/job-client-proxy/variables.tf
+++ b/iac/modules/job-client-proxy/variables.tf
@@ -50,6 +50,7 @@ variable "exposure_type" {
 }
 
 variable "job_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }

--- a/iac/modules/job-orchestrator/variables.tf
+++ b/iac/modules/job-orchestrator/variables.tf
@@ -147,7 +147,7 @@ variable "persistent_volume_mounts" {
 }
 
 variable "job_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
-

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -160,6 +160,18 @@ locals {
   api_db_migrator_env_vars = merge({
     POSTGRES_CONNECTION_STRING = module.init.postgres_connection_string
   }, var.api_db_migrator_env_vars)
+
+  client_proxy_env_vars = merge({
+    ENVIRONMENT                  = var.environment
+    OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:${local.otel_collector_port}"
+    LOGS_COLLECTOR_ADDRESS       = "http://localhost:${local.logs_proxy_port}"
+    REDIS_POOL_SIZE              = "40"
+    REDIS_CLUSTER_URL            = local.redis_cluster_url
+    REDIS_TLS_CA_BASE64          = local.redis_tls_ca_base64
+    REDIS_URL                    = local.redis_url
+    API_INTERNAL_GRPC_ADDRESS    = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
+    LAUNCH_DARKLY_API_KEY        = module.init.launch_darkly_api_key
+  }, var.client_proxy_env_vars)
 }
 
 module "redis" {
@@ -280,6 +292,7 @@ module "nomad" {
 
   client_proxy_count           = var.client_proxy_count
   client_proxy_repository_name = module.init.client_proxy_repository_name
+  client_proxy_env_vars        = local.client_proxy_env_vars
 
   orchestrator_node_pool              = local.client_pool_name
   allow_sandbox_internal_cidrs        = var.allow_sandbox_internal_cidrs

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -169,8 +169,9 @@ locals {
     REDIS_CLUSTER_URL            = local.redis_cluster_url
     REDIS_TLS_CA_BASE64          = local.redis_tls_ca_base64
     REDIS_URL                    = local.redis_url
-    API_INTERNAL_GRPC_ADDRESS    = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
-    LAUNCH_DARKLY_API_KEY        = module.init.launch_darkly_api_key
+    # Used by in-cluster client-proxy to call API ResumeSandbox over gRPC.
+    API_INTERNAL_GRPC_ADDRESS = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
+    LAUNCH_DARKLY_API_KEY     = module.init.launch_darkly_api_key
   }, var.client_proxy_env_vars)
 }
 

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -87,18 +87,10 @@ module "client_proxy" {
   update_stanza      = var.api_cluster_size > 1
   client_proxy_count = var.client_proxy_count
 
-  node_pool   = var.api_node_pool
-  environment = var.environment
+  node_pool = var.api_node_pool
 
-  redis_url                 = var.redis_url
-  redis_cluster_url         = var.redis_cluster_url
-  redis_tls_ca_base64       = var.redis_tls_ca_base64
-  image                     = data.aws_ecr_image.client_proxy.image_uri
-  api_internal_grpc_address = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
-
-  otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
-  logs_collector_address       = "http://localhost:${var.logs_proxy_port}"
-  launch_darkly_api_key        = var.launch_darkly_api_key
+  image        = data.aws_ecr_image.client_proxy.image_uri
+  job_env_vars = var.client_proxy_env_vars
 }
 
 module "api" {

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -66,8 +66,9 @@ variable "client_proxy_repository_name" {
 }
 
 variable "client_proxy_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 # Redis

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -65,6 +65,11 @@ variable "client_proxy_repository_name" {
   type = string
 }
 
+variable "client_proxy_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
 # Redis
 variable "redis_managed" {
   type = bool

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -178,13 +178,15 @@ variable "api_internal_grpc_port" {
 }
 
 variable "api_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_db_migrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_memory_mb" {

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -54,6 +54,11 @@ variable "api_db_migrator_env_vars" {
   default = {}
 }
 
+variable "client_proxy_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
 variable "api_server_machine_type" {
   type    = string
   default = "t3.xlarge"

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -45,13 +45,15 @@ variable "api_internal_grpc_port" {
 }
 
 variable "api_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_db_migrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "client_proxy_env_vars" {

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -55,8 +55,9 @@ variable "api_db_migrator_env_vars" {
 }
 
 variable "client_proxy_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_server_machine_type" {

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -139,6 +139,18 @@ locals {
     POSTGRES_CONNECTION_STRING = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
   }, var.api_db_migrator_env_vars)
 
+  client_proxy_env_vars = merge({
+    ENVIRONMENT                  = var.environment
+    OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:${local.otel_collector_grpc_port}"
+    LOGS_COLLECTOR_ADDRESS       = "http://localhost:${local.logs_proxy_port}"
+    REDIS_POOL_SIZE              = "40"
+    REDIS_CLUSTER_URL            = local.redis_cluster_url
+    REDIS_TLS_CA_BASE64          = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
+    REDIS_URL                    = local.redis_url
+    API_INTERNAL_GRPC_ADDRESS    = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
+    LAUNCH_DARKLY_API_KEY        = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+  }, var.client_proxy_env_vars)
+
   # Normalize additional_api_paths_handled_by_ingress to support both legacy (list of strings)
   # and new (list of objects) formats. Strings are converted to objects with paths = [string].
   normalized_api_paths_handled_by_ingress = [
@@ -352,6 +364,7 @@ module "nomad" {
 
   client_proxy_session_port = var.client_proxy_port.port
   client_proxy_health_port  = var.client_proxy_health_port.port
+  client_proxy_env_vars     = local.client_proxy_env_vars
 
   domain_name = var.domain_name
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -147,8 +147,9 @@ locals {
     REDIS_CLUSTER_URL            = local.redis_cluster_url
     REDIS_TLS_CA_BASE64          = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
     REDIS_URL                    = local.redis_url
-    API_INTERNAL_GRPC_ADDRESS    = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
-    LAUNCH_DARKLY_API_KEY        = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+    # Used by in-cluster client-proxy to call API ResumeSandbox over gRPC.
+    API_INTERNAL_GRPC_ADDRESS = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
+    LAUNCH_DARKLY_API_KEY     = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
   }, var.client_proxy_env_vars)
 
   # Normalize additional_api_paths_handled_by_ingress to support both legacy (list of strings)

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -152,21 +152,13 @@ module "client_proxy" {
   client_proxy_memory_mb           = var.client_proxy_resources_memory_mb
   client_proxy_update_max_parallel = var.client_proxy_update_max_parallel
 
-  node_pool   = var.api_node_pool
-  environment = var.environment
+  node_pool = var.api_node_pool
 
   proxy_port  = var.client_proxy_session_port
   health_port = var.client_proxy_health_port
 
-  redis_url                 = local.redis_url
-  redis_cluster_url         = local.redis_cluster_url
-  redis_tls_ca_base64       = trimspace(data.google_secret_manager_secret_version.redis_tls_ca_base64.secret_data)
-  image                     = data.google_artifact_registry_docker_image.client_proxy_image.self_link
-  api_internal_grpc_address = "api-internal-grpc.service.consul:${var.api_internal_grpc_port}"
-
-  otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
-  logs_collector_address       = "http://localhost:${var.logs_proxy_port.port}"
-  launch_darkly_api_key        = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+  image        = data.google_artifact_registry_docker_image.client_proxy_image.self_link
+  job_env_vars = var.client_proxy_env_vars
 }
 
 # grafana otel collector url

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -206,6 +206,11 @@ variable "client_proxy_health_port" {
   type = number
 }
 
+variable "client_proxy_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
 variable "domain_name" {
   type = string
 }

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -66,13 +66,15 @@ variable "api_internal_grpc_port" {
 }
 
 variable "api_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_db_migrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "ingress_port" {
@@ -550,8 +552,9 @@ variable "gcs_grpc_connection_pool_size" {
 }
 
 variable "orchestrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "orchestrator_enabled" {

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -207,8 +207,9 @@ variable "client_proxy_health_port" {
 }
 
 variable "client_proxy_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "domain_name" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -851,8 +851,9 @@ variable "api_db_migrator_env_vars" {
 }
 
 variable "client_proxy_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "orchestrator_enabled" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -850,6 +850,11 @@ variable "api_db_migrator_env_vars" {
   default = {}
 }
 
+variable "client_proxy_env_vars" {
+  type    = map(string)
+  default = {}
+}
+
 variable "orchestrator_enabled" {
   type        = bool
   default     = true

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -836,18 +836,21 @@ variable "anywhere_cache_ttl" {
 }
 
 variable "orchestrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "api_db_migrator_env_vars" {
-  type    = map(string)
-  default = {}
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "client_proxy_env_vars" {


### PR DESCRIPTION
Refactors the client-proxy Nomad job module to accept a filtered env var map, matching the API env var refactor pattern. Provider roots now assemble default client-proxy env maps and pass them through their nomad modules.

Verification:
- terraform fmt -check -recursive iac/modules/job-client-proxy iac/provider-gcp iac/provider-aws
- git diff --check
- terraform console templatefile render for iac/modules/job-client-proxy/jobs/client-proxy.hcl