### PR TITLE
perf(orchestrator): coalesce adjacent frame fetches into ranged reads (sketch)

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk.go
@@ -95,23 +95,34 @@ func (c *Chunker) Slice(ctx context.Context, off, length int64, ft *storage.Fram
 		return nil, fmt.Errorf("failed read from cache at offset %d: %w", off, err)
 	}
 
-	// Fetch every chunk the range spans (one fetch session per chunk).
-	end := off + length
-	for cur := off; cur < end; {
-		chunkOff, chunkLen, lerr := c.locateChunk(cur, ft)
-		if lerr != nil {
+	// Coalesced path: merge adjacent uncached frames into single fetch
+	// sessions (one upstream ranged read each) and run disjoint runs
+	// concurrently instead of fetching frame by frame serially.
+	if maxFrames := c.featureFlags.IntFlag(ctx, featureflags.ChunkerCoalesceFrames); maxFrames > 1 && ft.IsCompressed() {
+		if err := c.fetchCoalesced(ctx, off, length, ft, maxFrames); err != nil {
 			timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
 
-			return nil, fmt.Errorf("failed to locate chunk for offset %d: %w", cur, lerr)
+			return nil, fmt.Errorf("failed to ensure data at %d-%d: %w", off, off+length, err)
 		}
-		chunkEnd := chunkOff + chunkLen
-		rangeEnd := min(end, chunkEnd)
-		if err := c.fetch(ctx, cur, rangeEnd-cur, ft); err != nil {
-			timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
+	} else {
+		// Fetch every chunk the range spans (one fetch session per chunk).
+		end := off + length
+		for cur := off; cur < end; {
+			chunkOff, chunkLen, lerr := c.locateChunk(cur, ft)
+			if lerr != nil {
+				timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
 
-			return nil, fmt.Errorf("failed to ensure data at %d-%d: %w", cur, rangeEnd, err)
+				return nil, fmt.Errorf("failed to locate chunk for offset %d: %w", cur, lerr)
+			}
+			chunkEnd := chunkOff + chunkLen
+			rangeEnd := min(end, chunkEnd)
+			if err := c.fetch(ctx, cur, rangeEnd-cur, ft); err != nil {
+				timer.RecordRaw(ctx, length, attrs.failRemoteFetch)
+
+				return nil, fmt.Errorf("failed to ensure data at %d-%d: %w", cur, rangeEnd, err)
+			}
+			cur = chunkEnd
 		}
-		cur = chunkEnd
 	}
 
 	// sliceDirect skips isCached — the waiter already confirmed the data is in the mmap.
@@ -182,6 +193,88 @@ func (c *Chunker) fetch(ctx context.Context, off, length int64, ft *storage.Fram
 		}
 		if err := session.registerAndWait(ctx, b); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// fetchCoalesced ensures [off, off+length) is fetched. Adjacent uncached
+// frames are merged into single fetch sessions of up to maxFrames frames
+// (one upstream ranged read each); all sessions the range needs are started
+// before any waiting happens, so disjoint runs fetch concurrently.
+func (c *Chunker) fetchCoalesced(ctx context.Context, off, length int64, ft *storage.FrameTable, maxFrames int) error {
+	type wait struct {
+		s          *fetchSession
+		start, end int64 // requested range ∩ session range
+	}
+	end := off + length
+	var waits []wait
+
+	// Plan under one lock acquisition: chunks covered by an in-flight
+	// session are joined, cached chunks are skipped, and consecutive
+	// missing chunks accumulate into runs.
+	c.fetchMu.Lock()
+	runStart, runEnd := int64(-1), int64(0)
+	runFrames := 0
+	closeRun := func() {
+		if runStart < 0 {
+			return
+		}
+		s := newFetchSession(runStart, runEnd-runStart, c.cache)
+		c.fetchSessions = append(c.fetchSessions, s)
+		go c.runFetch(context.WithoutCancel(ctx), s, ft)
+		waits = append(waits, wait{s, max(off, runStart), min(end, runEnd)})
+		runStart, runFrames = -1, 0
+	}
+	for cur := off; cur < end; {
+		chunkOff, chunkLen, err := c.locateChunk(cur, ft)
+		if err != nil {
+			closeRun()
+			c.fetchMu.Unlock()
+
+			return fmt.Errorf("failed to locate chunk for offset %d: %w", cur, err)
+		}
+		chunkEnd := chunkOff + chunkLen
+
+		switch s := c.sessionCoveringLocked(chunkOff, chunkLen); {
+		case s != nil:
+			closeRun()
+			waits = append(waits, wait{s, max(off, chunkOff), min(end, chunkEnd)})
+		case c.cache.isCached(chunkOff, chunkLen):
+			closeRun()
+		case runStart >= 0 && chunkOff == runEnd && runFrames < maxFrames:
+			runEnd = chunkEnd
+			runFrames++
+		default:
+			closeRun()
+			runStart, runEnd, runFrames = chunkOff, chunkEnd, 1
+		}
+		cur = chunkEnd
+	}
+	closeRun()
+	c.fetchMu.Unlock()
+
+	blockSize := c.cache.BlockSize()
+	for _, w := range waits {
+		startBlock := (w.start / blockSize) * blockSize
+		endBlock := ((w.end - 1) / blockSize) * blockSize
+		for b := startBlock; b <= endBlock; b += blockSize {
+			if err := w.s.registerAndWait(ctx, b); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// sessionCoveringLocked returns the in-flight session containing
+// [off, off+length), or nil. Caller must hold fetchMu.
+func (c *Chunker) sessionCoveringLocked(off, length int64) *fetchSession {
+	for _, s := range c.fetchSessions {
+		if s.contains(off, length) {
+			return s
 		}
 	}
 

--- a/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/streaming_chunk_test.go
@@ -106,31 +106,41 @@ func (s *fakeSeekable) OpenRangeReader(_ context.Context, offsetU int64, length 
 		}, nil
 	}
 
-	var fetchOff, fetchLen int64
 	if frameTable.IsCompressed() {
-		r, err := frameTable.LocateCompressed(offsetU)
-		if err != nil {
-			return nil, fmt.Errorf("frame lookup: %w", err)
+		// Serve every frame the uncompressed range spans (the production
+		// upstream honors multi-frame lengths the same way).
+		var readers []io.Reader
+		for cur := offsetU; cur < offsetU+length; {
+			u, err := frameTable.LocateUncompressed(cur)
+			if err != nil {
+				return nil, fmt.Errorf("frame lookup: %w", err)
+			}
+			c, err := frameTable.LocateCompressed(cur)
+			if err != nil {
+				return nil, fmt.Errorf("frame lookup: %w", err)
+			}
+			end := min(c.Offset+int64(c.Length), int64(len(s.data)))
+			if s.failAfter > 0 {
+				end = min(end, s.failAfter)
+			}
+			dec, err := storage.NewDecompressingReader(bytes.NewReader(s.data[c.Offset:end]), frameTable.CompressionType())
+			if err != nil {
+				return nil, err
+			}
+			readers = append(readers, dec)
+			cur = u.Offset + int64(u.Length)
 		}
 
-		fetchOff = r.Offset
-		fetchLen = int64(r.Length)
-	} else {
-		fetchOff = offsetU
-		fetchLen = length
+		return io.NopCloser(io.MultiReader(readers...)), nil
 	}
 
+	fetchOff, fetchLen := offsetU, length
 	end := min(fetchOff+fetchLen, int64(len(s.data)))
 	if s.failAfter > 0 {
 		end = min(end, s.failAfter)
 	}
 
-	r := io.Reader(bytes.NewReader(s.data[fetchOff:end]))
-	if frameTable.IsCompressed() {
-		return storage.NewDecompressingReader(r, frameTable.CompressionType())
-	}
-
-	return io.NopCloser(r), nil
+	return io.NopCloser(bytes.NewReader(s.data[fetchOff:end])), nil
 }
 
 func makeCompressedTestData(tb testing.TB, data []byte) (*storage.FrameTable, *fakeSeekable) {
@@ -190,6 +200,75 @@ func TestChunker_BasicSlice(t *testing.T) {
 			require.Equal(t, data[:testBlockSize], slice)
 		})
 	}
+}
+
+// TestChunker_CoalescedFetch verifies that with coalescing enabled, a read
+// spanning several adjacent uncached frames issues a single upstream fetch,
+// while the default path issues one per frame.
+func TestChunker_CoalescedFetch(t *testing.T) {
+	t.Parallel()
+
+	data := makeTestData(testFileSize) // 4 frames
+
+	t.Run("disabled: one fetch per frame", func(t *testing.T) {
+		t.Parallel()
+
+		ft, file := makeCompressedTestData(t, data)
+		chunker := newTestChunker(t, file, int64(len(data)))
+		defer chunker.Close()
+
+		slice, err := chunker.Slice(t.Context(), 0, int64(testFileSize), ft)
+		require.NoError(t, err)
+		require.Equal(t, data, slice)
+		require.EqualValues(t, 4, file.fetchCount.Load())
+	})
+
+	t.Run("enabled: one fetch for the whole run", func(t *testing.T) {
+		t.Parallel()
+
+		featureflags.NewIntFlag("chunker-coalesce-frames", 8)
+		ff, err := featureflags.NewClient()
+		require.NoError(t, err)
+
+		ft, file := makeCompressedTestData(t, data)
+		chunker, err := NewChunker(ff, int64(len(data)), testBlockSize, file, t.TempDir()+"/cache", newTestMetrics(t))
+		require.NoError(t, err)
+		defer chunker.Close()
+
+		slice, err := chunker.Slice(t.Context(), 0, int64(testFileSize), ft)
+		require.NoError(t, err)
+		require.Equal(t, data, slice)
+		require.EqualValues(t, 1, file.fetchCount.Load())
+
+		// Cached after the run fetch: no further upstream reads.
+		_, err = chunker.Slice(t.Context(), 0, testBlockSize, ft)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, file.fetchCount.Load())
+	})
+
+	t.Run("enabled: cached frame splits the run", func(t *testing.T) {
+		t.Parallel()
+
+		featureflags.NewIntFlag("chunker-coalesce-frames", 8)
+		ff, err := featureflags.NewClient()
+		require.NoError(t, err)
+
+		ft, file := makeCompressedTestData(t, data)
+		chunker, err := NewChunker(ff, int64(len(data)), testBlockSize, file, t.TempDir()+"/cache", newTestMetrics(t))
+		require.NoError(t, err)
+		defer chunker.Close()
+
+		// Fetch frame 2 alone, then the whole file: frames 0-1 and frame 3
+		// are two disjoint uncached runs → two more fetches.
+		_, err = chunker.Slice(t.Context(), 2*testFrameSize, testBlockSize, ft)
+		require.NoError(t, err)
+		require.EqualValues(t, 1, file.fetchCount.Load())
+
+		slice, err := chunker.Slice(t.Context(), 0, int64(testFileSize), ft)
+		require.NoError(t, err)
+		require.Equal(t, data, slice)
+		require.EqualValues(t, 3, file.fetchCount.Load())
+	})
 }
 
 // TestChunker_CacheHit verifies that a second read of the same block

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -269,6 +269,11 @@ var (
 
 	MinChunkerReadSizeKB = NewIntFlag("min-chunker-read-size-kb", 16)
 
+	// ChunkerCoalesceFrames is the maximum number of adjacent compressed
+	// frames one chunker fetch may coalesce into a single upstream ranged
+	// read. 1 or lower keeps the existing one-fetch-per-frame behavior.
+	ChunkerCoalesceFrames = NewIntFlag("chunker-coalesce-frames", 1)
+
 	// MaxParallelBuildReadSegments limits concurrent backing reads within one fragmented build read.
 	// 1 or lower keeps the existing serial path.
 	MaxParallelBuildReadSegments = NewIntFlag("max-parallel-build-read-segments", 1)

--- a/packages/shared/pkg/storage/storage_cache_seekable.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable.go
@@ -90,7 +90,7 @@ func (c *cachedSeekable) OpenRangeReader(ctx context.Context, off int64, length 
 	))
 
 	if compressed {
-		rc, err := c.openReaderCompressed(ctx, off, frameTable)
+		rc, err := c.openReaderCompressed(ctx, off, length, frameTable)
 		if err != nil {
 			recordError(span, err)
 			span.End()

--- a/packages/shared/pkg/storage/storage_cache_seekable_compressed.go
+++ b/packages/shared/pkg/storage/storage_cache_seekable_compressed.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,8 +19,19 @@ var compressedCacheReadAttrs = []attribute.KeyValue{
 
 // openReaderCompressed handles the compressed cache path for OpenRangeReader.
 // NFS stores compressed frames (.frm); on hit we decompress, on miss we fetch
-// raw compressed bytes and tee them to NFS on Close.
-func (c *cachedSeekable) openReaderCompressed(ctx context.Context, offsetU int64, frameTable *FrameTable) (io.ReadCloser, error) {
+// raw compressed bytes and tee them to NFS on Close. When the requested range
+// exactly spans several frames, missing frames that are contiguous in
+// compressed space are fetched with one upstream ranged read (see
+// frameRunReader); single-frame and unaligned requests keep the legacy path.
+func (c *cachedSeekable) openReaderCompressed(ctx context.Context, offsetU, length int64, frameTable *FrameTable) (io.ReadCloser, error) {
+	if frames, ok := collectFrameRun(frameTable, offsetU, length); ok && len(frames) > 1 {
+		return &frameRunReader{ctx: ctx, cache: c, ft: frameTable, frames: frames}, nil
+	}
+
+	return c.openSingleFrameReader(ctx, offsetU, frameTable)
+}
+
+func (c *cachedSeekable) openSingleFrameReader(ctx context.Context, offsetU int64, frameTable *FrameTable) (io.ReadCloser, error) {
 	r, err := frameTable.LocateCompressed(offsetU)
 	if err != nil {
 		return nil, fmt.Errorf("frame lookup for offset %d: %w", offsetU, err)
@@ -181,4 +193,194 @@ func (r *decompressingCacheReader) Close() error {
 // Format: {cacheBasePath}/{016xStart}-{xLength}.frm
 func makeFrameFilename(cacheBasePath string, r Range) string {
 	return fmt.Sprintf("%s/%016x-%x.frm", cacheBasePath, r.Offset, uint32(r.Length))
+}
+
+// runFrame is one frame of a coalesced read: its uncompressed and compressed
+// ranges in the stored file.
+type runFrame struct {
+	u, c Range
+}
+
+// collectFrameRun resolves the frames covering [offsetU, offsetU+length).
+// ok is false when the range does not start and end exactly on frame
+// boundaries (legacy single-frame callers) or a frame lookup fails.
+func collectFrameRun(ft *FrameTable, offsetU, length int64) ([]runFrame, bool) {
+	if length <= 0 {
+		return nil, false
+	}
+
+	var frames []runFrame
+	for cur := offsetU; cur < offsetU+length; {
+		u, err := ft.LocateUncompressed(cur)
+		if err != nil {
+			return nil, false
+		}
+		if cur == offsetU && u.Offset != offsetU {
+			return nil, false
+		}
+		cr, err := ft.LocateCompressed(cur)
+		if err != nil {
+			return nil, false
+		}
+		frames = append(frames, runFrame{u: u, c: cr})
+		cur = u.Offset + int64(u.Length)
+	}
+
+	last := frames[len(frames)-1]
+	if last.u.Offset+int64(last.u.Length) != offsetU+length {
+		return nil, false
+	}
+
+	return frames, true
+}
+
+// frameRunReader serves a run of frames sequentially: cached frames from
+// their .frm files, misses via grouped upstream reads — one ranged read per
+// maximal compressed-contiguous group of missing frames. Each missed frame
+// is decompressed through its own bounded sub-reader and written back to the
+// cache individually, so the cache layout matches the single-frame path
+// exactly.
+type frameRunReader struct {
+	ctx    context.Context //nolint:containedctx // reader API has no ctx; needed for cache write-back
+	cache  *cachedSeekable
+	ft     *FrameTable
+	frames []runFrame
+
+	idx     int
+	cur     io.ReadCloser // reader for frames[idx]
+	raw     io.ReadCloser // active grouped upstream read shared by the group
+	rawLeft int           // frames remaining in the active group (incl. current)
+	err     error
+}
+
+func (r *frameRunReader) Read(p []byte) (int, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+	for {
+		if r.cur == nil {
+			if r.idx >= len(r.frames) {
+				return 0, io.EOF
+			}
+			if err := r.openFrame(); err != nil {
+				r.err = err
+
+				return 0, err
+			}
+		}
+
+		n, err := r.cur.Read(p)
+		if err == io.EOF {
+			r.finishFrame()
+			if n > 0 {
+				return n, nil
+			}
+
+			continue
+		}
+		if err != nil {
+			r.err = err
+		}
+
+		return n, err
+	}
+}
+
+func (r *frameRunReader) openFrame() error {
+	f := r.frames[r.idx]
+	path := makeFrameFilename(r.cache.path, f.c)
+
+	// Cache-hit check only between groups: while a grouped read is active
+	// the current frame is by construction part of the miss group.
+	if r.raw == nil {
+		if fl, err := os.Open(path); err == nil {
+			if fi, statErr := fl.Stat(); statErr == nil && fi.Size() == int64(f.c.Length) {
+				recordCacheRead(r.ctx, true, int64(f.c.Length), cacheTypeSeekable, cacheOpOpenRangeReader)
+				dec, derr := newDecompressingReadCloser(fl, r.ft.CompressionType())
+				if derr != nil {
+					fl.Close()
+
+					return fmt.Errorf("decompress cached frame: %w", derr)
+				}
+				r.cur = dec
+
+				return nil
+			}
+			fl.Close()
+		}
+
+		frames, cLen := r.groupExtent()
+		raw, err := r.cache.inner.OpenRangeReader(r.ctx, f.c.Offset, cLen, nil)
+		if err != nil {
+			return fmt.Errorf("raw fetch at C=%d: %w", f.c.Offset, err)
+		}
+		r.raw = raw
+		r.rawLeft = frames
+	}
+
+	recordCacheRead(r.ctx, false, int64(f.c.Length), cacheTypeSeekable, cacheOpOpenRangeReader)
+
+	limited := io.NopCloser(io.LimitReader(r.raw, int64(f.c.Length)))
+	rc, err := newDecompressingCacheReader(limited, r.ft.CompressionType(), f.c.Length, r.cache, r.ctx, path, f.u.Offset)
+	if err != nil {
+		return fmt.Errorf("create decompressor: %w", err)
+	}
+	r.cur = rc
+
+	return nil
+}
+
+// groupExtent returns how many frames starting at idx form one upstream read:
+// consecutive in compressed space and not present in the frame cache.
+func (r *frameRunReader) groupExtent() (frames int, cLen int64) {
+	nextC := r.frames[r.idx].c.Offset
+	for i := r.idx; i < len(r.frames); i++ {
+		f := r.frames[i]
+		if f.c.Offset != nextC {
+			break // compressed-space gap: separate read
+		}
+		if i > r.idx {
+			if fi, err := os.Stat(makeFrameFilename(r.cache.path, f.c)); err == nil && fi.Size() == int64(f.c.Length) {
+				break // cached frame: serve locally, end the group
+			}
+		}
+		frames++
+		cLen += int64(f.c.Length)
+		nextC = f.c.Offset + int64(f.c.Length)
+	}
+
+	return frames, cLen
+}
+
+// finishFrame closes the completed frame reader (triggering its cache
+// write-back) and releases the grouped upstream read once exhausted.
+func (r *frameRunReader) finishFrame() {
+	if closeErr := r.cur.Close(); closeErr != nil && r.err == nil {
+		r.err = closeErr
+	}
+	r.cur = nil
+	r.idx++
+	if r.raw != nil {
+		r.rawLeft--
+		if r.rawLeft == 0 {
+			if closeErr := r.raw.Close(); closeErr != nil && r.err == nil {
+				r.err = closeErr
+			}
+			r.raw = nil
+		}
+	}
+}
+
+func (r *frameRunReader) Close() error {
+	var errs []error
+	if r.cur != nil {
+		errs = append(errs, r.cur.Close()) // drains the frame, triggering write-back
+		r.cur = nil
+	}
+	if r.raw != nil {
+		errs = append(errs, r.raw.Close())
+		r.raw = nil
+	}
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
Sketch for discussion: read-side fetch coalescing, orthogonal to the dedup budgets in #2862.

Today every cold frame miss is one remote round trip, and a read spanning several frames fetches them serially. This PR:

- Chunker: with `chunker-coalesce-frames > 1`, adjacent uncached frames merge into one fetch session per run (capped by the flag), and all sessions a read needs are started before waiting, so disjoint runs fetch concurrently. In-flight sessions are joined; cached frames split runs.
- Seekable cache: multi-frame requests are served with one upstream ranged read per compressed-contiguous group of missing frames. Each frame is still decompressed through its own bounded sub-reader and written back to its own `.frm` file - the NFS cache layout, hit path, and write-back are unchanged.

Flag default `1` = byte-for-byte current behavior. Read path only; worst case is a larger ranged GET, never different data.

Known gaps (sketch, merge-blockers tracked in EN-42): **no cap on concurrent run fetches — disjoint uncached runs all start in parallel, so simultaneous cold resumes on one node can fan out to upstream/NFS without limit; must be bounded by a flag-sized semaphore (and consider sharing a node budget with the prefetcher) before this can be enabled anywhere**. Also: the run path skips the per-frame slab timer and NFS gauge wrappers of the single-frame path; no gap tolerance yet (a cached frame always splits a run); no integration bench. Sim in #2862 predicts ~2-3x fewer round trips for fragmented restores.


Tracking: [EN-42](https://linear.app/e2b/issue/EN-42/read-side-fetch-coalescing-for-cold-sandbox-restores)

