### PR TITLE
refactor(iac): lift filestore cleanup env vars

### DIFF
--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -210,6 +210,10 @@ locals {
     DOMAIN_NAME                   = var.domain_name
   }, var.docker_reverse_proxy_env_vars)
 
+  filestore_cleanup_env_vars = merge({
+    LAUNCH_DARKLY_API_KEY = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+  }, var.filestore_cleanup_env_vars)
+
   # Normalize additional_api_paths_handled_by_ingress to support both legacy (list of strings)
   # and new (list of objects) formats. Strings are converted to objects with paths = [string].
   normalized_api_paths_handled_by_ingress = [
@@ -488,6 +492,7 @@ module "nomad" {
   filestore_cache_cleanup_max_concurrent_scan   = var.filestore_cache_cleanup_max_concurrent_scan
   filestore_cache_cleanup_max_concurrent_delete = var.filestore_cache_cleanup_max_concurrent_delete
   filestore_cache_cleanup_max_retries           = var.filestore_cache_cleanup_max_retries
+  filestore_cleanup_env_vars                    = local.filestore_cleanup_env_vars
 
   volume_token_issuer           = local.volume_token_issuer
   volume_token_signing_key      = local.volume_token_signing_key

--- a/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
+++ b/iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl
@@ -23,9 +23,9 @@ job "filestore-cleanup" {
 
           env {
             NODE_ID = "$${node.unique.name}"
-            %{ if launch_darkly_api_key != "" }
-                LAUNCH_DARKLY_API_KEY         = "${launch_darkly_api_key}"
-            %{ endif }
+%{ for key, value in job_env_vars ~}
+            ${key} = "${value}"
+%{ endfor ~}
           }
 
           config {

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -7,6 +7,11 @@ locals {
     for key, value in var.docker_reverse_proxy_env_vars : key => trimspace(value)
     if value != null && try(trimspace(value), "") != ""
   }
+
+  filestore_cleanup_env_vars = {
+    for key, value in var.filestore_cleanup_env_vars : key => trimspace(value)
+    if value != null && try(trimspace(value), "") != ""
+  }
 }
 
 # API
@@ -529,6 +534,6 @@ resource "nomad_job" "clean_nfs_cache" {
     max_concurrent_delete        = var.filestore_cache_cleanup_max_concurrent_delete
     max_retries                  = var.filestore_cache_cleanup_max_retries
     otel_collector_grpc_endpoint = "localhost:${var.otel_collector_grpc_port}"
-    launch_darkly_api_key        = trimspace(data.google_secret_manager_secret_version.launch_darkly_api_key.secret_data)
+    job_env_vars                 = local.filestore_cleanup_env_vars
   })
 }

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -453,6 +453,12 @@ variable "filestore_cache_cleanup_max_retries" {
   description = "Maximum number of continuous error or miss retries before giving up"
 }
 
+variable "filestore_cleanup_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
+}
+
 variable "dockerhub_remote_repository_url" {
   type = string
 }

--- a/iac/provider-gcp/variables.tf
+++ b/iac/provider-gcp/variables.tf
@@ -877,6 +877,12 @@ variable "docker_reverse_proxy_env_vars" {
   sensitive = true
 }
 
+variable "filestore_cleanup_env_vars" {
+  type      = map(string)
+  default   = {}
+  sensitive = true
+}
+
 variable "orchestrator_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
Refactors the GCP filestore-cleanup Nomad job to accept a filtered sensitive env var map, matching the env var pattern used by the other jobs. GCP root now assembles the default filestore-cleanup env vars and passes them through the nomad module.

Verification:
- terraform fmt -check -recursive iac/provider-gcp
- git diff --check
- terraform console templatefile render for iac/provider-gcp/nomad/jobs/clean-nfs-cache.hcl with null and empty env values
- Python comparison script for filestore-cleanup effective env key set against origin/main