### PR TITLE
fix(shared): deflake TestProxyRetriesOnDelayedBackendStartup

### DIFF
--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -808,15 +809,46 @@ func TestProxyDoesNotReuseConnectionsWhenBackendChanges(t *testing.T) {
 	assert.Equal(t, uint64(2), proxy.TotalPoolConnections(), "proxy should not have reused the connection")
 }
 
+// reservedPort holds a TCP socket that is bound but not yet listening:
+// connections are refused while the port stays reserved for this test, and
+// listen turns the same socket into a live listener. This avoids the
+// close-and-rebind race where another process grabs the port in between.
+type reservedPort struct {
+	fd   int
+	addr string
+}
+
+func reserveTCPPort(t *testing.T) *reservedPort {
+	t.Helper()
+
+	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrInet4{Addr: [4]byte{127, 0, 0, 1}}))
+	sa, err := syscall.Getsockname(fd)
+	require.NoError(t, err)
+
+	return &reservedPort{fd: fd, addr: fmt.Sprintf("127.0.0.1:%d", sa.(*syscall.SockaddrInet4).Port)}
+}
+
+func (r *reservedPort) listen() (net.Listener, error) {
+	if err := syscall.Listen(r.fd, 128); err != nil {
+		return nil, fmt.Errorf("listen on reserved port: %w", err)
+	}
+	if err := syscall.SetNonblock(r.fd, true); err != nil {
+		return nil, fmt.Errorf("set nonblock: %w", err)
+	}
+	f := os.NewFile(uintptr(r.fd), "reserved-port")
+	defer f.Close() // net.FileListener dups the fd
+
+	return net.FileListener(f)
+}
+
 // TestProxyRetriesOnDelayedBackendStartup simulates the scenario where a backend
 // server starts up after the initial connection attempt (like envd port forwarding delay).
 func TestProxyRetriesOnDelayedBackendStartup(t *testing.T) {
 	t.Parallel()
-	var lisCfg net.ListenConfig
-	tempListener, err := lisCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	backendAddr := tempListener.Addr().String()
-	tempListener.Close() // Close to simulate "connection refused" - small race is acceptable
+	reserved := reserveTCPPort(t)
+	backendAddr := reserved.addr
 
 	backendURL, err := url.Parse(fmt.Sprintf("http://%s", backendAddr))
 	require.NoError(t, err)
@@ -845,7 +877,7 @@ func TestProxyRetriesOnDelayedBackendStartup(t *testing.T) {
 		// Wait 300ms before starting the backend (should succeed on retry 2 or 3)
 		time.Sleep(300 * time.Millisecond)
 
-		listener, err := lisCfg.Listen(t.Context(), "tcp", backendAddr)
+		listener, err := reserved.listen()
 		if err != nil {
 			backendReady <- backendResult{nil, fmt.Errorf("failed to create delayed backend listener: %w", err)}
 

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -814,8 +814,9 @@ func TestProxyDoesNotReuseConnectionsWhenBackendChanges(t *testing.T) {
 // listen turns the same socket into a live listener. This avoids the
 // close-and-rebind race where another process grabs the port in between.
 type reservedPort struct {
-	fd   int
-	addr string
+	fd     int
+	addr   string
+	closed bool
 }
 
 func reserveTCPPort(t *testing.T) *reservedPort {
@@ -823,11 +824,24 @@ func reserveTCPPort(t *testing.T) *reservedPort {
 
 	fd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_STREAM, 0)
 	require.NoError(t, err)
+	r := &reservedPort{fd: fd}
+	t.Cleanup(r.close)
+
 	require.NoError(t, syscall.Bind(fd, &syscall.SockaddrInet4{Addr: [4]byte{127, 0, 0, 1}}))
 	sa, err := syscall.Getsockname(fd)
 	require.NoError(t, err)
+	r.addr = fmt.Sprintf("127.0.0.1:%d", sa.(*syscall.SockaddrInet4).Port)
 
-	return &reservedPort{fd: fd, addr: fmt.Sprintf("127.0.0.1:%d", sa.(*syscall.SockaddrInet4).Port)}
+	return r
+}
+
+// close releases the raw fd unless listen already handed it off.
+func (r *reservedPort) close() {
+	if r.closed {
+		return
+	}
+	r.closed = true
+	_ = syscall.Close(r.fd)
 }
 
 func (r *reservedPort) listen() (net.Listener, error) {
@@ -837,6 +851,7 @@ func (r *reservedPort) listen() (net.Listener, error) {
 	if err := syscall.SetNonblock(r.fd, true); err != nil {
 		return nil, fmt.Errorf("set nonblock: %w", err)
 	}
+	r.closed = true // fd ownership moves to the os.File below
 	f := os.NewFile(uintptr(r.fd), "reserved-port")
 	defer f.Close() // net.FileListener dups the fd
 


### PR DESCRIPTION
The test reserved a port by bind-and-close and rebound it 300 ms later, so any other process or ephemeral socket could take the port in between - it failed in CI with `bind: address already in use`. The port is now held by a bound but not-yet-listening socket the whole time: connections get refused exactly as before (exercising the proxy retry path), and the same socket starts listening when the delayed backend comes up, eliminating the race.

Verified with `-run TestProxyRetriesOnDelayedBackendStartup -count=30 -race`.