### PR TITLE
Stop automatic envd image uploads

### DIFF
--- a/.github/workflows/build-and-upload-images.yml
+++ b/.github/workflows/build-and-upload-images.yml
@@ -94,4 +94,4 @@ jobs:
       - name: Build and upload images
         env:
           AUTO_CONFIRM_DEPLOY: true
-        run: make build-and-upload
+        run: make build-and-upload-images

--- a/.github/workflows/build-and-upload-images.yml
+++ b/.github/workflows/build-and-upload-images.yml
@@ -94,4 +94,5 @@ jobs:
       - name: Build and upload images
         env:
           AUTO_CONFIRM_DEPLOY: true
-        run: make build-and-upload-images
+          ENVD_UPLOAD_MODE: versioned
+        run: make build-and-upload

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
-          if [[ ! "$ENVD_COMMIT_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
-            echo "commit_sha must be a 7-40 character hexadecimal SHA."
+          if [[ ! "$ENVD_COMMIT_SHA" =~ ^[0-9a-f]{9}$ ]]; then
+            echo "commit_sha must be the lowercase 9-character SHA suffix uploaded by the build workflow."
             exit 1
           fi
 

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -82,27 +82,15 @@ jobs:
           ENVIRONMENT: staging
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          load_env() {
-            local key="$1"
-            local value
-            value="$(awk -v key="$key" '
-              $0 ~ "^" key "=" {
-                value = substr($0, index($0, "=") + 1)
-                if (value ~ /^'\''.*'\''$/) {
-                  value = substr(value, 2, length(value) - 2)
-                }
-                print value
-                found = 1
-                exit
-              }
-              END { if (!found) exit 1 }
-            ' .env.infisical)"
-            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
-          }
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
 
-          load_env GCP_REGION
-          load_env GCP_PROJECT_ID
-          load_env GH_WORKLOAD_IDENTITY_PROVIDER
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16
@@ -162,27 +150,15 @@ jobs:
           ENVIRONMENT: foxtrot
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          load_env() {
-            local key="$1"
-            local value
-            value="$(awk -v key="$key" '
-              $0 ~ "^" key "=" {
-                value = substr($0, index($0, "=") + 1)
-                if (value ~ /^'\''.*'\''$/) {
-                  value = substr(value, 2, length(value) - 2)
-                }
-                print value
-                found = 1
-                exit
-              }
-              END { if (!found) exit 1 }
-            ' .env.infisical)"
-            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
-          }
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
 
-          load_env GCP_REGION
-          load_env GCP_PROJECT_ID
-          load_env GH_WORKLOAD_IDENTITY_PROVIDER
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16
@@ -242,27 +218,15 @@ jobs:
           ENVIRONMENT: juliett
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          load_env() {
-            local key="$1"
-            local value
-            value="$(awk -v key="$key" '
-              $0 ~ "^" key "=" {
-                value = substr($0, index($0, "=") + 1)
-                if (value ~ /^'\''.*'\''$/) {
-                  value = substr(value, 2, length(value) - 2)
-                }
-                print value
-                found = 1
-                exit
-              }
-              END { if (!found) exit 1 }
-            ' .env.infisical)"
-            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
-          }
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
 
-          load_env GCP_REGION
-          load_env GCP_PROJECT_ID
-          load_env GH_WORKLOAD_IDENTITY_PROVIDER
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -88,6 +88,7 @@ jobs:
           . ".env.${ENVIRONMENT}"
           set +a
 
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
@@ -155,6 +156,7 @@ jobs:
           . ".env.${ENVIRONMENT}"
           set +a
 
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
@@ -222,6 +224,7 @@ jobs:
           . ".env.${ENVIRONMENT}"
           set +a
 
+          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -1,0 +1,222 @@
+name: Promote envd
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: Commit SHA suffix to promote
+        required: true
+        type: string
+      staging:
+        description: Promote to staging
+        required: false
+        type: boolean
+        default: false
+      foxtrot:
+        description: Promote to foxtrot
+        required: false
+        type: boolean
+        default: false
+      juliett:
+        description: Promote to juliett
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate-inputs:
+    name: Validate inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Validate commit SHA
+        env:
+          ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          if [[ ! "$ENVD_COMMIT_SHA" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+            echo "commit_sha must be a 7-40 character hexadecimal SHA."
+            exit 1
+          fi
+
+      - name: Require an environment
+        if: ${{ inputs.staging != true && inputs.foxtrot != true && inputs.juliett != true }}
+        run: |
+          echo "Select at least one environment to promote envd."
+          exit 1
+
+  promote-staging:
+    name: Promote envd to staging
+    needs: validate-inputs
+    if: ${{ inputs.staging == true }}
+    runs-on: ci-builder
+    environment: staging
+    concurrency:
+      group: promote-envd-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Pull deployment secrets into temporary file
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment"
+          env-slug: "staging"
+          export-type: "file"
+          file-output-path: "/.env.infisical"
+
+      - name: Load deployment environment
+        env:
+          ENVIRONMENT: staging
+        run: |
+          echo "${ENVIRONMENT}" > .last_used_env
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+
+      - name: Setup Service Account
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GH_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Promote envd
+        env:
+          ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: make -C packages/envd promote
+
+  promote-foxtrot:
+    name: Promote envd to foxtrot
+    needs: validate-inputs
+    if: ${{ inputs.foxtrot == true }}
+    runs-on: ci-builder
+    environment: foxtrot
+    concurrency:
+      group: promote-envd-foxtrot
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Pull deployment secrets into temporary file
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment"
+          env-slug: "foxtrot"
+          export-type: "file"
+          file-output-path: "/.env.infisical"
+
+      - name: Load deployment environment
+        env:
+          ENVIRONMENT: foxtrot
+        run: |
+          echo "${ENVIRONMENT}" > .last_used_env
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+
+      - name: Setup Service Account
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GH_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Promote envd
+        env:
+          ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: make -C packages/envd promote
+
+  promote-juliett:
+    name: Promote envd to juliett
+    needs: validate-inputs
+    if: ${{ inputs.juliett == true }}
+    runs-on: ci-builder
+    environment: juliett
+    concurrency:
+      group: promote-envd-juliett
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Pull deployment secrets into temporary file
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment"
+          env-slug: "juliett"
+          export-type: "file"
+          file-output-path: "/.env.infisical"
+
+      - name: Load deployment environment
+        env:
+          ENVIRONMENT: juliett
+        run: |
+          echo "${ENVIRONMENT}" > .last_used_env
+          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+
+          set -a
+          . ".env.${ENVIRONMENT}"
+          set +a
+
+          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
+          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+
+      - name: Setup Service Account
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+          workload_identity_provider: ${{ env.GH_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Promote envd
+        env:
+          ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: make -C packages/envd promote

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -91,6 +91,15 @@ jobs:
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
+      - name: Load runtime environment
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment-env"
+          env-slug: "staging"
+          export-type: "env"
+
       - name: Setup Service Account
         uses: google-github-actions/auth@v3
         with:
@@ -149,6 +158,15 @@ jobs:
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
 
+      - name: Load runtime environment
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment-env"
+          env-slug: "foxtrot"
+          export-type: "env"
+
       - name: Setup Service Account
         uses: google-github-actions/auth@v3
         with:
@@ -206,6 +224,15 @@ jobs:
 
           echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
           echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+
+      - name: Load runtime environment
+        uses: Infisical/secrets-action@v1.0.16
+        with:
+          method: "oidc"
+          identity-id: ${{ vars.INFISICAL_MACHINE_IDENTITY_ID }}
+          project-slug: "infra-deployment-env"
+          env-slug: "juliett"
+          export-type: "env"
 
       - name: Setup Service Account
         uses: google-github-actions/auth@v3

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           ENVD_COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
-          if [[ ! "$ENVD_COMMIT_SHA" =~ ^[0-9a-f]{9}$ ]]; then
-            echo "commit_sha must be the lowercase 9-character SHA suffix uploaded by the build workflow."
+          if [[ ! "$ENVD_COMMIT_SHA" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "commit_sha must be a lowercase hexadecimal Git SHA suffix."
             exit 1
           fi
 

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -82,15 +82,27 @@ jobs:
           ENVIRONMENT: staging
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+          load_env() {
+            local key="$1"
+            local value
+            value="$(awk -v key="$key" '
+              $0 ~ "^" key "=" {
+                value = substr($0, index($0, "=") + 1)
+                if (value ~ /^'\''.*'\''$/) {
+                  value = substr(value, 2, length(value) - 2)
+                }
+                print value
+                found = 1
+                exit
+              }
+              END { if (!found) exit 1 }
+            ' .env.infisical)"
+            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
+          }
 
-          set -a
-          . ".env.${ENVIRONMENT}"
-          set +a
-
-          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
-          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
-          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+          load_env GCP_REGION
+          load_env GCP_PROJECT_ID
+          load_env GH_WORKLOAD_IDENTITY_PROVIDER
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16
@@ -150,15 +162,27 @@ jobs:
           ENVIRONMENT: foxtrot
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+          load_env() {
+            local key="$1"
+            local value
+            value="$(awk -v key="$key" '
+              $0 ~ "^" key "=" {
+                value = substr($0, index($0, "=") + 1)
+                if (value ~ /^'\''.*'\''$/) {
+                  value = substr(value, 2, length(value) - 2)
+                }
+                print value
+                found = 1
+                exit
+              }
+              END { if (!found) exit 1 }
+            ' .env.infisical)"
+            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
+          }
 
-          set -a
-          . ".env.${ENVIRONMENT}"
-          set +a
-
-          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
-          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
-          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+          load_env GCP_REGION
+          load_env GCP_PROJECT_ID
+          load_env GH_WORKLOAD_IDENTITY_PROVIDER
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16
@@ -218,15 +242,27 @@ jobs:
           ENVIRONMENT: juliett
         run: |
           echo "${ENVIRONMENT}" > .last_used_env
-          cat .env.infisical | sed "s/='\(.*\)'$/=\1/g" > ".env.${ENVIRONMENT}"
+          load_env() {
+            local key="$1"
+            local value
+            value="$(awk -v key="$key" '
+              $0 ~ "^" key "=" {
+                value = substr($0, index($0, "=") + 1)
+                if (value ~ /^'\''.*'\''$/) {
+                  value = substr(value, 2, length(value) - 2)
+                }
+                print value
+                found = 1
+                exit
+              }
+              END { if (!found) exit 1 }
+            ' .env.infisical)"
+            printf "%s=%s\n" "$key" "$value" >> "$GITHUB_ENV"
+          }
 
-          set -a
-          . ".env.${ENVIRONMENT}"
-          set +a
-
-          echo "GCP_REGION=${GCP_REGION}" >> "$GITHUB_ENV"
-          echo "GCP_PROJECT_ID=${GCP_PROJECT_ID}" >> "$GITHUB_ENV"
-          echo "GH_WORKLOAD_IDENTITY_PROVIDER=${GH_WORKLOAD_IDENTITY_PROVIDER}" >> "$GITHUB_ENV"
+          load_env GCP_REGION
+          load_env GCP_PROJECT_ID
+          load_env GH_WORKLOAD_IDENTITY_PROVIDER
 
       - name: Load runtime environment
         uses: Infisical/secrets-action@v1.0.16

--- a/Makefile
+++ b/Makefile
@@ -83,17 +83,6 @@ build-and-upload:build-and-upload/template-manager
 build-and-upload:build-and-upload/envd
 build-and-upload:build-and-upload/clickhouse-migrator
 build-and-upload:build-and-upload/nomad-nodepool-apm
-
-.PHONY: build-and-upload-images
-build-and-upload-images:build-and-upload/api
-build-and-upload-images:build-and-upload/client-proxy
-build-and-upload-images:build-and-upload/dashboard-api
-build-and-upload-images:build-and-upload/docker-reverse-proxy
-build-and-upload-images:build-and-upload/clean-nfs-cache
-build-and-upload-images:build-and-upload/orchestrator
-build-and-upload-images:build-and-upload/template-manager
-build-and-upload-images:build-and-upload/clickhouse-migrator
-build-and-upload-images:build-and-upload/nomad-nodepool-apm
 build-and-upload/clean-nfs-cache:
 	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
 	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/orchestrator build-and-upload/clean-nfs-cache

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,17 @@ build-and-upload:build-and-upload/template-manager
 build-and-upload:build-and-upload/envd
 build-and-upload:build-and-upload/clickhouse-migrator
 build-and-upload:build-and-upload/nomad-nodepool-apm
+
+.PHONY: build-and-upload-images
+build-and-upload-images:build-and-upload/api
+build-and-upload-images:build-and-upload/client-proxy
+build-and-upload-images:build-and-upload/dashboard-api
+build-and-upload-images:build-and-upload/docker-reverse-proxy
+build-and-upload-images:build-and-upload/clean-nfs-cache
+build-and-upload-images:build-and-upload/orchestrator
+build-and-upload-images:build-and-upload/template-manager
+build-and-upload-images:build-and-upload/clickhouse-migrator
+build-and-upload-images:build-and-upload/nomad-nodepool-apm
 build-and-upload/clean-nfs-cache:
 	./scripts/confirm.sh $(TERRAFORM_ENVIRONMENT)
 	GCP_PROJECT_ID=$(GCP_PROJECT_ID) $(MAKE) -C packages/orchestrator build-and-upload/clean-nfs-cache

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -1,7 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
-BUILD := $(shell git rev-parse --short HEAD)
+BUILD := $(shell git rev-parse --short=9 HEAD)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -7,6 +7,7 @@ PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
+ENVD_UPLOAD_MODE ?= latest
 
 # Architecture for builds. Defaults to amd64; override for ARM64 builds.
 # (e.g., BUILD_ARCH=arm64 make build-local)
@@ -22,9 +23,17 @@ init:
 upload:
 	chmod +x bin/envd
 ifeq ($(PROVIDER),aws)
+ifeq ($(ENVD_UPLOAD_MODE),versioned)
+	aws s3 cp ./bin/envd "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd.$(BUILD)" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+else
 	aws s3 cp ./bin/envd "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+endif
+else
+ifeq ($(ENVD_UPLOAD_MODE),versioned)
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp bin/envd "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd.$(BUILD)"
 else
 	gsutil -h "Cache-Control:no-cache, max-age=0" cp bin/envd "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd"
+endif
 endif
 
 build:
@@ -49,8 +58,8 @@ start-docker:
 	/usr/bin/envd -isnotfc -verbose
 
 build-and-upload:
-	make build
-	make upload
+	$(MAKE) build
+	$(MAKE) upload
 
 .PHONY: generate
 generate:

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -1,7 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
-BUILD := $(shell git rev-parse --short=9 HEAD)
+BUILD := $(shell git rev-parse --short HEAD)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -1,7 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
-BUILD := $(shell git rev-parse HEAD | cut -c1-9)
+BUILD := $(shell git rev-parse --short=9 HEAD)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -1,7 +1,7 @@
 ENV := $(shell cat ../../.last_used_env || echo "not-set")
 -include ../../.env.${ENV}
 
-BUILD := $(shell git rev-parse --short=9 HEAD)
+BUILD := $(shell git rev-parse HEAD | cut -c1-9)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
 

--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -36,6 +36,15 @@ else
 endif
 endif
 
+.PHONY: promote
+promote:
+	$(if $(ENVD_COMMIT_SHA),,$(error ENVD_COMMIT_SHA is required))
+ifeq ($(PROVIDER),aws)
+	aws s3 cp "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA)" "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+else
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA)" "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd"
+endif
+
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -trimpath -buildvcs=false -a -o bin/envd ${PROD_LDFLAGS}
 


### PR DESCRIPTION
## Summary
- upload envd as an immutable envd.<sha> artifact from the automatic image workflow
- keep local envd uploads targeting the mutable envd object by default
- add a manual Promote envd workflow with commit SHA input and staging/foxtrot/juliett checkboxes

## Validation
- make -n -C packages/envd build-and-upload uploads bare envd
- ENVD_UPLOAD_MODE=versioned make -n -C packages/envd build-and-upload uploads envd.<sha>
- make -n -C packages/envd promote ENVD_COMMIT_SHA=abc1234 copies envd.abc1234 to bare envd
- workflow YAML parses with Ruby YAML.load_file
- git diff --check