### PR TITLE
Enable Nomad memory oversubscription

### DIFF
--- a/iac/modules/job-orchestrator/jobs/orchestrator.hcl
+++ b/iac/modules/job-orchestrator/jobs/orchestrator.hcl
@@ -62,7 +62,7 @@ job "orchestrator-${latest_orchestrator_job_id}" {
 
       resources {
         memory     = 1024
-        memory_max = 1024 * 1024 # high memory to avoid OOM
+        memory_max = -1
       }
 
       env {

--- a/iac/modules/job-template-manager/jobs/template-manager.hcl
+++ b/iac/modules/job-template-manager/jobs/template-manager.hcl
@@ -89,8 +89,7 @@ job "template-manager" {
 
       resources {
         memory     = 1024
-        cpu        = 256
-        memory_max = 1024 * 1024 # high memory to avoid OOM
+        memory_max = -1
       }
 
       env {

--- a/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-aws/nomad-cluster/scripts/run-nomad.sh
@@ -219,6 +219,10 @@ server {
   enabled = true
   bootstrap_expect = $num_servers
   heartbeat_grace = "1m"
+
+  default_scheduler_config {
+    memory_oversubscription_enabled = true
+  }
 }
 
 EOF

--- a/iac/provider-aws/nomad/main.tf
+++ b/iac/provider-aws/nomad/main.tf
@@ -22,6 +22,11 @@ data "aws_ecr_image" "clickhouse_migrator" {
   image_tag       = "latest"
 }
 
+// Its already set up in Nomad server config, but from there its taked only for newly created clusters so we need to make sure its apply here to existing.
+resource "nomad_scheduler_config" "config" {
+  memory_oversubscription_enabled = true
+}
+
 module "otel_collector" {
   source = "../../modules/job-otel-collector"
 

--- a/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
+++ b/iac/provider-gcp/nomad-cluster/scripts/run-nomad.sh
@@ -192,6 +192,10 @@ server {
   enabled = true
   bootstrap_expect = $num_servers
   heartbeat_grace = "1m"
+
+  default_scheduler_config {
+    memory_oversubscription_enabled = true
+  }
 }
 
 EOF

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -36,6 +36,12 @@ provider "nomad" {
   consul_token = var.consul_acl_token_secret
 }
 
+// Turn on memory oversubscription
+// Its already set up in Nomad server config, but from there its taked only for newly created clusters so we need to make sure its apply here to existing.
+resource "nomad_scheduler_config" "config" {
+  memory_oversubscription_enabled = true
+}
+
 data "google_secret_manager_secret_version" "redis_cluster_url" {
   secret = var.redis_cluster_url_secret_version.secret
 }


### PR DESCRIPTION
This was affecting all compute (not just raw exec) that was using memory max different than memory. Everything over the memory soft limit was swapped to disk instead of using the memory max as a hard limit.

This change sets `memory_oversubscription_enabled` for newly bootstrapped clusters and provides back compatibility for existing clusters where the default config is not applied, so we need to call the cluster change from the Terraform provider.

Remove dummy memory max value from orch and template builder, as now we can set memory_max to -1 (without limits).


https://developer.hashicorp.com/nomad/tutorials/advanced-scheduling/memory-oversubscription