### PR TITLE
refactor(iac): lift docker proxy env vars

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -201,6 +201,15 @@ locals {
     LAUNCH_DARKLY_API_KEY           = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
   }, var.template_manager_env_vars)
 
+  docker_reverse_proxy_env_vars = merge({
+    POSTGRES_CONNECTION_STRING    = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
+    GOOGLE_SERVICE_ACCOUNT_BASE64 = google_service_account_key.google_service_key.private_key
+    GCP_REGION                    = var.gcp_region
+    GCP_PROJECT_ID                = var.gcp_project_id
+    GCP_DOCKER_REPOSITORY_NAME    = google_artifact_registry_repository.custom_environments_repository.name
+    DOMAIN_NAME                   = var.domain_name
+  }, var.docker_reverse_proxy_env_vars)
+
   # Normalize additional_api_paths_handled_by_ingress to support both legacy (list of strings)
   # and new (list of objects) formats. Strings are converted to objects with paths = [string].
   normalized_api_paths_handled_by_ingress = [
@@ -442,8 +451,8 @@ module "nomad" {
   dashboard_api_env_vars = local.dashboard_api_env_vars
 
   # Docker reverse proxy
-  docker_reverse_proxy_port                = var.docker_reverse_proxy_port
-  docker_reverse_proxy_service_account_key = google_service_account_key.google_service_key.private_key
+  docker_reverse_proxy_port     = var.docker_reverse_proxy_port
+  docker_reverse_proxy_env_vars = local.docker_reverse_proxy_env_vars
 
   # Orchestrator
   orchestrator_node_pool         = var.orchestrator_node_pool

--- a/iac/provider-gcp/nomad/jobs/docker-reverse-proxy.hcl
+++ b/iac/provider-gcp/nomad/jobs/docker-reverse-proxy.hcl
@@ -43,12 +43,9 @@ job "docker-reverse-proxy" {
       }
 
       env {
-        POSTGRES_CONNECTION_STRING    = "${postgres_connection_string}"
-        GOOGLE_SERVICE_ACCOUNT_BASE64 = "${google_service_account_secret}"
-        GCP_REGION                    = "${gcp_region}"
-        GCP_PROJECT_ID                = "${gcp_project_id}"
-        GCP_DOCKER_REPOSITORY_NAME    = "${docker_registry}"
-        DOMAIN_NAME                   = "${domain_name}"
+%{ for key, value in job_env_vars ~}
+        ${key} = "${value}"
+%{ endfor ~}
       }
 
       config {

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -2,6 +2,11 @@ locals {
   clickhouse_connection_string = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${var.clickhouse_password}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
   redis_url                    = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
   redis_cluster_url            = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
+
+  docker_reverse_proxy_env_vars = {
+    for key, value in var.docker_reverse_proxy_env_vars : key => trimspace(value)
+    if value != null && try(trimspace(value), "") != ""
+  }
 }
 
 # API
@@ -103,17 +108,12 @@ module "redis" {
 resource "nomad_job" "docker_reverse_proxy" {
   jobspec = templatefile("${path.module}/jobs/docker-reverse-proxy.hcl",
     {
-      node_pool                     = var.api_node_pool
-      image_name                    = data.google_artifact_registry_docker_image.docker_reverse_proxy_image.self_link
-      postgres_connection_string    = data.google_secret_manager_secret_version.postgres_connection_string.secret_data
-      google_service_account_secret = var.docker_reverse_proxy_service_account_key
-      port_number                   = var.docker_reverse_proxy_port.port
-      port_name                     = var.docker_reverse_proxy_port.name
-      health_check_path             = var.docker_reverse_proxy_port.health_path
-      domain_name                   = var.domain_name
-      gcp_project_id                = var.gcp_project_id
-      gcp_region                    = var.gcp_region
-      docker_registry               = var.custom_envs_repository_name
+      node_pool         = var.api_node_pool
+      image_name        = data.google_artifact_registry_docker_image.docker_reverse_proxy_image.self_link
+      port_number       = var.docker_reverse_proxy_port.port
+      port_name         = var.docker_reverse_proxy_port.name
+      health_check_path = var.docker_reverse_proxy_port.health_path
+      job_env_vars      = local.docker_reverse_proxy_env_vars
     }
   )
 }

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -256,8 +256,10 @@ variable "docker_reverse_proxy_port" {
   })
 }
 
-variable "docker_reverse_proxy_service_account_key" {
-  type = string
+variable "docker_reverse_proxy_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
 }
 
 # Orchestrator

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -871,6 +871,12 @@ variable "template_manager_env_vars" {
   sensitive = true
 }
 
+variable "docker_reverse_proxy_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
+}
+
 variable "orchestrator_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
Refactors the GCP docker-reverse-proxy Nomad job to accept a filtered sensitive env var map, matching the env var pattern used by the other jobs. GCP root now assembles the default docker-reverse-proxy env vars and passes them through the nomad module.

Verification:
- terraform fmt -check -recursive iac/provider-gcp
- git diff --check
- terraform console templatefile render for iac/provider-gcp/nomad/jobs/docker-reverse-proxy.hcl with null and empty env values
- Python comparison script for docker-reverse-proxy env key set against origin/main