### PR TITLE
feat(iac): support extra api instance groups on nomad LB backend

### DIFF
--- a/iac/provider-gcp/nomad-cluster/main.tf
+++ b/iac/provider-gcp/nomad-cluster/main.tf
@@ -121,8 +121,9 @@ module "network" {
   client_proxy_port        = var.client_proxy_port
   client_proxy_health_port = var.client_proxy_health_port
 
-  api_instance_group    = google_compute_instance_group_manager.api_pool.instance_group
-  server_instance_group = google_compute_region_instance_group_manager.server_pool.instance_group
+  api_instance_group        = google_compute_instance_group_manager.api_pool.instance_group
+  extra_api_instance_groups = var.extra_api_instance_groups
+  server_instance_group     = google_compute_region_instance_group_manager.server_pool.instance_group
 
   nomad_port = var.nomad_port
 

--- a/iac/provider-gcp/nomad-cluster/network/main.tf
+++ b/iac/provider-gcp/nomad-cluster/network/main.tf
@@ -64,7 +64,10 @@ locals {
         timeout_sec        = 3
         check_interval_sec = 3
       }
-      groups = [{ group = var.api_instance_group }]
+      groups = concat(
+        [{ group = var.api_instance_group }],
+        [for g in var.extra_api_instance_groups : { group = g }],
+      )
     }
     docker-reverse-proxy = {
       protocol                        = "HTTP"

--- a/iac/provider-gcp/nomad-cluster/network/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/network/variables.tf
@@ -94,6 +94,13 @@ variable "api_instance_group" {
   type = string
 }
 
+variable "extra_api_instance_groups" {
+  description = "Additional instance-group self-links to attach to the api LB backend (e.g. GKE-managed MIGs whose nodes run the api pod with hostPort = api_port.port)."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "server_instance_group" {
   type = string
 }

--- a/iac/provider-gcp/nomad-cluster/variables.tf
+++ b/iac/provider-gcp/nomad-cluster/variables.tf
@@ -80,6 +80,13 @@ variable "api_port" {
   })
 }
 
+variable "extra_api_instance_groups" {
+  description = "Additional instance-group self-links to attach to the api LB backend (e.g. GKE-managed MIGs whose nodes run the api pod with hostPort = api_port.port)."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "ingress_port" {
   type = object({
     name        = string


### PR DESCRIPTION
Add an optional extra_api_instance_groups variable to the nomad-cluster module and its network submodule, concatenating the additional instance-group self-links onto the api load balancer backend. This lets externally-managed MIGs serve api traffic alongside the nomad-managed api pool.