### PR TITLE
feat(orch): snapshot fragmentation metrics

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -62,11 +62,15 @@ func (b *File) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
 	maxParallel := b.store.flags.IntFlag(ctx, featureflags.MaxParallelBuildReadSegments)
 
 	for {
-		segments, n, err := b.planRead(ctx, p, off)
+		segments, n, distinctBuilds, err := b.planRead(ctx, p, off)
 		if err == nil {
 			err = b.readSegments(ctx, p, segments, maxParallel)
 		}
 		if err == nil {
+			// Recorded only for the attempt that succeeded, so eviction /
+			// transition retries don't double-count the read.
+			recordReadFanout(ctx, b.fileType, len(segments), distinctBuilds)
+
 			// Fewer bytes than requested means the mappings ran out: report the
 			// bytes filled so far with io.EOF, matching io.ReaderAt semantics.
 			if n < len(p) {
@@ -137,7 +141,10 @@ func (b *File) readSegment(ctx context.Context, p []byte, s readSegment) error {
 
 // planRead resolves the segments covering p, zero-filling uuid.Nil regions.
 // A returned byte count below len(p) means the mappings ran out (EOF).
-func (b *File) planRead(ctx context.Context, p []byte, off int64) ([]readSegment, int, error) {
+// distinctBuilds counts the distinct builds the segments reference; it
+// saturates at buildCacheSize when a single read crosses more builds than the
+// per-read cache holds (already deep in the "very fragmented" regime).
+func (b *File) planRead(ctx context.Context, p []byte, off int64) (segments []readSegment, n int, distinctBuilds int, err error) {
 	// Per-read Diff cache: avoids the DiffStore TTL cache mutex on every mapping.
 	const buildCacheSize = 16
 	var (
@@ -145,21 +152,19 @@ func (b *File) planRead(ctx context.Context, p []byte, off int64) ([]readSegment
 		underlyingDiffs [buildCacheSize]Diff
 		cacheIDs        = underlyingIDs[:0]
 		cacheDiffs      = underlyingDiffs[:0]
-		segments        []readSegment
 	)
 
-	var n int
 	for n < len(p) {
 		h := b.Header()
 		mappedToBuild, err := h.GetShiftedMapping(ctx, off+int64(n))
 		if err != nil {
-			return nil, 0, fmt.Errorf("failed to get mapping: %w", err)
+			return nil, 0, 0, fmt.Errorf("failed to get mapping: %w", err)
 		}
 		readLength := min(int64(mappedToBuild.Length), int64(len(p)-n))
 		// A zero-length mapping means off+n is past the last mapping (EOF); stop
 		// and let the caller surface io.EOF for the bytes covered so far.
 		if readLength <= 0 {
-			return segments, n, nil
+			return segments, n, len(cacheIDs), nil
 		}
 		// uuid.Nil marks an unmapped/empty region; zero-fill it in place.
 		if mappedToBuild.BuildId == uuid.Nil {
@@ -171,7 +176,7 @@ func (b *File) planRead(ctx context.Context, p []byte, off int64) ([]readSegment
 
 		diff, err := b.cachedBuild(ctx, h, mappedToBuild.BuildId, &cacheIDs, &cacheDiffs)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, 0, err
 		}
 		segments = append(segments, readSegment{
 			dstOff: n,
@@ -183,7 +188,7 @@ func (b *File) planRead(ctx context.Context, p []byte, off int64) ([]readSegment
 		n += int(readLength)
 	}
 
-	return segments, n, nil
+	return segments, n, len(cacheIDs), nil
 }
 
 func (b *File) cachedBuild(ctx context.Context, h *header.Header, buildID uuid.UUID, ids *[]uuid.UUID, diffs *[]Diff) (Diff, error) {

--- a/packages/orchestrator/pkg/sandbox/build/read_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/build/read_metrics.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package build
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// readSegmentsMetric and readBuildsMetric record, once per successful
+// File.ReadAt, how many build-backed segments the read decomposed into and how
+// many distinct builds those segments referenced. They are the direct
+// resume-side measure of snapshot fragmentation: page-granular dedup
+// interleaves a header's mapping across many ancestor builds, and a single
+// hugepage fault then fans out into one backing read per mapping run it
+// crosses (serially, unless MaxParallelBuildReadSegments raises the limit).
+// Zero-filled (uuid.Nil) runs cost no I/O and are not counted.
+var (
+	readSegmentsMetric = utils.Must(meter.Int64Histogram("orchestrator.build.read.segments",
+		metric.WithDescription("Build-backed segments a single build.File read decomposed into")))
+	readBuildsMetric = utils.Must(meter.Int64Histogram("orchestrator.build.read.builds",
+		metric.WithDescription("Distinct builds referenced by a single build.File read")))
+)
+
+// readFanoutAttrs precomputes the per-file-type attribute sets so the
+// per-read hot path allocates nothing (mirrors uffd/userfaultfd/metrics.go).
+var readFanoutAttrs = map[DiffType]metric.MeasurementOption{
+	Memfile: telemetry.PrecomputeAttrs(attribute.String("file_type", string(Memfile))),
+	Rootfs:  telemetry.PrecomputeAttrs(attribute.String("file_type", string(Rootfs))),
+}
+
+// recordReadFanout records the fan-out of one completed File.ReadAt.
+func recordReadFanout(ctx context.Context, fileType DiffType, segments, builds int) {
+	attrs, ok := readFanoutAttrs[fileType]
+	if !ok {
+		attrs = telemetry.PrecomputeAttrs(attribute.String("file_type", string(fileType)))
+	}
+	readSegmentsMetric.Record(ctx, int64(segments), attrs)
+	readBuildsMetric.Record(ctx, int64(builds), attrs)
+}

--- a/packages/orchestrator/pkg/sandbox/build/read_metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/read_metrics_test.go
@@ -1,0 +1,127 @@
+//go:build linux
+
+package build
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	blockmetrics "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/metrics"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// swapReadFanoutMetrics points the package-level fan-out histograms at a
+// manual reader for the duration of the test. NOT parallel-safe.
+func swapReadFanoutMetrics(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m := mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build")
+
+	prevSegments, prevBuilds := readSegmentsMetric, readBuildsMetric
+	readSegmentsMetric = utils.Must(m.Int64Histogram("orchestrator.build.read.segments"))
+	readBuildsMetric = utils.Must(m.Int64Histogram("orchestrator.build.read.builds"))
+	t.Cleanup(func() { readSegmentsMetric, readBuildsMetric = prevSegments, prevBuilds })
+
+	return reader
+}
+
+// fanoutSums returns, keyed by file_type label, the (sum, count) of the named
+// histogram's datapoints.
+func fanoutSums(t *testing.T, reader *sdkmetric.ManualReader, name string) map[string][2]int64 {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	out := map[string][2]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			hist, ok := m.Data.(metricdata.Histogram[int64])
+			if m.Name != name || !ok {
+				continue
+			}
+			for _, dp := range hist.DataPoints {
+				ft, ok := dp.Attributes.Value("file_type")
+				require.True(t, ok, "datapoint missing file_type attribute")
+				cur := out[ft.AsString()]
+				out[ft.AsString()] = [2]int64{cur[0] + dp.Sum, cur[1] + int64(dp.Count)}
+			}
+		}
+	}
+
+	return out
+}
+
+// recordReadFanout emits one datapoint per histogram, tagged with the file
+// type, for both the precomputed and the fallback attribute paths.
+//
+//nolint:paralleltest // swaps the package-level fan-out histograms
+func TestRecordReadFanout(t *testing.T) {
+	reader := swapReadFanoutMetrics(t)
+	ctx := context.Background()
+
+	recordReadFanout(ctx, Memfile, 13, 4)
+	recordReadFanout(ctx, Memfile, 1, 1)
+	recordReadFanout(ctx, Rootfs, 2, 2)
+	recordReadFanout(ctx, DiffType("other"), 5, 5) // fallback attr path
+
+	segments := fanoutSums(t, reader, "orchestrator.build.read.segments")
+	assert.Equal(t, [2]int64{14, 2}, segments[string(Memfile)], "memfile segments sum/count")
+	assert.Equal(t, [2]int64{2, 1}, segments[string(Rootfs)], "rootfs segments sum/count")
+	assert.Equal(t, [2]int64{5, 1}, segments["other"], "fallback segments sum/count")
+
+	builds := fanoutSums(t, reader, "orchestrator.build.read.builds")
+	assert.Equal(t, [2]int64{5, 2}, builds[string(Memfile)], "memfile builds sum/count")
+	assert.Equal(t, [2]int64{2, 1}, builds[string(Rootfs)], "rootfs builds sum/count")
+}
+
+// A ReadAt resolved entirely from uuid.Nil (zero-fill) mappings records one
+// datapoint with zero segments and zero builds — fan-out is only counted for
+// build-backed runs.
+//
+//nolint:paralleltest // swaps the package-level fan-out histograms
+func TestFileReadAt_RecordsZeroFanoutForNilMapping(t *testing.T) {
+	reader := swapReadFanoutMetrics(t)
+
+	store, err := NewDiffStore(
+		mustParseCfg(t),
+		flagsWithMaxBuildCachePercentage(t, 90),
+		t.TempDir(),
+		time.Hour,
+		time.Minute,
+	)
+	require.NoError(t, err)
+
+	const size = 4096
+	hdr, err := header.NewHeader(
+		header.NewTemplateMetadata(uuid.Nil, size, size),
+		[]header.BuildMap{{Offset: 0, Length: size, BuildId: uuid.Nil}},
+	)
+	require.NoError(t, err)
+
+	m, err := blockmetrics.NewMetrics(noop.NewMeterProvider())
+	require.NoError(t, err)
+	f := NewFile(hdr, store, Memfile, nil, m)
+
+	buf := make([]byte, size)
+	n, err := f.ReadAt(t.Context(), buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, size, n)
+
+	segments := fanoutSums(t, reader, "orchestrator.build.read.segments")
+	assert.Equal(t, [2]int64{0, 1}, segments[string(Memfile)], "zero-fill read records 0 segments")
+
+	builds := fanoutSums(t, reader, "orchestrator.build.read.builds")
+	assert.Equal(t, [2]int64{0, 1}, builds[string(Memfile)], "zero-fill read records 0 builds")
+}

--- a/packages/orchestrator/pkg/sandbox/template/header_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/template/header_metrics.go
@@ -1,0 +1,97 @@
+//go:build linux
+
+package template
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// Header-shape metrics, recorded once per header load (template-cache miss on
+// a node). Together they describe how fragmented the snapshots being resumed
+// are — the static upper bound on the per-read fan-out that
+// orchestrator.build.read.* measures at fault time:
+//
+//   - generation: pause/resume cycles behind this snapshot
+//   - mapping_entries: runs in the flattened mapping
+//   - distinct_builds: ancestor builds still referenced (each is a separate
+//     storage object + local cache file + chunker at resume)
+//   - max_entries_per_block: worst-case build-backed runs intersecting one
+//     2 MiB block — the ceiling on segments a single hugepage fault fans
+//     out into
+var (
+	headerGenerationMetric = utils.Must(meter.Int64Histogram("orchestrator.header.generation",
+		metric.WithDescription("Snapshot generation (pause/resume cycles) of a loaded header")))
+	headerMappingEntriesMetric = utils.Must(meter.Int64Histogram("orchestrator.header.mapping_entries",
+		metric.WithDescription("Mapping entries (runs) in a loaded header")))
+	headerDistinctBuildsMetric = utils.Must(meter.Int64Histogram("orchestrator.header.distinct_builds",
+		metric.WithDescription("Distinct builds referenced by a loaded header's mapping")))
+	headerMaxEntriesPerBlockMetric = utils.Must(meter.Int64Histogram("orchestrator.header.max_entries_per_block",
+		metric.WithDescription("Max build-backed mapping runs intersecting one 2 MiB block of a loaded header")))
+)
+
+var headerShapeAttrs = map[build.DiffType]metric.MeasurementOption{
+	build.Memfile: telemetry.PrecomputeAttrs(attribute.String("file_type", string(build.Memfile))),
+	build.Rootfs:  telemetry.PrecomputeAttrs(attribute.String("file_type", string(build.Rootfs))),
+}
+
+// recordHeaderShape records the fragmentation shape of a freshly loaded
+// header. Cheap relative to the load itself: one O(entries) scan.
+func recordHeaderShape(ctx context.Context, fileType build.DiffType, h *header.Header) {
+	if h == nil || h.Metadata == nil {
+		return
+	}
+
+	attrs, ok := headerShapeAttrs[fileType]
+	if !ok {
+		attrs = telemetry.PrecomputeAttrs(attribute.String("file_type", string(fileType)))
+	}
+
+	headerGenerationMetric.Record(ctx, int64(h.Metadata.Generation), attrs)
+	headerMappingEntriesMetric.Record(ctx, int64(h.Mapping.Len()), attrs)
+	headerDistinctBuildsMetric.Record(ctx, int64(len(h.Mapping.Builds())), attrs)
+	headerMaxEntriesPerBlockMetric.Record(ctx, maxEntriesPerBlock(h.Mapping), attrs)
+}
+
+// maxEntriesPerBlock returns the maximum number of build-backed mapping runs
+// intersecting any single 2 MiB-aligned block of the virtual space. Empty
+// (uuid.Nil) runs are skipped: they zero-fill without I/O, so they don't add
+// to a fault's fan-out. Relies on mapping runs being sorted and
+// non-overlapping (validated at header construction).
+func maxEntriesPerBlock(m header.Mapping) int64 {
+	var maxCount, count int64
+	curBlock := int64(-1)
+
+	for _, bm := range m.All() {
+		if bm.BuildId == uuid.Nil || bm.Length == 0 {
+			continue
+		}
+
+		start := int64(bm.Offset) / header.HugepageSize
+		end := int64(bm.Offset+bm.Length-1) / header.HugepageSize
+
+		if start == curBlock {
+			count++
+		} else {
+			count = 1
+		}
+		maxCount = max(maxCount, count)
+
+		// A run spilling past its first block is the only one intersecting the
+		// later blocks so far, so the running count there restarts at 1.
+		curBlock = end
+		if end > start {
+			count = 1
+		}
+	}
+
+	return maxCount
+}

--- a/packages/orchestrator/pkg/sandbox/template/header_metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/template/header_metrics_test.go
@@ -1,0 +1,107 @@
+//go:build linux
+
+package template
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+)
+
+// mustMapping packs the given runs into a compact Mapping. Offsets/lengths
+// are in bytes and must be PageSize-aligned (the universal granularity).
+func mustMapping(t *testing.T, runs []header.BuildMap) header.Mapping {
+	t.Helper()
+
+	m, err := header.NewMapping(header.PageSize, runs)
+	require.NoError(t, err)
+
+	return m
+}
+
+func TestMaxEntriesPerBlock(t *testing.T) {
+	t.Parallel()
+
+	const (
+		page  = uint64(header.PageSize)
+		block = uint64(header.HugepageSize)
+	)
+	buildA := uuid.New()
+	buildB := uuid.New()
+
+	tests := []struct {
+		name string
+		runs []header.BuildMap
+		want int64
+	}{
+		{
+			name: "empty mapping",
+			runs: nil,
+			want: 0,
+		},
+		{
+			name: "single run covering one block",
+			runs: []header.BuildMap{
+				{Offset: 0, Length: block, BuildId: buildA},
+			},
+			want: 1,
+		},
+		{
+			name: "single run spanning many blocks still counts once per block",
+			runs: []header.BuildMap{
+				{Offset: 0, Length: 4 * block, BuildId: buildA},
+			},
+			want: 1,
+		},
+		{
+			name: "interleaved builds inside one block",
+			runs: []header.BuildMap{
+				{Offset: 0, Length: page, BuildId: buildA},
+				{Offset: page, Length: page, BuildId: buildB},
+				{Offset: 2 * page, Length: page, BuildId: buildA},
+				{Offset: 3 * page, Length: block - 3*page, BuildId: buildB},
+			},
+			want: 4,
+		},
+		{
+			name: "empty (uuid.Nil) runs are not counted",
+			runs: []header.BuildMap{
+				{Offset: 0, Length: page, BuildId: buildA},
+				{Offset: page, Length: page, BuildId: uuid.Nil},
+				{Offset: 2 * page, Length: block - 2*page, BuildId: buildB},
+			},
+			want: 2,
+		},
+		{
+			name: "run spilling into the next block joins its count",
+			runs: []header.BuildMap{
+				// Block 0: A only. Block 1: A's tail + B + A = 3.
+				{Offset: 0, Length: block + page, BuildId: buildA},
+				{Offset: block + page, Length: page, BuildId: buildB},
+				{Offset: block + 2*page, Length: block - 2*page, BuildId: buildA},
+			},
+			want: 3,
+		},
+		{
+			name: "fragmented block after a coarse block wins",
+			runs: []header.BuildMap{
+				{Offset: 0, Length: block, BuildId: buildA},
+				{Offset: block, Length: page, BuildId: buildA},
+				{Offset: block + page, Length: page, BuildId: buildB},
+				{Offset: block + 2*page, Length: block - 2*page, BuildId: buildA},
+			},
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, maxEntriesPerBlock(mustMapping(t, tt.runs)))
+		})
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/template/storage.go
+++ b/packages/orchestrator/pkg/sandbox/template/storage.go
@@ -122,6 +122,8 @@ func NewStorage(
 		}
 	}
 
+	recordHeaderShape(ctx, fileType, h)
+
 	b := build.NewFile(h, store, fileType, persistence, metrics)
 
 	return &Storage{

--- a/packages/orchestrator/pkg/sandbox/uffd/uffd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/uffd.go
@@ -169,10 +169,18 @@ func (u *Uffd) handle(ctx context.Context, sandboxId string, fdExit *fdexit.FdEx
 
 	m := memory.NewMapping(regions)
 
+	// The memfile header's generation (pause/resume cycle count) tags this
+	// sandbox's fault metrics so latency can be cut by snapshot chain depth.
+	var generation uint64
+	if h := u.memfile.Header(); h != nil && h.Metadata != nil {
+		generation = h.Metadata.Generation
+	}
+
 	uffd, err := userfaultfd.NewUserfaultfdFromFd(
 		uintptr(fds[0]),
 		u.memfile,
 		m,
+		generation,
 		logger.L().With(logger.WithSandboxID(sandboxId)),
 	)
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/close_race_test.go
@@ -62,7 +62,7 @@ func TestPrefaultConcurrentWithClose(t *testing.T) {
 		log, err := logger.NewDevelopmentLogger()
 		require.NoError(t, err)
 
-		u, err := NewUserfaultfdFromFd(uintptr(uffdFd), src, mapping, log)
+		u, err := NewUserfaultfdFromFd(uintptr(uffdFd), src, mapping, 0, log)
 		require.NoError(t, err)
 
 		// Barrier channels: park Prefault at faultPhaseBeforePrefaultRLock so

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics.go
@@ -72,12 +72,54 @@ var resultNames = [numFaultResult]string{
 	faultResultSkipped:   "skipped",
 }
 
+// generationBucket coarsens the snapshot's Metadata.Generation (its
+// pause/resume cycle count) into log-scale ranges, so fault latency can be
+// cut by snapshot chain depth — the fragmentation axis — without
+// per-generation label cardinality. Generations reach thousands in prod
+// (p99 ≈ 2.3k), hence the split tail.
+type generationBucket uint8
+
+const (
+	genBucket0 generationBucket = iota // generation 0: fresh template build
+	genBucket1To10
+	genBucket11To100
+	genBucket101To1000
+	genBucketOver1000
+	numGenerationBucket
+)
+
+// generationBucketNames maps generationBucket values to their metric label
+// strings.
+var generationBucketNames = [numGenerationBucket]string{
+	genBucket0:         "0",
+	genBucket1To10:     "1-10",
+	genBucket11To100:   "11-100",
+	genBucket101To1000: "101-1000",
+	genBucketOver1000:  ">1000",
+}
+
+func bucketForGeneration(generation uint64) generationBucket {
+	switch {
+	case generation == 0:
+		return genBucket0
+	case generation <= 10:
+		return genBucket1To10
+	case generation <= 100:
+		return genBucket11To100
+	case generation <= 1000:
+		return genBucket101To1000
+	default:
+		return genBucketOver1000
+	}
+}
+
 // serveAttrs holds a precomputed metric.MeasurementOption per
-// (pageClass, faultResult) combination so the per-fault hot path allocates no
-// attributes (mirrors the precomputed attrs in block/streaming_chunk.go).
+// (generationBucket, pageClass, faultResult) combination so the per-fault hot
+// path allocates no attributes (mirrors the precomputed attrs in
+// block/streaming_chunk.go).
 var serveAttrs = buildServeAttrs()
 
-func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
+func buildServeAttrs() [numGenerationBucket][numPageClass][numFaultResult]metric.MeasurementOption {
 	classNames := [numPageClass]string{
 		pageClassNew:      "new",
 		pageClassZero:     "zero",
@@ -85,13 +127,16 @@ func buildServeAttrs() [numPageClass][numFaultResult]metric.MeasurementOption {
 		pageClassUnknown:  "unknown",
 	}
 
-	var t [numPageClass][numFaultResult]metric.MeasurementOption
-	for c := range classNames {
-		for r := range resultNames {
-			t[c][r] = telemetry.PrecomputeAttrs(
-				attribute.String("page_class", classNames[c]),
-				attribute.String("result", resultNames[r]),
-			)
+	var t [numGenerationBucket][numPageClass][numFaultResult]metric.MeasurementOption
+	for g := range generationBucketNames {
+		for c := range classNames {
+			for r := range resultNames {
+				t[g][c][r] = telemetry.PrecomputeAttrs(
+					attribute.String("generation_bucket", generationBucketNames[g]),
+					attribute.String("page_class", classNames[c]),
+					attribute.String("result", resultNames[r]),
+				)
+			}
 		}
 	}
 
@@ -163,15 +208,21 @@ func (u *Userfaultfd) recordServeStats(pclass pageClass, result faultResult, ser
 	}
 }
 
-// prefaultAttrs holds a precomputed metric.MeasurementOption per faultResult.
-// Prefaults have no page_class: they only ever target not-present pages (the
-// Dirty/Zero pre-check records result="skipped" instead).
+// prefaultAttrs holds a precomputed metric.MeasurementOption per
+// (generationBucket, faultResult). Prefaults have no page_class: they only
+// ever target not-present pages (the Dirty/Zero pre-check records
+// result="skipped" instead).
 var prefaultAttrs = buildPrefaultAttrs()
 
-func buildPrefaultAttrs() [numFaultResult]metric.MeasurementOption {
-	var t [numFaultResult]metric.MeasurementOption
-	for r := range resultNames {
-		t[r] = telemetry.PrecomputeAttrs(attribute.String("result", resultNames[r]))
+func buildPrefaultAttrs() [numGenerationBucket][numFaultResult]metric.MeasurementOption {
+	var t [numGenerationBucket][numFaultResult]metric.MeasurementOption
+	for g := range generationBucketNames {
+		for r := range resultNames {
+			t[g][r] = telemetry.PrecomputeAttrs(
+				attribute.String("generation_bucket", generationBucketNames[g]),
+				attribute.String("result", resultNames[r]),
+			)
+		}
 	}
 
 	return t

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
@@ -176,6 +176,83 @@ func TestServeStats(t *testing.T) {
 	assert.Equal(t, 4*pageSize, stats.Bytes, "bytes installed (new+zero), present/deferred/error contribute none")
 }
 
+// bucketForGeneration pins the log-scale bucket edges: 0 is its own bucket
+// (fresh template), then 1-10 / 11-100 / 101-1000 / >1000.
+func TestBucketForGeneration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		generation uint64
+		want       generationBucket
+	}{
+		{0, genBucket0},
+		{1, genBucket1To10},
+		{10, genBucket1To10},
+		{11, genBucket11To100},
+		{100, genBucket11To100},
+		{101, genBucket101To1000},
+		{1000, genBucket101To1000},
+		{1001, genBucketOver1000},
+		{2314, genBucketOver1000}, // prod p99 at time of writing
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.want, bucketForGeneration(tt.generation), "generation %d", tt.generation)
+	}
+}
+
+// Serve datapoints recorded under different generation buckets land in
+// distinct series, tagged with the right generation_bucket label value.
+//
+//nolint:paralleltest // swaps the package-level serveTimer
+func TestServeMetric_GenerationBucket(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := serveTimer
+	serveTimer = utils.Must(telemetry.NewTimerFactory(
+		mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/uffd/userfaultfd"),
+		serveMetricName,
+		"Time to serve a UFFD page fault",
+		"Bytes faulted into the guest",
+		"UFFD faults served",
+	))
+	t.Cleanup(func() { serveTimer = prev })
+
+	ctx := context.Background()
+
+	record := func(bucket generationBucket, n int) {
+		for range n {
+			sw := serveTimer.Begin()
+			sw.RecordRaw(ctx, int64(header.PageSize), serveAttrs[bucket][pageClassNew][faultResultInstalled])
+		}
+	}
+	record(genBucket0, 1)
+	record(genBucket11To100, 2)
+	record(genBucketOver1000, 3)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	// Count datapoints by generation_bucket label value.
+	counts := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			hist, ok := m.Data.(metricdata.Histogram[int64])
+			if m.Name != serveMetricName || !ok {
+				continue
+			}
+			for _, dp := range hist.DataPoints {
+				g, ok := dp.Attributes.Value("generation_bucket")
+				require.True(t, ok, "datapoint missing generation_bucket attribute")
+				counts[g.AsString()] += int64(dp.Count)
+			}
+		}
+	}
+
+	assert.Equal(t, map[string]int64{"0": 1, "11-100": 2, ">1000": 3}, counts)
+}
+
 func key(pageClass, result string) string { return pageClass + "/" + result }
 
 // attrKey returns "page_class/result" for serve datapoints and just "result"

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/metrics_test.go
@@ -45,11 +45,13 @@ func TestServeMetric(t *testing.T) {
 	ctx := context.Background()
 	pageSize := int64(header.PageSize)
 
-	// Record a mix of faults the way the worker would.
+	// Record a mix of faults the way the worker would. All under one
+	// generation bucket — the per-bucket split is pinned separately by
+	// TestServeMetric_GenerationBucket.
 	record := func(class pageClass, result faultResult, bytes int64, n int) {
 		for range n {
 			sw := serveTimer.Begin()
-			sw.RecordRaw(ctx, bytes, serveAttrs[class][result])
+			sw.RecordRaw(ctx, bytes, serveAttrs[genBucket1To10][class][result])
 		}
 	}
 	record(pageClassNew, faultResultInstalled, pageSize, 3)
@@ -114,7 +116,7 @@ func TestPrefaultMetric(t *testing.T) {
 	record := func(result faultResult, bytes int64, n int) {
 		for range n {
 			sw := prefaultTimer.Begin()
-			sw.RecordRaw(ctx, bytes, prefaultAttrs[result])
+			sw.RecordRaw(ctx, bytes, prefaultAttrs[genBucket0][result])
 		}
 	}
 	record(faultResultInstalled, pageSize, 3)
@@ -177,9 +179,13 @@ func TestServeStats(t *testing.T) {
 func key(pageClass, result string) string { return pageClass + "/" + result }
 
 // attrKey returns "page_class/result" for serve datapoints and just "result"
-// for prefault datapoints (which carry no page_class).
+// for prefault datapoints (which carry no page_class). Both kinds must carry
+// a generation_bucket attribute; its value is asserted separately by
+// TestServeMetric_GenerationBucket, not folded into the key.
 func attrKey(t *testing.T, attrs attribute.Set) string {
 	t.Helper()
+	_, ok := attrs.Value("generation_bucket")
+	require.True(t, ok, "datapoint missing generation_bucket attribute")
 	r, ok := attrs.Value("result")
 	require.True(t, ok, "datapoint missing result attribute")
 	pc, ok := attrs.Value("page_class")

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/prefault.go
@@ -31,7 +31,7 @@ func (u *Userfaultfd) Prefault(ctx context.Context, offset int64, data []byte) (
 	var installedBytes int64
 	defer func() {
 		if record {
-			sw.RecordRaw(ctx, installedBytes, prefaultAttrs[result])
+			sw.RecordRaw(ctx, installedBytes, prefaultAttrs[u.genBucket][result])
 		}
 	}()
 

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/rpc_services_test.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/rpc_services_test.go
@@ -113,7 +113,7 @@ func (l *Lifecycle) Bootstrap(args *testharness.BootstrapArgs, _ *testharness.Bo
 		return fmt.Errorf("logger: %w", err)
 	}
 
-	uffd, err := NewUserfaultfdFromFd(l.state.uffdFd, data, mapping, log)
+	uffd, err := NewUserfaultfdFromFd(l.state.uffdFd, data, mapping, 0, log)
 	if err != nil {
 		return fmt.Errorf("NewUserfaultfdFromFd: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
+++ b/packages/orchestrator/pkg/sandbox/uffd/userfaultfd/userfaultfd.go
@@ -117,6 +117,10 @@ type Userfaultfd struct {
 	servedSourcePages atomic.Int64 // subset installed from the source (page_class=new)
 	servedBytes       atomic.Int64 // bytes installed into the guest (new + zero)
 
+	// genBucket tags this sandbox's serve/prefault metrics with its snapshot
+	// generation range, so fault latency can be cut by chain depth.
+	genBucket generationBucket
+
 	logger logger.Logger
 }
 
@@ -150,8 +154,10 @@ const (
 )
 
 // NewUserfaultfdFromFd creates a new userfaultfd instance. Page size is
-// taken from the FC-registered regions; all regions must agree.
-func NewUserfaultfdFromFd(fd uintptr, src PageReader, m *memory.Mapping, logger logger.Logger) (*Userfaultfd, error) {
+// taken from the FC-registered regions; all regions must agree. generation is
+// the snapshot's pause/resume cycle count (Metadata.Generation), used only to
+// tag this instance's metrics.
+func NewUserfaultfdFromFd(fd uintptr, src PageReader, m *memory.Mapping, generation uint64, logger logger.Logger) (*Userfaultfd, error) {
 	if len(m.Regions) == 0 {
 		return nil, errors.New("memory mapping has no regions")
 	}
@@ -178,6 +184,7 @@ func NewUserfaultfdFromFd(fd uintptr, src PageReader, m *memory.Mapping, logger 
 		prefetchTracker: block.NewPrefetchTracker(int64(pageSize)),
 		ma:              m,
 		wakeupPipe:      wakeupPipe,
+		genBucket:       bucketForGeneration(generation),
 		logger:          logger,
 	}
 	u.wg.SetLimit(maxRequestsInProgress)
@@ -427,7 +434,7 @@ func (u *Userfaultfd) Serve(
 				result := faultResultInstalled
 				var servedBytes int64
 				defer func() {
-					sw.RecordRaw(ctx, servedBytes, serveAttrs[pclass][result])
+					sw.RecordRaw(ctx, servedBytes, serveAttrs[u.genBucket][pclass][result])
 					u.recordServeStats(pclass, result, servedBytes)
 				}()
 


### PR DESCRIPTION
## Motivation

With `memfile-diff-dedup` enabled, every pause stores only the 4 KiB pages that actually changed and leaves the rest pointing at whichever ancestor build last wrote them. Over repeated pause/resume cycles the flattened header mapping becomes finely **interleaved** across many ancestor builds — and a single 2 MiB hugepage fault then decomposes in `build.File.planRead` into up to 512 backing segments, read **serially by default** (`max-parallel-build-read-segments` = 1).

This fragmentation is invisible today. All existing telemetry is pause-side span attributes (`dedup.*`, `snapshot.header.mappings.length`); nothing measures what a *resume* actually pays. The exposure is real:

- prod sandboxes routinely accumulate deep snapshot chains (pause-generation p50 ≈ 5, p90 ≈ 191, **p99 ≈ 2,314** on foxtrot, 24 h window);
- on dedup-enabled stacks, memfile headers carry **~35× more mapping entries at the same generation depth** than on dedup-off stacks (staging p50 2,223 vs foxtrot 61 at generation 1–10).

[PR #2862](https://github.com/e2b-dev/infra/pull/2862) adds a pause-time `DedupBudget` to bound exactly this ("distinct non-empty backing fetch windows per block"), but its three knobs currently have no data to be set from. These metrics provide that data, quantify whether fragmentation costs fault latency fleet-wide, and gate any decision to enable dedup on environments where it is currently off.

## New metrics

All are always-on, low-cardinality, with attribute sets precomputed so the per-fault hot path allocates nothing.

### 1. Per-read fan-out — `build.File.ReadAt` (one datapoint per successful read)

| metric | type | meaning |
|---|---|---|
| `orchestrator.build.read.segments` | int histogram | build-backed segments the read decomposed into (memfile: per 2 MiB fault, max 512; 1 = contiguous mapping). Zero-fill (`uuid.Nil`) runs are not counted. |
| `orchestrator.build.read.builds` | int histogram | distinct builds those segments referenced (saturates at 16, the per-read build-cache size) |

Labels: `file_type` (`memfile` / `rootfs.ext4`).

Interpretation: `segments` is the upper bound on cold fetches and the exact count of serial backing reads (warm-path overhead, parallelism fan-out); `builds` is within ~2× of the true cold-fetch count for single-block reads, because each build's pages for one guest block are contiguous in its packed diff (≤ 2 fetch windows per build per block). Together they bracket the cold cost without paying for frame-level window resolution in the hot path.

### 2. Header shape — recorded once per header load into a node's template cache

| metric | type | meaning |
|---|---|---|
| `orchestrator.header.generation` | int histogram | pause/resume cycles behind the loaded snapshot |
| `orchestrator.header.mapping_entries` | int histogram | runs in the flattened mapping |
| `orchestrator.header.distinct_builds` | int histogram | ancestor builds still referenced (each = a separate storage object + local cache file + chunker at resume; cap 65,535, no compaction exists) |
| `orchestrator.header.max_entries_per_block` | int histogram | worst-case build-backed runs intersecting one 2 MiB block — the static ceiling on per-fault fan-out, and the direct read for choosing PR #2862's `maxFetchWindowsPerBlock` |

Labels: `file_type`. Cost: one O(entries) scan per header load.

### 3. Generation bucket on the UFFD fault metrics

The existing `orchestrator.sandbox.uffd.serve` / `.prefault` triplets gain a `generation_bucket` attribute with log-scale edges: `0`, `1-10`, `11-100`, `101-1000`, `>1000` (generations reach thousands in prod, hence the split tail). Resolved once per sandbox from the memfile header at UFFD construction.

This is the money query: **fault latency conditioned on snapshot chain depth**. If deeper buckets sit above shallow ones on dedup-enabled environments but not on dedup-off ones, fragmentation costs latency — measured, not inferred. Cardinality: ×5 on the serve/prefault series (5 × 4 page-classes × 6 results = 120 precomputed sets).