### PR TITLE
ci: skip generated check for iac-only PRs

### DIFF
--- a/.github/workflows/pr-no-generated-changes.yml
+++ b/.github/workflows/pr-no-generated-changes.yml
@@ -70,12 +70,6 @@ jobs:
       - name: Generate all code
         run: make generate  # cannot do this in parallel, as there are some race conditions
 
-      - name: Install golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          install-only: true
-          version: "v${{ env.GOLANGCI_LINT }}"
-
       - name: Format code
         run: make fmt
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,7 +56,6 @@ jobs:
               - 'packages/**'
               - 'tests/**'
               - 'spec/**'
-              - 'iac/**'
               - 'go.work'
               - 'go.work.sum'
               - 'Makefile'

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -46,7 +46,6 @@ jobs:
               - 'packages/**'
               - 'tests/**'
               - 'spec/**'
-              - 'iac/**'
               - 'go.work'
               - 'go.work.sum'
               - 'Makefile'

--- a/.github/workflows/validate-iac.yml
+++ b/.github/workflows/validate-iac.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           terraform_version: "${{ env.TERRAFORM }}"
 
+      - name: Check Terraform formatting
+        run: terraform fmt -check -recursive
+
       - name: Validate terraform
         working-directory: ./iac/provider-gcp
         run: |


### PR DESCRIPTION
## Summary
- stop treating iac/** changes as generated-code inputs
- move Terraform formatting enforcement into IaC validation
- remove the unused golangci-lint-action install/cache from generated-code check

## Validation
- git diff --check
- parsed edited workflow YAML files with Ruby