### PR TITLE
test(envd): pin create-next-app to stable in TestCommandKillNextApp

### DIFF
--- a/tests/integration/internal/tests/envd/process_test.go
+++ b/tests/integration/internal/tests/envd/process_test.go
@@ -25,7 +25,9 @@ func TestCommandKillNextApp(t *testing.T) {
 	envdClient := setup.GetEnvdClient(t, ctx)
 
 	// Run `npx create-next-app`
-	err := utils.ExecCommand(t, ctx, sbx, envdClient, "npx", "create-next-app@latest", "nextapp", "--yes")
+	// Pinned to the latest known-good stable release; `@latest` currently resolves
+	// to a 16.3.0 pre-release that ships a broken SWC binary and 404s on preview.
+	err := utils.ExecCommand(t, ctx, sbx, envdClient, "npx", "create-next-app@16.2.8", "nextapp", "--yes")
 	require.NoError(t, err)
 
 	// Run `npm run dev` in background


### PR DESCRIPTION
`create-next-app@latest` currently resolves to a `16.3.0` pre-release that ships a broken SWC binary, causing `TestCommandKillNextApp` to 404 on the Next.js dev preview. This pins the scaffold to `16.2.8`, the latest known-good stable release (the highest non-prerelease on the npm registry). The change is test-only and unrelated to other branch work — it just keeps the integration test deterministic until `latest` points back at a working stable build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)