### PR TITLE
fix(dashboard-api): avoid repeated Ory bootstrap provisioning

### DIFF
--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -26,6 +26,7 @@ const (
 	baseTierID                   = "base_v1"
 	maxTeamsPerUser              = 3
 	maxTeamsPerUserWithProTier   = 10
+	bootstrapProvisionRetryAge   = 30 * time.Second
 	teamProvisionRollbackTimeout = 5 * time.Second
 )
 
@@ -209,14 +210,16 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 			return provisionedTeam{}, fmt.Errorf("commit existing user bootstrap transaction: %w", err)
 		}
 
-		req := teamprovision.TeamBillingProvisionRequestedV1{
-			TeamID:        existingTeam.ID,
-			TeamName:      existingTeam.Name,
-			TeamEmail:     existingTeam.Email,
-			CreatorUserID: profile.UserID,
-			Reason:        teamprovision.ReasonDefaultSignupTeam,
+		if time.Since(existingTeam.CreatedAt) < bootstrapProvisionRetryAge {
+			req := teamprovision.TeamBillingProvisionRequestedV1{
+				TeamID:        existingTeam.ID,
+				TeamName:      existingTeam.Name,
+				TeamEmail:     existingTeam.Email,
+				CreatorUserID: profile.UserID,
+				Reason:        teamprovision.ReasonDefaultSignupTeam,
+			}
+			_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
 		}
-		_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
 
 		return provisionedTeam{
 			ID:            existingTeam.ID,


### PR DESCRIPTION
## Summary
- keep Ory bootstrap idempotency in dashboard-api by returning an existing default team
- retry the provisioning event only while the default team is younger than 30 seconds