### PR TITLE
refactor(dashboard-api): read Ory project API key from external secret

### DIFF
--- a/iac/provider-gcp/dashboard-api.tf
+++ b/iac/provider-gcp/dashboard-api.tf
@@ -2,8 +2,11 @@ data "google_secret_manager_secret_version" "dashboard_api_admin_token" {
   secret = module.init.dashboard_api_admin_token_secret_name
 }
 
-data "google_secret_manager_secret_version" "ory_project_api_token" {
-  secret = module.init.ory_project_api_token_secret_name
+data "google_secret_manager_secret_version" "ory_project_api_key" {
+  count   = local.dashboard_api_deployed && module.init.ory_project_api_key_secret_exists ? 1 : 0
+  project = var.gcp_project_id
+  secret  = module.init.ory_project_api_key_secret_name
+  version = "latest"
 }
 
 data "google_secret_manager_secret_version" "supabase_db_connection_string" {
@@ -46,11 +49,17 @@ locals {
   dashboard_api_billing_server_url       = try(trimspace(data.google_secret_manager_secret_version.billing_server_url[0].secret_data), "")
   dashboard_api_billing_server_api_token = try(trimspace(data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data), "")
 
+  dashboard_api_ory_project_api_token = try(trimspace(data.google_secret_manager_secret_version.ory_project_api_key[0].secret_data), "")
+  dashboard_api_extra_env_vars = {
+    for key, value in var.dashboard_api_env_vars : key => value
+    if key != "ORY_PROJECT_API_TOKEN"
+  }
+
   dashboard_api_ory_env_vars = {
     USER_PROFILE_PROVIDER = var.user_profile_provider
     ORY_SDK_URL           = var.ory_sdk_url
     ORY_ISSUER_URL        = var.ory_issuer_url
-    ORY_PROJECT_API_TOKEN = trimspace(data.google_secret_manager_secret_version.ory_project_api_token.secret_data)
+    ORY_PROJECT_API_TOKEN = local.dashboard_api_ory_project_api_token
   }
 
   dashboard_api_env_vars = merge({
@@ -73,5 +82,5 @@ locals {
     BILLING_SERVER_API_TOKEN     = local.dashboard_api_billing_server_api_token
     OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:${local.otel_collector_grpc_port}"
     LOGS_COLLECTOR_ADDRESS       = "http://localhost:${local.logs_proxy_port}"
-  }, local.dashboard_api_ory_env_vars, var.dashboard_api_env_vars)
+  }, local.dashboard_api_ory_env_vars, local.dashboard_api_extra_env_vars)
 }

--- a/iac/provider-gcp/dashboard-api.tf
+++ b/iac/provider-gcp/dashboard-api.tf
@@ -50,10 +50,6 @@ locals {
   dashboard_api_billing_server_api_token = try(trimspace(data.google_secret_manager_secret_version.billing_server_api_token[0].secret_data), "")
 
   dashboard_api_ory_project_api_token = try(trimspace(data.google_secret_manager_secret_version.ory_project_api_key[0].secret_data), "")
-  dashboard_api_extra_env_vars = {
-    for key, value in var.dashboard_api_env_vars : key => value
-    if key != "ORY_PROJECT_API_TOKEN"
-  }
 
   dashboard_api_ory_env_vars = {
     USER_PROFILE_PROVIDER = var.user_profile_provider
@@ -82,5 +78,5 @@ locals {
     BILLING_SERVER_API_TOKEN     = local.dashboard_api_billing_server_api_token
     OTEL_COLLECTOR_GRPC_ENDPOINT = "localhost:${local.otel_collector_grpc_port}"
     LOGS_COLLECTOR_ADDRESS       = "http://localhost:${local.logs_proxy_port}"
-  }, local.dashboard_api_ory_env_vars, local.dashboard_api_extra_env_vars)
+  }, local.dashboard_api_ory_env_vars, var.dashboard_api_env_vars)
 }

--- a/iac/provider-gcp/init/outputs.tf
+++ b/iac/provider-gcp/init/outputs.tf
@@ -66,8 +66,12 @@ output "posthog_api_key_secret_name" {
   value = google_secret_manager_secret_version.posthog_api_key.secret
 }
 
-output "ory_project_api_token_secret_name" {
-  value = google_secret_manager_secret_version.ory_project_api_token.secret
+output "ory_project_api_key_secret_name" {
+  value = local.ory_project_api_key_secret_id
+}
+
+output "ory_project_api_key_secret_exists" {
+  value = local.ory_project_api_key_secret_exists
 }
 
 output "supabase_jwt_secret_name" {

--- a/iac/provider-gcp/init/secrets.tf
+++ b/iac/provider-gcp/init/secrets.tf
@@ -258,26 +258,18 @@ resource "google_secret_manager_secret_version" "posthog_api_key" {
   }
 }
 
-
-resource "google_secret_manager_secret" "ory_project_api_token" {
-  secret_id = "${var.prefix}ory-project-api-token"
-
-  replication {
-    auto {}
-  }
-
-  depends_on = [time_sleep.secrets_api_wait_60_seconds]
+locals {
+  ory_project_api_key_secret_id = "${var.prefix}ory-project-api-key"
 }
 
-resource "google_secret_manager_secret_version" "ory_project_api_token" {
-  secret      = google_secret_manager_secret.ory_project_api_token.name
-  secret_data = " "
-
-  lifecycle {
-    ignore_changes = [secret_data]
-  }
+data "google_secret_manager_secrets" "ory_project_api_key" {
+  project = var.gcp_project_id
+  filter  = "name:${local.ory_project_api_key_secret_id}"
 }
 
+locals {
+  ory_project_api_key_secret_exists = try(length(data.google_secret_manager_secrets.ory_project_api_key.secrets) > 0, false)
+}
 
 resource "google_secret_manager_secret" "redis_cluster_url" {
   secret_id = "${var.prefix}redis-cluster-url"

--- a/iac/provider-gcp/init/secrets.tf
+++ b/iac/provider-gcp/init/secrets.tf
@@ -265,6 +265,8 @@ locals {
 data "google_secret_manager_secrets" "ory_project_api_key" {
   project = var.gcp_project_id
   filter  = "name:${local.ory_project_api_key_secret_id}"
+
+  depends_on = [time_sleep.secrets_api_wait_60_seconds]
 }
 
 locals {

--- a/packages/dashboard-api/internal/cfg/model.go
+++ b/packages/dashboard-api/internal/cfg/model.go
@@ -2,7 +2,6 @@ package cfg
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"strings"
 
@@ -36,6 +35,45 @@ type Config struct {
 	OryIssuerURL        string           `env:"ORY_ISSUER_URL"`
 }
 
+type FailureCondition string
+
+const (
+	FailureConditionMissingRedisConnection FailureCondition = "missing_redis_connection"
+	FailureConditionMissingOrySDKURL       FailureCondition = "missing_ory_sdk_url"
+	FailureConditionMissingOryProjectToken FailureCondition = "missing_ory_project_api_token"
+	FailureConditionMissingOryIssuerURL    FailureCondition = "missing_ory_issuer_url"
+	FailureConditionOryIssuerURLMismatch   FailureCondition = "ory_issuer_url_mismatch"
+)
+
+type FailureError struct {
+	Condition FailureCondition
+	err       error
+}
+
+func (e *FailureError) Error() string {
+	return e.err.Error()
+}
+
+func (e *FailureError) Unwrap() error {
+	return e.err
+}
+
+func ParseFailureCondition(err error) (FailureCondition, bool) {
+	var failureErr *FailureError
+	if !errors.As(err, &failureErr) {
+		return "", false
+	}
+
+	return failureErr.Condition, true
+}
+
+func newFailureError(condition FailureCondition, message string) error {
+	return &FailureError{
+		Condition: condition,
+		err:       errors.New(message),
+	}
+}
+
 func Parse() (Config, error) {
 	var config Config
 	err := env.ParseWithOptions(&config, env.Options{
@@ -58,7 +96,7 @@ func Parse() (Config, error) {
 	}
 
 	if err == nil && config.RedisURL == "" && config.RedisClusterURL == "" {
-		err = errors.New("at least one of REDIS_URL or REDIS_CLUSTER_URL must be set")
+		err = newFailureError(FailureConditionMissingRedisConnection, "at least one of REDIS_URL or REDIS_CLUSTER_URL must be set")
 	}
 
 	if err == nil {
@@ -77,17 +115,17 @@ func validateUserProfileProvider(config *Config) error {
 	}
 
 	if config.OrySDKURL == "" {
-		return errors.New("ORY_SDK_URL is required when USER_PROFILE_PROVIDER uses ory")
+		return newFailureError(FailureConditionMissingOrySDKURL, "ORY_SDK_URL is required when USER_PROFILE_PROVIDER uses ory")
 	}
 	if config.OryProjectAPIToken == "" {
-		return errors.New("ORY_PROJECT_API_TOKEN is required when USER_PROFILE_PROVIDER uses ory")
+		return newFailureError(FailureConditionMissingOryProjectToken, "ORY_PROJECT_API_TOKEN is required when USER_PROFILE_PROVIDER uses ory")
 	}
 
 	if config.OryIssuerURL == "" && len(config.AuthProvider.JWT) == 1 {
 		config.OryIssuerURL = strings.TrimSpace(config.AuthProvider.JWT[0].Issuer.URL)
 	}
 	if config.OryIssuerURL == "" {
-		return errors.New("ORY_ISSUER_URL is required when USER_PROFILE_PROVIDER uses ory")
+		return newFailureError(FailureConditionMissingOryIssuerURL, "ORY_ISSUER_URL is required when USER_PROFILE_PROVIDER uses ory")
 	}
 
 	if len(config.AuthProvider.JWT) > 0 {
@@ -97,7 +135,7 @@ func validateUserProfileProvider(config *Config) error {
 			}
 		}
 
-		return fmt.Errorf("ORY_ISSUER_URL %q does not match any AUTH_PROVIDER_CONFIG.jwt[].issuer.url; identities stored at bootstrap would be invisible to the Ory profile provider", config.OryIssuerURL)
+		return newFailureError(FailureConditionOryIssuerURLMismatch, "ORY_ISSUER_URL does not match any AUTH_PROVIDER_CONFIG.jwt[].issuer.url; identities stored at bootstrap would be invisible to the Ory profile provider")
 	}
 
 	return nil

--- a/packages/dashboard-api/internal/cfg/model_test.go
+++ b/packages/dashboard-api/internal/cfg/model_test.go
@@ -185,6 +185,7 @@ func TestParseUserProfileProviderOryIssuerRejectsMismatchAgainstAuthProvider(t *
 	_, err := Parse()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match any AUTH_PROVIDER_CONFIG")
+	require.NotContains(t, err.Error(), "https://tenant.projects.oryapis.com")
 }
 
 func TestParseUserProfileProviderOryIssuerOverrideWithoutAuthProvider(t *testing.T) {
@@ -211,4 +212,90 @@ func TestParseUserProfileProviderInvalidModeErrors(t *testing.T) {
 	_, err := Parse()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid user profile provider")
+}
+
+func TestParseFailureCondition(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want FailureCondition
+	}{
+		{
+			name: "missing redis connection",
+			env: map[string]string{
+				"POSTGRES_CONNECTION_STRING": "postgres://example",
+				"ADMIN_TOKEN":                "admin-token",
+			},
+			want: FailureConditionMissingRedisConnection,
+		},
+		{
+			name: "missing ory sdk url",
+			env: map[string]string{
+				"POSTGRES_CONNECTION_STRING": "postgres://example",
+				"ADMIN_TOKEN":                "admin-token",
+				"REDIS_URL":                  "redis://example",
+				"USER_PROFILE_PROVIDER":      "ory",
+				"ORY_PROJECT_API_TOKEN":      "pat",
+				"ORY_ISSUER_URL":             "https://auth.example.com",
+			},
+			want: FailureConditionMissingOrySDKURL,
+		},
+		{
+			name: "missing ory project token",
+			env: map[string]string{
+				"POSTGRES_CONNECTION_STRING": "postgres://example",
+				"ADMIN_TOKEN":                "admin-token",
+				"REDIS_URL":                  "redis://example",
+				"USER_PROFILE_PROVIDER":      "ory",
+				"ORY_SDK_URL":                "https://tenant.projects.oryapis.com",
+				"ORY_ISSUER_URL":             "https://auth.example.com",
+			},
+			want: FailureConditionMissingOryProjectToken,
+		},
+		{
+			name: "missing ory issuer url",
+			env: map[string]string{
+				"POSTGRES_CONNECTION_STRING": "postgres://example",
+				"ADMIN_TOKEN":                "admin-token",
+				"REDIS_URL":                  "redis://example",
+				"USER_PROFILE_PROVIDER":      "ory",
+				"ORY_SDK_URL":                "https://tenant.projects.oryapis.com",
+				"ORY_PROJECT_API_TOKEN":      "pat",
+			},
+			want: FailureConditionMissingOryIssuerURL,
+		},
+		{
+			name: "ory issuer url mismatch",
+			env: map[string]string{
+				"POSTGRES_CONNECTION_STRING": "postgres://example",
+				"ADMIN_TOKEN":                "admin-token",
+				"REDIS_URL":                  "redis://example",
+				"USER_PROFILE_PROVIDER":      "ory",
+				"ORY_SDK_URL":                "https://tenant.projects.oryapis.com",
+				"ORY_PROJECT_API_TOKEN":      "pat",
+				"ORY_ISSUER_URL":             "https://tenant.projects.oryapis.com",
+				"AUTH_PROVIDER_CONFIG": `{
+					"jwt": [
+						{"issuer": {"url": "https://auth.example.com", "audiences": ["dashboard-api"]}}
+					]
+				}`,
+			},
+			want: FailureConditionOryIssuerURLMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.env {
+				t.Setenv(key, value)
+			}
+
+			_, err := Parse()
+			require.Error(t, err)
+
+			got, ok := ParseFailureCondition(err)
+			require.True(t, ok)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -98,7 +98,11 @@ func run() int {
 
 	config, err := cfg.Parse()
 	if err != nil {
-		l.Error(ctx, "failed to parse config", zap.Error(err))
+		fields := []zap.Field{zap.Error(err)}
+		if condition, ok := cfg.ParseFailureCondition(err); ok {
+			fields = append(fields, zap.String("config_failure_condition", string(condition)))
+		}
+		l.Error(ctx, "failed to parse config", fields...)
 
 		return 1
 	}


### PR DESCRIPTION
## Summary
- stop creating `${prefix}ory-project-api-token` and its blank placeholder version in the GCP init module
- allow the next infra plan/apply to remove the old `${prefix}ory-project-api-token` Secret Manager secret; it is currently empty and unused in all clusters
- add an init-module Secret Manager presence lookup for the externally-managed `${prefix}ory-project-api-key` secret
- pass that Secret Manager value into dashboard-api as `ORY_PROJECT_API_TOKEN`, which is the env var the binary reads
- keep the standard `dashboard_api_env_vars` merge behavior instead of special-casing `ORY_PROJECT_API_TOKEN`; this variable is not wired through the normal Makefile/Doppler env path
- add safe dashboard-api config parse failure conditions to startup logs without logging sensitive config values

## Deploy Notes
- The old `${prefix}ory-project-api-token` secret is intentionally removed from this repo and does not need a Terraform state handoff because it is empty and unused.
- The new `${prefix}ory-project-api-key` secret is owned and populated by the separate Ory Terraform state/repo.
- In the normal Makefile/Doppler deployment path, if the new secret is absent, this repo skips reading the secret version and dashboard-api receives no `ORY_PROJECT_API_TOKEN` value.