### PR TITLE
refactor(iac): lift template-manager env vars

### DIFF
--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -96,43 +96,13 @@ job "template-manager" {
         NODE_ID     = "$${node.unique.name}"
         NODE_LABELS = "$${meta.node_labels}"
 
-        CONSUL_TOKEN                  = "${consul_acl_token}"
-%{ if provider == "gcp" }
-        GOOGLE_SERVICE_ACCOUNT_BASE64 = "${provider_gcp_config.service_account_key}"
-        GCP_PROJECT_ID                = "${provider_gcp_config.project_id}"
-        GCP_REGION                    = "${provider_gcp_config.region}"
-        GCP_DOCKER_REPOSITORY_NAME    = "${provider_gcp_config.docker_registry}"
-
-        %{ if provider_gcp_config.gcs_grpc_connection_pool_size != 0 }
-        GCS_GRPC_CONNECTION_POOL_SIZE = "${provider_gcp_config.gcs_grpc_connection_pool_size}"
-        %{ endif }
-%{ endif }
-%{ if provider == "aws" }
-        ARTIFACTS_REGISTRY_PROVIDER   = "AWS_ECR"
-        STORAGE_PROVIDER              = "AWSBucket"
-        AWS_REGION                    = "${provider_aws_config.region}"
-        AWS_DOCKER_REPOSITORY_NAME    = "${provider_aws_config.docker_repository_name}"
-%{ endif }
-        API_SECRET                    = "${api_secret}"
-        ENVIRONMENT                   = "${environment}"
-        DOMAIN_NAME                   = "${domain_name}"
-        TEMPLATE_BUCKET_NAME          = "${template_bucket_name}"
-        BUILD_CACHE_BUCKET_NAME       = "${build_cache_bucket_name}"
-        OTEL_COLLECTOR_GRPC_ENDPOINT     = "${otel_collector_grpc_endpoint}"
-        LOGS_COLLECTOR_ADDRESS           = "${logs_collector_address}"
-        ORCHESTRATOR_SERVICES            = "${orchestrator_services}"
-        REDIS_POOL_SIZE                  = "${redis_pool_size}"
-        SHARED_CHUNK_CACHE_PATH       = "${shared_chunk_cache_path}"
-        CLICKHOUSE_CONNECTION_STRING  = "${clickhouse_connection_string}"
-        DOCKERHUB_REMOTE_REPOSITORY_URL  = "${dockerhub_remote_repository_url}"
         GRPC_PORT                     = "${port}"
-        GIN_MODE                      = "release"
 %{ if !update_stanza }
         FORCE_STOP                    = "true"
 %{ endif }
-%{ if launch_darkly_api_key != "" }
-        LAUNCH_DARKLY_API_KEY         = "${launch_darkly_api_key}"
-%{ endif }
+%{ for key, value in job_env_vars ~}
+        ${key} = "${value}"
+%{ endfor ~}
       }
 
       config {

--- a/iac/modules/job-template-manager/main.tf
+++ b/iac/modules/job-template-manager/main.tf
@@ -12,32 +12,21 @@ data "external" "template_manager_count" {
   }
 }
 
+locals {
+  job_env_vars = {
+    for key, value in var.job_env_vars : key => trimspace(value)
+    if try(trimspace(value), "") != ""
+  }
+}
+
 resource "nomad_job" "template_manager" {
   jobspec = templatefile("${path.module}/jobs/template-manager.hcl", {
     update_stanza = var.update_stanza
     node_pool     = var.node_pool
     current_count = tonumber(data.external.template_manager_count.result.count)
 
-    provider            = var.provider_name
-    provider_gcp_config = var.provider_gcp_config
-    provider_aws_config = var.provider_aws_config
-
-    port             = var.port
-    environment      = var.environment
-    consul_acl_token = var.consul_acl_token
-    domain_name      = var.domain_name
-
-    api_secret                      = var.api_secret
-    artifact_source                 = var.artifact_source
-    template_bucket_name            = var.template_bucket_name
-    build_cache_bucket_name         = var.build_cache_bucket_name
-    otel_collector_grpc_endpoint    = var.otel_collector_grpc_endpoint
-    logs_collector_address          = var.logs_collector_address
-    orchestrator_services           = var.orchestrator_services
-    clickhouse_connection_string    = var.clickhouse_connection_string
-    dockerhub_remote_repository_url = var.dockerhub_remote_repository_url
-    redis_pool_size                 = var.redis_pool_size
-    launch_darkly_api_key           = trimspace(var.launch_darkly_api_key)
-    shared_chunk_cache_path         = var.shared_chunk_cache_path
+    port            = var.port
+    artifact_source = var.artifact_source
+    job_env_vars    = local.job_env_vars
   })
 }

--- a/iac/modules/job-template-manager/main.tf
+++ b/iac/modules/job-template-manager/main.tf
@@ -15,7 +15,7 @@ data "external" "template_manager_count" {
 locals {
   job_env_vars = {
     for key, value in var.job_env_vars : key => trimspace(value)
-    if try(trimspace(value), "") != ""
+    if value != null && try(trimspace(value), "") != ""
   }
 }
 

--- a/iac/modules/job-template-manager/variables.tf
+++ b/iac/modules/job-template-manager/variables.tf
@@ -1,55 +1,9 @@
-variable "provider_name" {
-  type        = string
-  description = "Cloud provider: gcp or aws"
-
-  validation {
-    condition     = contains(["gcp", "aws"], var.provider_name)
-    error_message = "provider_name must be 'gcp' or 'aws'"
-  }
-}
-
-variable "provider_gcp_config" {
-  type = object({
-    service_account_key           = optional(string, "")
-    project_id                    = optional(string, "")
-    region                        = optional(string, "")
-    docker_registry               = optional(string, "")
-    gcs_grpc_connection_pool_size = optional(number, 0)
-  })
-  default = {
-    service_account_key           = ""
-    project_id                    = ""
-    region                        = ""
-    docker_registry               = ""
-    gcs_grpc_connection_pool_size = 0
-  }
-}
-
-variable "provider_aws_config" {
-  type = object({
-    region                 = string
-    docker_repository_name = string
-  })
-  default = {
-    region                 = ""
-    docker_repository_name = ""
-  }
-}
-
 variable "node_pool" {
   type = string
 }
 
 variable "port" {
   type = number
-}
-
-variable "environment" {
-  type = string
-}
-
-variable "domain_name" {
-  type = string
 }
 
 variable "update_stanza" {
@@ -62,65 +16,6 @@ variable "artifact_source" {
   description = "Full artifact URL for the template-manager binary (e.g. gcs::https://... or s3::https://...)"
 }
 
-variable "api_secret" {
-  type      = string
-  sensitive = true
-}
-
-variable "consul_acl_token" {
-  type      = string
-  sensitive = true
-}
-
-variable "template_bucket_name" {
-  type = string
-}
-
-variable "build_cache_bucket_name" {
-  type    = string
-  default = ""
-}
-
-variable "otel_collector_grpc_endpoint" {
-  type = string
-}
-
-variable "logs_collector_address" {
-  type = string
-}
-
-variable "orchestrator_services" {
-  type    = string
-  default = "template-manager"
-}
-
-variable "shared_chunk_cache_path" {
-  type    = string
-  default = ""
-}
-
-variable "clickhouse_connection_string" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
-variable "dockerhub_remote_repository_url" {
-  type    = string
-  default = ""
-}
-
-variable "redis_pool_size" {
-  type    = number
-  default = 10
-}
-
-variable "launch_darkly_api_key" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 // Nomad API access for job count query
 variable "nomad_addr" {
   type        = string
@@ -129,5 +24,11 @@ variable "nomad_addr" {
 
 variable "nomad_token" {
   type      = string
+  sensitive = true
+}
+
+variable "job_env_vars" {
+  type      = map(string)
+  default   = {}
   sensitive = true
 }

--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -199,6 +199,26 @@ locals {
     AWS_REGION                   = data.aws_region.current.id
     AWS_DOCKER_REPOSITORY_NAME   = module.init.custom_environments_repository_name
   }, var.orchestrator_env_vars)
+
+  template_manager_env_vars = merge({
+    CONSUL_TOKEN                 = module.init.cluster.consul_acl_token
+    ARTIFACTS_REGISTRY_PROVIDER  = "AWS_ECR"
+    STORAGE_PROVIDER             = "AWSBucket"
+    AWS_REGION                   = data.aws_region.current.id
+    AWS_DOCKER_REPOSITORY_NAME   = module.init.custom_environments_repository_name
+    API_SECRET                   = module.init.api_secret
+    ENVIRONMENT                  = var.environment
+    DOMAIN_NAME                  = var.domain_name
+    TEMPLATE_BUCKET_NAME         = module.init.fc_template_bucket_name
+    BUILD_CACHE_BUCKET_NAME      = module.init.fc_template_build_cache_bucket_name
+    OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:${local.otel_collector_port}"
+    LOGS_COLLECTOR_ADDRESS       = "http://localhost:${local.logs_proxy_port}"
+    ORCHESTRATOR_SERVICES        = "template-manager"
+    REDIS_POOL_SIZE              = "10"
+    CLICKHOUSE_CONNECTION_STRING = local.clickhouse_connection_string
+    GIN_MODE                     = "release"
+    LAUNCH_DARKLY_API_KEY        = module.init.launch_darkly_api_key
+  }, var.template_manager_env_vars)
 }
 
 module "redis" {
@@ -329,11 +349,10 @@ module "nomad" {
   build_cache_bucket_name             = module.init.fc_template_build_cache_bucket_name
   custom_environments_repository_name = module.init.custom_environments_repository_name
   orchestrator_env_vars               = local.orchestrator_env_vars
+  template_manager_env_vars           = local.template_manager_env_vars
 
-  build_node_pool    = local.build_pool_name
-  build_cluster_size = var.build_cluster_size
-  api_secret         = module.init.api_secret
-
+  build_node_pool     = local.build_pool_name
+  build_cluster_size  = var.build_cluster_size
   redis_managed       = var.redis_managed
   redis_port          = local.redis_port
   redis_url           = local.redis_url

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -152,28 +152,13 @@ locals {
 module "template_manager" {
   source = "../../modules/job-template-manager"
 
-  provider_name = "aws"
-  provider_aws_config = {
-    region                 = var.aws_region
-    docker_repository_name = var.custom_environments_repository_name
-  }
-
   update_stanza = var.build_cluster_size > 1
   node_pool     = var.build_node_pool
 
-  port             = var.template_manager_port
-  environment      = var.environment
-  consul_acl_token = var.consul_acl_token
-  domain_name      = var.domain_name
+  port = var.template_manager_port
 
-  api_secret                   = var.api_secret
-  artifact_source              = local.template_manager_artifact_source
-  template_bucket_name         = var.template_bucket_name
-  build_cache_bucket_name      = var.build_cache_bucket_name
-  otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
-  logs_collector_address       = "http://localhost:${var.logs_proxy_port}"
-  clickhouse_connection_string = local.clickhouse_connection_string
-  launch_darkly_api_key        = var.launch_darkly_api_key
+  artifact_source = local.template_manager_artifact_source
+  job_env_vars    = var.template_manager_env_vars
 
   nomad_addr  = "https://nomad.${var.domain_name}"
   nomad_token = var.nomad_acl_token

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -255,8 +255,9 @@ variable "template_manager_port" {
   default = 5008
 }
 
-variable "api_secret" {
-  type      = string
+variable "template_manager_env_vars" {
+  type      = map(string)
+  default   = {}
   sensitive = true
 }
 

--- a/iac/provider-aws/variables.tf
+++ b/iac/provider-aws/variables.tf
@@ -68,6 +68,12 @@ variable "orchestrator_env_vars" {
   sensitive = true
 }
 
+variable "template_manager_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
+}
+
 variable "api_server_machine_type" {
   type    = string
   default = "t3.xlarge"

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -178,6 +178,29 @@ locals {
     LAUNCH_DARKLY_API_KEY         = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
   }, var.orchestrator_env_vars)
 
+  template_manager_env_vars = merge({
+    CONSUL_TOKEN                    = module.init.consul_acl_token_secret
+    GOOGLE_SERVICE_ACCOUNT_BASE64   = module.init.google_service_account_key
+    GCP_PROJECT_ID                  = var.gcp_project_id
+    GCP_REGION                      = var.gcp_region
+    GCP_DOCKER_REPOSITORY_NAME      = google_artifact_registry_repository.custom_environments_repository.name
+    GCS_GRPC_CONNECTION_POOL_SIZE   = var.gcs_grpc_connection_pool_size != 0 ? tostring(var.gcs_grpc_connection_pool_size) : ""
+    API_SECRET                      = random_password.api_secret.result
+    ENVIRONMENT                     = var.environment
+    DOMAIN_NAME                     = var.domain_name
+    TEMPLATE_BUCKET_NAME            = module.init.fc_template_bucket_name
+    BUILD_CACHE_BUCKET_NAME         = module.init.fc_build_cache_bucket_name
+    OTEL_COLLECTOR_GRPC_ENDPOINT    = "localhost:${local.otel_collector_grpc_port}"
+    LOGS_COLLECTOR_ADDRESS          = "http://localhost:${local.logs_proxy_port}"
+    ORCHESTRATOR_SERVICES           = "template-manager"
+    REDIS_POOL_SIZE                 = "10"
+    SHARED_CHUNK_CACHE_PATH         = module.cluster.shared_chunk_cache_path
+    CLICKHOUSE_CONNECTION_STRING    = local.clickhouse_connection_string
+    DOCKERHUB_REMOTE_REPOSITORY_URL = var.remote_repository_enabled ? module.remote_repository[0].dockerhub_remote_repository_url : ""
+    GIN_MODE                        = "release"
+    LAUNCH_DARKLY_API_KEY           = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+  }, var.template_manager_env_vars)
+
   # Normalize additional_api_paths_handled_by_ingress to support both legacy (list of strings)
   # and new (list of objects) formats. Strings are converted to objects with paths = [string].
   normalized_api_paths_handled_by_ingress = [
@@ -375,7 +398,6 @@ module "nomad" {
   api_db_migrator_env_vars                               = local.api_db_migrator_env_vars
   environment                                            = var.environment
   google_service_account_key                             = module.init.google_service_account_key
-  api_secret                                             = random_password.api_secret.result
   custom_envs_repository_name                            = google_artifact_registry_repository.custom_environments_repository.name
   postgres_connection_string_secret_name                 = module.init.postgres_connection_string_secret_name
   postgres_read_replica_connection_string_secret_version = google_secret_manager_secret_version.postgres_read_replica_connection_string
@@ -439,6 +461,7 @@ module "nomad" {
   build_cache_bucket_name             = module.init.fc_build_cache_bucket_name
   template_manages_clusters_size_gt_1 = local.template_manages_clusters_size_gt_1
   dockerhub_remote_repository_url     = var.remote_repository_enabled ? module.remote_repository[0].dockerhub_remote_repository_url : ""
+  template_manager_env_vars           = local.template_manager_env_vars
 
   # Redis
   redis_managed = var.redis_managed

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -379,33 +379,13 @@ locals {
 module "template_manager" {
   source = "../../modules/job-template-manager"
 
-  provider_name = "gcp"
-  provider_gcp_config = {
-    service_account_key           = var.google_service_account_key
-    project_id                    = var.gcp_project_id
-    region                        = var.gcp_region
-    docker_registry               = var.custom_envs_repository_name
-    gcs_grpc_connection_pool_size = var.gcs_grpc_connection_pool_size
-  }
-
   update_stanza = var.template_manages_clusters_size_gt_1
   node_pool     = var.builder_node_pool
 
-  port             = var.template_manager_port
-  environment      = var.environment
-  consul_acl_token = var.consul_acl_token_secret
-  domain_name      = var.domain_name
+  port = var.template_manager_port
 
-  api_secret                      = var.api_secret
-  artifact_source                 = local.template_manager_artifact_source
-  template_bucket_name            = var.template_bucket_name
-  build_cache_bucket_name         = var.build_cache_bucket_name
-  otel_collector_grpc_endpoint    = "localhost:${var.otel_collector_grpc_port}"
-  logs_collector_address          = "http://localhost:${var.logs_proxy_port.port}"
-  clickhouse_connection_string    = local.clickhouse_connection_string
-  dockerhub_remote_repository_url = var.dockerhub_remote_repository_url
-  launch_darkly_api_key           = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
-  shared_chunk_cache_path         = var.shared_chunk_cache_path
+  artifact_source = local.template_manager_artifact_source
+  job_env_vars    = var.template_manager_env_vars
 
   nomad_addr  = "https://nomad.${var.domain_name}"
   nomad_token = var.nomad_acl_token_secret

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -100,10 +100,6 @@ variable "api_resources_memory_mb" {
   type = number
 }
 
-variable "api_secret" {
-  type = string
-}
-
 variable "environment" {
   type = string
 }
@@ -280,6 +276,12 @@ variable "fc_env_pipeline_bucket_name" {
 # Template manager
 variable "template_manager_port" {
   type = number
+}
+
+variable "template_manager_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 variable "template_manages_clusters_size_gt_1" {

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -865,6 +865,12 @@ variable "dashboard_api_env_vars" {
   sensitive = true
 }
 
+variable "template_manager_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
+}
+
 variable "orchestrator_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
Refactors the template-manager Nomad job module to accept a filtered sensitive env var map, matching the API and client-proxy env var pattern. AWS and GCP provider roots now assemble default template-manager env vars and pass them through their nomad modules.

Verification:
- terraform fmt -check -recursive iac/modules/job-template-manager iac/provider-gcp iac/provider-aws
- git diff --check
- terraform console templatefile render for iac/modules/job-template-manager/jobs/template-manager.hcl