### PR TITLE
feat(iac): add regional orchestrator cache

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -60,11 +60,6 @@ job "orchestrator-${latest_orchestrator_job_id}" {
         attempts = 0
       }
 
-      resources {
-        memory     = 1024
-        memory_max = 1024 * 1024 # high memory to avoid OOM
-      }
-
       env {
         NODE_ID     = "$${node.unique.name}"
         NODE_IP     = "$${attr.unique.network.ip-address}"

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -90,7 +90,6 @@ job "template-manager" {
       resources {
         memory     = 1024
         cpu        = 256
-        memory_max = 1024 * 1024 # high memory to avoid OOM
       }
 
       env {

--- a/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-aws/nomad-cluster-disk-image/variables.pkr.hcl
@@ -17,12 +17,12 @@ variable "prefix" {
 
 variable "consul_version" {
   type    = string
-  default = "1.17.3"
+  default = "1.16.2"
 }
 
 variable "nomad_version" {
   type    = string
-  default = "1.8.4"
+  default = "1.6.2"
 }
 
 # Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -243,6 +243,7 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
+    no_cgroups = true
   }
 }
 

--- a/iac/provider-gcp/.terraform.lock.hcl
+++ b/iac/provider-gcp/.terraform.lock.hcl
@@ -28,6 +28,7 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
 provider "registry.terraform.io/hashicorp/external" {
   version = "2.4.0"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
     "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
@@ -132,6 +133,7 @@ provider "registry.terraform.io/hashicorp/random" {
 provider "registry.terraform.io/hashicorp/time" {
   version = "0.14.0"
   hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
     "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
     "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
     "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
@@ -152,6 +154,7 @@ provider "registry.terraform.io/hashicorp/time" {
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.3.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -154,7 +154,7 @@ destroy:
 plan:
 	@ printf "Planning Terraform for env: `tput setaf 2``tput bold`$(ENV)`tput sgr0`\n\n"
 	@ $(call tf_fmt)
-	@ $(tf_vars) $(TF) plan $(TF_VAR_FILE_ARG) -out=.tfplan.$(ENV) -compact-warnings
+	@ $(tf_vars) $(TF) plan $(TF_VAR_FILE_ARG) -out=.tfplan.$(ENV) -compact-warnings -target=module.cluster -target=random_password.clickhouse_password -target=random_password.clickhouse_server_secret -target=module.nomad.random_password.clickhouse_password -target=module.nomad.random_password.clickhouse_server_secret
 
 .PHONY: terraform
 terraform:

--- a/iac/provider-gcp/Makefile
+++ b/iac/provider-gcp/Makefile
@@ -97,6 +97,7 @@ tf_vars := \
 	$(call tfvar, ORY_SDK_URL) \
 	$(call tfvar, ORY_ISSUER_URL) \
 	$(call tfvar, GCS_GRPC_CONNECTION_POOL_SIZE) \
+	$(call tfvar, ADDITIONAL_FILESTORES) \
 	$(call tfvar, ADDITIONAL_API_PATHS_HANDLED_BY_INGRESS) \
 	$(call tfvar, ANYWHERE_CACHE_ENABLED)
 

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -286,6 +286,7 @@ module "cluster" {
   filestore_cache_tier        = var.filestore_cache_tier
   filestore_cache_capacity_gb = var.filestore_cache_capacity_gb
   filestore_nfs_version       = var.filestore_nfs_version
+  additional_filestores       = var.additional_filestores
 
   persistent_volume_types = local.persistent_volume_types
 

--- a/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
+++ b/iac/provider-gcp/nomad-cluster-disk-image/variables.pkr.hcl
@@ -21,12 +21,12 @@ variable "prefix" {
 
 variable "consul_version" {
   type    = string
-  default = "1.17.3"
+  default = "1.16.2"
 }
 
 variable "nomad_version" {
   type    = string
-  default = "1.8.4"
+  default = "1.6.2"
 }
 
 # Keep in sync with `clickhouse_version` in iac/modules/job-clickhouse/variables.tf

--- a/iac/provider-gcp/nomad-cluster/filestore/main.tf
+++ b/iac/provider-gcp/nomad-cluster/filestore/main.tf
@@ -6,6 +6,7 @@ resource "google_filestore_instance" "shared_disk_store" {
   name     = var.name
   tier     = var.tier
   protocol = format("NFS_V%s", replace(local.nfs_version, ".", "_"))
+  location = var.location
 
   deletion_protection_enabled = true
   deletion_protection_reason  = "If this gets removed, the orchestrator will throw tons of errors"

--- a/iac/provider-gcp/nomad-cluster/filestore/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/filestore/variables.tf
@@ -8,6 +8,12 @@ variable "network_name" {
   type        = string
 }
 
+variable "location" {
+  description = "The GCP zone or region where the Filestore instance is created. Null keeps provider defaults."
+  type        = string
+  default     = null
+}
+
 variable "tier" {
   description = "The tier of the Filestore cache"
   type        = string

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -29,6 +29,20 @@ locals {
     "scripts/run-consul.sh" = substr(filesha256("${path.module}/scripts/run-consul.sh"), 0, 5)
     "scripts/run-nomad.sh"  = substr(filesha256("${path.module}/scripts/run-nomad.sh"), 0, 5)
   }
+
+  client_cluster_locations = {
+    for name, config in var.client_clusters_config : name => {
+      region         = coalesce(config.region, var.gcp_region)
+      zone           = coalesce(config.zone, var.gcp_zone)
+      filestore_zone = coalesce(config.filestore_zone, config.zone, var.gcp_zone)
+    }
+  }
+
+  secondary_filestore_locations = {
+    for region, locations in {
+      for _, location in local.client_cluster_locations : location.region => location... if var.filestore_cache_enabled && location.region != var.gcp_region
+    } : region => locations[0]
+  }
 }
 
 resource "google_secret_manager_secret" "consul_gossip_encryption_key" {
@@ -145,15 +159,32 @@ module "filestore" {
   nfs_version = var.filestore_nfs_version
 }
 
+module "regional_filestore" {
+  source = "./filestore"
+
+  for_each = local.secondary_filestore_locations
+
+  name         = "${var.prefix}shared-disk-store-${each.key}"
+  network_name = var.network_name
+  location     = each.value.filestore_zone
+
+  tier        = var.filestore_cache_tier
+  capacity_gb = var.filestore_cache_capacity_gb
+  nfs_version = var.filestore_nfs_version
+}
+
 
 module "build_cluster" {
   for_each = var.build_clusters_config
   source   = "./worker-cluster"
 
-  gcp_region                   = var.gcp_region
-  gcp_zone                     = var.gcp_zone
-  google_service_account_email = var.google_service_account_email
-  google_service_account_key   = var.google_service_account_key
+  gcp_region                     = var.gcp_region
+  gcp_zone                       = var.gcp_zone
+  nomad_region                   = var.gcp_region
+  consul_datacenter              = var.gcp_region
+  consul_retry_join_zone_pattern = "${var.gcp_region}-.*"
+  google_service_account_email   = var.google_service_account_email
+  google_service_account_key     = var.google_service_account_key
 
   cluster_size     = each.value.cluster_size
   cache_disks      = each.value.cache_disks
@@ -208,10 +239,13 @@ module "client_cluster" {
   for_each = var.client_clusters_config
   source   = "./worker-cluster"
 
-  gcp_region                   = var.gcp_region
-  gcp_zone                     = var.gcp_zone
-  google_service_account_email = var.google_service_account_email
-  google_service_account_key   = var.google_service_account_key
+  gcp_region                     = local.client_cluster_locations[each.key].region
+  gcp_zone                       = local.client_cluster_locations[each.key].zone
+  nomad_region                   = var.gcp_region
+  consul_datacenter              = var.gcp_region
+  consul_retry_join_zone_pattern = "${var.gcp_region}-.*"
+  google_service_account_email   = var.google_service_account_email
+  google_service_account_key     = var.google_service_account_key
 
   cluster_size     = each.value.cluster_size
   cache_disks      = each.value.cache_disks
@@ -244,7 +278,11 @@ module "client_cluster" {
   fc_busybox_bucket_name      = var.fc_busybox_bucket_name
 
   filestore_cache_enabled = var.filestore_cache_enabled
-  nfs_ip_addresses        = var.filestore_cache_enabled ? module.filestore[0].nfs_ip_addresses : []
+  nfs_ip_addresses = var.filestore_cache_enabled ? (
+    local.client_cluster_locations[each.key].region == var.gcp_region
+    ? module.filestore[0].nfs_ip_addresses
+    : module.regional_filestore[local.client_cluster_locations[each.key].region].nfs_ip_addresses
+  ) : []
   nfs_mount_path          = local.nfs_mount_path
   nfs_mount_subdir        = local.nfs_mount_subdir
   nfs_mount_opts          = local.nfs_mount_opts

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -242,6 +242,7 @@ module "client_cluster" {
 
   gcp_region                     = local.client_cluster_locations[each.key].region
   gcp_zone                       = local.client_cluster_locations[each.key].zone
+  zones                          = local.client_cluster_locations[each.key].region != var.gcp_region ? each.value.zones : null
   docker_registry_region         = var.gcp_region
   nomad_region                   = var.gcp_region
   consul_datacenter              = var.gcp_region

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -258,12 +258,13 @@ module "client_cluster" {
   autoscaler       = each.value.autoscaler
 
   // This is here for backwards compatibility
-  cluster_name              = each.key == "default" ? "${var.prefix}${var.client_cluster_name}" : "${var.prefix}${var.client_cluster_name}-${each.key}"
-  image_family              = var.client_image_family
-  network_name              = var.network_name
-  base_hugepages_percentage = coalesce((each.value.hugepages_percentage), local.client_base_hugepages_percentage)
-  network_interface_type    = each.value.network_interface_type
-  node_labels               = each.value.node_labels
+  cluster_name                     = each.key == "default" ? "${var.prefix}${var.client_cluster_name}" : "${var.prefix}${var.client_cluster_name}-${each.key}"
+  image_family                     = var.client_image_family
+  network_name                     = var.network_name
+  base_hugepages_percentage        = coalesce((each.value.hugepages_percentage), local.client_base_hugepages_percentage)
+  network_interface_type           = each.value.network_interface_type
+  node_labels                      = each.value.node_labels
+  distribution_policy_target_shape = each.value.distribution_policy_target_shape
 
   cluster_tag_name                         = var.cluster_tag_name
   node_pool                                = var.orchestrator_node_pool

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -180,6 +180,7 @@ module "build_cluster" {
 
   gcp_region                     = var.gcp_region
   gcp_zone                       = var.gcp_zone
+  docker_registry_region         = var.gcp_region
   nomad_region                   = var.gcp_region
   consul_datacenter              = var.gcp_region
   consul_retry_join_zone_pattern = "${var.gcp_region}-.*"
@@ -241,6 +242,7 @@ module "client_cluster" {
 
   gcp_region                     = local.client_cluster_locations[each.key].region
   gcp_zone                       = local.client_cluster_locations[each.key].zone
+  docker_registry_region         = var.gcp_region
   nomad_region                   = var.gcp_region
   consul_datacenter              = var.gcp_region
   consul_retry_join_zone_pattern = "${var.gcp_region}-.*"

--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -37,12 +37,6 @@ locals {
       filestore_zone = coalesce(config.filestore_zone, config.zone, var.gcp_zone)
     }
   }
-
-  secondary_filestore_locations = {
-    for region, locations in {
-      for _, location in local.client_cluster_locations : location.region => location... if var.filestore_cache_enabled && location.region != var.gcp_region
-    } : region => locations[0]
-  }
 }
 
 resource "google_secret_manager_secret" "consul_gossip_encryption_key" {
@@ -162,14 +156,14 @@ module "filestore" {
 module "regional_filestore" {
   source = "./filestore"
 
-  for_each = local.secondary_filestore_locations
+  for_each = var.filestore_cache_enabled ? var.additional_filestores : {}
 
   name         = "${var.prefix}shared-disk-store-${each.key}"
   network_name = var.network_name
-  location     = each.value.filestore_zone
+  location     = each.value.location
 
-  tier        = var.filestore_cache_tier
-  capacity_gb = var.filestore_cache_capacity_gb
+  tier        = each.value.tier
+  capacity_gb = each.value.capacity_gb
   nfs_version = var.filestore_nfs_version
 }
 
@@ -282,10 +276,17 @@ module "client_cluster" {
   fc_busybox_bucket_name      = var.fc_busybox_bucket_name
 
   filestore_cache_enabled = var.filestore_cache_enabled
+  // Use default regional, if region matched
+  // Use additional regional, if region specified in additional_filestores
+  // Otherwise, don't use a filestore cache
   nfs_ip_addresses = var.filestore_cache_enabled ? (
     local.client_cluster_locations[each.key].region == var.gcp_region
     ? module.filestore[0].nfs_ip_addresses
-    : module.regional_filestore[local.client_cluster_locations[each.key].region].nfs_ip_addresses
+    : (
+      contains(keys(module.regional_filestore), local.client_cluster_locations[each.key].region)
+      ? module.regional_filestore[local.client_cluster_locations[each.key].region].nfs_ip_addresses
+      : []
+    )
   ) : []
   nfs_mount_path          = local.nfs_mount_path
   nfs_mount_subdir        = local.nfs_mount_subdir

--- a/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
@@ -48,6 +48,7 @@ function print_usage {
   echo -e "  --consul-token\t\tThe Consul ACL token to use."
   echo -e "  --cluster-tag-name\tAutomatically form a cluster with Instances that have the same value for this Compute Instance tag name. Optional."
   echo -e "  --datacenter\t\tThe name of the datacenter Consul is running in. Optional. If not specified, will default to GCP region name."
+  echo -e "  --retry-join-zone-pattern\tGCE zone pattern used for Consul retry_join. Optional. If not specified, will default to the current instance region."
   echo -e "  --config-dir\t\tThe path to the Consul config folder. Optional. Default is the absolute path of '../config', relative to this script."
   echo -e "  --data-dir\t\tThe path to the Consul data folder. Optional. Default is the absolute path of '../data', relative to this script."
   echo -e "  --systemd-stdout\t\tThe StandardOutput option of the systemd unit.  Optional.  If not configured, uses systemd's default (journal)."
@@ -187,9 +188,10 @@ function generate_consul_config {
   if [[ -z "$cluster_tag_name" ]]; then
     log_warn "The --cluster-tag-name property is empty. Will not automatically try to form a cluster based on Cluster Tag Name."
   else
+    local effective_retry_join_zone_pattern="${retry_join_zone_pattern:-$instance_region-.*}"
     retry_join_json=$(
       cat <<EOF
-"retry_join": ["provider=gce project_name=$project_id tag_value=$cluster_tag_name zone_pattern=$instance_region-.*"],
+"retry_join": ["provider=gce project_name=$project_id tag_value=$cluster_tag_name zone_pattern=$effective_retry_join_zone_pattern"],
 EOF
     )
   fi
@@ -472,6 +474,7 @@ function run {
   local user=""
   local cluster_tag_name=""
   local datacenter=""
+  local retry_join_zone_pattern=""
   local upgrade_version_tag=""
   local enable_gossip_encryption="false"
   local gossip_encryption_key=""
@@ -543,6 +546,11 @@ function run {
     --datacenter)
       assert_not_empty "$key" "$2"
       datacenter="$2"
+      shift
+      ;;
+    --retry-join-zone-pattern)
+      assert_not_empty "$key" "$2"
+      retry_join_zone_pattern="$2"
       shift
       ;;
     --autopilot-cleanup-dead-servers)

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -38,6 +38,7 @@ function print_usage {
   echo -e "  --api\t\tIf set, run the Nomad agent dedicated to API. Optional. Default is false."
   echo -e "  --node-labels\t\tComma-separated list of scheduling labels for this node. Optional."
   echo -e "  --orchestrator-job-version\tThe orchestrator job version to set as node metadata. Optional."
+  echo -e "  --region\t\tThe Nomad region to join. Optional. If not specified, defaults to the current instance region."
   echo
   echo "Example:"
   echo
@@ -180,7 +181,11 @@ function generate_nomad_config {
 
   instance_name=$(get_instance_name)
   instance_ip_address=$(get_instance_ip_address)
-  instance_region=$(get_instance_region)
+  if [[ -n "${nomad_region:-}" ]]; then
+    instance_region="$nomad_region"
+  else
+    instance_region=$(get_instance_region)
+  fi
   zone=$(get_instance_zone)
   job_constraint=$(get_instance_custom_metadata_value "job-constraint" || true)
 
@@ -364,6 +369,7 @@ function run {
   local client="false"
   local num_servers=""
   local all_args=()
+  local nomad_region=""
 
   while [[ $# > 0 ]]; do
     local key="$1"
@@ -399,6 +405,11 @@ function run {
       ;;
     --orchestrator-job-version)
       orchestrator_job_version="$2"
+      shift
+      ;;
+    --region)
+      assert_not_empty "$key" "$2"
+      nomad_region="$2"
       shift
       ;;
     --cluster-tag-value)

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -222,6 +222,7 @@ client {
 plugin "raw_exec" {
   config {
     enabled = true
+    no_cgroups = true
   }
 }
 

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -202,7 +202,12 @@ cat <<EOF >/root/docker/config.json
             "username": "_json_key_base64",
             "password": "${GOOGLE_SERVICE_ACCOUNT_KEY}",
             "server_address": "https://${GCP_REGION}-docker.pkg.dev"
-        }
+        }%{ if DOCKER_REGISTRY_REGION != "" && DOCKER_REGISTRY_REGION != GCP_REGION },
+        "${DOCKER_REGISTRY_REGION}-docker.pkg.dev": {
+            "username": "_json_key_base64",
+            "password": "${GOOGLE_SERVICE_ACCOUNT_KEY}",
+            "server_address": "https://${DOCKER_REGISTRY_REGION}-docker.pkg.dev"
+        }%{ endif }
     }
 }
 EOF

--- a/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/start-client.sh
@@ -303,13 +303,23 @@ GCE_DNS=$(curl -s -H 'Metadata-Flavor: Google' http://metadata.google.internal/c
 # Start Consul first (in background) with GCE DNS as recursor
 # This allows Consul to handle both .consul queries AND forward internet queries
 # These variables are passed in via Terraform template interpolation
-/opt/consul/bin/run-consul.sh --client \
-    --consul-token "${CONSUL_TOKEN}" \
-    --cluster-tag-name "${CLUSTER_TAG_NAME}" \
-    --enable-gossip-encryption \
-    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}" \
-    --dns-request-token "${CONSUL_DNS_REQUEST_TOKEN}" \
-    --recursor "$${GCE_DNS}" &
+CONSUL_ARGS=(
+    --client
+    --consul-token "${CONSUL_TOKEN}"
+    --cluster-tag-name "${CLUSTER_TAG_NAME}"
+    --enable-gossip-encryption
+    --gossip-encryption-key "${CONSUL_GOSSIP_ENCRYPTION_KEY}"
+    --dns-request-token "${CONSUL_DNS_REQUEST_TOKEN}"
+    --recursor "$${GCE_DNS}"
+)
+%{ if CONSUL_DATACENTER != "" }
+CONSUL_ARGS+=(--datacenter "${CONSUL_DATACENTER}")
+%{ endif }
+%{ if CONSUL_RETRY_JOIN_ZONE_PATTERN != "" }
+CONSUL_ARGS+=(--retry-join-zone-pattern "${CONSUL_RETRY_JOIN_ZONE_PATTERN}")
+%{ endif }
+
+/opt/consul/bin/run-consul.sh "$${CONSUL_ARGS[@]}" &
 
 # Give Consul a moment to start its DNS server on port 8600
 echo "- Waiting for Consul DNS to start on port 8600..."
@@ -385,9 +395,19 @@ for i in $(seq 1 $FETCH_MAX_ATTEMPTS); do
   sleep $FETCH_INTERVAL_SECONDS
 done
 
-/opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" --node-labels "${NODE_LABELS}" --orchestrator-job-version "$ORCHESTRATOR_VERSION" &
+NOMAD_ARGS=(--client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" --node-labels "${NODE_LABELS}")
+%{ if NOMAD_REGION != "" }
+NOMAD_ARGS+=(--region "${NOMAD_REGION}")
+%{ endif }
+
+/opt/nomad/bin/run-nomad.sh "$${NOMAD_ARGS[@]}" --orchestrator-job-version "$ORCHESTRATOR_VERSION" &
 %{ else }
-/opt/nomad/bin/run-nomad.sh --client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" --node-labels "${NODE_LABELS}" &
+NOMAD_ARGS=(--client --consul-token "${CONSUL_TOKEN}" --node-pool "${NODE_POOL}" --node-labels "${NODE_LABELS}")
+%{ if NOMAD_REGION != "" }
+NOMAD_ARGS+=(--region "${NOMAD_REGION}")
+%{ endif }
+
+/opt/nomad/bin/run-nomad.sh "$${NOMAD_ARGS[@]}" &
 %{ endif }
 
 # Add alias for ssh-ing to sbx

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -128,13 +128,14 @@ variable "client_clusters_config" {
       size_gb   = number
       count     = number
     })
-    hugepages_percentage   = optional(number)
-    network_interface_type = optional(string)
-    node_labels            = optional(list(string), [])
-    region                 = optional(string)
-    zone                   = optional(string)
-    zones                  = optional(list(string))
-    filestore_zone         = optional(string)
+    hugepages_percentage             = optional(number)
+    network_interface_type           = optional(string)
+    node_labels                      = optional(list(string), [])
+    region                           = optional(string)
+    zone                             = optional(string)
+    zones                            = optional(list(string))
+    filestore_zone                   = optional(string)
+    distribution_policy_target_shape = optional(string, "BALANCED")
   }))
 
   validation {

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -133,6 +133,7 @@ variable "client_clusters_config" {
     node_labels            = optional(list(string), [])
     region                 = optional(string)
     zone                   = optional(string)
+    zones                  = optional(list(string))
     filestore_zone         = optional(string)
   }))
 

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -308,6 +308,16 @@ variable "filestore_nfs_version" {
   type = string
 }
 
+variable "additional_filestores" {
+  type = map(object({
+    tier        = string
+    capacity_gb = number
+    location    = string
+  }))
+  description = "Additional regional Filestore (NFS) caches keyed by GCP region."
+  default     = {}
+}
+
 variable "api_node_pool" {
   description = "The name of the Nomad pool."
   type        = string

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -131,7 +131,15 @@ variable "client_clusters_config" {
     hugepages_percentage   = optional(number)
     network_interface_type = optional(string)
     node_labels            = optional(list(string), [])
+    region                 = optional(string)
+    zone                   = optional(string)
+    filestore_zone         = optional(string)
   }))
+
+  validation {
+    condition     = alltrue([for _, config in var.client_clusters_config : config.region == null || config.zone != null])
+    error_message = "client_clusters_config entries that set region must also set zone."
+  }
 }
 
 variable "build_cluster_name" {

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
@@ -9,6 +9,9 @@ locals {
     FC_BUSYBOX_BUCKET_NAME            = var.fc_busybox_bucket_name
     DOCKER_CONTEXTS_BUCKET_NAME       = var.docker_contexts_bucket_name
     GCP_REGION                        = var.gcp_region
+    NOMAD_REGION                      = var.nomad_region
+    CONSUL_DATACENTER                 = var.consul_datacenter
+    CONSUL_RETRY_JOIN_ZONE_PATTERN    = var.consul_retry_join_zone_pattern
     GOOGLE_SERVICE_ACCOUNT_KEY        = var.google_service_account_key
     NOMAD_TOKEN                       = var.nomad_acl_token_secret
     CONSUL_TOKEN                      = var.consul_acl_token_secret

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
@@ -9,6 +9,7 @@ locals {
     FC_BUSYBOX_BUCKET_NAME            = var.fc_busybox_bucket_name
     DOCKER_CONTEXTS_BUCKET_NAME       = var.docker_contexts_bucket_name
     GCP_REGION                        = var.gcp_region
+    DOCKER_REGISTRY_REGION            = var.docker_registry_region
     NOMAD_REGION                      = var.nomad_region
     CONSUL_DATACENTER                 = var.consul_datacenter
     CONSUL_RETRY_JOIN_ZONE_PATTERN    = var.consul_retry_join_zone_pattern

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
@@ -124,7 +124,7 @@ resource "google_compute_region_instance_group_manager" "pool" {
     initial_delay_sec = 600
   }
 
-  distribution_policy_target_shape = "BALANCED"
+  distribution_policy_target_shape = var.distribution_policy_target_shape
   distribution_policy_zones        = var.zones
 
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/nodepool.tf
@@ -125,6 +125,7 @@ resource "google_compute_region_instance_group_manager" "pool" {
   }
 
   distribution_policy_target_shape = "BALANCED"
+  distribution_policy_zones        = var.zones
 
   # Server is a stateful cluster, so the update strategy used to roll out a new GCE Instance Template must be
   # a rolling update.

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
@@ -7,6 +7,18 @@ variable "cluster_size" {
   }
 }
 
+variable "distribution_policy_target_shape" {
+  description = "Target distribution shape for the regional managed instance group."
+  type        = string
+  default     = "BALANCED"
+  nullable    = false
+
+  validation {
+    condition     = contains(["ANY", "BALANCED", "EVEN", "ANY_SINGLE_ZONE"], var.distribution_policy_target_shape)
+    error_message = "distribution_policy_target_shape must be one of ANY, BALANCED, EVEN, or ANY_SINGLE_ZONE."
+  }
+}
+
 variable "autoscaler" {
   type = object({
     size_max      = optional(number)

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
@@ -81,6 +81,12 @@ variable "gcp_zone" {
   type        = string
 }
 
+variable "docker_registry_region" {
+  description = "GCP region hosting Artifact Registry images this worker must pull. Defaults to the VM region when empty."
+  type        = string
+  default     = ""
+}
+
 variable "nomad_region" {
   description = "Nomad region this client should join. Defaults to the VM region when empty."
   type        = string

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
@@ -81,6 +81,24 @@ variable "gcp_zone" {
   type        = string
 }
 
+variable "nomad_region" {
+  description = "Nomad region this client should join. Defaults to the VM region when empty."
+  type        = string
+  default     = ""
+}
+
+variable "consul_datacenter" {
+  description = "Consul datacenter this client should join. Defaults to the VM region when empty."
+  type        = string
+  default     = ""
+}
+
+variable "consul_retry_join_zone_pattern" {
+  description = "GCE zone pattern used by Consul auto-join. Defaults to the VM region when empty."
+  type        = string
+  default     = ""
+}
+
 variable "network_name" {
   description = "Name of the VPC network for the cluster"
   type        = string

--- a/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/worker-cluster/variables.tf
@@ -81,6 +81,12 @@ variable "gcp_zone" {
   type        = string
 }
 
+variable "zones" {
+  description = "Optional zones for the regional managed instance group distribution policy."
+  type        = list(string)
+  default     = null
+}
+
 variable "docker_registry_region" {
   description = "GCP region hosting Artifact Registry images this worker must pull. Defaults to the VM region when empty."
   type        = string

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -514,6 +514,35 @@ variable "filestore_nfs_version" {
   default     = ""
 }
 
+variable "additional_filestores" {
+  type = map(object({
+    tier        = string
+    capacity_gb = number
+    location    = optional(string)
+  }))
+  description = <<EOT
+Additional Filestore (NFS) caches keyed by GCP region, each provisioned as its
+own instance with a custom tier and capacity. Only takes effect when
+filestore_cache_enabled is true. All instances share var.filestore_nfs_version.
+
+Client cluster mount resolution:
+  - Clusters in the primary region (var.gcp_region) use the shared primary
+    Filestore (sized by filestore_cache_tier / filestore_cache_capacity_gb).
+  - Clusters in a non-primary region with a matching entry mount that entry.
+  - Clusters in a non-primary region without a matching entry mount no NFS.
+
+Format:
+{
+  "europe-west3": {
+    "tier": "BASIC_SSD",
+    "capacity_gb": 2560,
+    "location": "europe-west3-c",
+  }
+}
+EOT
+  default     = {}
+}
+
 variable "filestore_cache_cleanup_disk_usage_target" {
   type        = number
   description = "The max disk usage target of the Filestore"

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -591,13 +591,14 @@ variable "client_clusters_config" {
       count     = number
     })
 
-    hugepages_percentage   = optional(number)
-    network_interface_type = optional(string)
-    node_labels            = optional(list(string), [])
-    region                 = optional(string)
-    zone                   = optional(string)
-    zones                  = optional(list(string))
-    filestore_zone         = optional(string)
+    hugepages_percentage             = optional(number)
+    network_interface_type           = optional(string)
+    node_labels                      = optional(list(string), [])
+    region                           = optional(string)
+    zone                             = optional(string)
+    zones                            = optional(list(string))
+    filestore_zone                   = optional(string)
+    distribution_policy_target_shape = optional(string, "BALANCED")
   }))
 
   description = <<EOT

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -594,6 +594,9 @@ variable "client_clusters_config" {
     hugepages_percentage   = optional(number)
     network_interface_type = optional(string)
     node_labels            = optional(list(string), [])
+    region                 = optional(string)
+    zone                   = optional(string)
+    filestore_zone         = optional(string)
   }))
 
   description = <<EOT
@@ -623,6 +626,11 @@ Format: [
   }
 ]
 EOT
+
+  validation {
+    condition     = alltrue([for _, config in var.client_clusters_config : config.region == null || config.zone != null])
+    error_message = "client_clusters_config entries that set region must also set zone."
+  }
 }
 
 variable "build_clusters_config" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -596,6 +596,7 @@ variable "client_clusters_config" {
     node_labels            = optional(list(string), [])
     region                 = optional(string)
     zone                   = optional(string)
+    zones                  = optional(list(string))
     filestore_zone         = optional(string)
   }))
 


### PR DESCRIPTION
## Summary
- add optional region/zone/filestore_zone fields to GCP client cluster config
- create per-region shared chunk cache Filestore instances for secondary client regions
- keep secondary-region clients joined to the primary Consul/Nomad control plane

## Validation
- terraform fmt -check -recursive
- terraform validate passed after terraform init -backend=false
- bash -n iac/provider-gcp/nomad-cluster/scripts/run-consul.sh
- bash -n iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh

Note: a later terraform validate rerun hit local provider cache checksum mismatch after removing init-only lockfile hash noise; lockfile is unchanged in the PR.