### PR TITLE
chore(iac): remove unused nomad redis inputs

### DIFF
--- a/iac/provider-aws/main.tf
+++ b/iac/provider-aws/main.tf
@@ -334,11 +334,8 @@ module "nomad" {
   build_cluster_size = var.build_cluster_size
   api_secret         = module.init.api_secret
 
-  redis_managed       = var.redis_managed
-  redis_port          = local.redis_port
-  redis_url           = local.redis_url
-  redis_cluster_url   = local.redis_cluster_url
-  redis_tls_ca_base64 = local.redis_tls_ca_base64
+  redis_managed = var.redis_managed
+  redis_port    = local.redis_port
 
   loki_bucket_name = module.init.loki_bucket_name
   loki_port        = local.loki_port

--- a/iac/provider-aws/nomad/variables.tf
+++ b/iac/provider-aws/nomad/variables.tf
@@ -80,23 +80,6 @@ variable "redis_port" {
   type = number
 }
 
-variable "redis_url" {
-  type    = string
-  default = ""
-}
-
-variable "redis_cluster_url" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
-variable "redis_tls_ca_base64" {
-  type      = string
-  default   = ""
-  sensitive = true
-}
-
 # ClickHouse
 variable "clickhouse_cluster_size" {
   type = number

--- a/iac/provider-gcp/main.tf
+++ b/iac/provider-gcp/main.tf
@@ -379,8 +379,6 @@ module "nomad" {
   custom_envs_repository_name                            = google_artifact_registry_repository.custom_environments_repository.name
   postgres_connection_string_secret_name                 = module.init.postgres_connection_string_secret_name
   postgres_read_replica_connection_string_secret_version = google_secret_manager_secret_version.postgres_read_replica_connection_string
-  redis_cluster_url_secret_version                       = module.init.redis_cluster_url_secret_version
-  redis_tls_ca_base64_secret_version                     = module.init.redis_tls_ca_base64_secret_version
 
   # Click Proxy
   client_proxy_count               = var.client_proxy_count

--- a/iac/provider-gcp/nomad/main.tf
+++ b/iac/provider-gcp/nomad/main.tf
@@ -1,7 +1,5 @@
 locals {
   clickhouse_connection_string = var.clickhouse_server_count > 0 ? "clickhouse://${var.clickhouse_username}:${var.clickhouse_password}@clickhouse.service.consul:${var.clickhouse_server_port.port}/${var.clickhouse_database}" : ""
-  redis_url                    = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data) == "" ? "redis.service.consul:${var.redis_port.port}" : ""
-  redis_cluster_url            = trimspace(data.google_secret_manager_secret_version.redis_cluster_url.secret_data)
 }
 
 # API
@@ -28,14 +26,6 @@ provider "nomad" {
 // Its already set up in Nomad server config, but from there its taked only for newly created clusters so we need to make sure its apply here to existing.
 resource "nomad_scheduler_config" "config" {
   memory_oversubscription_enabled = true
-}
-
-data "google_secret_manager_secret_version" "redis_cluster_url" {
-  secret = var.redis_cluster_url_secret_version.secret
-}
-
-data "google_secret_manager_secret_version" "redis_tls_ca_base64" {
-  secret = var.redis_tls_ca_base64_secret_version.secret
 }
 
 module "ingress" {

--- a/iac/provider-gcp/nomad/variables.tf
+++ b/iac/provider-gcp/nomad/variables.tf
@@ -243,14 +243,6 @@ variable "loki_service_port" {
   })
 }
 
-variable "redis_cluster_url_secret_version" {
-  type = any
-}
-
-variable "redis_tls_ca_base64_secret_version" {
-  type = any
-}
-
 # Docker reverse proxy
 variable "docker_reverse_proxy_port" {
   type = object({


### PR DESCRIPTION
Removes Redis connection pass-through inputs that became unused after the orchestrator env var lift.

Cleanup:
- AWS nomad: remove unused redis_url, redis_cluster_url, redis_tls_ca_base64 variables.
- GCP nomad: remove unused Redis Secret Manager data sources, local Redis connection values, and corresponding input variables.
- GCP root: stop passing Redis secret versions into the nomad module. The managed Redis module still receives them separately.

Verification:
- terraform fmt -check -recursive iac/provider-aws/nomad iac/provider-gcp
- git diff --check
- grep checks for stale Redis references in AWS/GCP nomad modules