### PR TITLE
fix(ci): arch-specific Go cache for ARM64 cross-compile

### DIFF
--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -24,8 +24,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      # Don't use go-setup-cache here: its key has no arch component, so this
+      # job would share it with amd64 jobs and restore a multi-GB cache of
+      # useless amd64 objects, then rebuild everything for arm64 on top —
+      # which can fill the runner disk (and the arm64 objects never get
+      # saved). Keep a dedicated arm64-keyed cache instead.
       - name: Setup Go
-        uses: ./.github/actions/go-setup-cache
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.work
+          cache: false
+
+      - name: Restore ARM64 Go cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-arm64-cross-${{ hashFiles('go.work', 'packages/*/go.mod', 'packages/*/go.sum') }}
+          restore-keys: go-arm64-cross-
 
       - name: Install ARM64 cross-compiler
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu


### PR DESCRIPTION
The ARM64 cross-compile job uses the shared `go-setup-cache` action, whose `setup-go` cache key has no architecture component. With the default dependency paths the key collides with amd64 jobs (e.g. generated-code-check), so the job restores a ~2.4 GB (compressed) cache of amd64 build objects it can't use, rebuilds every package for arm64 on top, and intermittently fills the runner disk — ENOSPC at link time, as in [this run](https://github.com/e2b-dev/infra/actions/runs/27241520853/job/80446184549). On an exact key hit nothing is saved back, so the arm64 build repeats in full on every PR.

Give the job its own `go-arm64-cross-*` cache for `GOMODCACHE`/`GOCACHE`: no foreign amd64 objects on disk, arm64 builds become incremental, and disk usage stays bounded.