### PR TITLE
Update cluster to 1.8 (Nomad) and 1.17 (Consul)

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -60,6 +60,11 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         attempts = 0
       }
 
+      resources {
+        memory     = 1024
+        memory_max = 1024 * 1024 # high memory to avoid OOM
+      }
+
       env {
         NODE_ID     = "$${node.unique.name}"
         NODE_IP     = "$${attr.unique.network.ip-address}"

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -90,6 +90,7 @@ job "template-manager" {
       resources {
         memory     = 1024
         cpu        = 256
+        memory_max = 1024 * 1024 # high memory to avoid OOM
       }
 
       env {

--- a/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
@@ -17,12 +17,12 @@ variable "prefix" {
 
 variable "consul_version" {
   type    = string
-  default = "1.16.2"
+  default = "1.17.3"
 }
 
 variable "nomad_version" {
   type    = string
-  default = "1.6.2"
+  default = "1.8.4"
 }
 
 # Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -243,7 +243,6 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
-    no_cgroups = true
   }
 }
 

--- a/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
@@ -21,12 +21,12 @@ variable "prefix" {
 
 variable "consul_version" {
   type    = string
-  default = "1.16.2"
+  default = "1.17.3"
 }
 
 variable "nomad_version" {
   type    = string
-  default = "1.6.2"
+  default = "1.8.4"
 }
 
 # Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -217,7 +217,6 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
-    no_cgroups = true
   }
 }
 


### PR DESCRIPTION
Details on Nomad and Consul update flow - https://github.com/e2b-dev/infra/pull/2870

Now we need to go to 1.8 (Nomad) and 1.17 (Consul), which are still backward-compatible with the current versions.
After this is set up and running on all nodes we will do two more updates to go to LTS 1.21.5 (Consul), 1.10.5 (Nomad)