### PR TITLE
ci: skip tests by changed paths

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,10 +7,16 @@ on:
         type: boolean
         description: "Whether to publish the results"
         required: true
+      run-tests:
+        type: boolean
+        description: "Whether to run integration tests"
+        required: false
+        default: true
     secrets:
       CODECOV_TOKEN: { required: false }
 jobs:
   run:
+    if: ${{ inputs.run-tests == true }}
     runs-on: infra-tests
     timeout-minutes: 30
     permissions:
@@ -139,11 +145,17 @@ jobs:
 
   integration_tests:
     needs: run
-    if: always()
+    if: ${{ always() }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Aggregate matrix result
         run: |
+          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
+            echo "integration tests skipped because test inputs did not change"
+            exit 0
+          fi
+
           if [[ "${{ needs.run.result }}" != "success" ]]; then
             echo "matrix result: ${{ needs.run.result }}"
             exit 1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,7 +56,6 @@ jobs:
           verify: 'false'
 
   lint:
-    name: Lint
     needs:
       - detect-modules
       - golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,22 @@
 name: Lint
 
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      run-lint:
+        type: boolean
+        description: "Whether to run package linting"
+        required: false
+        default: true
 
 permissions:
   contents: read
 
 jobs:
   detect-modules:
+    if: ${{ inputs.run-lint == true }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       modules: ${{ steps.set-modules.outputs.modules }}
     steps:
@@ -17,6 +26,7 @@ jobs:
 
   golangci-lint:
     needs: detect-modules
+    if: ${{ inputs.run-lint == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,3 +54,31 @@ jobs:
           # disable, as it randomly fails with the following error:
           # The command is terminated due to an error: [../../.golangci.yml] validate: compile schema: failing loading "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json": Get "https://golangci-lint.run/jsonschema/golangci.v2.11.jsonschema.json": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
           verify: 'false'
+
+  lint:
+    name: Lint
+    needs:
+      - detect-modules
+      - golangci-lint
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate lint result
+        run: |
+          if [[ "${{ inputs.run-lint }}" != "true" ]]; then
+            echo "lint skipped because lint inputs did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.detect-modules.result }}" != "success" ]]; then
+            echo "detect modules result: ${{ needs.detect-modules.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.golangci-lint.result }}" != "success" ]]; then
+            echo "golangci-lint result: ${{ needs.golangci-lint.result }}"
+            exit 1
+          fi
+
+          echo "lint succeeded"

--- a/.github/workflows/pr-no-generated-changes.yml
+++ b/.github/workflows/pr-no-generated-changes.yml
@@ -3,6 +3,11 @@ name: Ensure generated files are up-to-date
 on:
   workflow_call:
     inputs:
+      run-check:
+        type: boolean
+        description: 'Whether to run generated-code validation'
+        required: false
+        default: true
       commit:
         type: boolean
         description: 'Whether to commit and push changes automatically'
@@ -20,6 +25,7 @@ permissions:
 
 jobs:
   run-check:
+    if: ${{ inputs.run-check == true }}
     runs-on: ubuntu-24.04
     steps:
       - name: Generate GitHub App installation token
@@ -105,3 +111,23 @@ jobs:
 
           # There were changes, exit with an error code so that the workflow fails.
           exit 1
+
+  generated_code_check:
+    needs: run-check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate generated-code result
+        run: |
+          if [[ "${{ inputs.run-check }}" != "true" ]]; then
+            echo "generated-code check skipped because generated-code inputs did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.run-check.result }}" != "success" ]]; then
+            echo "generated-code check result: ${{ needs.run-check.result }}"
+            exit 1
+          fi
+
+          echo "generated-code check succeeded"

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -203,8 +203,7 @@ jobs:
           disable_search: true
           report_type: test_results
 
-  arm64-tests:
-    name: ARM64 tests
+  arm64_tests:
     needs:
       - cross-compile
       - arm64-unit-tests

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: packages/orchestrator
 
   arm64-unit-tests:
-    name: ARM64 tests for ${{ matrix.package }}
+    name: Run ARM64 test shards
     if: ${{ inputs.run-tests == true }}
     runs-on: infra-runner-arm
     timeout-minutes: 45

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -47,26 +47,10 @@ jobs:
           CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOARCH=arm64 go vet ./...
         working-directory: packages/orchestrator
 
-  arm64-test-matrix:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: |
-          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
-            matrix='[{"name":"Run ARM64 tests (skipped)","runner":"ubuntu-latest","package":".","flag":"arm64-skipped","test_path":"./...","sudo":false,"skip":true}]'
-          else
-            matrix='[{"name":"ARM64 tests for packages/api","runner":"infra-runner-arm","package":"packages/api","flag":"arm64-api","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/client-proxy","runner":"infra-runner-arm","package":"packages/client-proxy","flag":"arm64-client-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/db","runner":"infra-runner-arm","package":"packages/db","flag":"arm64-db","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/docker-reverse-proxy","runner":"infra-runner-arm","package":"packages/docker-reverse-proxy","flag":"arm64-docker-reverse-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/envd","runner":"infra-runner-arm","package":"packages/envd","flag":"arm64-envd","test_path":"./...","sudo":true,"skip":false},{"name":"ARM64 tests for packages/orchestrator","runner":"infra-runner-arm","package":"packages/orchestrator","flag":"arm64-orchestrator","test_path":"./...","sudo":true,"skip":false},{"name":"ARM64 tests for packages/shared","runner":"infra-runner-arm","package":"packages/shared","flag":"arm64-shared","test_path":"./pkg/...","sudo":false,"skip":false}]'
-          fi
-
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   arm64-unit-tests:
-    needs: arm64-test-matrix
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    name: Run ARM64 test shards
+    if: ${{ inputs.run-tests == true }}
+    runs-on: infra-runner-arm
     timeout-minutes: 45
     env:
       GIN_MODE: test
@@ -78,15 +62,41 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.arm64-test-matrix.outputs.matrix) }}
+        include:
+          - package: packages/api
+            flag: arm64-api
+            test_path: ./...
+            sudo: false
+          - package: packages/client-proxy
+            flag: arm64-client-proxy
+            test_path: ./...
+            sudo: false
+          - package: packages/db
+            flag: arm64-db
+            test_path: ./...
+            sudo: false
+          - package: packages/docker-reverse-proxy
+            flag: arm64-docker-reverse-proxy
+            test_path: ./...
+            sudo: false
+          - package: packages/envd
+            flag: arm64-envd
+            test_path: ./...
+            sudo: true
+          - package: packages/orchestrator
+            flag: arm64-orchestrator
+            test_path: ./...
+            sudo: true
+          - package: packages/shared
+            flag: arm64-shared
+            test_path: ./pkg/...
+            sudo: false
       fail-fast: false
     steps:
       - name: Checkout repository
-        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
-        if: ${{ matrix.skip != true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -95,7 +105,6 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        if: ${{ matrix.skip != true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -117,7 +126,7 @@ jobs:
       - name: Setup envd tests
         run: |
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: ${{ matrix.skip != true && matrix.package == 'packages/envd' }}
+        if: matrix.package == 'packages/envd'
 
       - name: Setup orchestrator tests
         run: |
@@ -142,16 +151,15 @@ jobs:
           echo 'ACTION=="add|change", KERNEL=="nbd*", OPTIONS:="nowatch"' | sudo tee /etc/udev/rules.d/97-nbd-device.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger
-        if: ${{ matrix.skip != true && matrix.package == 'packages/orchestrator' }}
+        if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        if: ${{ matrix.skip != true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
       # toolchain (1.26.3) instead of /usr/bin/go. Trap chowns reports back to
@@ -162,22 +170,22 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: go test -run '^$' ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -186,7 +194,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -198,7 +206,6 @@ jobs:
   arm64_tests:
     needs:
       - cross-compile
-      - arm64-test-matrix
       - arm64-unit-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -206,11 +213,6 @@ jobs:
     steps:
       - name: Aggregate ARM64 test result
         run: |
-          if [[ "${{ needs.arm64-test-matrix.result }}" != "success" ]]; then
-            echo "ARM64 test matrix result: ${{ needs.arm64-test-matrix.result }}"
-            exit 1
-          fi
-
           if [[ "${{ inputs.run-tests }}" != "true" ]]; then
             echo "ARM64 tests skipped because test inputs did not change"
             exit 0

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -48,9 +48,8 @@ jobs:
         working-directory: packages/orchestrator
 
   arm64-unit-tests:
-    name: Run ARM64 test shards
-    if: ${{ inputs.run-tests == true }}
-    runs-on: infra-runner-arm
+    name: ARM64 tests for ${{ matrix.package }}
+    runs-on: ${{ inputs.run-tests && 'infra-runner-arm' || 'ubuntu-latest' }}
     timeout-minutes: 45
     env:
       GIN_MODE: test
@@ -93,10 +92,16 @@ jobs:
             sudo: false
       fail-fast: false
     steps:
+      - name: Skip ARM64 test shard
+        if: ${{ inputs.run-tests != true }}
+        run: echo "ARM64 test shard skipped because test inputs did not change"
+
       - name: Checkout repository
+        if: ${{ inputs.run-tests == true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
+        if: ${{ inputs.run-tests == true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -105,6 +110,7 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
+        if: ${{ inputs.run-tests == true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -126,7 +132,7 @@ jobs:
       - name: Setup envd tests
         run: |
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: matrix.package == 'packages/envd'
+        if: ${{ inputs.run-tests == true && matrix.package == 'packages/envd' }}
 
       - name: Setup orchestrator tests
         run: |
@@ -151,15 +157,16 @@ jobs:
           echo 'ACTION=="add|change", KERNEL=="nbd*", OPTIONS:="nowatch"' | sudo tee /etc/udev/rules.d/97-nbd-device.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger
-        if: matrix.package == 'packages/orchestrator'
+        if: ${{ inputs.run-tests == true && matrix.package == 'packages/orchestrator' }}
 
       - name: Install gotestsum
+        if: ${{ inputs.run-tests == true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
       # toolchain (1.26.3) instead of /usr/bin/go. Trap chowns reports back to
@@ -170,22 +177,22 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: go test -run '^$' ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -194,7 +201,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -48,8 +48,9 @@ jobs:
         working-directory: packages/orchestrator
 
   arm64-unit-tests:
-    name: ARM64 tests for ${{ matrix.package }}
-    runs-on: ${{ inputs.run-tests && 'infra-runner-arm' || 'ubuntu-latest' }}
+    name: Run ARM64 test shards
+    if: ${{ inputs.run-tests == true }}
+    runs-on: infra-runner-arm
     timeout-minutes: 45
     env:
       GIN_MODE: test
@@ -92,16 +93,10 @@ jobs:
             sudo: false
       fail-fast: false
     steps:
-      - name: Skip ARM64 test shard
-        if: ${{ inputs.run-tests != true }}
-        run: echo "ARM64 test shard skipped because test inputs did not change"
-
       - name: Checkout repository
-        if: ${{ inputs.run-tests == true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
-        if: ${{ inputs.run-tests == true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -110,7 +105,6 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        if: ${{ inputs.run-tests == true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -132,7 +126,7 @@ jobs:
       - name: Setup envd tests
         run: |
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: ${{ inputs.run-tests == true && matrix.package == 'packages/envd' }}
+        if: matrix.package == 'packages/envd'
 
       - name: Setup orchestrator tests
         run: |
@@ -157,16 +151,15 @@ jobs:
           echo 'ACTION=="add|change", KERNEL=="nbd*", OPTIONS:="nowatch"' | sudo tee /etc/udev/rules.d/97-nbd-device.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger
-        if: ${{ inputs.run-tests == true && matrix.package == 'packages/orchestrator' }}
+        if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        if: ${{ inputs.run-tests == true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
       # toolchain (1.26.3) instead of /usr/bin/go. Trap chowns reports back to
@@ -177,22 +170,22 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: go test -run '^$' ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
-        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -201,7 +194,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -2,6 +2,12 @@ name: ARM64 tests on PRs
 
 on:
   workflow_call:
+    inputs:
+      run-tests:
+        type: boolean
+        description: "Whether to run ARM64 checks and tests"
+        required: false
+        default: true
     secrets:
       CODECOV_TOKEN: { required: false }
 
@@ -11,6 +17,7 @@ permissions:
 jobs:
   cross-compile:
     name: Cross-compile all packages for ARM64
+    if: ${{ inputs.run-tests == true }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -42,6 +49,7 @@ jobs:
 
   arm64-unit-tests:
     name: ARM64 tests for ${{ matrix.package }}
+    if: ${{ inputs.run-tests == true }}
     runs-on: infra-runner-arm
     timeout-minutes: 45
     env:
@@ -194,3 +202,31 @@ jobs:
           flags: ${{ matrix.flag }},unit
           disable_search: true
           report_type: test_results
+
+  arm64-tests:
+    name: ARM64 tests
+    needs:
+      - cross-compile
+      - arm64-unit-tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate ARM64 test result
+        run: |
+          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
+            echo "ARM64 tests skipped because test inputs did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.cross-compile.result }}" != "success" ]]; then
+            echo "cross-compile result: ${{ needs.cross-compile.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.arm64-unit-tests.result }}" != "success" ]]; then
+            echo "ARM64 unit tests result: ${{ needs.arm64-unit-tests.result }}"
+            exit 1
+          fi
+
+          echo "all ARM64 checks succeeded"

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -47,10 +47,26 @@ jobs:
           CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc GOARCH=arm64 go vet ./...
         working-directory: packages/orchestrator
 
+  arm64-test-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
+            matrix='[{"name":"Run ARM64 tests (skipped)","runner":"ubuntu-latest","package":".","flag":"arm64-skipped","test_path":"./...","sudo":false,"skip":true}]'
+          else
+            matrix='[{"name":"ARM64 tests for packages/api","runner":"infra-runner-arm","package":"packages/api","flag":"arm64-api","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/client-proxy","runner":"infra-runner-arm","package":"packages/client-proxy","flag":"arm64-client-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/db","runner":"infra-runner-arm","package":"packages/db","flag":"arm64-db","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/docker-reverse-proxy","runner":"infra-runner-arm","package":"packages/docker-reverse-proxy","flag":"arm64-docker-reverse-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"ARM64 tests for packages/envd","runner":"infra-runner-arm","package":"packages/envd","flag":"arm64-envd","test_path":"./...","sudo":true,"skip":false},{"name":"ARM64 tests for packages/orchestrator","runner":"infra-runner-arm","package":"packages/orchestrator","flag":"arm64-orchestrator","test_path":"./...","sudo":true,"skip":false},{"name":"ARM64 tests for packages/shared","runner":"infra-runner-arm","package":"packages/shared","flag":"arm64-shared","test_path":"./pkg/...","sudo":false,"skip":false}]'
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   arm64-unit-tests:
-    name: Run ARM64 test shards
-    if: ${{ inputs.run-tests == true }}
-    runs-on: infra-runner-arm
+    needs: arm64-test-matrix
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
       GIN_MODE: test
@@ -62,41 +78,15 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        include:
-          - package: packages/api
-            flag: arm64-api
-            test_path: ./...
-            sudo: false
-          - package: packages/client-proxy
-            flag: arm64-client-proxy
-            test_path: ./...
-            sudo: false
-          - package: packages/db
-            flag: arm64-db
-            test_path: ./...
-            sudo: false
-          - package: packages/docker-reverse-proxy
-            flag: arm64-docker-reverse-proxy
-            test_path: ./...
-            sudo: false
-          - package: packages/envd
-            flag: arm64-envd
-            test_path: ./...
-            sudo: true
-          - package: packages/orchestrator
-            flag: arm64-orchestrator
-            test_path: ./...
-            sudo: true
-          - package: packages/shared
-            flag: arm64-shared
-            test_path: ./pkg/...
-            sudo: false
+        include: ${{ fromJSON(needs.arm64-test-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
       - name: Checkout repository
+        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
+        if: ${{ matrix.skip != true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -105,6 +95,7 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
+        if: ${{ matrix.skip != true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -126,7 +117,7 @@ jobs:
       - name: Setup envd tests
         run: |
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: matrix.package == 'packages/envd'
+        if: ${{ matrix.skip != true && matrix.package == 'packages/envd' }}
 
       - name: Setup orchestrator tests
         run: |
@@ -151,15 +142,16 @@ jobs:
           echo 'ACTION=="add|change", KERNEL=="nbd*", OPTIONS:="nowatch"' | sudo tee /etc/udev/rules.d/97-nbd-device.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger
-        if: matrix.package == 'packages/orchestrator'
+        if: ${{ matrix.skip != true && matrix.package == 'packages/orchestrator' }}
 
       - name: Install gotestsum
+        if: ${{ matrix.skip != true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: sudo -E `which go` test -run '^$' ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ matrix.skip != true && matrix.sudo == true }}
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
       # toolchain (1.26.3) instead of /usr/bin/go. Trap chowns reports back to
@@ -170,22 +162,22 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ matrix.skip != true && matrix.sudo == true }}
 
       - name: Compile test binaries
         working-directory: ${{ matrix.package }}
         run: go test -run '^$' ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ matrix.skip != true && matrix.sudo == false }}
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ matrix.skip != true && matrix.sudo == false }}
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
+        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -194,7 +186,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
+        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' && hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -206,6 +198,7 @@ jobs:
   arm64_tests:
     needs:
       - cross-compile
+      - arm64-test-matrix
       - arm64-unit-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
@@ -213,6 +206,11 @@ jobs:
     steps:
       - name: Aggregate ARM64 test result
         run: |
+          if [[ "${{ needs.arm64-test-matrix.result }}" != "success" ]]; then
+            echo "ARM64 test matrix result: ${{ needs.arm64-test-matrix.result }}"
+            exit 1
+          fi
+
           if [[ "${{ inputs.run-tests }}" != "true" ]]; then
             echo "ARM64 tests skipped because test inputs did not change"
             exit 0

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -161,8 +161,7 @@ jobs:
           disable_search: true
           report_type: test_results
 
-  unit-tests:
-    name: Unit tests
+  unit_tests:
     needs: run-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   run-tests:
-    name: Run tests for ${{ matrix.package }}
+    name: Run unit test shards
     if: ${{ inputs.run-tests == true }}
     runs-on: infra-tests
     env:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,26 +15,10 @@ permissions:
   contents: read
 
 jobs:
-  unit-test-matrix:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: |
-          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
-            matrix='[{"name":"Run unit tests (skipped)","runner":"ubuntu-latest","package":".","flag":"unit-skipped","test_path":"./...","sudo":false,"skip":true}]'
-          else
-            matrix='[{"name":"Run tests for packages/api","runner":"infra-tests","package":"packages/api","flag":"unit-api","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/client-proxy","runner":"infra-tests","package":"packages/client-proxy","flag":"unit-client-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/db","runner":"infra-tests","package":"packages/db","flag":"unit-db","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/docker-reverse-proxy","runner":"infra-tests","package":"packages/docker-reverse-proxy","flag":"unit-docker-reverse-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/envd","runner":"infra-tests","package":"packages/envd","flag":"unit-envd","test_path":"./...","sudo":true,"skip":false},{"name":"Run tests for packages/orchestrator","runner":"infra-tests","package":"packages/orchestrator","flag":"unit-orchestrator","test_path":"./...","sudo":true,"skip":false},{"name":"Run tests for packages/shared","runner":"infra-tests","package":"packages/shared","flag":"unit-shared","test_path":"./pkg/...","sudo":false,"skip":false}]'
-          fi
-
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   run-tests:
-    needs: unit-test-matrix
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    name: Run unit test shards
+    if: ${{ inputs.run-tests == true }}
+    runs-on: infra-tests
     env:
       GIN_MODE: test
       # Parallel `go test ./...` binaries derive the same Ryuk session id
@@ -45,15 +29,41 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.unit-test-matrix.outputs.matrix) }}
+        include:
+          - package: packages/api
+            flag: unit-api
+            test_path: ./...
+            sudo: false
+          - package: packages/client-proxy
+            flag: unit-client-proxy
+            test_path: ./...
+            sudo: false
+          - package: packages/db
+            flag: unit-db
+            test_path: ./...
+            sudo: false
+          - package: packages/docker-reverse-proxy
+            flag: unit-docker-reverse-proxy
+            test_path: ./...
+            sudo: false
+          - package: packages/envd
+            flag: unit-envd
+            test_path: ./...
+            sudo: true
+          - package: packages/orchestrator
+            flag: unit-orchestrator
+            test_path: ./...
+            sudo: true
+          - package: packages/shared
+            flag: unit-shared
+            test_path: ./pkg/...
+            sudo: false
       fail-fast: false
     steps:
       - name: Checkout repository
-        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
-        if: ${{ matrix.skip != true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -62,7 +72,6 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        if: ${{ matrix.skip != true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -85,7 +94,7 @@ jobs:
         run: |
           # Install bindfs for FUSE mount tests
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: ${{ matrix.skip != true && matrix.package == 'packages/envd' }}
+        if: matrix.package == 'packages/envd'
 
       - name: Setup orchestrator tests
         run: |
@@ -108,10 +117,9 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger
 
-        if: ${{ matrix.skip != true && matrix.package == 'packages/orchestrator' }}
+        if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        if: ${{ matrix.skip != true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
@@ -123,17 +131,17 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ matrix.skip != true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
-        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -143,7 +151,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -154,20 +162,13 @@ jobs:
           report_type: test_results
 
   unit_tests:
-    needs:
-      - unit-test-matrix
-      - run-tests
+    needs: run-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Aggregate unit test result
         run: |
-          if [[ "${{ needs.unit-test-matrix.result }}" != "success" ]]; then
-            echo "unit test matrix result: ${{ needs.unit-test-matrix.result }}"
-            exit 1
-          fi
-
           if [[ "${{ inputs.run-tests }}" != "true" ]]; then
             echo "unit tests skipped because test inputs did not change"
             exit 0

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,9 +16,8 @@ permissions:
 
 jobs:
   run-tests:
-    name: Run unit test shards
-    if: ${{ inputs.run-tests == true }}
-    runs-on: infra-tests
+    name: Run tests for ${{ matrix.package }}
+    runs-on: ${{ inputs.run-tests && 'infra-tests' || 'ubuntu-latest' }}
     env:
       GIN_MODE: test
       # Parallel `go test ./...` binaries derive the same Ryuk session id
@@ -60,10 +59,16 @@ jobs:
             sudo: false
       fail-fast: false
     steps:
+      - name: Skip unit test shard
+        if: ${{ inputs.run-tests != true }}
+        run: echo "unit test shard skipped because test inputs did not change"
+
       - name: Checkout repository
+        if: ${{ inputs.run-tests == true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
+        if: ${{ inputs.run-tests == true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -72,6 +77,7 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
+        if: ${{ inputs.run-tests == true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -94,7 +100,7 @@ jobs:
         run: |
           # Install bindfs for FUSE mount tests
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: matrix.package == 'packages/envd'
+        if: ${{ inputs.run-tests == true && matrix.package == 'packages/envd' }}
 
       - name: Setup orchestrator tests
         run: |
@@ -117,9 +123,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger
 
-        if: matrix.package == 'packages/orchestrator'
+        if: ${{ inputs.run-tests == true && matrix.package == 'packages/orchestrator' }}
 
       - name: Install gotestsum
+        if: ${{ inputs.run-tests == true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
@@ -131,17 +138,17 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -151,7 +158,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,8 +16,9 @@ permissions:
 
 jobs:
   run-tests:
-    name: Run tests for ${{ matrix.package }}
-    runs-on: ${{ inputs.run-tests && 'infra-tests' || 'ubuntu-latest' }}
+    name: Run unit test shards
+    if: ${{ inputs.run-tests == true }}
+    runs-on: infra-tests
     env:
       GIN_MODE: test
       # Parallel `go test ./...` binaries derive the same Ryuk session id
@@ -59,16 +60,10 @@ jobs:
             sudo: false
       fail-fast: false
     steps:
-      - name: Skip unit test shard
-        if: ${{ inputs.run-tests != true }}
-        run: echo "unit test shard skipped because test inputs did not change"
-
       - name: Checkout repository
-        if: ${{ inputs.run-tests == true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
-        if: ${{ inputs.run-tests == true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -77,7 +72,6 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
-        if: ${{ inputs.run-tests == true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -100,7 +94,7 @@ jobs:
         run: |
           # Install bindfs for FUSE mount tests
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: ${{ inputs.run-tests == true && matrix.package == 'packages/envd' }}
+        if: matrix.package == 'packages/envd'
 
       - name: Setup orchestrator tests
         run: |
@@ -123,10 +117,9 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger
 
-        if: ${{ inputs.run-tests == true && matrix.package == 'packages/orchestrator' }}
+        if: matrix.package == 'packages/orchestrator'
 
       - name: Install gotestsum
-        if: ${{ inputs.run-tests == true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
@@ -138,17 +131,17 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == true }}
+        if: matrix.sudo == true
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: ${{ inputs.run-tests == true && matrix.sudo == false }}
+        if: matrix.sudo == false
 
       - name: Upload coverage to Codecov
-        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -158,7 +151,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ inputs.run-tests == true && !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -15,10 +15,26 @@ permissions:
   contents: read
 
 jobs:
+  unit-test-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
+            matrix='[{"name":"Run unit tests (skipped)","runner":"ubuntu-latest","package":".","flag":"unit-skipped","test_path":"./...","sudo":false,"skip":true}]'
+          else
+            matrix='[{"name":"Run tests for packages/api","runner":"infra-tests","package":"packages/api","flag":"unit-api","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/client-proxy","runner":"infra-tests","package":"packages/client-proxy","flag":"unit-client-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/db","runner":"infra-tests","package":"packages/db","flag":"unit-db","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/docker-reverse-proxy","runner":"infra-tests","package":"packages/docker-reverse-proxy","flag":"unit-docker-reverse-proxy","test_path":"./...","sudo":false,"skip":false},{"name":"Run tests for packages/envd","runner":"infra-tests","package":"packages/envd","flag":"unit-envd","test_path":"./...","sudo":true,"skip":false},{"name":"Run tests for packages/orchestrator","runner":"infra-tests","package":"packages/orchestrator","flag":"unit-orchestrator","test_path":"./...","sudo":true,"skip":false},{"name":"Run tests for packages/shared","runner":"infra-tests","package":"packages/shared","flag":"unit-shared","test_path":"./pkg/...","sudo":false,"skip":false}]'
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   run-tests:
-    name: Run unit test shards
-    if: ${{ inputs.run-tests == true }}
-    runs-on: infra-tests
+    needs: unit-test-matrix
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     env:
       GIN_MODE: test
       # Parallel `go test ./...` binaries derive the same Ryuk session id
@@ -29,41 +45,15 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:
       matrix:
-        include:
-          - package: packages/api
-            flag: unit-api
-            test_path: ./...
-            sudo: false
-          - package: packages/client-proxy
-            flag: unit-client-proxy
-            test_path: ./...
-            sudo: false
-          - package: packages/db
-            flag: unit-db
-            test_path: ./...
-            sudo: false
-          - package: packages/docker-reverse-proxy
-            flag: unit-docker-reverse-proxy
-            test_path: ./...
-            sudo: false
-          - package: packages/envd
-            flag: unit-envd
-            test_path: ./...
-            sudo: true
-          - package: packages/orchestrator
-            flag: unit-orchestrator
-            test_path: ./...
-            sudo: true
-          - package: packages/shared
-            flag: unit-shared
-            test_path: ./pkg/...
-            sudo: false
+        include: ${{ fromJSON(needs.unit-test-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
       - name: Checkout repository
+        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Setup Go
+        if: ${{ matrix.skip != true }}
         uses: ./.github/actions/go-setup-cache
         with:
           cache-dependency-paths: |
@@ -72,6 +62,7 @@ jobs:
             ${{ matrix.package }}/go.sum
 
       - name: Reap orphaned Testcontainers from previous runs
+        if: ${{ matrix.skip != true }}
         # Persistent runner + Ryuk disabled: prune leftover containers
         # from SIGKILL/timeout/OOM in prior jobs.
         # Two `docker ps` calls because different filter keys AND inside
@@ -94,7 +85,7 @@ jobs:
         run: |
           # Install bindfs for FUSE mount tests
           sudo apt-get update && sudo apt-get install -y bindfs
-        if: matrix.package == 'packages/envd'
+        if: ${{ matrix.skip != true && matrix.package == 'packages/envd' }}
 
       - name: Setup orchestrator tests
         run: |
@@ -117,9 +108,10 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger
 
-        if: matrix.package == 'packages/orchestrator'
+        if: ${{ matrix.skip != true && matrix.package == 'packages/orchestrator' }}
 
       - name: Install gotestsum
+        if: ${{ matrix.skip != true }}
         run: go install gotest.tools/gotestsum@v1.13.0
 
       # sudo strips PATH; pass it through so gotestsum/go resolve to the runner's
@@ -131,17 +123,17 @@ jobs:
           trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
           sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == true
+        if: ${{ matrix.skip != true && matrix.sudo == true }}
 
       - name: Run tests
         working-directory: ${{ matrix.package }}
         run: |
           gotestsum --junitfile=junit.xml --format=standard-verbose \
             -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ matrix.test_path }}
-        if: matrix.sudo == false
+        if: ${{ matrix.skip != true && matrix.sudo == false }}
 
       - name: Upload coverage to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/coverage.txt', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -151,7 +143,7 @@ jobs:
           disable_search: true
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' &&
+        if: ${{ matrix.skip != true && !cancelled() && env.CODECOV_TOKEN != '' &&
           hashFiles(format('{0}/junit.xml', matrix.package)) != '' }}
         uses: codecov/codecov-action@v6
         with:
@@ -162,13 +154,20 @@ jobs:
           report_type: test_results
 
   unit_tests:
-    needs: run-tests
+    needs:
+      - unit-test-matrix
+      - run-tests
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Aggregate unit test result
         run: |
+          if [[ "${{ needs.unit-test-matrix.result }}" != "success" ]]; then
+            echo "unit test matrix result: ${{ needs.unit-test-matrix.result }}"
+            exit 1
+          fi
+
           if [[ "${{ inputs.run-tests }}" != "true" ]]; then
             echo "unit tests skipped because test inputs did not change"
             exit 0

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,6 +2,12 @@ name: Run tests on PRs
 
 on:
   workflow_call:
+    inputs:
+      run-tests:
+        type: boolean
+        description: "Whether to run unit tests"
+        required: false
+        default: true
     secrets:
       CODECOV_TOKEN: { required: false }
 
@@ -11,6 +17,7 @@ permissions:
 jobs:
   run-tests:
     name: Run tests for ${{ matrix.package }}
+    if: ${{ inputs.run-tests == true }}
     runs-on: infra-tests
     env:
       GIN_MODE: test
@@ -154,23 +161,23 @@ jobs:
           disable_search: true
           report_type: test_results
 
-  validate-iac:
-    name: Validate terraform
-    runs-on: ubuntu-24.04
+  unit-tests:
+    name: Unit tests
+    needs: run-tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Parse .tool-versions
-        uses: wistia/parse-tool-versions@v2.1.1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "${{ env.TERRAFORM }}"
-
-      - name: Validate terraform
-        working-directory: ./iac/provider-gcp
+      - name: Aggregate unit test result
         run: |
-          terraform init -backend=false
-          terraform validate
+          if [[ "${{ inputs.run-tests }}" != "true" ]]; then
+            echo "unit tests skipped because test inputs did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.run-tests.result }}" != "success" ]]; then
+            echo "unit tests result: ${{ needs.run-tests.result }}"
+            exit 1
+          fi
+
+          echo "all unit test shards succeeded"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,9 +33,18 @@ jobs:
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
+            lint-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'go.work'
+              - 'go.work.sum'
+              - '.golangci.yml'
 
   lint:
+    needs: [detect-changes]
     uses: ./.github/workflows/lint.yml
+    with:
+      run-lint: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'lint-inputs') }}
   validate-openapi:
     uses: ./.github/workflows/validate-openapi.yml
   generated-code-check:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,20 +28,28 @@ jobs:
           filters: |
             iac:
               - 'iac/**'
+              - '.github/**'
+              - '.tool-versions'
             test-inputs:
               - 'packages/**'
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
+              - '.github/**'
+              - '.tool-versions'
             lint-inputs:
               - 'packages/**'
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
               - '.golangci.yml'
+              - '.github/**'
+              - '.tool-versions'
             openapi-inputs:
               - 'spec/openapi*.yml'
               - 'packages/envd/spec/envd.yaml'
+              - '.github/**'
+              - '.tool-versions'
             generated-inputs:
               - 'packages/**'
               - 'tests/**'
@@ -56,6 +64,8 @@ jobs:
               - 'scripts/fix-tracers.sh'
               - 'scripts/fix-meters.sh'
               - 'scripts/golang-dependencies-integrity.sh'
+              - '.github/**'
+              - '.tool-versions'
 
   lint:
     needs: [detect-changes]

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -33,6 +33,7 @@ jobs:
             test-inputs:
               - 'packages/**'
               - 'tests/**'
+              - 'spec/**'
               - 'go.work'
               - 'go.work.sum'
               - 'Makefile'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,7 @@ jobs:
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
+              - 'Makefile'
               - '.github/**'
               - '.tool-versions'
             lint-inputs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,6 +39,23 @@ jobs:
               - 'go.work'
               - 'go.work.sum'
               - '.golangci.yml'
+            openapi-inputs:
+              - 'spec/openapi*.yml'
+              - 'packages/envd/spec/envd.yaml'
+            generated-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'spec/**'
+              - 'iac/**'
+              - 'go.work'
+              - 'go.work.sum'
+              - 'Makefile'
+              - '.golangci.yml'
+              - '.mockery.yaml'
+              - 'packages/**/.mockery.yaml'
+              - 'scripts/fix-tracers.sh'
+              - 'scripts/fix-meters.sh'
+              - 'scripts/golang-dependencies-integrity.sh'
 
   lint:
     needs: [detect-changes]
@@ -46,10 +63,15 @@ jobs:
     with:
       run-lint: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'lint-inputs') }}
   validate-openapi:
+    needs: [detect-changes]
     uses: ./.github/workflows/validate-openapi.yml
+    with:
+      run-validation: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'openapi-inputs') }}
   generated-code-check:
+    needs: [detect-changes]
     uses: ./.github/workflows/pr-no-generated-changes.yml
     with:
+      run-check: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'generated-inputs') }}
       # Only auto-commit for same-repo PRs (secrets aren't available for forks)
       commit: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,28 @@ on:
   pull_request:
 
 jobs:
+  detect-changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      changed-scopes: ${{ steps.changed-paths.outputs.changes }}
+    steps:
+      - id: changed-paths
+        name: Detect CI-relevant changes
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            iac:
+              - 'iac/**'
+            test-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'go.work'
+              - 'go.work.sum'
+
   lint:
     uses: ./.github/workflows/lint.yml
   validate-openapi:
@@ -27,34 +49,53 @@ jobs:
   out-of-order-migrations:
     uses: ./.github/workflows/out-of-order-migrations.yml
   unit-tests:
+    needs: [detect-changes]
     uses: ./.github/workflows/pr-tests.yml
+    with:
+      run-tests: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  terraform-validation:
+    needs: [detect-changes]
+    uses: ./.github/workflows/validate-iac.yml
+    with:
+      run-validation: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'iac') }}
   arm64-tests:
+    needs: [detect-changes]
     uses: ./.github/workflows/pr-tests-arm64.yml
+    with:
+      run-tests: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   integration-tests:
-    needs: [out-of-order-migrations]
+    needs: [detect-changes, out-of-order-migrations]
     uses: ./.github/workflows/integration_tests.yml
     with:
       # Only publish the results for same-repo PRs
       publish: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      run-tests: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   publish-test-results:
     needs:
+      - detect-changes
       - unit-tests
       - integration-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
     # Skip on cancellation (e.g. superseded by a newer push) so partial
     # artifacts aren't published as failed tests.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.detect-changes.result == 'success' }}
 
     steps:
+      - name: Skip publishing when tests did not run
+        if: ${{ !contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
+        run: echo "test result publishing skipped because test inputs did not change"
+
       - name: Download Artifacts
+        if: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
         uses: actions/download-artifact@v7
         with:
           path: artifacts
@@ -63,6 +104,7 @@ jobs:
           pattern: "!*.dockerbuild"
 
       - name: Publish Test Results
+        if: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           comment_mode: off

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -36,6 +36,12 @@ jobs:
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
+            lint-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'go.work'
+              - 'go.work.sum'
+              - '.golangci.yml'
 
   generated-code-check:
     uses: ./.github/workflows/pr-no-generated-changes.yml

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -10,33 +10,77 @@ on:
       - main
 
 jobs:
+  detect-changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      changed-scopes: ${{ steps.changed-paths.outputs.changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 20
+          persist-credentials: false
+
+      - id: changed-paths
+        name: Detect CI-relevant changes
+        uses: dorny/paths-filter@v4
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            iac:
+              - 'iac/**'
+            test-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'go.work'
+              - 'go.work.sum'
+
   generated-code-check:
     uses: ./.github/workflows/pr-no-generated-changes.yml
     with:
       commit: false
 
   unit-tests:
+    needs: [detect-changes]
     uses: ./.github/workflows/pr-tests.yml
+    with:
+      run-tests: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  terraform-validation:
+    needs: [detect-changes]
+    uses: ./.github/workflows/validate-iac.yml
+    with:
+      run-validation: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'iac') }}
   integration-tests:
+    needs: [detect-changes]
     uses: ./.github/workflows/integration_tests.yml
     with:
       publish: true
+      run-tests: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   publish-test-results:
     needs:
+      - detect-changes
       - unit-tests
       - integration-tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       checks: write
     # Skip on cancellation so partial artifacts aren't published as failed tests.
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && needs.detect-changes.result == 'success' }}
 
     steps:
+      - name: Skip publishing when tests did not run
+        if: ${{ !contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
+        run: echo "test result publishing skipped because test inputs did not change"
+
       - name: Download Artifacts
+        if: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
         uses: actions/download-artifact@v7
         with:
           path: artifacts
@@ -45,6 +89,7 @@ jobs:
           pattern: "!*.dockerbuild"
 
       - name: Publish Test Results
+        if: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'test-inputs') }}
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           comment_mode: off

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -36,6 +36,7 @@ jobs:
             test-inputs:
               - 'packages/**'
               - 'tests/**'
+              - 'spec/**'
               - 'go.work'
               - 'go.work.sum'
               - 'Makefile'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -31,17 +31,23 @@ jobs:
           filters: |
             iac:
               - 'iac/**'
+              - '.github/**'
+              - '.tool-versions'
             test-inputs:
               - 'packages/**'
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
+              - '.github/**'
+              - '.tool-versions'
             lint-inputs:
               - 'packages/**'
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
               - '.golangci.yml'
+              - '.github/**'
+              - '.tool-versions'
             generated-inputs:
               - 'packages/**'
               - 'tests/**'
@@ -56,6 +62,8 @@ jobs:
               - 'scripts/fix-tracers.sh'
               - 'scripts/fix-meters.sh'
               - 'scripts/golang-dependencies-integrity.sh'
+              - '.github/**'
+              - '.tool-versions'
 
   generated-code-check:
     needs: [detect-changes]

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -42,10 +42,26 @@ jobs:
               - 'go.work'
               - 'go.work.sum'
               - '.golangci.yml'
+            generated-inputs:
+              - 'packages/**'
+              - 'tests/**'
+              - 'spec/**'
+              - 'iac/**'
+              - 'go.work'
+              - 'go.work.sum'
+              - 'Makefile'
+              - '.golangci.yml'
+              - '.mockery.yaml'
+              - 'packages/**/.mockery.yaml'
+              - 'scripts/fix-tracers.sh'
+              - 'scripts/fix-meters.sh'
+              - 'scripts/golang-dependencies-integrity.sh'
 
   generated-code-check:
+    needs: [detect-changes]
     uses: ./.github/workflows/pr-no-generated-changes.yml
     with:
+      run-check: ${{ contains(fromJSON(needs.detect-changes.outputs.changed-scopes), 'generated-inputs') }}
       commit: false
 
   unit-tests:

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -38,14 +38,7 @@ jobs:
               - 'tests/**'
               - 'go.work'
               - 'go.work.sum'
-              - '.github/**'
-              - '.tool-versions'
-            lint-inputs:
-              - 'packages/**'
-              - 'tests/**'
-              - 'go.work'
-              - 'go.work.sum'
-              - '.golangci.yml'
+              - 'Makefile'
               - '.github/**'
               - '.tool-versions'
             generated-inputs:

--- a/.github/workflows/validate-iac.yml
+++ b/.github/workflows/validate-iac.yml
@@ -1,0 +1,60 @@
+name: Validate IaC
+
+on:
+  workflow_call:
+    inputs:
+      run-validation:
+        type: boolean
+        description: "Whether to run Terraform validation"
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  run-terraform-validation:
+    name: Run Terraform validation
+    if: ${{ inputs.run-validation == true }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "${{ env.TERRAFORM }}"
+
+      - name: Validate terraform
+        working-directory: ./iac/provider-gcp
+        run: |
+          terraform init -backend=false
+          terraform validate
+
+  terraform-validation:
+    name: Validate terraform
+    needs: run-terraform-validation
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate Terraform validation result
+        run: |
+          if [[ "${{ inputs.run-validation }}" != "true" ]]; then
+            echo "Terraform validation skipped because IaC paths did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.run-terraform-validation.result }}" != "success" ]]; then
+            echo "Terraform validation result: ${{ needs.run-terraform-validation.result }}"
+            exit 1
+          fi
+
+          echo "Terraform validation succeeded"

--- a/.github/workflows/validate-iac.yml
+++ b/.github/workflows/validate-iac.yml
@@ -38,8 +38,7 @@ jobs:
           terraform init -backend=false
           terraform validate
 
-  terraform-validation:
-    name: Validate terraform
+  validate_terraform:
     needs: run-terraform-validation
     if: ${{ always() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -13,34 +13,54 @@ permissions:
   contents: read
 
 jobs:
+  openapi-validation-matrix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ "${{ inputs.run-validation }}" != "true" ]]; then
+            matrix='[{"name":"Validate OpenAPI specs (skipped)","spec":"spec/openapi.yml","skip":true}]'
+          else
+            matrix='[{"name":"Validate spec/openapi.yml","spec":"spec/openapi.yml","skip":false},{"name":"Validate spec/openapi-edge.yml","spec":"spec/openapi-edge.yml","skip":false},{"name":"Validate spec/openapi-hyperloop.yml","spec":"spec/openapi-hyperloop.yml","skip":false},{"name":"Validate spec/openapi-dashboard.yml","spec":"spec/openapi-dashboard.yml","skip":false},{"name":"Validate packages/envd/spec/envd.yaml","spec":"packages/envd/spec/envd.yaml","skip":false}]'
+          fi
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   validate-openapi:
-    name: Validate OpenAPI specs
-    if: ${{ inputs.run-validation == true }}
+    needs: openapi-validation-matrix
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        spec:
-          - spec/openapi.yml
-          - spec/openapi-edge.yml
-          - spec/openapi-hyperloop.yml
-          - spec/openapi-dashboard.yml
-          - packages/envd/spec/envd.yaml
+        include: ${{ fromJSON(needs.openapi-validation-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
       - name: Checkout repository
+        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Validate OpenAPI spec
+        if: ${{ matrix.skip != true }}
         run: npx --yes @redocly/cli lint ${{ matrix.spec }}
 
   validate_openapi:
-    needs: validate-openapi
+    needs:
+      - openapi-validation-matrix
+      - validate-openapi
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Aggregate OpenAPI validation result
         run: |
+          if [[ "${{ needs.openapi-validation-matrix.result }}" != "success" ]]; then
+            echo "OpenAPI validation matrix result: ${{ needs.openapi-validation-matrix.result }}"
+            exit 1
+          fi
+
           if [[ "${{ inputs.run-validation }}" != "true" ]]; then
             echo "OpenAPI validation skipped because OpenAPI specs did not change"
             exit 0

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -14,8 +14,7 @@ permissions:
 
 jobs:
   validate-openapi:
-    name: Validate OpenAPI specs
-    if: ${{ inputs.run-validation == true }}
+    name: Validate ${{ matrix.spec }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,10 +26,16 @@ jobs:
           - packages/envd/spec/envd.yaml
       fail-fast: false
     steps:
+      - name: Skip OpenAPI validation
+        if: ${{ inputs.run-validation != true }}
+        run: echo "OpenAPI validation skipped because OpenAPI specs did not change"
+
       - name: Checkout repository
+        if: ${{ inputs.run-validation == true }}
         uses: actions/checkout@v5
 
       - name: Validate OpenAPI spec
+        if: ${{ inputs.run-validation == true }}
         run: npx --yes @redocly/cli lint ${{ matrix.spec }}
 
   validate_openapi:

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -1,6 +1,13 @@
 name: Validate OpenAPI specs
 
-on: [workflow_call]
+on:
+  workflow_call:
+    inputs:
+      run-validation:
+        type: boolean
+        description: "Whether to run OpenAPI validation"
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -8,6 +15,7 @@ permissions:
 jobs:
   validate-openapi:
     name: Validate ${{ matrix.spec }}
+    if: ${{ inputs.run-validation == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,3 +32,23 @@ jobs:
 
       - name: Validate OpenAPI spec
         run: npx --yes @redocly/cli lint ${{ matrix.spec }}
+
+  validate_openapi:
+    needs: validate-openapi
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Aggregate OpenAPI validation result
+        run: |
+          if [[ "${{ inputs.run-validation }}" != "true" ]]; then
+            echo "OpenAPI validation skipped because OpenAPI specs did not change"
+            exit 0
+          fi
+
+          if [[ "${{ needs.validate-openapi.result }}" != "success" ]]; then
+            echo "OpenAPI validation result: ${{ needs.validate-openapi.result }}"
+            exit 1
+          fi
+
+          echo "OpenAPI validation succeeded"

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   validate-openapi:
-    name: Validate ${{ matrix.spec }}
+    name: Validate OpenAPI specs
     if: ${{ inputs.run-validation == true }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -13,54 +13,34 @@ permissions:
   contents: read
 
 jobs:
-  openapi-validation-matrix:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        run: |
-          if [[ "${{ inputs.run-validation }}" != "true" ]]; then
-            matrix='[{"name":"Validate OpenAPI specs (skipped)","spec":"spec/openapi.yml","skip":true}]'
-          else
-            matrix='[{"name":"Validate spec/openapi.yml","spec":"spec/openapi.yml","skip":false},{"name":"Validate spec/openapi-edge.yml","spec":"spec/openapi-edge.yml","skip":false},{"name":"Validate spec/openapi-hyperloop.yml","spec":"spec/openapi-hyperloop.yml","skip":false},{"name":"Validate spec/openapi-dashboard.yml","spec":"spec/openapi-dashboard.yml","skip":false},{"name":"Validate packages/envd/spec/envd.yaml","spec":"packages/envd/spec/envd.yaml","skip":false}]'
-          fi
-
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
   validate-openapi:
-    needs: openapi-validation-matrix
-    name: ${{ matrix.name }}
+    name: Validate OpenAPI specs
+    if: ${{ inputs.run-validation == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include: ${{ fromJSON(needs.openapi-validation-matrix.outputs.matrix) }}
+        spec:
+          - spec/openapi.yml
+          - spec/openapi-edge.yml
+          - spec/openapi-hyperloop.yml
+          - spec/openapi-dashboard.yml
+          - packages/envd/spec/envd.yaml
       fail-fast: false
     steps:
       - name: Checkout repository
-        if: ${{ matrix.skip != true }}
         uses: actions/checkout@v5
 
       - name: Validate OpenAPI spec
-        if: ${{ matrix.skip != true }}
         run: npx --yes @redocly/cli lint ${{ matrix.spec }}
 
   validate_openapi:
-    needs:
-      - openapi-validation-matrix
-      - validate-openapi
+    needs: validate-openapi
     if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Aggregate OpenAPI validation result
         run: |
-          if [[ "${{ needs.openapi-validation-matrix.result }}" != "success" ]]; then
-            echo "OpenAPI validation matrix result: ${{ needs.openapi-validation-matrix.result }}"
-            exit 1
-          fi
-
           if [[ "${{ inputs.run-validation }}" != "true" ]]; then
             echo "OpenAPI validation skipped because OpenAPI specs did not change"
             exit 0

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -14,7 +14,8 @@ permissions:
 
 jobs:
   validate-openapi:
-    name: Validate ${{ matrix.spec }}
+    name: Validate OpenAPI specs
+    if: ${{ inputs.run-validation == true }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -26,16 +27,10 @@ jobs:
           - packages/envd/spec/envd.yaml
       fail-fast: false
     steps:
-      - name: Skip OpenAPI validation
-        if: ${{ inputs.run-validation != true }}
-        run: echo "OpenAPI validation skipped because OpenAPI specs did not change"
-
       - name: Checkout repository
-        if: ${{ inputs.run-validation == true }}
         uses: actions/checkout@v5
 
       - name: Validate OpenAPI spec
-        if: ${{ inputs.run-validation == true }}
         run: npx --yes @redocly/cli lint ${{ matrix.spec }}
 
   validate_openapi:


### PR DESCRIPTION
## Summary
- detect CI-relevant path groups with dorny/paths-filter
- skip unit, ARM64, integration, and Terraform worker jobs when their inputs did not change
- keep stable aggregate gate jobs so required checks can remain configured

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "infra-tests" is unknown' -ignore 'label "infra-runner-arm" is unknown' -ignore 'shellcheck reported issue' .github/workflows/pull-request.yml .github/workflows/push-main.yml .github/workflows/pr-tests.yml .github/workflows/pr-tests-arm64.yml .github/workflows/integration_tests.yml .github/workflows/validate-iac.yml
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/validate-iac.yml .github/workflows/pull-request.yml .github/workflows/push-main.yml .github/workflows/pr-tests.yml .github/workflows/pr-tests-arm64.yml .github/workflows/integration_tests.yml
- git diff --check origin/main...HEAD