### PR TITLE
feat(placement): allow forward-compatible CPU models for sandbox placement

### DIFF
--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -241,8 +241,9 @@ func (c *Cluster) GetAvailableTemplateBuilder(ctx context.Context, expectedInfo 
 			return false
 		}
 
-		// Check machine compatibility
-		if expectedInfo.CPUModel != "" && !expectedInfo.IsCompatibleWith(machineInfo) {
+		// Check machine compatibility. Builder nodes require an exact CPU match
+		// (no forward-compatibility) so the build runs on the same CPU model.
+		if expectedInfo.CPUModel != "" && !expectedInfo.IsExactMatch(machineInfo) {
 			return false
 		}
 

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -355,6 +355,7 @@ func (o *Orchestrator) CreateSandbox(
 		sbxData.Network,
 		trafficAccessToken,
 		nodemanager.ConvertOrchestratorMountsToDatabaseMounts(sbxData.VolumeMounts),
+		builds.ToMachineInfo(sbxData.Build),
 	)
 
 	err = o.sandboxStore.Add(ctx, sbx, &creationMeta)

--- a/packages/api/internal/orchestrator/nodemanager/mock.go
+++ b/packages/api/internal/orchestrator/nodemanager/mock.go
@@ -16,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	infogrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
+	"github.com/e2b-dev/infra/packages/shared/pkg/machineinfo"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 )
 
@@ -86,6 +87,12 @@ func WithCPUInfo(cpuArch, cpuFamily, cpuModel string) TestOptions {
 		node.machineInfo.CPUArchitecture = cpuArch
 		node.machineInfo.CPUFamily = cpuFamily
 		node.machineInfo.CPUModel = cpuModel
+	}
+}
+
+func WithMachineInfo(info machineinfo.MachineInfo) TestOptions {
+	return func(node *TestNode) {
+		node.machineInfo = info
 	}
 }
 

--- a/packages/api/internal/orchestrator/nodemanager/sandboxes.go
+++ b/packages/api/internal/orchestrator/nodemanager/sandboxes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
+	"github.com/e2b-dev/infra/packages/shared/pkg/machineinfo"
 )
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager")
@@ -139,6 +140,10 @@ func (n *Node) GetSandboxes(ctx context.Context) ([]sandbox.Sandbox, error) {
 				network,
 				networkTrafficAccessToken,
 				volumeMounts,
+				// The orchestrator gRPC config does not carry the build's CPU
+				// machine info, so it is left empty here. buildUpsertSnapshotParams
+				// falls back to the running node's machine info in that case.
+				machineinfo.MachineInfo{},
 			),
 		)
 	}

--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -104,13 +104,19 @@ func (o *Orchestrator) WaitForStateChange(ctx context.Context, teamID uuid.UUID,
 }
 
 func buildUpsertSnapshotParams(sbx sandbox.Sandbox, node *nodemanager.Node) queries.UpsertSnapshotParams {
-	machineInfo := node.MachineInfo()
+	// This is a fallback,
+	// remove after migration period
+	machineInfo := sbx.MachineInfo
+	if machineInfo.CPUArchitecture == "" {
+		machineInfo = node.MachineInfo()
+	}
 
 	metadata := types.JSONBStringMap(sbx.Metadata)
 	if metadata == nil {
 		metadata = types.JSONBStringMap{}
 	}
 
+	// TODO: Is it possible to rewrite the query to use machineInfo from the BaseTemplate instead?
 	return queries.UpsertSnapshotParams{
 		// Used if there's no snapshot for this sandbox yet
 		TemplateID:     id.Generate(),

--- a/packages/api/internal/sandbox/sandboxtypes/sandbox.go
+++ b/packages/api/internal/sandbox/sandboxtypes/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
+	"github.com/e2b-dev/infra/packages/shared/pkg/machineinfo"
 )
 
 func NewSandbox(
@@ -39,6 +40,7 @@ func NewSandbox(
 	network *types.SandboxNetworkConfig,
 	trafficAccessToken *string,
 	mounts []*types.SandboxVolumeMountConfig,
+	buildMachineInfo machineinfo.MachineInfo,
 ) Sandbox {
 	return Sandbox{
 		SandboxID:  sandboxID,
@@ -71,6 +73,7 @@ func NewSandbox(
 		BaseTemplateID:      baseTemplateID,
 		Network:             network,
 		VolumeMounts:        mounts,
+		MachineInfo:         buildMachineInfo,
 	}
 }
 
@@ -104,6 +107,8 @@ type Sandbox struct {
 	AutoResume          *types.SandboxAutoResumeConfig    `json:"autoResume,omitempty"`
 	Network             *types.SandboxNetworkConfig       `json:"network"`
 	VolumeMounts        []*types.SandboxVolumeMountConfig `json:"volumeMounts"`
+
+	MachineInfo machineinfo.MachineInfo `json:"machineInfo"`
 
 	State State `json:"state"`
 }

--- a/packages/api/internal/sandbox/store_test.go
+++ b/packages/api/internal/sandbox/store_test.go
@@ -16,6 +16,7 @@ import (
 
 	sandboxredis "github.com/e2b-dev/infra/packages/api/internal/sandbox/storage/redis"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"github.com/e2b-dev/infra/packages/shared/pkg/machineinfo"
 	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
 )
 
@@ -210,10 +211,11 @@ func createTestSandbox() Sandbox {
 		nil,   // envdAccessToken
 		nil,   // allowInternetAccess
 		"base-template",
-		nil, // domain
-		nil, // network
-		nil, // trafficAccessToken
-		nil, // volumes
+		nil,                       // domain
+		nil,                       // network
+		nil,                       // trafficAccessToken
+		nil,                       // volumes
+		machineinfo.MachineInfo{}, // buildMachineInfo
 	)
 }
 

--- a/packages/shared/pkg/machineinfo/machine_info.go
+++ b/packages/shared/pkg/machineinfo/machine_info.go
@@ -3,12 +3,24 @@ package machineinfo
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 	"go.uber.org/zap"
 
 	infogrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+const (
+	archAMD64 = "amd64"
+
+	// intelCPUFamily is CPU family 6, used by modern Intel CPUs. (e.g. N2, C3, C4 nodes in GCP)
+	intelCPUFamily = "6"
+
+	// minForwardCompatibleModel is the minimum CPU model (Ice Lake) from which
+	// newer Intel CPUs are treated as forward-compatible.
+	minForwardCompatibleModel = 106
 )
 
 type MachineInfo struct {
@@ -19,8 +31,34 @@ type MachineInfo struct {
 	CPUFlags        []string `json:"cpu_flags"`
 }
 
+// IsCompatibleWith reports whether a build (the receiver m) can run on a node
+// (the argument other). The receiver must be the build's machine info and the
+// argument must be the node's machine info; the relationship is not symmetric.
 func (m MachineInfo) IsCompatibleWith(other MachineInfo) bool {
-	return m.CPUArchitecture == other.CPUArchitecture && m.CPUFamily == other.CPUFamily && m.CPUModel == other.CPUModel
+	// Architecture and family must always match.
+	if m.CPUArchitecture != other.CPUArchitecture || m.CPUFamily != other.CPUFamily {
+		return false
+	}
+
+	// For amd64 builds on CPU family 6 with model >= minForwardCompatibleModel
+	// (Ice Lake and newer Intel), a node is compatible as long as its CPU model
+	// is >= the build's CPU model, i.e. newer Intel CPUs are forward-compatible.
+	if m.CPUArchitecture == archAMD64 {
+		buildModel, buildErr := strconv.Atoi(m.CPUModel)
+		nodeModel, nodeErr := strconv.Atoi(other.CPUModel)
+		if buildErr == nil && nodeErr == nil && m.CPUFamily == intelCPUFamily && buildModel >= minForwardCompatibleModel {
+			return nodeModel >= buildModel
+		}
+	}
+
+	// Default: require an exact CPU model match.
+	return m.IsExactMatch(other)
+}
+
+func (m MachineInfo) IsExactMatch(other MachineInfo) bool {
+	return m.CPUArchitecture == other.CPUArchitecture &&
+		m.CPUFamily == other.CPUFamily &&
+		m.CPUModel == other.CPUModel
 }
 
 func FromGRPCInfo(info *infogrpc.MachineInfo) MachineInfo {


### PR DESCRIPTION
Allow amd64 builds on Intel family 6 with model >= 106 to run on nodes with a CPU model >= the build's model. Builder node selection keeps an exact CPU match via the new IsExactMatch method.