### PR TITLE
fix(api): raise canary min_healthy_time to bridge GCP LB heal-in

### DIFF
--- a/iac/modules/job-api/jobs/api.hcl
+++ b/iac/modules/job-api/jobs/api.hcl
@@ -133,7 +133,6 @@ job "api" {
       # admitted as a routable backend. A short value promotes and tears down
       # the old (still GCP-routable) backends before the new node is admitted,
       # leaving the LB with zero healthy backends -> 503 failed_to_pick_backend.
-      # Lower once API traffic is routed via traefik off live Consul state.
       min_healthy_time  = "120s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
       healthy_deadline  = "10800s"

--- a/iac/modules/job-api/jobs/api.hcl
+++ b/iac/modules/job-api/jobs/api.hcl
@@ -125,8 +125,16 @@ job "api" {
       max_parallel      = 1
       # Allows to spawn new version of the service before killing the old one
       canary            = 1
-      # Time to wait for the canary to be healthy
-      min_healthy_time  = "10s"
+
+      # Time the canary must stay healthy (in Consul) before it is promoted and
+      # the old allocations are stopped. Intentionally long: API traffic is
+      # routed by the GCP LB directly to allocations via a fixed-port health
+      # check, and a canary on a freshly created MIG node takes ~60s to be
+      # admitted as a routable backend. A short value promotes and tears down
+      # the old (still GCP-routable) backends before the new node is admitted,
+      # leaving the LB with zero healthy backends -> 503 failed_to_pick_backend.
+      # Lower once API traffic is routed via traefik off live Consul state.
+      min_healthy_time  = "120s"
       # Time to wait for the canary to be healthy, if not it will be marked as failed
       healthy_deadline  = "10800s"
       # Time to wait for the overall update to complete. Otherwise, the deployment is marked as failed and rolled back


### PR DESCRIPTION
API traffic is routed by the GCP load balancer directly to allocations via a fixed-port health check on the orch-api instance group. During a deploy that places a canary on a freshly created MIG node, the GCP LB can take ~60s to propagate the new instance and mark it healthy before routing to it.

With min_healthy_time=10s, Nomad/Consul considered the canary healthy and auto-promoted ~13s in, stopping the old (still GCP-routable) allocations long before GCP admitted the new node. That left the LB with zero healthy backends for ~40s, returning thousands of 503 failed_to_pick_backend.

Raise min_healthy_time to 120s so the old backends stay routable until the new node is admitted by the GCP LB.