### PR TITLE
feat(uffd): export UFFD stats as Mimir metrics

### DIFF
--- a/packages/orchestrator/pkg/sandbox/uffd/memory_backend.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/memory_backend.go
@@ -14,7 +14,9 @@ import (
 type MemoryBackend interface {
 	DiffMetadata(ctx context.Context, f *fc.Process) (*header.DiffMetadata, error)
 	PrefetchData(ctx context.Context) (block.PrefetchData, error)
-	Prefault(ctx context.Context, offset int64, data []byte) error
+	// Prefault returns whether this call installed the page (false on
+	// skipped/present/deferred nil-error paths); see Userfaultfd.Prefault.
+	Prefault(ctx context.Context, offset int64, data []byte) (installed bool, e error)
 	Start(ctx context.Context, sandboxId string) error
 	Stop() error
 	Ready() chan struct{}

--- a/packages/orchestrator/pkg/sandbox/uffd/noop.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/noop.go
@@ -30,8 +30,8 @@ func NewNoopMemory(size, blockSize int64) *NoopMemory {
 	}
 }
 
-func (m *NoopMemory) Prefault(_ context.Context, _ int64, _ []byte) error {
-	return nil
+func (m *NoopMemory) Prefault(_ context.Context, _ int64, _ []byte) (bool, error) {
+	return false, nil
 }
 
 func (m *NoopMemory) DiffMetadata(ctx context.Context, f *fc.Process) (*header.DiffMetadata, error) {

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/metrics.go
@@ -15,10 +15,13 @@ var meter = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandb
 
 // pagesCounter counts pages processed by prefetch runs, by stage:
 // fetched / fetch_skipped (fetch phase: cache population from the source) and
-// copied / copy_skipped (copy phase: Prefault into the guest). Recorded once
-// per run at completion, matching the "prefetch: completed" log line.
-// Per-page copy detail (latency, install outcome) lives in
-// orchestrator.sandbox.uffd.prefault.
+// copied / copy_skipped (copy phase: Prefault into the guest). copied counts
+// only pages this run actually installed — equal to
+// prefault{result="installed"} by construction; prefaults that found the page
+// already resident, lost the install race, or hit EAGAIN land in
+// copy_skipped. Recorded once per run at completion, matching the
+// "prefetch: completed" log line. Per-page copy detail (latency, install
+// outcome) lives in orchestrator.sandbox.uffd.prefault.
 var pagesCounter = utils.Must(meter.Int64Counter(
 	"orchestrator.sandbox.uffd.prefetch.pages",
 	metric.WithDescription("Pages processed by prefetch runs, by stage"),

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/metrics.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package prefetch
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+var meter = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/prefetch")
+
+// pagesCounter counts pages processed by prefetch runs, by stage:
+// fetched / fetch_skipped (fetch phase: cache population from the source) and
+// copied / copy_skipped (copy phase: Prefault into the guest). Recorded once
+// per run at completion, matching the "prefetch: completed" log line.
+// Per-page copy detail (latency, install outcome) lives in
+// orchestrator.sandbox.uffd.prefault.
+var pagesCounter = utils.Must(meter.Int64Counter(
+	"orchestrator.sandbox.uffd.prefetch.pages",
+	metric.WithDescription("Pages processed by prefetch runs, by stage"),
+))
+
+// durationHistogram records prefetch run phase durations. The fetch and copy
+// phases overlap (copy starts once uffd is ready); "total" spans the whole
+// run. copy/total durations far exceeding the resume duration mean the
+// prefetch ran too late to help.
+var durationHistogram = utils.Must(meter.Int64Histogram(
+	"orchestrator.sandbox.uffd.prefetch.duration",
+	metric.WithDescription("Prefetch run phase durations"),
+	metric.WithUnit("ms"),
+))
+
+var (
+	stageFetchedAttr      = telemetry.PrecomputeAttrs(attribute.String("stage", "fetched"))
+	stageFetchSkippedAttr = telemetry.PrecomputeAttrs(attribute.String("stage", "fetch_skipped"))
+	stageCopiedAttr       = telemetry.PrecomputeAttrs(attribute.String("stage", "copied"))
+	stageCopySkippedAttr  = telemetry.PrecomputeAttrs(attribute.String("stage", "copy_skipped"))
+
+	phaseFetchAttr = telemetry.PrecomputeAttrs(attribute.String("phase", "fetch"))
+	phaseCopyAttr  = telemetry.PrecomputeAttrs(attribute.String("phase", "copy"))
+	phaseTotalAttr = telemetry.PrecomputeAttrs(attribute.String("phase", "total"))
+)

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
@@ -4,8 +4,10 @@ package prefetch
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -13,6 +15,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/metadata"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -122,6 +125,13 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 	var fetchWg sync.WaitGroup
 	var copyWg sync.WaitGroup
 
+	runStart := time.Now()
+	// Set by the copy coordinator once uffd is ready; stays nil if the
+	// context is cancelled before the copy phase ever starts. Holds a
+	// *time.Time (not UnixNano) so the monotonic reading survives and the
+	// duration below is immune to wall-clock steps.
+	var copyStart atomic.Pointer[time.Time]
+
 	// Queue all offsets to fetch in the order they were originally accessed
 	for _, idx := range indices {
 		fetchCh <- header.BlockOffset(int64(idx), blockSize)
@@ -137,16 +147,29 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 
 	// Start copy coordinator - waits for uffd ready, then spawns copy workers
 	copyWg.Go(func() {
-		p.startCopyWorkers(ctx, copyCh, maxCopyWorkers, &copiedCount, &copySkippedCount)
+		p.startCopyWorkers(ctx, copyCh, maxCopyWorkers, &copyStart, &copiedCount, &copySkippedCount)
 	})
 
 	// Wait for fetch workers to complete
 	fetchWg.Wait()
+	fetchDuration := time.Since(runStart)
 	// Close copy channel when all fetch workers are done
 	close(copyCh)
 
 	// Wait for copy workers to complete
 	copyWg.Wait()
+
+	// Export the run stats: per-stage page counts plus phase durations. The
+	// fetch and copy phases overlap; "total" spans the whole run.
+	pagesCounter.Add(ctx, int64(fetchedCount.Load()), stageFetchedAttr)
+	pagesCounter.Add(ctx, int64(fetchSkippedCount.Load()), stageFetchSkippedAttr)
+	pagesCounter.Add(ctx, int64(copiedCount.Load()), stageCopiedAttr)
+	pagesCounter.Add(ctx, int64(copySkippedCount.Load()), stageCopySkippedAttr)
+	durationHistogram.Record(ctx, fetchDuration.Milliseconds(), phaseFetchAttr)
+	if cs := copyStart.Load(); cs != nil {
+		durationHistogram.Record(ctx, time.Since(*cs).Milliseconds(), phaseCopyAttr)
+	}
+	durationHistogram.Record(ctx, time.Since(runStart).Milliseconds(), phaseTotalAttr)
 
 	p.logger.Debug(ctx, "prefetch: completed",
 		zap.Uint64("fetched", fetchedCount.Load()),
@@ -164,6 +187,7 @@ func (p *Prefetcher) startCopyWorkers(
 	ctx context.Context,
 	copyCh chan prefetchData,
 	maxCopyWorkers int,
+	copyStart *atomic.Pointer[time.Time],
 	copiedCount *atomic.Uint64,
 	copySkippedCount *atomic.Uint64,
 ) {
@@ -173,6 +197,9 @@ func (p *Prefetcher) startCopyWorkers(
 		return
 	case <-p.uffd.Ready():
 	}
+
+	now := time.Now()
+	copyStart.Store(&now)
 
 	p.logger.Debug(ctx, "prefetch: uffd ready, starting copy workers")
 
@@ -246,6 +273,13 @@ func (p *Prefetcher) copyWorker(
 			}
 
 			err := p.uffd.Prefault(ctx, d.offset, d.data)
+			if errors.Is(err, userfaultfd.ErrClosed) {
+				// The uffd is gone (sandbox teardown): every remaining queued
+				// page would hit the same path. Stop draining and count
+				// nothing, keeping stage="copied" consistent with the
+				// per-page prefault metric, which skips this path too.
+				return
+			}
 			if err != nil {
 				p.logger.Debug(ctx, "prefetch: failed to copy page",
 					zap.Int64("offset", d.offset),

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
@@ -272,7 +272,7 @@ func (p *Prefetcher) copyWorker(
 				return
 			}
 
-			err := p.uffd.Prefault(ctx, d.offset, d.data)
+			installed, err := p.uffd.Prefault(ctx, d.offset, d.data)
 			if errors.Is(err, userfaultfd.ErrClosed) {
 				// The uffd is gone (sandbox teardown): every remaining queued
 				// page would hit the same path. Stop draining and count
@@ -290,7 +290,15 @@ func (p *Prefetcher) copyWorker(
 				continue
 			}
 
-			copiedCount.Add(1)
+			// A nil error doesn't mean this prefault copied the page: it may
+			// have been skipped (already resident), lost the install race to
+			// a demand fault, or deferred on EAGAIN. Count those as skipped so
+			// stage="copied" matches prefault{result="installed"} exactly.
+			if installed {
+				copiedCount.Add(1)
+			} else {
+				skippedCount.Add(1)
+			}
 		}
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher.go
@@ -93,6 +93,13 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 	maxFetchWorkers := p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxFetchWorkers)
 	maxCopyWorkers := p.featureFlags.IntFlag(ctx, featureflags.MemoryPrefetchMaxCopyWorkers)
 
+	// cancelRun aborts the whole run early. Copy workers fire it on ErrClosed
+	// (uffd gone: sandbox teardown) so fetch workers stop fetching and
+	// queueing pages nobody will ever copy, instead of running the fetch
+	// phase to completion for a dead sandbox.
+	ctx, cancelRun := context.WithCancel(ctx)
+	defer cancelRun()
+
 	blockSize := p.mapping.BlockSize
 	totalPages := len(indices)
 
@@ -147,7 +154,7 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 
 	// Start copy coordinator - waits for uffd ready, then spawns copy workers
 	copyWg.Go(func() {
-		p.startCopyWorkers(ctx, copyCh, maxCopyWorkers, &copyStart, &copiedCount, &copySkippedCount)
+		p.startCopyWorkers(ctx, cancelRun, copyCh, maxCopyWorkers, &copyStart, &copiedCount, &copySkippedCount)
 	})
 
 	// Wait for fetch workers to complete
@@ -185,6 +192,7 @@ func (p *Prefetcher) Start(ctx context.Context) error {
 // startCopyWorkers waits for uffd to be ready, then starts copy workers
 func (p *Prefetcher) startCopyWorkers(
 	ctx context.Context,
+	cancelRun context.CancelFunc,
 	copyCh chan prefetchData,
 	maxCopyWorkers int,
 	copyStart *atomic.Pointer[time.Time],
@@ -208,7 +216,7 @@ func (p *Prefetcher) startCopyWorkers(
 
 	for range maxCopyWorkers {
 		copyWorkerWg.Go(func() {
-			p.copyWorker(ctx, copyCh, copiedCount, copySkippedCount)
+			p.copyWorker(ctx, cancelRun, copyCh, copiedCount, copySkippedCount)
 		})
 	}
 
@@ -259,6 +267,7 @@ func (p *Prefetcher) fetchWorker(
 // copyWorker copies pages to guest memory via uffd
 func (p *Prefetcher) copyWorker(
 	ctx context.Context,
+	cancelRun context.CancelFunc,
 	copyCh <-chan prefetchData,
 	copiedCount *atomic.Uint64,
 	skippedCount *atomic.Uint64,
@@ -275,9 +284,12 @@ func (p *Prefetcher) copyWorker(
 			installed, err := p.uffd.Prefault(ctx, d.offset, d.data)
 			if errors.Is(err, userfaultfd.ErrClosed) {
 				// The uffd is gone (sandbox teardown): every remaining queued
-				// page would hit the same path. Stop draining and count
+				// page would hit the same path. Cancel the run so the fetch
+				// workers stop pulling pages nobody will copy, and count
 				// nothing, keeping stage="copied" consistent with the
 				// per-page prefault metric, which skips this path too.
+				cancelRun()
+
 				return
 			}
 			if err != nil {

--- a/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/prefetch/prefetcher_test.go
@@ -1,0 +1,127 @@
+//go:build linux
+
+package prefetch
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+// prefaultResult scripts one Prefault call of fakeBackend.
+type prefaultResult struct {
+	installed bool
+	err       error
+}
+
+// fakeBackend implements only Prefault; the embedded nil interface panics on
+// anything else copyWorker shouldn't touch.
+type fakeBackend struct {
+	uffd.MemoryBackend
+
+	results chan prefaultResult
+}
+
+func (f *fakeBackend) Prefault(context.Context, int64, []byte) (bool, error) {
+	r := <-f.results
+
+	return r.installed, r.err
+}
+
+func newTestPrefetcher(t *testing.T, results ...prefaultResult) *Prefetcher {
+	t.Helper()
+
+	log, err := logger.NewDevelopmentLogger()
+	require.NoError(t, err)
+
+	ch := make(chan prefaultResult, len(results))
+	for _, r := range results {
+		ch <- r
+	}
+
+	return &Prefetcher{logger: log, uffd: &fakeBackend{results: ch}}
+}
+
+func waitDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("copyWorker did not return within budget")
+	}
+}
+
+// ErrClosed (uffd gone: sandbox teardown) must cancel the whole run so fetch
+// workers stop fetching and queueing pages nobody will copy, and must count
+// nothing.
+func TestCopyWorkerCancelsRunOnErrClosed(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPrefetcher(t, prefaultResult{err: userfaultfd.ErrClosed})
+
+	ctx, cancelRun := context.WithCancel(t.Context())
+	defer cancelRun()
+
+	copyCh := make(chan prefetchData, 2)
+	copyCh <- prefetchData{}
+	copyCh <- prefetchData{} // must not be drained after ErrClosed
+
+	var copied, skipped atomic.Uint64
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.copyWorker(ctx, cancelRun, copyCh, &copied, &skipped)
+	}()
+
+	waitDone(t, done)
+
+	require.Error(t, ctx.Err(), "run context must be cancelled so fetch workers stop")
+	require.Zero(t, copied.Load())
+	require.Zero(t, skipped.Load())
+	require.Len(t, copyCh, 1, "remaining queued pages must not be drained")
+}
+
+// Only installed pages count as copied; nil-error no-op prefaults (already
+// resident / lost install race / deferred) and errors land in skipped, so
+// stage="copied" matches prefault{result="installed"}.
+func TestCopyWorkerCountsOnlyInstalledAsCopied(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPrefetcher(t,
+		prefaultResult{installed: true},               // copied
+		prefaultResult{installed: false},              // no-op (skipped/present/deferred)
+		prefaultResult{err: context.DeadlineExceeded}, // error
+		prefaultResult{installed: true},               // copied
+	)
+
+	ctx, cancelRun := context.WithCancel(t.Context())
+	defer cancelRun()
+
+	copyCh := make(chan prefetchData, 4)
+	for range 4 {
+		copyCh <- prefetchData{}
+	}
+	close(copyCh)
+
+	var copied, skipped atomic.Uint64
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.copyWorker(ctx, cancelRun, copyCh, &copied, &skipped)
+	}()
+
+	waitDone(t, done)
+
+	require.NoError(t, ctx.Err(), "non-ErrClosed outcomes must not cancel the run")
+	require.EqualValues(t, 2, copied.Load())
+	require.EqualValues(t, 2, skipped.Load())
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd.go
@@ -60,10 +60,10 @@ func New(memfile block.ReadonlyDevice, socketPath string) *Uffd {
 	}
 }
 
-func (u *Uffd) Prefault(ctx context.Context, offset int64, data []byte) error {
+func (u *Uffd) Prefault(ctx context.Context, offset int64, data []byte) (installed bool, e error) {
 	handler, err := u.handler.WaitWithContext(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get uffd: %w", err)
+		return false, fmt.Errorf("failed to get uffd: %w", err)
 	}
 
 	return handler.Prefault(ctx, offset, data)

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
@@ -25,14 +25,14 @@ import (
 //	                                    fd.close()          ← fd freed/recycled
 //	                                    releases Lock
 //	 acquires RLock
-//	 sees closed == true → return nil  ✓
+//	 sees closed == true → return ErrClosed  ✓
 //
 // Without the fix, Prefault had no closed check and would call UFFDIO_COPY
 // on the closed (and potentially recycled) fd, returning EBADF or ENOTTY.
 //
 // The test uses faultPhaseBeforePrefaultRLock to park Prefault before the
 // RLock acquisition, lets Close() run to completion, then releases the park
-// and asserts Prefault returns nil.
+// and asserts Prefault returns ErrClosed without touching the fd.
 func TestPrefaultConcurrentWithClose(t *testing.T) {
 	t.Parallel()
 
@@ -103,7 +103,7 @@ func TestPrefaultConcurrentWithClose(t *testing.T) {
 		// Pre-fix: fd gets closed and may be recycled; Prefault later calls
 		//   UFFDIO_COPY on it and returns EBADF or ENOTTY.
 		// Post-fix: Close() holds Lock(); Prefault acquires RLock, sees
-		//   closed==true, returns nil without touching the fd.
+		//   closed==true, returns ErrClosed without touching the fd.
 		require.NoError(t, u.Close())
 
 		// Release the parked Prefault goroutine.
@@ -111,9 +111,9 @@ func TestPrefaultConcurrentWithClose(t *testing.T) {
 
 		select {
 		case err := <-prefaultErrs:
-			require.NoError(t, err,
-				"Prefault must return nil after concurrent Close() — "+
-					"a non-nil error means UFFDIO_COPY was attempted on the closed fd (EBADF/ENOTTY regression)")
+			require.ErrorIs(t, err, ErrClosed,
+				"Prefault must return ErrClosed after concurrent Close() — "+
+					"any other error means UFFDIO_COPY was attempted on the closed fd (EBADF/ENOTTY regression)")
 		case <-ctx.Done():
 			t.Fatal("Prefault goroutine did not complete after hook release")
 		}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
@@ -89,7 +89,8 @@ func TestPrefaultConcurrentWithClose(t *testing.T) {
 
 		prefaultErrs := make(chan error, 1)
 		go func() {
-			prefaultErrs <- u.Prefault(ctx, 0, pageData)
+			_, err := u.Prefault(ctx, 0, pageData)
+			prefaultErrs <- err
 		}()
 
 		// Wait for Prefault to park at the pre-RLock hook.

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
@@ -54,12 +54,23 @@ type faultResult uint8
 
 const (
 	faultResultInstalled faultResult = iota // page installed by this serve
-	faultResultPresent                       // page already present: resident short-circuit or lost install race (EEXIST)
-	faultResultDeferred                      // EAGAIN: must be retried later
-	faultResultDiscarded                     // ESRCH: faulting thread gone, retry pointless
-	faultResultError                         // serving failed
+	faultResultPresent                      // page already present: resident short-circuit or lost install race (EEXIST)
+	faultResultDeferred                     // EAGAIN: must be retried later
+	faultResultDiscarded                    // ESRCH: faulting thread gone, retry pointless
+	faultResultError                        // serving failed
+	faultResultSkipped                      // prefault only: tracker already Dirty/Zero — prefetch arrived too late
 	numFaultResult
 )
+
+// resultNames maps faultResult values to their metric label strings.
+var resultNames = [numFaultResult]string{
+	faultResultInstalled: "installed",
+	faultResultPresent:   "present",
+	faultResultDeferred:  "deferred",
+	faultResultDiscarded: "discarded",
+	faultResultError:     "error",
+	faultResultSkipped:   "skipped",
+}
 
 // serveAttrs holds a precomputed metric.MeasurementOption per
 // (pageClass, faultResult) combination so the per-fault hot path allocates no
@@ -73,13 +84,6 @@ func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
 		pageClassResident: "resident",
 		pageClassUnknown:  "unknown",
 	}
-	resultNames := [numFaultResult]string{
-		faultResultInstalled: "installed",
-		faultResultPresent:   "present",
-		faultResultDeferred:  "deferred",
-		faultResultDiscarded: "discarded",
-		faultResultError:     "error",
-	}
 
 	var t [numPageClass][numFaultResult]metric.MeasurementOption
 	for c := range classNames {
@@ -89,6 +93,40 @@ func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
 				attribute.String("result", resultNames[r]),
 			)
 		}
+	}
+
+	return t
+}
+
+// prefaultMetricName is the metric under which per-page prefault latency /
+// installed bytes / attempt count are reported (a TimerFactory triplet).
+const prefaultMetricName = "orchestrator.sandbox.uffd.prefault"
+
+// prefaultTimer records, per Prefault call, the install latency (ms
+// histogram), bytes installed into the guest by this prefault (counter) and
+// the attempt count (counter) under prefaultMetricName. Prefault data is
+// already in memory, so the latency is lock wait + UFFDIO_COPY — a host
+// contention proxy rather than a storage signal. Together with serveTimer it
+// makes memory materialization race-proof: whichever side loses the EEXIST
+// install race records result="present" with zero bytes, so
+// serve.bytes + prefault.bytes never double-counts a page.
+var prefaultTimer = utils.Must(telemetry.NewTimerFactory(
+	meter,
+	prefaultMetricName,
+	"Time to prefault a page into the guest",
+	"Bytes installed into the guest by prefaults",
+	"UFFD prefault attempts",
+))
+
+// prefaultAttrs holds a precomputed metric.MeasurementOption per faultResult.
+// Prefaults have no page_class: they only ever target not-present pages (the
+// Dirty/Zero pre-check records result="skipped" instead).
+var prefaultAttrs = buildPrefaultAttrs()
+
+func buildPrefaultAttrs() [numFaultResult]metric.MeasurementOption {
+	var t [numFaultResult]metric.MeasurementOption
+	for r := range resultNames {
+		t[r] = telemetry.PrecomputeAttrs(attribute.String("result", resultNames[r]))
 	}
 
 	return t

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+var meter = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd")
+
+// serveMetricName is the metric under which per-fault serve latency / faulted
+// bytes / fault count are reported (a TimerFactory triplet).
+const serveMetricName = "orchestrator.sandbox.uffd.serve"
+
+// serveTimer records, per served UFFD demand fault, the serve latency (ms
+// histogram), bytes installed into the guest by this serve (counter) and the
+// serve-attempt count (counter) under serveMetricName. It is always on: the
+// fault-in window right after a resume is the prime suspect for slow resumes,
+// and this is the only fleet-wide signal for it.
+//
+// Scope: demand faults only. Pages installed by the prefetcher (Prefault)
+// bypass the serve loop and are not counted here; a demand fault that loses
+// the install race to a concurrent worker or prefault is recorded as
+// result="present" with zero bytes, so the bytes counter only ever counts
+// pages this serve actually copied.
+var serveTimer = utils.Must(telemetry.NewTimerFactory(
+	meter,
+	serveMetricName,
+	"Time to serve a UFFD demand page fault",
+	"Bytes installed into the guest by demand-fault serves",
+	"UFFD demand-fault serve attempts",
+))
+
+// pageClass classifies a fault by the page-tracker state at the time it was
+// served — the distinction that matters for diagnosing slow resumes, since only
+// pageClassNew faults reach the source (and may hit GCS).
+type pageClass uint8
+
+const (
+	pageClassNew      pageClass = iota // block.NotPresent: pulled from the source chunker
+	pageClassZero                      // block.Zero: zero-filled
+	pageClassResident                  // block.Dirty: already present, short-circuited
+	pageClassUnknown                   // classification failed (unexpected tracker state)
+	numPageClass
+)
+
+// faultResult is the terminal outcome of serving a fault.
+type faultResult uint8
+
+const (
+	faultResultInstalled faultResult = iota // page installed by this serve
+	faultResultPresent                       // page already present: resident short-circuit or lost install race (EEXIST)
+	faultResultDeferred                      // EAGAIN: must be retried later
+	faultResultDiscarded                     // ESRCH: faulting thread gone, retry pointless
+	faultResultError                         // serving failed
+	numFaultResult
+)
+
+// serveAttrs holds a precomputed metric.MeasurementOption per
+// (pageClass, faultResult) combination so the per-fault hot path allocates no
+// attributes (mirrors the precomputed attrs in block/streaming_chunk.go).
+var serveAttrs = buildServeAttrs()
+
+func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
+	classNames := [numPageClass]string{
+		pageClassNew:      "new",
+		pageClassZero:     "zero",
+		pageClassResident: "resident",
+		pageClassUnknown:  "unknown",
+	}
+	resultNames := [numFaultResult]string{
+		faultResultInstalled: "installed",
+		faultResultPresent:   "present",
+		faultResultDeferred:  "deferred",
+		faultResultDiscarded: "discarded",
+		faultResultError:     "error",
+	}
+
+	var t [numPageClass][numFaultResult]metric.MeasurementOption
+	for c := range classNames {
+		for r := range resultNames {
+			t[c][r] = telemetry.PrecomputeAttrs(
+				attribute.String("page_class", classNames[c]),
+				attribute.String("result", resultNames[r]),
+			)
+		}
+	}
+
+	return t
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package userfaultfd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// TestServeMetric exercises the serve-stats recording exactly as the Serve
+// worker does — serveTimer.Begin() + RecordRaw(ctx, bytes, serveAttrs[class][result])
+// — and asserts the resulting orchestrator.sandbox.uffd.serve datapoints carry
+// the right page_class / result attributes, fault counts and faulted bytes.
+//
+// The real serve loop runs in a forked child process (TestHelperServingProcess),
+// so its metrics can't be collected from the parent; this test pins the metric
+// definition and the page_class/result attribute table in-process instead. It
+// is intentionally NOT parallel: it swaps the package-level serveTimer.
+//
+//nolint:paralleltest // swaps the package-level serveTimer
+func TestServeMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := serveTimer
+	serveTimer = utils.Must(telemetry.NewTimerFactory(
+		mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"),
+		serveMetricName,
+		"Time to serve a UFFD page fault",
+		"Bytes faulted into the guest",
+		"UFFD faults served",
+	))
+	t.Cleanup(func() { serveTimer = prev })
+
+	ctx := context.Background()
+	pageSize := int64(header.PageSize)
+
+	// Record a mix of faults the way the worker would.
+	record := func(class pageClass, result faultResult, bytes int64, n int) {
+		for range n {
+			sw := serveTimer.Begin()
+			sw.RecordRaw(ctx, bytes, serveAttrs[class][result])
+		}
+	}
+	record(pageClassNew, faultResultInstalled, pageSize, 3)
+	record(pageClassZero, faultResultInstalled, pageSize, 1)
+	record(pageClassResident, faultResultPresent, 0, 2)
+	record(pageClassNew, faultResultPresent, 0, 1)
+	record(pageClassNew, faultResultDeferred, 0, 1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	counts, bytesSum := collectServe(t, rm)
+
+	// new+installed: 3 faults, each one page of faulted bytes.
+	assert.Equal(t, int64(3), counts[key("new", "installed")], "new+installed fault count")
+	assert.Equal(t, 3*pageSize, bytesSum[key("new", "installed")], "new+installed faulted bytes")
+
+	// zero+installed: 1 fault, one page installed (zeros) → counted as faulted.
+	assert.Equal(t, int64(1), counts[key("zero", "installed")])
+	assert.Equal(t, pageSize, bytesSum[key("zero", "installed")])
+
+	// resident short-circuit: counted as "present", nothing copied.
+	assert.Equal(t, int64(2), counts[key("resident", "present")])
+	assert.Equal(t, int64(0), bytesSum[key("resident", "present")])
+
+	// lost install race (EEXIST): counted as "present", no bytes attributed
+	// to this serve — keeps sum(bytes) == pages actually copied by serves.
+	assert.Equal(t, int64(1), counts[key("new", "present")])
+	assert.Equal(t, int64(0), bytesSum[key("new", "present")])
+
+	// deferred: counted, no bytes faulted.
+	assert.Equal(t, int64(1), counts[key("new", "deferred")])
+	assert.Equal(t, int64(0), bytesSum[key("new", "deferred")])
+}
+
+func key(pageClass, result string) string { return pageClass + "/" + result }
+
+func attrKey(t *testing.T, attrs attribute.Set) string {
+	t.Helper()
+	pc, ok := attrs.Value("page_class")
+	require.True(t, ok, "datapoint missing page_class attribute")
+	r, ok := attrs.Value("result")
+	require.True(t, ok, "datapoint missing result attribute")
+
+	return key(pc.AsString(), r.AsString())
+}
+
+// collectServe returns, keyed by "page_class/result", the fault count (from the
+// duration histogram) and the faulted-bytes sum (the "By"-unit counter) for the
+// serve metric.
+func collectServe(t *testing.T, rm metricdata.ResourceMetrics) (counts map[string]int64, bytesSum map[string]int64) {
+	t.Helper()
+
+	counts = map[string]int64{}
+	bytesSum = map[string]int64{}
+	sawMetric := false
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != serveMetricName {
+				continue
+			}
+			sawMetric = true
+
+			switch data := m.Data.(type) {
+			case metricdata.Histogram[int64]:
+				for _, dp := range data.DataPoints {
+					counts[attrKey(t, dp.Attributes)] += int64(dp.Count)
+				}
+			case metricdata.Sum[int64]:
+				// The TimerFactory emits two same-named counters; the
+				// faulted-bytes one carries the "By" unit.
+				if m.Unit != "By" {
+					continue
+				}
+				for _, dp := range data.DataPoints {
+					bytesSum[attrKey(t, dp.Attributes)] += dp.Value
+				}
+			}
+		}
+	}
+
+	require.True(t, sawMetric, "metric %q not found in collected metrics", serveMetricName)
+
+	return counts, bytesSum
+}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
@@ -61,7 +61,7 @@ func TestServeMetric(t *testing.T) {
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(ctx, &rm))
 
-	counts, bytesSum := collectServe(t, rm)
+	counts, bytesSum := collectTriplet(t, rm, serveMetricName)
 
 	// new+installed: 3 faults, each one page of faulted bytes.
 	assert.Equal(t, int64(3), counts[key("new", "installed")], "new+installed fault count")
@@ -85,22 +85,85 @@ func TestServeMetric(t *testing.T) {
 	assert.Equal(t, int64(0), bytesSum[key("new", "deferred")])
 }
 
+// TestPrefaultMetric exercises the prefault recording exactly as Prefault does
+// — prefaultTimer.Begin() + RecordRaw(ctx, bytes, prefaultAttrs[result]) — and
+// asserts the orchestrator.sandbox.uffd.prefault datapoints carry the right
+// result attribute, attempt counts and installed bytes. Like TestServeMetric,
+// the full Prefault path needs a real userfaultfd (root-only, forked harness),
+// so this pins the metric definition and attrs table in-process instead. NOT
+// parallel: it swaps the package-level prefaultTimer.
+//
+//nolint:paralleltest // swaps the package-level prefaultTimer
+func TestPrefaultMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := prefaultTimer
+	prefaultTimer = utils.Must(telemetry.NewTimerFactory(
+		mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"),
+		prefaultMetricName,
+		"Time to prefault a page into the guest",
+		"Bytes installed into the guest by prefaults",
+		"UFFD prefault attempts",
+	))
+	t.Cleanup(func() { prefaultTimer = prev })
+
+	ctx := context.Background()
+	pageSize := int64(header.PageSize)
+
+	record := func(result faultResult, bytes int64, n int) {
+		for range n {
+			sw := prefaultTimer.Begin()
+			sw.RecordRaw(ctx, bytes, prefaultAttrs[result])
+		}
+	}
+	record(faultResultInstalled, pageSize, 3)
+	record(faultResultPresent, 0, 1)
+	record(faultResultSkipped, 0, 2)
+	record(faultResultDeferred, 0, 1)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	counts, bytesSum := collectTriplet(t, rm, prefaultMetricName)
+
+	// installed: 3 prefaults, one page of installed bytes each.
+	assert.Equal(t, int64(3), counts["installed"])
+	assert.Equal(t, 3*pageSize, bytesSum["installed"])
+
+	// lost install race (EEXIST): counted, bytes belong to the winning serve.
+	assert.Equal(t, int64(1), counts["present"])
+	assert.Equal(t, int64(0), bytesSum["present"])
+
+	// tracker said Dirty/Zero: prefetch arrived too late, nothing copied.
+	assert.Equal(t, int64(2), counts["skipped"])
+	assert.Equal(t, int64(0), bytesSum["skipped"])
+
+	// EAGAIN: the prefetcher does not retry.
+	assert.Equal(t, int64(1), counts["deferred"])
+	assert.Equal(t, int64(0), bytesSum["deferred"])
+}
+
 func key(pageClass, result string) string { return pageClass + "/" + result }
 
+// attrKey returns "page_class/result" for serve datapoints and just "result"
+// for prefault datapoints (which carry no page_class).
 func attrKey(t *testing.T, attrs attribute.Set) string {
 	t.Helper()
-	pc, ok := attrs.Value("page_class")
-	require.True(t, ok, "datapoint missing page_class attribute")
 	r, ok := attrs.Value("result")
 	require.True(t, ok, "datapoint missing result attribute")
+	pc, ok := attrs.Value("page_class")
+	if !ok {
+		return r.AsString()
+	}
 
 	return key(pc.AsString(), r.AsString())
 }
 
-// collectServe returns, keyed by "page_class/result", the fault count (from the
-// duration histogram) and the faulted-bytes sum (the "By"-unit counter) for the
-// serve metric.
-func collectServe(t *testing.T, rm metricdata.ResourceMetrics) (counts map[string]int64, bytesSum map[string]int64) {
+// collectTriplet returns, keyed by attrKey, the attempt count (from the
+// duration histogram) and the bytes sum (the "By"-unit counter) for the named
+// TimerFactory metric.
+func collectTriplet(t *testing.T, rm metricdata.ResourceMetrics, name string) (counts map[string]int64, bytesSum map[string]int64) {
 	t.Helper()
 
 	counts = map[string]int64{}
@@ -109,7 +172,7 @@ func collectServe(t *testing.T, rm metricdata.ResourceMetrics) (counts map[strin
 
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name != serveMetricName {
+			if m.Name != name {
 				continue
 			}
 			sawMetric = true
@@ -121,7 +184,7 @@ func collectServe(t *testing.T, rm metricdata.ResourceMetrics) (counts map[strin
 				}
 			case metricdata.Sum[int64]:
 				// The TimerFactory emits two same-named counters; the
-				// faulted-bytes one carries the "By" unit.
+				// bytes one carries the "By" unit.
 				if m.Unit != "By" {
 					continue
 				}
@@ -132,7 +195,7 @@ func collectServe(t *testing.T, rm metricdata.ResourceMetrics) (counts map[strin
 		}
 	}
 
-	require.True(t, sawMetric, "metric %q not found in collected metrics", serveMetricName)
+	require.True(t, sawMetric, "metric %q not found in collected metrics", name)
 
 	return counts, bytesSum
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
@@ -13,7 +13,14 @@ import (
 // Prefault proactively copies a page to guest memory at the given offset
 // to speed up sandbox starts. EEXIST (already mapped) is handled gracefully;
 // a Prefault against an already-closed userfaultfd returns ErrClosed.
-func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) error {
+//
+// installed reports whether THIS call copied the page into the guest. It is
+// false on every nil-error path that didn't copy — tracker said the page is
+// already resident (skipped), a demand fault won the install race (present),
+// or the copy hit EAGAIN and the prefetcher won't retry (deferred) — so
+// callers can keep "copied" accounting consistent with the per-page prefault
+// metric's result label.
+func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) (installed bool, e error) {
 	// Record install latency / installed bytes / attempt count once per
 	// prefault, tagged by outcome. Begun before the RLock so the latency
 	// includes lock wait; with the data already in memory the remainder is
@@ -48,7 +55,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 	if u.closed {
 		record = false
 
-		return ErrClosed
+		return false, ErrClosed
 	}
 
 	ctx, span := tracer.Start(ctx, "prefault page")
@@ -58,13 +65,13 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 	if err != nil {
 		result = faultResultError
 
-		return fmt.Errorf("failed to get host virtual address: %w", err)
+		return false, fmt.Errorf("failed to get host virtual address: %w", err)
 	}
 
 	if len(data) != int(u.pageSize) {
 		result = faultResultError
 
-		return fmt.Errorf("data length (%d) does not match pagesize (%d)", len(data), u.pageSize)
+		return false, fmt.Errorf("data length (%d) does not match pagesize (%d)", len(data), u.pageSize)
 	}
 
 	idx := uint32(header.BlockIdx(offset, int64(u.pageSize)))
@@ -74,7 +81,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 		// got there first, so this prefetch arrived too late.
 		result = faultResultSkipped
 
-		return nil
+		return false, nil
 	}
 
 	// Prefault as a read so the page gets WP set. A concurrent on-demand
@@ -91,7 +98,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 		result = faultResultError
 		span.RecordError(err)
 
-		return fmt.Errorf("failed to fault page: %w", err)
+		return false, fmt.Errorf("failed to fault page: %w", err)
 	}
 
 	switch outcome {
@@ -99,6 +106,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 		if outcome == faultInstalled {
 			// Page copied by this prefault → count its bytes; on a lost
 			// install race (EEXIST) the winning demand serve counted them.
+			installed = true
 			installedBytes = int64(u.pageSize)
 		} else {
 			result = faultResultPresent
@@ -115,10 +123,10 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 	default:
 		result = faultResultError
 
-		return fmt.Errorf("unexpected faultOutcome: %#v", outcome)
+		return false, fmt.Errorf("unexpected faultOutcome: %#v", outcome)
 	}
 
-	return nil
+	return installed, nil
 }
 
 // directDataSource wraps a single page's bytes; off is ignored because the

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
@@ -49,7 +49,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 	}
 
 	// Prefault as a read so the page gets WP set. A concurrent on-demand
-	// fault that installs the page first returns faultInstalled via EEXIST.
+	// fault that installs the page first returns faultAlreadyPresent (EEXIST).
 	outcome, err := u.faultPage(
 		ctx,
 		addr,
@@ -65,7 +65,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 	}
 
 	switch outcome {
-	case faultInstalled:
+	case faultInstalled, faultAlreadyPresent:
 		u.pageTracker.SetRange(idx, idx+1, block.Dirty)
 		u.prefetchTracker.Add(offset, block.Prefetch)
 	case faultDeferred:

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
@@ -37,7 +37,8 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) (
 
 	// Test hook: fires before settleRequests.RLock so that a test can park
 	// the goroutine here, call Close() concurrently, then release and observe
-	// that the closed check below returns nil without calling UFFDIO_COPY.
+	// that the closed check below returns ErrClosed without calling
+	// UFFDIO_COPY.
 	if h := u.testFaultHook.Load(); h != nil {
 		(*h)(0, faultPhaseBeforePrefaultRLock)
 	}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
@@ -11,8 +11,23 @@ import (
 )
 
 // Prefault proactively copies a page to guest memory at the given offset
-// to speed up sandbox starts. EEXIST (already mapped) is handled gracefully.
+// to speed up sandbox starts. EEXIST (already mapped) is handled gracefully;
+// a Prefault against an already-closed userfaultfd returns ErrClosed.
 func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) error {
+	// Record install latency / installed bytes / attempt count once per
+	// prefault, tagged by outcome. Begun before the RLock so the latency
+	// includes lock wait; with the data already in memory the remainder is
+	// the UFFDIO_COPY itself, making this a host-contention proxy.
+	sw := prefaultTimer.Begin()
+	record := true
+	result := faultResultInstalled
+	var installedBytes int64
+	defer func() {
+		if record {
+			sw.RecordRaw(ctx, installedBytes, prefaultAttrs[result])
+		}
+	}()
+
 	// Test hook: fires before settleRequests.RLock so that a test can park
 	// the goroutine here, call Close() concurrently, then release and observe
 	// that the closed check below returns nil without calling UFFDIO_COPY.
@@ -25,9 +40,15 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 
 	// Close() sets closed under Lock(). Seeing it here under RLock means the
 	// fd is already closed and its number may have been recycled by the OS —
-	// skip silently instead of calling UFFDIO_COPY and getting EBADF/ENOTTY.
+	// skip instead of calling UFFDIO_COPY and getting EBADF/ENOTTY, and
+	// report ErrClosed so the caller can stop and keep its own accounting
+	// consistent. Not recorded: on sandbox stop the copy workers drain every
+	// remaining queued page through this path, which would flood the metric
+	// with teardown noise.
 	if u.closed {
-		return nil
+		record = false
+
+		return ErrClosed
 	}
 
 	ctx, span := tracer.Start(ctx, "prefault page")
@@ -35,16 +56,24 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 
 	addr, err := u.ma.GetHostVirtAddr(offset)
 	if err != nil {
+		result = faultResultError
+
 		return fmt.Errorf("failed to get host virtual address: %w", err)
 	}
 
 	if len(data) != int(u.pageSize) {
+		result = faultResultError
+
 		return fmt.Errorf("data length (%d) does not match pagesize (%d)", len(data), u.pageSize)
 	}
 
 	idx := uint32(header.BlockIdx(offset, int64(u.pageSize)))
 	state := u.pageTracker.Get(idx)
 	if state == block.Dirty || state == block.Zero {
+		// The page is already resident (or zero-installed): a demand fault
+		// got there first, so this prefetch arrived too late.
+		result = faultResultSkipped
+
 		return nil
 	}
 
@@ -59,6 +88,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 		nil,
 	)
 	if err != nil {
+		result = faultResultError
 		span.RecordError(err)
 
 		return fmt.Errorf("failed to fault page: %w", err)
@@ -66,12 +96,26 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) e
 
 	switch outcome {
 	case faultInstalled, faultAlreadyPresent:
+		if outcome == faultInstalled {
+			// Page copied by this prefault → count its bytes; on a lost
+			// install race (EEXIST) the winning demand serve counted them.
+			installedBytes = int64(u.pageSize)
+		} else {
+			result = faultResultPresent
+		}
 		u.pageTracker.SetRange(idx, idx+1, block.Dirty)
 		u.prefetchTracker.Add(offset, block.Prefetch)
 	case faultDeferred:
+		// The prefetcher does not retry: this page will not be prefaulted.
+		result = faultResultDeferred
 		span.AddEvent("prefault: write returned EAGAIN")
 	case faultDiscarded:
+		result = faultResultDiscarded
 		span.AddEvent("prefault: discarded (process gone)")
+	default:
+		result = faultResultError
+
+		return fmt.Errorf("unexpected faultOutcome: %#v", outcome)
 	}
 
 	return nil

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -45,6 +45,10 @@ const (
 
 var ErrUnexpectedEventType = errors.New("unexpected event type")
 
+// ErrClosed reports that the userfaultfd was already closed (sandbox
+// teardown) and the requested operation was skipped.
+var ErrClosed = errors.New("userfaultfd is closed")
+
 func hasEvent(revents, event int16) bool {
 	return revents&event != 0
 }

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -124,8 +124,11 @@ const (
 type faultOutcome uint8
 
 const (
-	// faultInstalled: page was installed (or already mapped; EEXIST).
+	// faultInstalled: page was installed by this call.
 	faultInstalled faultOutcome = iota
+	// faultAlreadyPresent: no install by this call — the page was already
+	// mapped (EEXIST), e.g. a concurrent worker or a prefault won the race.
+	faultAlreadyPresent
 	// faultDeferred: soft failure (EAGAIN); the caller must retry later.
 	faultDeferred
 	// faultDiscarded: no install happened and retry is pointless
@@ -399,6 +402,19 @@ func (u *Userfaultfd) Serve(
 			}
 
 			u.wg.Go(func() error {
+				// Record serve latency / installed bytes / fault count once
+				// per serve attempt, tagged by page class and outcome. Begun
+				// before the RLock so the latency covers lock wait + faultPage
+				// for this attempt. Note: a deferred fault is re-served (and
+				// re-timed) by a later worker, so the guest's full stall —
+				// including the deferred-queue wait — can exceed any single
+				// recorded serve.
+				sw := serveTimer.Begin()
+				pclass := pageClassUnknown
+				result := faultResultInstalled
+				var servedBytes int64
+				defer func() { sw.RecordRaw(ctx, servedBytes, serveAttrs[pclass][result]) }()
+
 				if h := u.testFaultHook.Load(); h != nil {
 					(*h)(addr, faultPhaseBeforeRLock)
 				}
@@ -417,13 +433,20 @@ func (u *Userfaultfd) Serve(
 				case block.Dirty:
 					// Pages must not be swappable for this short-circuit to hold:
 					// only UFFD_EVENT_REMOVE moves a page out of Dirty.
+					pclass = pageClassResident
+					result = faultResultPresent
+
 					return nil
 				case block.Zero:
 					// Zero-fill. We still owe the kernel an ack for the original
 					// MISSING fault or the faulting thread stays blocked.
+					pclass = pageClassZero
 				case block.NotPresent:
+					pclass = pageClassNew
 					source = u.src
 				default:
+					result = faultResultError
+
 					return fmt.Errorf("unexpected block.State: %#v", state)
 				}
 
@@ -447,11 +470,23 @@ func (u *Userfaultfd) Serve(
 					fdExit.SignalExit,
 				)
 				if err != nil {
+					result = faultResultError
+
 					return err
 				}
 
 				switch outcome {
-				case faultInstalled:
+				case faultInstalled, faultAlreadyPresent:
+					if outcome == faultInstalled {
+						// A page was installed (zero-filled or pulled from
+						// source) by this serve, so count its bytes. On
+						// faultAlreadyPresent a concurrent worker or prefault
+						// copied the page — record it as "present" with no
+						// bytes so the bytes counter stays attributable.
+						servedBytes = int64(u.pageSize)
+					} else {
+						result = faultResultPresent
+					}
 					// Zero-fill on a read fault installs zero+WP; the page still
 					// reads as zero, so keep the tracker entry as Zero so the
 					// snapshot diff marks it Empty. WP-async will catch any
@@ -461,10 +496,16 @@ func (u *Userfaultfd) Serve(
 					}
 					u.prefetchTracker.Add(offset, accessType)
 				case faultDeferred:
+					result = faultResultDeferred
 					deferred.push(pf)
 					u.signalWakeup()
 				case faultDiscarded:
 					// No install happened (ESRCH); retry would be pointless.
+					result = faultResultDiscarded
+				default:
+					result = faultResultError
+
+					return fmt.Errorf("unexpected faultOutcome: %#v", outcome)
 				}
 
 				return nil
@@ -601,7 +642,7 @@ func (u *Userfaultfd) faultPage(
 
 		u.fd.wake(addr, u.pageSize) //nolint:errcheck // best-effort; thread may already be awake
 
-		return faultInstalled, nil
+		return faultAlreadyPresent, nil
 	}
 
 	// ESRCH: faulting thread exited during sandbox teardown. No install

--- a/scripts/fix-meters.sh
+++ b/scripts/fix-meters.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Script to find and replace otel.Tracer declarations with file paths
-# Usage: ./replace_tracer.sh [directory]
+# Script to find and replace otel.Meter declarations with file paths
+# Usage: ./fix-meters.sh [directory]
 
 # Set the search directory (default to current directory if not provided)
 SEARCH_DIR="packages/"
@@ -11,9 +11,9 @@ processed=0
 skipped=0
 
 readonly prefix="github.com/e2b-dev/infra/packages"
-readonly search_pattern='\.Meter(".*'
+readonly search_pattern='\.Meter("[^"]*")'
 
-echo "Starting tracer replacement in directory: $SEARCH_DIR"
+echo "Starting meter replacement in directory: $SEARCH_DIR"
 echo "----------------------------------------"
 
 # Find all files containing the pattern

--- a/scripts/fix-tracers.sh
+++ b/scripts/fix-tracers.sh
@@ -11,7 +11,7 @@ processed=0
 skipped=0
 
 readonly prefix="github.com/e2b-dev/infra/packages"
-readonly search_pattern='\.Tracer(".*'
+readonly search_pattern='\.Tracer("[^"]*")'
 
 echo "Starting tracer replacement in directory: $SEARCH_DIR"
 echo "----------------------------------------"


### PR DESCRIPTION
## Why

Resume slowness is dominated by on-demand memory fault-in, but there was no fleet-wide
signal for it: storage metrics (`gcs.read`, `blocks.chunks.fetch`, …) measure I/O
without knowing whether a guest thread was blocked, and prefetch effectiveness was a
single debug log line plus unaggregatable per-page traces. This PR makes both —
demand-fault serving and prefetch activity — first-class in Mimir.

## What

**`orchestrator.sandbox.uffd.serve`** — per demand-fault serve: latency (ms histogram),
installed bytes, attempts. Labels (≤20 series/node, no `sandbox_id`):
- `page_class`: `new` (source-served; the only class that can hit NFS/GCS), `zero`
  (re-touch of a reclaimed page), `resident` (already present), `unknown`
- `result`: `installed`, `present` (lost the EEXIST install race — latency recorded,
  **zero bytes**), `deferred` (UFFDIO_COPY returned EAGAIN — concurrent
  madvise/mremap/fork changed the address space mid-copy; the fault is re-queued and
  each retry is recorded as its own attempt), `discarded` (ESRCH — the faulting
  process exited during teardown; no install, retry pointless), `error`

**`orchestrator.sandbox.uffd.prefault`** — per prefetch-copy attempt, with the same
`result` values plus one extra: `skipped` — the page was already Dirty/Zero in the
tracker when the prefault arrived, i.e. a demand fault won and the prefetch came too
late for that page. Unlike demand faults, `deferred` prefaults are never retried.
Prefault data is already in memory, so its latency = lock wait + `UFFDIO_COPY`, a
host-contention proxy. The EEXIST split makes the two metrics compose race-proof:
`materialized = serve.installed_bytes + prefault.installed_bytes`, never double-counted.

**`orchestrator.sandbox.uffd.prefetch.{pages,duration}`** — per prefetch run: page
counts by `stage` and phase wall times. The stages mirror the prefetcher's two
pipelines: `fetched` — pages read from the source into the chunk cache by the fetch
workers; `fetch_skipped` — pages whose source read failed (never reach the copy
phase, so they are invisible to the prefault metric); `copied` — pages handed to
`Prefault` successfully (its installed/present/skipped breakdown is in the prefault
metric); `copy_skipped` — pages where `Prefault` returned an error. The four counts
are the same values the `"prefetch: completed"` debug log line reports, now queryable.
Durations carry `phase` = `fetch`/`copy`/`total` (the phases overlap; copy starts when
uffd is ready) — copy ≫ resume duration means the prefetch ran too late to help.

Notes:

- **Scope**: `serve` counts demand faults only. Pages installed by the prefetcher are
  deliberately excluded — `serve` measures guest-visible stalls, and no guest thread
  waits on a prefault. Prefetch activity has its own metrics (above).
- **One code change beyond instrumentation**: `faultPage` used to return
  `faultInstalled` both when it copied a page and when `UFFDIO_COPY` returned `EEXIST`
  (someone else had already installed it). `EEXIST` is now a separate
  `faultAlreadyPresent` outcome so the metric can attribute bytes to the actual
  installer. The handling itself — tracker updates, waking the faulting thread — is
  byte-for-byte unchanged; this is a reclassification, not a behavior change.
- **Overhead**: recording costs one histogram record plus two counter adds per fault,
  using attribute sets precomputed at package init (no per-fault allocations for
  attributes) — the same pattern the existing `orchestrator.blocks.slices` metric
  already uses on this path.

```promql
# the slow-resume signal: storage-served fault latency per node
histogram_quantile(0.99, sum by (service_instance_id)
  (rate(orchestrator_sandbox_uffd_serve_milliseconds{page_class="new"}[5m])))
```