### PR TITLE
feat(orchestrator): add allocated resource metrics for sandboxes

### DIFF
--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -151,6 +151,45 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to register orchestrator status gauge: %w", err)
 	}
 
+	cpuAllocatedGauge, err := telemetry.GetGaugeInt(meter, telemetry.OrchestratorCpuAllocatedGaugeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orchestrator CPU allocated gauge: %w", err)
+	}
+
+	memoryAllocatedGauge, err := telemetry.GetGaugeInt(meter, telemetry.OrchestratorMemoryAllocatedGaugeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orchestrator memory allocated gauge: %w", err)
+	}
+
+	diskAllocatedGauge, err := telemetry.GetGaugeInt(meter, telemetry.OrchestratorDiskAllocatedGaugeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create orchestrator disk allocated gauge: %w", err)
+	}
+
+	_, err = meter.RegisterCallback(
+		func(_ context.Context, obs metric.Observer) error {
+			var (
+				cpuAllocated    int64
+				memoryAllocated int64
+				diskAllocated   int64
+			)
+
+			for _, item := range server.sandboxFactory.Sandboxes.Items() {
+				cpuAllocated += item.Config.Vcpu
+				memoryAllocated += item.Config.RamMB * 1024 * 1024
+				diskAllocated += item.Config.TotalDiskSizeMB * 1024 * 1024
+			}
+
+			obs.ObserveInt64(cpuAllocatedGauge, cpuAllocated)
+			obs.ObserveInt64(memoryAllocatedGauge, memoryAllocated)
+			obs.ObserveInt64(diskAllocatedGauge, diskAllocated)
+
+			return nil
+		}, cpuAllocatedGauge, memoryAllocatedGauge, diskAllocatedGauge)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register orchestrator sandbox resource gauges: %w", err)
+	}
+
 	go server.refreshStartingSandboxesLimit(ctx)
 
 	return server, nil

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -148,6 +148,11 @@ const (
 	ApiOrchestratorCountMeterName GaugeIntType = "api.orchestrator.status"
 	OrchestratorStatusGaugeName   GaugeIntType = "orchestrator.status"
 
+	// Orchestrator node resources allocated to running sandboxes (sum across running sandboxes)
+	OrchestratorCpuAllocatedGaugeName    GaugeIntType = "orchestrator.sandbox.cpu.allocated"
+	OrchestratorMemoryAllocatedGaugeName GaugeIntType = "orchestrator.sandbox.memory.allocated"
+	OrchestratorDiskAllocatedGaugeName   GaugeIntType = "orchestrator.sandbox.disk.allocated"
+
 	// Sandbox metrics
 	SandboxRamUsedGaugeName   GaugeIntType = "e2b.sandbox.ram.used"
 	SandboxRamTotalGaugeName  GaugeIntType = "e2b.sandbox.ram.total"
@@ -274,29 +279,35 @@ var gaugeFloatUnits = map[GaugeFloatType]string{
 }
 
 var gaugeIntDesc = map[GaugeIntType]string{
-	ApiOrchestratorCountMeterName: "Counter of running orchestrators.",
-	OrchestratorStatusGaugeName:   "Self-reported orchestrator status (always 1, labelled with status and version).",
-	SandboxRamUsedGaugeName:       "Amount of RAM used by the sandbox.",
-	SandboxRamTotalGaugeName:      "Amount of RAM available to the sandbox.",
-	SandboxRamCacheGaugeName:      "Amount of RAM used by the page cache in the sandbox.",
-	SandboxCpuTotalGaugeName:      "Amount of CPU available to the sandbox.",
-	SandboxDiskUsedGaugeName:      "Amount of disk space used by the sandbox.",
-	SandboxDiskTotalGaugeName:     "Amount of disk space available to the sandbox.",
-	TeamSandboxRunningGaugeName:   "The number of sandboxes running for the team in the interval.",
-	SandboxCountGaugeName:         "Number of running sandbox instances per team.",
+	ApiOrchestratorCountMeterName:        "Counter of running orchestrators.",
+	OrchestratorStatusGaugeName:          "Self-reported orchestrator status (always 1, labelled with status and version).",
+	OrchestratorCpuAllocatedGaugeName:    "Total vCPUs allocated to running sandboxes on the orchestrator node.",
+	OrchestratorMemoryAllocatedGaugeName: "Total memory allocated to running sandboxes on the orchestrator node.",
+	OrchestratorDiskAllocatedGaugeName:   "Total disk space allocated to running sandboxes on the orchestrator node.",
+	SandboxRamUsedGaugeName:              "Amount of RAM used by the sandbox.",
+	SandboxRamTotalGaugeName:             "Amount of RAM available to the sandbox.",
+	SandboxRamCacheGaugeName:             "Amount of RAM used by the page cache in the sandbox.",
+	SandboxCpuTotalGaugeName:             "Amount of CPU available to the sandbox.",
+	SandboxDiskUsedGaugeName:             "Amount of disk space used by the sandbox.",
+	SandboxDiskTotalGaugeName:            "Amount of disk space available to the sandbox.",
+	TeamSandboxRunningGaugeName:          "The number of sandboxes running for the team in the interval.",
+	SandboxCountGaugeName:                "Number of running sandbox instances per team.",
 }
 
 var gaugeIntUnits = map[GaugeIntType]string{
-	ApiOrchestratorCountMeterName: "{orchestrator}",
-	OrchestratorStatusGaugeName:   "{orchestrator}",
-	SandboxRamUsedGaugeName:       "{By}",
-	SandboxRamTotalGaugeName:      "{By}",
-	SandboxRamCacheGaugeName:      "{By}",
-	SandboxCpuTotalGaugeName:      "{count}",
-	SandboxDiskUsedGaugeName:      "{By}",
-	SandboxDiskTotalGaugeName:     "{By}",
-	TeamSandboxRunningGaugeName:   "{sandbox}",
-	SandboxCountGaugeName:         "{sandbox}",
+	ApiOrchestratorCountMeterName:        "{orchestrator}",
+	OrchestratorStatusGaugeName:          "{orchestrator}",
+	OrchestratorCpuAllocatedGaugeName:    "{count}",
+	OrchestratorMemoryAllocatedGaugeName: "{By}",
+	OrchestratorDiskAllocatedGaugeName:   "{By}",
+	SandboxRamUsedGaugeName:              "{By}",
+	SandboxRamTotalGaugeName:             "{By}",
+	SandboxRamCacheGaugeName:             "{By}",
+	SandboxCpuTotalGaugeName:             "{count}",
+	SandboxDiskUsedGaugeName:             "{By}",
+	SandboxDiskTotalGaugeName:            "{By}",
+	TeamSandboxRunningGaugeName:          "{sandbox}",
+	SandboxCountGaugeName:                "{sandbox}",
 }
 
 func GetCounter(meter metric.Meter, name CounterType) (metric.Int64Counter, error) {


### PR DESCRIPTION
Add observable gauges for CPU, memory, and disk allocated to running sandboxes on the orchestrator node, under the orchestrator.sandbox.* prefix. Computed from a single Sandboxes.Items() iteration.