### PR TITLE
Use file-backed block cache

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,5 +95,6 @@
   "mise.configureExtensionsAutomaticallyIgnoreList": [
     "ms-vscode.js-debug"
   ],
-  "python.defaultInterpreterPath": "${workspaceFolder}/.vscode/mise-tools/python"
+  "python.defaultInterpreterPath": "${workspaceFolder}/.vscode/mise-tools/python",
+  "makefile.configureOnOpen": false
 }

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -107,8 +107,8 @@ func (c *Cache) ExportToDiff(ctx context.Context, out *os.File) (*header.DiffMet
 	ctx, childSpan := tracer.Start(ctx, "export-to-diff")
 	defer childSpan.End()
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if c.isClosed() {
 		return nil, NewErrCacheClosed(c.filePath)

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -410,6 +410,7 @@ func (c *Cache) Dedup(
 		}
 
 		_, err := c.ReadAt(p, idx)
+
 		return err
 	}
 
@@ -471,8 +472,8 @@ func (c *Cache) readAtWithoutLock(b []byte, off int64, skipCachedCheck bool) (in
 }
 
 func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if len(b) == 0 || c.size == 0 {
 		return 0, nil
@@ -532,8 +533,8 @@ func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
 }
 
 func (c *Cache) writeRawAt(b []byte, off int64) (int, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if len(b) == 0 || c.size == 0 {
 		return 0, nil
@@ -588,13 +589,6 @@ func (c *Cache) Slice(off, length int64) ([]byte, error) {
 	defer c.mu.RUnlock()
 
 	return c.slice(off, length, false)
-}
-
-func (c *Cache) sliceDirect(off, length int64) ([]byte, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	return c.slice(off, length, true)
 }
 
 func (c *Cache) slice(off, length int64, skipCachedCheck bool) ([]byte, error) {
@@ -653,8 +647,8 @@ func (c *Cache) punchHole(off, length int64) error {
 // WriteZeroesAt punches the range and marks all touched blocks Zero.
 // Caller must pass a block-aligned offset/length (NBD invariant).
 func (c *Cache) WriteZeroesAt(off, length int64) (int, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if length == 0 || c.size == 0 {
 		return 0, nil
@@ -738,8 +732,8 @@ func (c *Cache) copyProcessMemory(
 	pid int,
 	rs []Range,
 ) error {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	if c.isClosed() {
 		return NewErrCacheClosed(c.filePath)

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -52,6 +53,7 @@ type Cache struct {
 	size      int64
 	blockSize int64
 	file      *os.File
+	mu        sync.RWMutex
 	tracker   *Tracker // Dirty: payload in file; Zero: punched, emitted as Empty in the diff
 	dirtyFile bool
 	closed    atomic.Bool
@@ -104,6 +106,9 @@ func (c *Cache) isClosed() bool {
 func (c *Cache) ExportToDiff(ctx context.Context, out *os.File) (*header.DiffMetadata, error) {
 	ctx, childSpan := tracer.Start(ctx, "export-to-diff")
 	defer childSpan.End()
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.isClosed() {
 		return nil, NewErrCacheClosed(c.filePath)
@@ -435,10 +440,13 @@ func (c *Cache) Dedup(
 }
 
 func (c *Cache) ReadAt(b []byte, off int64) (int, error) {
-	return c.readAt(b, off, false)
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.readAtWithoutLock(b, off, false)
 }
 
-func (c *Cache) readAt(b []byte, off int64, skipCachedCheck bool) (int, error) {
+func (c *Cache) readAtWithoutLock(b []byte, off int64, skipCachedCheck bool) (int, error) {
 	if len(b) == 0 || c.size == 0 {
 		return 0, nil
 	}
@@ -463,6 +471,9 @@ func (c *Cache) readAt(b []byte, off int64, skipCachedCheck bool) (int, error) {
 }
 
 func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if len(b) == 0 || c.size == 0 {
 		return 0, nil
 	}
@@ -521,6 +532,9 @@ func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
 }
 
 func (c *Cache) writeRawAt(b []byte, off int64) (int, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if len(b) == 0 || c.size == 0 {
 		return 0, nil
 	}
@@ -547,6 +561,9 @@ func (c *Cache) Close() (e error) {
 		return NewErrCacheClosed(c.filePath)
 	}
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.file != nil {
 		e = errors.Join(e, c.file.Close())
 	}
@@ -567,10 +584,16 @@ func (c *Cache) Size() (int64, error) {
 
 // Slice returns a copy of the cached bytes.
 func (c *Cache) Slice(off, length int64) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.slice(off, length, false)
 }
 
 func (c *Cache) sliceDirect(off, length int64) ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.slice(off, length, true)
 }
 
@@ -581,7 +604,7 @@ func (c *Cache) slice(off, length int64, skipCachedCheck bool) ([]byte, error) {
 	}
 
 	out := make([]byte, end-off)
-	n, err := c.readAt(out, off, skipCachedCheck)
+	n, err := c.readAtWithoutLock(out, off, skipCachedCheck)
 	if err != nil {
 		return nil, err
 	}
@@ -630,6 +653,9 @@ func (c *Cache) punchHole(off, length int64) error {
 // WriteZeroesAt punches the range and marks all touched blocks Zero.
 // Caller must pass a block-aligned offset/length (NBD invariant).
 func (c *Cache) WriteZeroesAt(off, length int64) (int, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	if length == 0 || c.size == 0 {
 		return 0, nil
 	}
@@ -712,6 +738,13 @@ func (c *Cache) copyProcessMemory(
 	pid int,
 	rs []Range,
 ) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.isClosed() {
+		return NewErrCacheClosed(c.filePath)
+	}
+
 	// Pre-split so no single iov exceeds MAX_RW_COUNT.
 	ranges := splitOversizedRanges(rs, getAlignedMaxRwCount(c.blockSize))
 

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -8,16 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"os"
-	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
-	"github.com/edsrzf/mmap-go"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -54,9 +51,8 @@ type Cache struct {
 	filePath  string
 	size      int64
 	blockSize int64
-	mmap      *mmap.MMap
-	mu        sync.RWMutex
-	tracker   *Tracker // Dirty: payload in mmap; Zero: punched, emitted as Empty in the diff
+	file      *os.File
+	tracker   *Tracker // Dirty: payload in file; Zero: punched, emitted as Empty in the diff
 	dirtyFile bool
 	closed    atomic.Bool
 }
@@ -67,41 +63,38 @@ func NewCache(size, blockSize int64, filePath string, dirtyFile bool) (*Cache, e
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
 
-	defer f.Close()
-
-	if size == 0 {
-		return &Cache{
-			filePath:  filePath,
-			size:      size,
-			blockSize: blockSize,
-			dirtyFile: dirtyFile,
-			tracker:   NewTracker(),
-		}, nil
-	}
-
 	// This should create a sparse file on Linux.
 	err = f.Truncate(size)
 	if err != nil {
+		_ = f.Close()
+
 		return nil, fmt.Errorf("error allocating file: %w", err)
 	}
 
-	if size > math.MaxInt {
-		return nil, fmt.Errorf("size too big: %d > %d", size, math.MaxInt)
-	}
-
-	mm, err := mmap.MapRegion(f, int(size), mmap.RDWR, 0, 0)
-	if err != nil {
-		return nil, fmt.Errorf("error mapping file: %w", err)
-	}
-
 	return &Cache{
-		mmap:      &mm,
 		filePath:  filePath,
 		size:      size,
 		blockSize: blockSize,
+		file:      f,
 		dirtyFile: dirtyFile,
 		tracker:   NewTracker(),
 	}, nil
+}
+
+func writeFullAt(f *os.File, b []byte, off int64) error {
+	for len(b) > 0 {
+		n, err := f.WriteAt(b, off)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		off += int64(n)
+		b = b[n:]
+	}
+
+	return nil
 }
 
 func (c *Cache) isClosed() bool {
@@ -112,29 +105,19 @@ func (c *Cache) ExportToDiff(ctx context.Context, out *os.File) (*header.DiffMet
 	ctx, childSpan := tracer.Start(ctx, "export-to-diff")
 	defer childSpan.End()
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if c.isClosed() {
 		return nil, NewErrCacheClosed(c.filePath)
 	}
 
-	if c.mmap == nil {
+	if c.size == 0 {
 		return header.NewDiffMetadata(c.blockSize, nil, nil), nil
 	}
 
-	f, err := os.Open(c.filePath)
-	if err != nil {
-		return nil, fmt.Errorf("error opening file: %w", err)
-	}
-	defer f.Close()
+	src := int(c.file.Fd())
 
-	src := int(f.Fd())
-
-	// Explicit mmap flush is not necessary, because the kernel will handle that as part of the copy_file_range syscall.
 	// Calling sync_file_range marks the range for writeback and starts it early.
 	// This is just an optimization, so if it fails just log a warning and let copy_file_range do the actual work.
-	err = unix.SyncFileRange(src, 0, c.size, unix.SYNC_FILE_RANGE_WRITE)
+	err := unix.SyncFileRange(src, 0, c.size, unix.SYNC_FILE_RANGE_WRITE)
 	if err != nil {
 		logger.L().Warn(ctx, "error syncing file", zap.Error(err))
 	}
@@ -184,7 +167,7 @@ func (c *Cache) ExportToDiff(ctx context.Context, out *os.File) (*header.DiffMet
 				if _, err := out.Seek(writeOffset, io.SeekStart); err != nil {
 					return nil, fmt.Errorf("error seeking: %w", err)
 				}
-				sr := io.NewSectionReader(f, readOffset, int64(remaining))
+				sr := io.NewSectionReader(c.file, readOffset, int64(remaining))
 				if _, err := io.Copy(out, sr); err != nil {
 					return nil, fmt.Errorf("error copying file range. %w", err)
 				}
@@ -217,7 +200,7 @@ type dedupPlan struct {
 // cached pages of the same block when the parent header is page-granular.
 func dedupCompare(
 	ctx context.Context,
-	src func(absOff int64) ([]byte, error),
+	src func(absOff int64, p []byte) error,
 	base ReadonlyDevice,
 	dirty *roaring.Bitmap,
 	blockSize int64,
@@ -239,8 +222,8 @@ func dedupCompare(
 			}
 
 			absOff := r.Start + chunkOff
-			srcBuf, err := src(absOff)
-			if err != nil {
+			srcBuf := make([]byte, blockSize)
+			if err := src(absOff, srcBuf); err != nil {
 				return nil, err
 			}
 
@@ -272,9 +255,9 @@ func dedupCompare(
 					continue
 				}
 
-				basePage, sErr := base.Slice(ctx, pageOff, header.PageSize)
-				if sErr != nil {
-					return nil, fmt.Errorf("slice base at %d: %w", pageOff, sErr)
+				basePage := make([]byte, header.PageSize)
+				if _, err := base.ReadAt(ctx, basePage, pageOff); err != nil {
+					return nil, fmt.Errorf("read base at %d: %w", pageOff, err)
 				}
 				if bytes.Equal(srcPage, basePage) {
 					continue
@@ -291,7 +274,7 @@ func dedupCompare(
 // dedupDrain writes pageDirty pages from src to outPath packed at PageSize.
 func dedupDrain(
 	ctx context.Context,
-	src func(absOff int64) ([]byte, error),
+	src func(absOff int64, p []byte) error,
 	pageDirty *roaring.Bitmap,
 	blockSize int64,
 	outPath string,
@@ -354,7 +337,7 @@ func recordDedupAttrs(ctx context.Context, totalPages, uniquePages, emptyPages i
 // drainDirtyPages packs pageDirty pages from src into fd. Mirrors
 // Cache.copyProcessMemory: coalesce contiguous pages into ranges, carve at
 // source-block boundaries, pre-split over MAX_RW_COUNT, then drainIovs.
-func drainDirtyPages(ctx context.Context, fd int, src func(absOff int64) ([]byte, error), pageDirty *roaring.Bitmap, blockSize int64) (int64, error) {
+func drainDirtyPages(ctx context.Context, fd int, src func(absOff int64, p []byte) error, pageDirty *roaring.Bitmap, blockSize int64) (int64, error) {
 	var ranges []Range
 	for r := range BitsetRanges(pageDirty, header.PageSize) {
 		for off := r.Start; off < r.End(); {
@@ -374,9 +357,9 @@ func drainDirtyPages(ctx context.Context, fd int, src func(absOff int64) ([]byte
 			iovs := make([][]byte, len(batch))
 			for i, r := range batch {
 				blockOff := (r.Start / blockSize) * blockSize
-				buf, srcErr := src(blockOff)
-				if srcErr != nil {
-					return fmt.Errorf("slice src at %d: %w", blockOff, srcErr)
+				buf := make([]byte, blockSize)
+				if err := src(blockOff, buf); err != nil {
+					return fmt.Errorf("read src at %d: %w", blockOff, err)
 				}
 				iovs[i] = buf[r.Start-blockOff : r.Start-blockOff+r.Size]
 			}
@@ -415,13 +398,14 @@ func (c *Cache) Dedup(
 			cum += blockSize
 		}
 	}
-	src := func(absOff int64) ([]byte, error) {
+	src := func(absOff int64, p []byte) error {
 		idx, ok := packed[absOff]
 		if !ok {
-			return nil, fmt.Errorf("dedup src: %d not packed", absOff)
+			return fmt.Errorf("dedup src: %d not packed", absOff)
 		}
 
-		return c.Slice(idx, blockSize)
+		_, err := c.ReadAt(p, idx)
+		return err
 	}
 
 	compareStart := time.Now()
@@ -451,30 +435,35 @@ func (c *Cache) Dedup(
 }
 
 func (c *Cache) ReadAt(b []byte, off int64) (int, error) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	return c.readAt(b, off, false)
+}
 
-	if c.mmap == nil {
+func (c *Cache) readAt(b []byte, off int64, skipCachedCheck bool) (int, error) {
+	if len(b) == 0 || c.size == 0 {
 		return 0, nil
 	}
 
 	if c.isClosed() {
 		return 0, NewErrCacheClosed(c.filePath)
 	}
-
-	slice, err := c.Slice(off, int64(len(b)))
-	if err != nil {
-		return 0, fmt.Errorf("error slicing mmap: %w", err)
+	if off < 0 || off >= c.size {
+		return 0, BytesNotAvailableError{}
 	}
 
-	return copy(b, slice), nil
+	if !skipCachedCheck && !c.dirtyFile && !c.isCached(off, int64(len(b))) {
+		return 0, BytesNotAvailableError{}
+	}
+
+	n, err := c.file.ReadAt(b, off)
+	if errors.Is(err, io.EOF) && n > 0 {
+		err = nil
+	}
+
+	return n, err
 }
 
 func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.mmap == nil {
+	if len(b) == 0 || c.size == 0 {
 		return 0, nil
 	}
 
@@ -482,25 +471,84 @@ func (c *Cache) WriteAt(b []byte, off int64) (int, error) {
 		return 0, NewErrCacheClosed(c.filePath)
 	}
 
-	return c.WriteAtWithoutLock(b, off)
+	if int64(len(b))%c.blockSize != 0 || off%c.blockSize != 0 {
+		return 0, fmt.Errorf("misaligned write: len=%d off=%d block=%d", len(b), off, c.blockSize)
+	}
+
+	end := min(off+int64(len(b)), c.size)
+	if end <= off {
+		return 0, nil
+	}
+
+	// detect-zeroes=unmap: coalesce contiguous same-state blocks into one bulk
+	// copy or punchHole call. Caller must pass a block-aligned write (NBD invariant).
+	flush := func(runStart, runEnd int64, runZero bool) error {
+		startIdx := uint32(header.BlockIdx(runStart, c.blockSize))
+		endIdx := uint32(header.BlockCeilIdx(runEnd, c.blockSize))
+		if runZero {
+			if err := c.punchHole(runStart, runEnd-runStart); err != nil {
+				return err
+			}
+			c.tracker.SetRange(startIdx, endIdx, Zero)
+		} else {
+			if err := writeFullAt(c.file, b[runStart-off:runEnd-off], runStart); err != nil {
+				return err
+			}
+			c.tracker.SetRange(startIdx, endIdx, Dirty)
+		}
+
+		return nil
+	}
+
+	runStart := off
+	runZero := header.IsZero(b[:c.blockSize])
+	for i := off + c.blockSize; i < end; i += c.blockSize {
+		z := header.IsZero(b[i-off : i-off+c.blockSize])
+		if z == runZero {
+			continue
+		}
+		if err := flush(runStart, i, runZero); err != nil {
+			return 0, err
+		}
+		runStart = i
+		runZero = z
+	}
+	if err := flush(runStart, end, runZero); err != nil {
+		return 0, err
+	}
+
+	return int(end - off), nil
+}
+
+func (c *Cache) writeRawAt(b []byte, off int64) (int, error) {
+	if len(b) == 0 || c.size == 0 {
+		return 0, nil
+	}
+
+	if c.isClosed() {
+		return 0, NewErrCacheClosed(c.filePath)
+	}
+
+	end := min(off+int64(len(b)), c.size)
+	if end <= off {
+		return 0, nil
+	}
+	b = b[:end-off]
+	if err := writeFullAt(c.file, b, off); err != nil {
+		return 0, err
+	}
+
+	return len(b), nil
 }
 
 func (c *Cache) Close() (e error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.mmap == nil {
-		return os.RemoveAll(c.filePath)
-	}
-
 	succ := c.closed.CompareAndSwap(false, true)
 	if !succ {
 		return NewErrCacheClosed(c.filePath)
 	}
 
-	err := c.mmap.Unmap()
-	if err != nil {
-		e = errors.Join(e, fmt.Errorf("error unmapping mmap: %w", err))
+	if c.file != nil {
+		e = errors.Join(e, c.file.Close())
 	}
 
 	// TODO: Move to to the scope of the caller
@@ -517,47 +565,31 @@ func (c *Cache) Size() (int64, error) {
 	return c.size, nil
 }
 
-// Slice returns a slice of the mmap.
-// When using Slice you must ensure thread safety, ideally by only writing to the same block once and the exposing the slice.
+// Slice returns a copy of the cached bytes.
 func (c *Cache) Slice(off, length int64) ([]byte, error) {
-	if c.isClosed() {
-		return nil, NewErrCacheClosed(c.filePath)
-	}
-
-	if c.mmap == nil {
-		return nil, nil
-	}
-
-	if c.dirtyFile || c.isCached(off, length) {
-		end := min(off+length, c.size)
-
-		return (*c.mmap)[off:end], nil
-	}
-
-	return nil, BytesNotAvailableError{}
+	return c.slice(off, length, false)
 }
 
-// sliceDirect returns a slice of the mmap without checking isCached.
-// Used by the streaming chunker after the waiter mechanism has confirmed data availability.
 func (c *Cache) sliceDirect(off, length int64) ([]byte, error) {
-	if c.isClosed() {
-		return nil, NewErrCacheClosed(c.filePath)
-	}
+	return c.slice(off, length, true)
+}
 
-	if c.mmap == nil {
-		return nil, nil
-	}
-
-	if off < 0 || off >= c.size {
+func (c *Cache) slice(off, length int64, skipCachedCheck bool) ([]byte, error) {
+	end := min(off+length, c.size)
+	if off < 0 || off >= end {
 		return nil, BytesNotAvailableError{}
 	}
 
-	end := min(off+length, c.size)
+	out := make([]byte, end-off)
+	n, err := c.readAt(out, off, skipCachedCheck)
+	if err != nil {
+		return nil, err
+	}
 
-	return (*c.mmap)[off:end], nil
+	return out[:n], nil
 }
 
-// Zero blocks are treated as cached: the mmap region reads back as zero (punched).
+// Zero blocks are treated as cached: the file range reads back as zero (punched).
 func (c *Cache) isCached(off, length int64) bool {
 	start := uint32(header.BlockIdx(off, c.blockSize))
 	end := uint32(header.BlockCeilIdx(min(off+length, c.size), c.blockSize))
@@ -572,69 +604,33 @@ func (c *Cache) setIsCached(off, length int64) {
 	c.tracker.SetRange(start, end, Dirty)
 }
 
-// punchHole frees backing pages; clear() fallback if MADV_REMOVE is unsupported.
-func (c *Cache) punchHole(off, length int64) {
-	if err := unix.Madvise((*c.mmap)[off:off+length], unix.MADV_REMOVE); err != nil {
-		clear((*c.mmap)[off : off+length])
-	}
-}
-
-// When using WriteAtWithoutLock you must ensure thread safety, ideally by only writing to the same block once and the exposing the slice.
-func (c *Cache) WriteAtWithoutLock(b []byte, off int64) (int, error) {
-	if c.isClosed() {
-		return 0, NewErrCacheClosed(c.filePath)
+// punchHole frees backing pages; zero-write fallback if hole punching is unsupported.
+func (c *Cache) punchHole(off, length int64) error {
+	if length <= 0 {
+		return nil
 	}
 
-	if c.mmap == nil {
-		return 0, nil
+	if err := unix.Fallocate(int(c.file.Fd()), unix.FALLOC_FL_PUNCH_HOLE|unix.FALLOC_FL_KEEP_SIZE, off, length); err == nil {
+		return nil
 	}
 
-	if int64(len(b))%c.blockSize != 0 || off%c.blockSize != 0 {
-		return 0, fmt.Errorf("misaligned write: len=%d off=%d block=%d", len(b), off, c.blockSize)
-	}
-
-	end := min(off+int64(len(b)), c.size)
-	if end <= off {
-		return 0, nil
-	}
-
-	// detect-zeroes=unmap: coalesce contiguous same-state blocks into one bulk
-	// copy or punchHole call. Caller must pass a block-aligned write (NBD invariant).
-	flush := func(runStart, runEnd int64, runZero bool) {
-		startIdx := uint32(header.BlockIdx(runStart, c.blockSize))
-		endIdx := uint32(header.BlockCeilIdx(runEnd, c.blockSize))
-		if runZero {
-			c.punchHole(runStart, runEnd-runStart)
-			c.tracker.SetRange(startIdx, endIdx, Zero)
-		} else {
-			copy((*c.mmap)[runStart:runEnd], b[runStart-off:runEnd-off])
-			c.tracker.SetRange(startIdx, endIdx, Dirty)
+	const zeroChunkSize = 1 << 20
+	zeroes := make([]byte, min(length, zeroChunkSize))
+	for written := int64(0); written < length; {
+		n := min(int64(len(zeroes)), length-written)
+		if err := writeFullAt(c.file, zeroes[:n], off+written); err != nil {
+			return err
 		}
+		written += n
 	}
 
-	runStart := off
-	runZero := header.IsZero(b[:c.blockSize])
-	for i := off + c.blockSize; i < end; i += c.blockSize {
-		z := header.IsZero(b[i-off : i-off+c.blockSize])
-		if z == runZero {
-			continue
-		}
-		flush(runStart, i, runZero)
-		runStart = i
-		runZero = z
-	}
-	flush(runStart, end, runZero)
-
-	return int(end - off), nil
+	return nil
 }
 
 // WriteZeroesAt punches the range and marks all touched blocks Zero.
 // Caller must pass a block-aligned offset/length (NBD invariant).
 func (c *Cache) WriteZeroesAt(off, length int64) (int, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.mmap == nil {
+	if length == 0 || c.size == 0 {
 		return 0, nil
 	}
 
@@ -647,7 +643,9 @@ func (c *Cache) WriteZeroesAt(off, length int64) (int, error) {
 		return 0, nil
 	}
 
-	c.punchHole(off, end-off)
+	if err := c.punchHole(off, end-off); err != nil {
+		return 0, err
+	}
 	c.tracker.SetRange(
 		uint32(header.BlockIdx(off, c.blockSize)),
 		uint32(header.BlockCeilIdx(end, c.blockSize)),
@@ -673,49 +671,6 @@ func (c *Cache) FileSize(_ context.Context) (int64, error) {
 	}
 
 	return stat.Blocks * fsStat.Bsize, nil
-}
-
-func (c *Cache) address(off int64) (*byte, error) {
-	if c.mmap == nil {
-		return nil, nil
-	}
-
-	if off >= c.size {
-		return nil, fmt.Errorf("offset %d is out of bounds", off)
-	}
-
-	return &(*c.mmap)[off], nil
-}
-
-// addressBytes returns a slice of the mmap and a function to release the read lock which blocks the cache from being closed.
-func (c *Cache) addressBytes(off, length int64) ([]byte, func(), error) {
-	c.mu.RLock()
-
-	if c.mmap == nil {
-		c.mu.RUnlock()
-
-		return nil, func() {}, nil
-	}
-
-	if c.isClosed() {
-		c.mu.RUnlock()
-
-		return nil, func() {}, NewErrCacheClosed(c.filePath)
-	}
-
-	if off >= c.size {
-		c.mu.RUnlock()
-
-		return nil, func() {}, fmt.Errorf("offset %d is out of bounds", off)
-	}
-
-	releaseCacheCloseLock := func() {
-		c.mu.RUnlock()
-	}
-
-	end := min(off+length, c.size)
-
-	return (*c.mmap)[off:end], releaseCacheCloseLock, nil
 }
 
 func (c *Cache) BlockSize() int64 {
@@ -766,11 +721,8 @@ func (c *Cache) copyProcessMemory(
 			for i, r := range batch {
 				remote[i] = unix.RemoteIovec{Base: uintptr(r.Start), Len: int(r.Size)}
 			}
-			address, err := c.address(off)
-			if err != nil {
-				return fmt.Errorf("failed to get address: %w", err)
-			}
-			local := []unix.Iovec{{Base: address, Len: uint64(batchBytes)}}
+			buf := make([]byte, batchBytes)
+			local := []unix.Iovec{{Base: &buf[0], Len: uint64(batchBytes)}}
 
 			for {
 				select {
@@ -795,6 +747,9 @@ func (c *Cache) copyProcessMemory(
 					return fmt.Errorf("failed to read memory: expected %d bytes, got %d", batchBytes, n)
 				}
 
+				if err := writeFullAt(c.file, buf, off); err != nil {
+					return fmt.Errorf("failed to write memory cache: %w", err)
+				}
 				c.setIsCached(off, batchBytes)
 
 				return nil

--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -217,6 +217,8 @@ func dedupCompare(
 
 	baseHeader := base.Header()
 	peeker, _ := base.(CachePeeker)
+	srcBuf := make([]byte, blockSize)
+	basePage := make([]byte, header.PageSize)
 
 	for r := range BitsetRanges(dirty, blockSize) {
 		exportedSize += r.Size
@@ -227,7 +229,6 @@ func dedupCompare(
 			}
 
 			absOff := r.Start + chunkOff
-			srcBuf := make([]byte, blockSize)
 			if err := src(absOff, srcBuf); err != nil {
 				return nil, err
 			}
@@ -260,7 +261,7 @@ func dedupCompare(
 					continue
 				}
 
-				basePage := make([]byte, header.PageSize)
+				clear(basePage)
 				if _, err := base.ReadAt(ctx, basePage, pageOff); err != nil {
 					return nil, fmt.Errorf("read base at %d: %w", pageOff, err)
 				}
@@ -361,12 +362,11 @@ func drainDirtyPages(ctx context.Context, fd int, src func(absOff int64, p []byt
 			}
 			iovs := make([][]byte, len(batch))
 			for i, r := range batch {
-				blockOff := (r.Start / blockSize) * blockSize
-				buf := make([]byte, blockSize)
-				if err := src(blockOff, buf); err != nil {
-					return fmt.Errorf("read src at %d: %w", blockOff, err)
+				buf := make([]byte, r.Size)
+				if err := src(r.Start, buf); err != nil {
+					return fmt.Errorf("read src at %d: %w", r.Start, err)
 				}
-				iovs[i] = buf[r.Start-blockOff : r.Start-blockOff+r.Size]
+				iovs[i] = buf
 			}
 			if err := pwritevAll(fd, destOff, iovs); err != nil {
 				return fmt.Errorf("pwritev dedup pages: %w", err)
@@ -404,12 +404,13 @@ func (c *Cache) Dedup(
 		}
 	}
 	src := func(absOff int64, p []byte) error {
-		idx, ok := packed[absOff]
+		blockOff := (absOff / blockSize) * blockSize
+		idx, ok := packed[blockOff]
 		if !ok {
 			return fmt.Errorf("dedup src: %d not packed", absOff)
 		}
 
-		_, err := c.ReadAt(p, idx)
+		_, err := c.ReadAt(p, idx+absOff-blockOff)
 
 		return err
 	}

--- a/packages/orchestrator/pkg/sandbox/block/cache_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache_test.go
@@ -208,17 +208,17 @@ func TestCopyFromProcess_HugepageToRegularPage(t *testing.T) {
 	require.NoError(t, compareData(data[:n], mem[pageSize*4:pageSize*8]))
 }
 
-func TestSliceDirectOutOfBoundsReturnsBytesNotAvailable(t *testing.T) {
+func TestSliceOutOfBoundsReturnsBytesNotAvailable(t *testing.T) {
 	t.Parallel()
 
 	cache, err := NewCache(16, 4, t.TempDir()+"/cache", false)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cache.Close() })
 
-	_, err = cache.sliceDirect(16, 4)
+	_, err = cache.Slice(16, 4)
 	require.ErrorIs(t, err, BytesNotAvailableError{})
 
-	_, err = cache.sliceDirect(32, 4)
+	_, err = cache.Slice(32, 4)
 	require.ErrorIs(t, err, BytesNotAvailableError{})
 }
 

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
@@ -21,7 +22,7 @@ import (
 )
 
 // Memfd wraps a memfd received from Firecracker. NewFromFd takes ownership of
-// the fd and mmaps it; Close releases both.
+// the fd and mmaps it. The memfd is RAM/hugetlb-backed, not cache-file backed.
 type Memfd struct {
 	fd   int
 	mmap []byte
@@ -44,16 +45,20 @@ func NewFromFd(fd int) (*Memfd, error) {
 	return &Memfd{fd: fd, mmap: b}, nil
 }
 
-// Slice returns a zero-copy view of [offset, offset+size). Valid until Close.
-func (m *Memfd) Slice(offset, size int64) ([]byte, error) {
-	if offset < 0 || offset+size > int64(len(m.mmap)) {
-		return nil, fmt.Errorf("range [%d, %d) out of bounds (size %d)", offset, offset+size, len(m.mmap))
+func (m *Memfd) ReadAt(p []byte, off int64) (int, error) {
+	if off < 0 || off >= int64(len(m.mmap)) {
+		return 0, io.EOF
 	}
 
-	return m.mmap[offset : offset+size], nil
+	n := copy(p, m.mmap[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+
+	return n, nil
 }
 
-// Close releases the mmap and the fd. Single-use: every Memfd has exactly
+// Close releases the mmap and fd. Single-use: every Memfd has exactly
 // one owner (NewCacheFromMemfd consumes it during construction; the UFFD
 // handshake transfers ownership via atomic Swap), so we don't guard against
 // double-close.
@@ -106,12 +111,22 @@ func copyFromMemfd(ctx context.Context, cache *Cache, memfd *Memfd, dirty *roari
 			return err
 		}
 
-		src, err := memfd.Slice(r.Start, r.Size)
+		src := make([]byte, r.Size)
+		n, err := memfd.ReadAt(src, r.Start)
 		if err != nil {
-			return fmt.Errorf("memfd slice [%d,%d): %w", r.Start, r.Start+r.Size, err)
+			return fmt.Errorf("memfd read [%d,%d): %w", r.Start, r.Start+r.Size, err)
+		}
+		if int64(n) != r.Size {
+			return fmt.Errorf("short memfd read: expected %d bytes, got %d", r.Size, n)
 		}
 
-		copy((*cache.mmap)[cacheOff:cacheOff+r.Size], src)
+		n, err = cache.writeRawAt(src, cacheOff)
+		if err != nil {
+			return fmt.Errorf("write memfd cache [%d,%d): %w", cacheOff, cacheOff+r.Size, err)
+		}
+		if int64(n) != r.Size {
+			return fmt.Errorf("short memfd cache write: expected %d bytes, got %d", r.Size, n)
+		}
 		cache.setIsCached(cacheOff, r.Size)
 		cacheOff += r.Size
 	}
@@ -193,14 +208,6 @@ func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
 	return m.cache.ReadAt(b, off)
 }
 
-func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
-	if err := m.Wait(context.Background()); err != nil {
-		return nil, err
-	}
-
-	return m.cache.Slice(off, length)
-}
-
 func (m *MemfdCache) Close() error {
 	if m.cancel != nil {
 		m.cancel()
@@ -276,7 +283,17 @@ func (d *DedupedMemfdCache) runDedup(
 	ctx, span := tracer.Start(ctx, "dedup-pages")
 	defer span.End()
 
-	src := func(absOff int64) ([]byte, error) { return memfd.Slice(absOff, blockSize) }
+	src := func(absOff int64, p []byte) error {
+		n, err := memfd.ReadAt(p, absOff)
+		if err != nil {
+			return err
+		}
+		if n != len(p) {
+			return fmt.Errorf("short memfd read: expected %d bytes, got %d", len(p), n)
+		}
+
+		return nil
+	}
 
 	compareStart := time.Now()
 	plan, err := dedupCompare(ctx, src, base, dirty, blockSize, bestEffort)
@@ -333,15 +350,6 @@ func (d *DedupedMemfdCache) ReadAt(b []byte, off int64) (int, error) {
 	}
 
 	return c.ReadAt(b, off)
-}
-
-func (d *DedupedMemfdCache) Slice(off, length int64) ([]byte, error) {
-	c, err := d.Wait(context.Background())
-	if err != nil {
-		return nil, err
-	}
-
-	return c.Slice(off, length)
 }
 
 func (d *DedupedMemfdCache) Close() error {

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -208,6 +208,14 @@ func (m *MemfdCache) ReadAt(b []byte, off int64) (int, error) {
 	return m.cache.ReadAt(b, off)
 }
 
+func (m *MemfdCache) Slice(off, length int64) ([]byte, error) {
+	if err := m.Wait(context.Background()); err != nil {
+		return nil, err
+	}
+
+	return m.cache.Slice(off, length)
+}
+
 func (m *MemfdCache) Close() error {
 	if m.cancel != nil {
 		m.cancel()
@@ -350,6 +358,15 @@ func (d *DedupedMemfdCache) ReadAt(b []byte, off int64) (int, error) {
 	}
 
 	return c.ReadAt(b, off)
+}
+
+func (d *DedupedMemfdCache) Slice(off, length int64) ([]byte, error) {
+	c, err := d.Wait(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Slice(off, length)
 }
 
 func (d *DedupedMemfdCache) Close() error {

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -253,9 +253,9 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, ft *stor
 		// granularity with the read size and minimize lock/notify overhead.
 		readEnd := min(totalRead+readBatch, s.chunkLen)
 		sw := c.metrics.WriteChunksTimerFactory.Begin()
+		writeOff := s.chunkOff + totalRead
 		n, readErr := io.ReadFull(reader, buf[:readEnd-totalRead])
 		if n > 0 {
-			writeOff := s.chunkOff + totalRead
 			written, writeErr := c.cache.writeRawAt(buf[:n], writeOff)
 			if writeErr != nil {
 				sw.RecordRaw(ctx, int64(n), writeFailureAttr)
@@ -267,7 +267,6 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, ft *stor
 
 				return totalRead, fmt.Errorf("short cache write at offset %d: expected %d bytes, got %d", writeOff, n, written)
 			}
-			c.cache.setIsCached(writeOff, int64(n))
 		}
 		totalRead += int64(n)
 		if readErr == nil || totalRead >= s.chunkLen {
@@ -276,8 +275,10 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, ft *stor
 			sw.RecordRaw(ctx, int64(n), writeFailureAttr)
 		}
 
-		if n > 0 {
-			s.advance(totalRead)
+		fullBlocksReady := (totalRead / blockSize) * blockSize
+		if fullBlocksReady > 0 {
+			c.cache.setIsCached(s.chunkOff, fullBlocksReady)
+			s.advance(fullBlocksReady)
 		}
 
 		if readErr != nil {

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -38,9 +38,7 @@ type Chunker struct {
 	fetchSessions []*fetchSession
 }
 
-var (
-	_ FramedReader = (*Chunker)(nil)
-)
+var _ FramedReader = (*Chunker)(nil)
 
 func NewChunker(
 	ff *featureflags.Client,

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -40,7 +40,6 @@ type Chunker struct {
 
 var (
 	_ FramedReader = (*Chunker)(nil)
-	_ FramedSlicer = (*Chunker)(nil)
 )
 
 func NewChunker(
@@ -66,65 +65,69 @@ func NewChunker(
 }
 
 func (c *Chunker) ReadAt(ctx context.Context, b []byte, off int64, ft *storage.FrameTable) (int, error) {
-	slice, err := c.Slice(ctx, off, int64(len(b)), ft)
-	if err != nil {
-		return 0, fmt.Errorf("failed to slice cache at %d-%d: %w", off, off+int64(len(b)), err)
-	}
-
-	return copy(b, slice), nil
-}
-
-func (c *Chunker) Slice(ctx context.Context, off, length int64, ft *storage.FrameTable) ([]byte, error) {
 	attrs := chunkerAttrs
 	if ft.IsCompressed() {
 		attrs = chunkerAttrsCompressed
 	}
 	timer := c.metrics.SlicesTimerFactory.Begin()
 
-	// Fast path: already cached
-	b, err := c.cache.Slice(off, length)
+	n, err := c.cache.ReadAt(b, off)
 	if err == nil {
-		timer.RecordRaw(ctx, length, attrs.successFromCache)
+		timer.RecordRaw(ctx, int64(len(b)), attrs.successFromCache)
 
-		return b, nil
+		return n, nil
 	}
-
 	if !errors.As(err, &BytesNotAvailableError{}) {
-		timer.RecordRaw(ctx, length, attrs.failCacheRead)
+		timer.RecordRaw(ctx, int64(len(b)), attrs.failCacheRead)
 
-		return nil, fmt.Errorf("failed read from cache at offset %d: %w", off, err)
+		return 0, fmt.Errorf("failed read from cache at offset %d: %w", off, err)
 	}
 
+	if err := c.ensureCached(ctx, off, int64(len(b)), ft); err != nil {
+		timer.RecordRaw(ctx, int64(len(b)), attrs.failRemoteFetch)
+
+		return 0, err
+	}
+
+	n, err = c.cache.ReadAt(b, off)
+	if err != nil {
+		timer.RecordRaw(ctx, int64(len(b)), attrs.failLocalReadAgain)
+
+		return 0, fmt.Errorf("failed to read from cache after ensuring data at %d-%d: %w", off, off+int64(len(b)), err)
+	}
+
+	timer.RecordRaw(ctx, int64(len(b)), attrs.successFromRemote)
+
+	return n, nil
+}
+
+func (c *Chunker) Slice(ctx context.Context, off, length int64, ft *storage.FrameTable) ([]byte, error) {
+	out := make([]byte, length)
+	n, err := c.ReadAt(ctx, out, off, ft)
+	if err != nil {
+		return nil, err
+	}
+
+	return out[:n], nil
+}
+
+func (c *Chunker) ensureCached(ctx context.Context, off, length int64, ft *storage.FrameTable) error {
 	// Fetch every chunk the range spans (one fetch session per chunk).
 	end := off + length
 	for cur := off; cur < end; {
 		chunkOff, chunkLen, lerr := c.locateChunk(cur, ft)
 		if lerr != nil {
-			timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
-
-			return nil, fmt.Errorf("failed to locate chunk for offset %d: %w", cur, lerr)
+			return fmt.Errorf("failed to locate chunk for offset %d: %w", cur, lerr)
 		}
 		chunkEnd := chunkOff + chunkLen
 		rangeEnd := min(end, chunkEnd)
 		if err := c.fetch(ctx, cur, rangeEnd-cur, ft); err != nil {
-			timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
-
-			return nil, fmt.Errorf("failed to ensure data at %d-%d: %w", cur, rangeEnd, err)
+			return fmt.Errorf("failed to ensure data at %d-%d: %w", cur, rangeEnd, err)
 		}
 		cur = chunkEnd
 	}
 
-	// sliceDirect skips isCached — the waiter already confirmed the data is in the mmap.
-	b, cacheErr := c.cache.sliceDirect(off, length)
-	if cacheErr != nil {
-		timer.RecordRaw(ctx, length, attrs.failLocalReadAgain)
-
-		return nil, fmt.Errorf("failed to read from cache after ensuring data at %d-%d: %w", off, off+length, cacheErr)
-	}
-
-	timer.RecordRaw(ctx, length, attrs.successFromRemote)
-
-	return b, nil
+	return nil
 }
 
 // getOrCreateSession returns a fetch session for the chunk at [off, off+length),
@@ -188,7 +191,7 @@ func (c *Chunker) fetch(ctx context.Context, off, length int64, ft *storage.Fram
 	return nil
 }
 
-// runFetch fetches data from storage into the mmap cache. Runs in a background goroutine.
+// runFetch fetches data from storage into the file cache. Runs in a background goroutine.
 func (c *Chunker) runFetch(ctx context.Context, s *fetchSession, ft *storage.FrameTable) {
 	ctx, cancel := context.WithTimeout(ctx, c.fetchTimeout)
 	defer cancel()
@@ -208,21 +211,13 @@ func (c *Chunker) runFetch(ctx context.Context, s *fetchSession, ft *storage.Fra
 		s.failIfRunning(errors.New("fetch exited without completing"))
 	}()
 
-	mmapSlice, releaseLock, err := c.cache.addressBytes(s.chunkOff, s.chunkLen)
-	if err != nil {
-		s.fail(err)
-
-		return
-	}
-	defer releaseLock()
-
 	attrs := chunkerAttrs
 	if ft.IsCompressed() {
 		attrs = chunkerAttrsCompressed
 	}
 	fetchTimer := c.metrics.RemoteReadsTimerFactory.Begin()
 
-	readBytes, err := c.progressiveRead(ctx, s, mmapSlice, ft)
+	readBytes, err := c.progressiveRead(ctx, s, ft)
 	if err != nil {
 		fetchTimer.RecordRaw(ctx, readBytes, attrs.remoteFailure)
 
@@ -240,7 +235,7 @@ func (c *Chunker) runFetch(ctx context.Context, s *fetchSession, ft *storage.Fra
 	s.setDone()
 }
 
-func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, mmapSlice []byte, ft *storage.FrameTable) (totalRead int64, err error) {
+func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, ft *storage.FrameTable) (totalRead int64, err error) {
 	reader, err := c.upstream.OpenRangeReader(ctx, s.chunkOff, s.chunkLen, ft)
 	if err != nil {
 		return 0, fmt.Errorf("failed to open range reader at %d: %w", s.chunkOff, err)
@@ -253,13 +248,29 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, mmapSlic
 
 	blockSize := c.cache.BlockSize()
 	readBatch := max(blockSize, int64(c.featureFlags.IntFlag(ctx, featureflags.MinChunkerReadSizeKB))*1024)
+	buf := make([]byte, readBatch)
 
 	for totalRead < s.chunkLen {
 		// Read in batches of max(blockSize, minReadBatchSize) to align notification
 		// granularity with the read size and minimize lock/notify overhead.
 		readEnd := min(totalRead+readBatch, s.chunkLen)
 		sw := c.metrics.WriteChunksTimerFactory.Begin()
-		n, readErr := io.ReadFull(reader, mmapSlice[totalRead:readEnd])
+		n, readErr := io.ReadFull(reader, buf[:readEnd-totalRead])
+		if n > 0 {
+			writeOff := s.chunkOff + totalRead
+			written, writeErr := c.cache.writeRawAt(buf[:n], writeOff)
+			if writeErr != nil {
+				sw.RecordRaw(ctx, int64(n), writeFailureAttr)
+
+				return totalRead, fmt.Errorf("failed writing cache at offset %d after %d bytes: %w", writeOff, totalRead, writeErr)
+			}
+			if written != n {
+				sw.RecordRaw(ctx, int64(n), writeFailureAttr)
+
+				return totalRead, fmt.Errorf("short cache write at offset %d: expected %d bytes, got %d", writeOff, n, written)
+			}
+			c.cache.setIsCached(writeOff, int64(n))
+		}
 		totalRead += int64(n)
 		if readErr == nil || totalRead >= s.chunkLen {
 			sw.RecordRaw(ctx, int64(n), writeSuccessAttr)
@@ -268,8 +279,6 @@ func (c *Chunker) progressiveRead(ctx context.Context, s *fetchSession, mmapSlic
 		}
 
 		if n > 0 {
-			// Dirty marking is deferred to runFetch after the full chunk is fetched.
-			// With coarse dirty granularity, marking here would expose partially-written data.
 			s.advance(totalRead)
 		}
 
@@ -325,7 +334,7 @@ func (c *Chunker) Close() error {
 }
 
 // IsCached reports whether [off, off+length) is fully present in the local
-// mmap cache (no remote fetch needed). Used by best-effort dedup.
+// file cache (no remote fetch needed). Used by best-effort dedup.
 func (c *Chunker) IsCached(_ context.Context, off, length int64) bool {
 	return c.cache.isCached(off, length)
 }
@@ -334,7 +343,7 @@ func (c *Chunker) FileSize(ctx context.Context) (int64, error) {
 	return c.cache.FileSize(ctx)
 }
 
-// writeSuccessAttr and writeFailureAttr are pre-allocated result attributes for mmap write observations.
+// writeSuccessAttr and writeFailureAttr are pre-allocated result attributes for cache write observations.
 var (
 	writeSuccessAttr = telemetry.PrecomputeAttrs(telemetry.Success)
 	writeFailureAttr = telemetry.PrecomputeAttrs(telemetry.Failure)


### PR DESCRIPTION
## Summary
- Replace the disk-backed block cache mmap with file `ReadAt`/`WriteAt` access.
- Keep memfd internally mmap-backed because it is RAM/hugetlb-backed, while exposing it through `ReadAt`.
- Preserve existing `Slice` APIs as compatibility wrappers over copied reads.

## Test plan
- `go test ./packages/orchestrator/pkg/sandbox/block ./packages/orchestrator/pkg/sandbox/build ./packages/orchestrator/pkg/sandbox/template ./packages/orchestrator/pkg/sandbox/template/peerserver ./packages/orchestrator/pkg/sandbox/nbd -timeout=5m`


Made with [Cursor](https://cursor.com)