### PR TITLE
Fix: Support snapshots for non-default clusters

### DIFF
--- a/packages/api/internal/orchestrator/pause_instance.go
+++ b/packages/api/internal/orchestrator/pause_instance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -126,10 +127,16 @@ func buildUpsertSnapshotParams(sbx sandbox.Sandbox, node *nodemanager.Node) quer
 		metadata = types.JSONBStringMap{}
 	}
 
+	var clusterID *uuid.UUID
+	if sbx.ClusterID != consts.LocalClusterID {
+		clusterID = &sbx.ClusterID
+	}
+
 	return queries.UpsertSnapshotParams{
 		// Used if there's no snapshot for this sandbox yet
 		TemplateID:     id.Generate(),
 		TeamID:         sbx.TeamID,
+		ClusterID:      clusterID,
 		BaseTemplateID: sbx.BaseTemplateID,
 		SandboxID:      sbx.SandboxID,
 		StartedAt:      pgtype.Timestamptz{Time: sbx.StartTime, Valid: true},

--- a/packages/api/internal/orchestrator/snapshot_template.go
+++ b/packages/api/internal/orchestrator/snapshot_template.go
@@ -11,6 +11,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/db/pkg/types"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -72,7 +73,7 @@ func (o *Orchestrator) CreateSnapshotTemplate(ctx context.Context, teamID uuid.U
 		return SnapshotTemplateResult{}, fmt.Errorf("error upserting snapshot: %w", err)
 	}
 
-	snapshotTemplateEnvID, err := o.resolveOrCreateSnapshotTemplate(ctx, sandboxID, teamID, upsertResult.BuildID, sbx.NodeID, opts)
+	snapshotTemplateEnvID, err := o.resolveOrCreateSnapshotTemplate(ctx, sandboxID, teamID, upsertResult.BuildID, sbx.NodeID, sbx.ClusterID, opts)
 	if err != nil {
 		o.failSnapshotBuild(ctx, upsertResult.BuildID, err)
 
@@ -142,6 +143,7 @@ func (o *Orchestrator) resolveOrCreateSnapshotTemplate(
 	teamID uuid.UUID,
 	buildID uuid.UUID,
 	originNodeID string,
+	clusterID uuid.UUID,
 	opts SnapshotTemplateOpts,
 ) (string, error) {
 	// Existing template — just assign the build
@@ -158,10 +160,16 @@ func (o *Orchestrator) resolveOrCreateSnapshotTemplate(
 		return *opts.ExistingTemplateID, nil
 	}
 
+	var clusterIDPtr *uuid.UUID
+	if clusterID != consts.LocalClusterID {
+		clusterIDPtr = &clusterID
+	}
+
 	// Create new snapshot template env
 	envID, err := o.sqlcDB.CreateSnapshotTemplateEnv(ctx, queries.CreateSnapshotTemplateEnvParams{
 		SnapshotID:   id.Generate(),
 		TeamID:       teamID,
+		ClusterID:    clusterIDPtr,
 		SandboxID:    sandboxID,
 		OriginNodeID: &originNodeID,
 		BuildID:      &buildID,

--- a/packages/db/queries/create_new_snapshot.sql.go
+++ b/packages/db/queries/create_new_snapshot.sql.go
@@ -15,12 +15,12 @@ import (
 
 const upsertSnapshot = `-- name: UpsertSnapshot :one
 WITH new_template AS (
-    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source)
-    SELECT $1, FALSE, NULL, $2, now(), 'snapshot'
+    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source, cluster_id)
+    SELECT $1, FALSE, NULL, $2, now(), 'snapshot', $3
     WHERE NOT EXISTS (
         SELECT id
         FROM "public"."snapshots" s
-        WHERE s.sandbox_id = $3
+        WHERE s.sandbox_id = $4
     ) RETURNING id
 ),
 
@@ -40,18 +40,18 @@ snapshot as (
        created_at
     )
     VALUES (
-            $3,
             $4,
+            $5,
             $2,
             -- If snapshot already exists, new_template id will be null, env_id can't be null, so use placeholder ''
             COALESCE((SELECT id FROM new_template), ''),
-            $5,
             $6,
             $7,
             $8,
             $9,
             $10,
             $11,
+            $12,
             now()
    )
     ON CONFLICT (sandbox_id) DO UPDATE SET
@@ -83,21 +83,21 @@ new_build as (
         cpu_flags
     )
     VALUES (
-        $12,
         $13,
         $14,
         $15,
         $16,
         $17,
         $18,
-        $9,
         $19,
+        $10,
+        $20,
         now(),
-        (SELECT eb.cpu_architecture FROM "public"."env_builds" eb WHERE eb.id = $20),
-        (SELECT eb.cpu_family FROM "public"."env_builds" eb WHERE eb.id = $20),
-        (SELECT eb.cpu_model FROM "public"."env_builds" eb WHERE eb.id = $20),
-        (SELECT eb.cpu_model_name FROM "public"."env_builds" eb WHERE eb.id = $20),
-        (SELECT eb.cpu_flags FROM "public"."env_builds" eb WHERE eb.id = $20)
+        (SELECT eb.cpu_architecture FROM "public"."env_builds" eb WHERE eb.id = $21),
+        (SELECT eb.cpu_family FROM "public"."env_builds" eb WHERE eb.id = $21),
+        (SELECT eb.cpu_model FROM "public"."env_builds" eb WHERE eb.id = $21),
+        (SELECT eb.cpu_model_name FROM "public"."env_builds" eb WHERE eb.id = $21),
+        (SELECT eb.cpu_flags FROM "public"."env_builds" eb WHERE eb.id = $21)
     )
     RETURNING id as build_id
 ),
@@ -118,6 +118,7 @@ SELECT build_id, template_id FROM build_assignment
 type UpsertSnapshotParams struct {
 	TemplateID          string
 	TeamID              uuid.UUID
+	ClusterID           *uuid.UUID
 	SandboxID           string
 	BaseTemplateID      string
 	Metadata            types.JSONBStringMap
@@ -153,6 +154,7 @@ func (q *Queries) UpsertSnapshot(ctx context.Context, arg UpsertSnapshotParams) 
 	row := q.db.QueryRow(ctx, upsertSnapshot,
 		arg.TemplateID,
 		arg.TeamID,
+		arg.ClusterID,
 		arg.SandboxID,
 		arg.BaseTemplateID,
 		arg.Metadata,

--- a/packages/db/queries/create_snapshot_template_env.sql.go
+++ b/packages/db/queries/create_snapshot_template_env.sql.go
@@ -13,8 +13,8 @@ import (
 
 const createSnapshotTemplateEnv = `-- name: CreateSnapshotTemplateEnv :one
 WITH new_env AS (
-    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source)
-    VALUES ($1, FALSE, NULL, $2, now(), 'snapshot_template')
+    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source, cluster_id)
+    VALUES ($1, FALSE, NULL, $2, now(), 'snapshot_template', $3)
     RETURNING id
 ),
 
@@ -22,9 +22,9 @@ snapshot_template AS (
     INSERT INTO "public"."snapshot_templates" (env_id, sandbox_id, origin_node_id, build_id)
     VALUES (
         (SELECT id FROM new_env),
-        $3,
         $4,
-        $5
+        $5,
+        $6
     )
 ),
 
@@ -32,8 +32,8 @@ build_assignment AS (
     INSERT INTO "public"."env_build_assignments" (env_id, build_id, tag)
     VALUES (
         (SELECT id FROM new_env),
-        $5,
-        $6
+        $6,
+        $7
     )
     RETURNING env_id as snapshot_id
 )
@@ -44,6 +44,7 @@ SELECT snapshot_id FROM build_assignment
 type CreateSnapshotTemplateEnvParams struct {
 	SnapshotID   string
 	TeamID       uuid.UUID
+	ClusterID    *uuid.UUID
 	SandboxID    string
 	OriginNodeID *string
 	BuildID      *uuid.UUID
@@ -56,6 +57,7 @@ func (q *Queries) CreateSnapshotTemplateEnv(ctx context.Context, arg CreateSnaps
 	row := q.db.QueryRow(ctx, createSnapshotTemplateEnv,
 		arg.SnapshotID,
 		arg.TeamID,
+		arg.ClusterID,
 		arg.SandboxID,
 		arg.OriginNodeID,
 		arg.BuildID,

--- a/packages/db/queries/snapshots/create_new_snapshot.sql
+++ b/packages/db/queries/snapshots/create_new_snapshot.sql
@@ -1,7 +1,7 @@
 -- name: UpsertSnapshot :one
 WITH new_template AS (
-    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source)
-    SELECT @template_id, FALSE, NULL, @team_id, now(), 'snapshot'
+    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source, cluster_id)
+    SELECT @template_id, FALSE, NULL, @team_id, now(), 'snapshot', @cluster_id
     WHERE NOT EXISTS (
         SELECT id
         FROM "public"."snapshots" s

--- a/packages/db/queries/snapshots/create_snapshot_template_env.sql
+++ b/packages/db/queries/snapshots/create_snapshot_template_env.sql
@@ -2,8 +2,8 @@
 -- Creates a snapshot_template env entry with source='snapshot_template' and links it to an existing build
 -- This is used after UpsertSnapshot to create a persistent snapshot template
 WITH new_env AS (
-    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source)
-    VALUES (@snapshot_id, FALSE, NULL, @team_id, now(), 'snapshot_template')
+    INSERT INTO "public"."envs" (id, public, created_by, team_id, updated_at, source, cluster_id)
+    VALUES (@snapshot_id, FALSE, NULL, @team_id, now(), 'snapshot_template', @cluster_id)
     RETURNING id
 ),
 


### PR DESCRIPTION
Add cluster ID (if not default) to snaphost, allowing to resume template when using BYOC.