### PR TITLE
feat(orchestrator): honor ALLOW_SANDBOX_INTERNAL_CIDRS in TCP egress firewall

### DIFF
--- a/packages/orchestrator/benchmarks/benchmark_test.go
+++ b/packages/orchestrator/benchmarks/benchmark_test.go
@@ -232,13 +232,14 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 
 	var proxyPort uint16 = 5007
 
-	tcpFirewall := tcpfirewall.New(
+	tcpFirewall, err := tcpfirewall.New(
 		l,
 		config.NetworkConfig,
 		sandboxes,
 		noop.NewMeterProvider(),
 		featureFlags,
 	)
+	require.NoError(b, err)
 	go func() {
 		err := tcpFirewall.Start(b.Context())
 		assert.NoError(b, err)

--- a/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
+++ b/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
@@ -301,7 +301,8 @@ func BenchmarkConcurrentResume(b *testing.B) {
 
 	var proxyPort uint16 = 5007
 
-	tcpFw := tcpfirewall.New(l, config.NetworkConfig, sandboxes, noop.NewMeterProvider(), featureFlags)
+	tcpFw, err := tcpfirewall.New(l, config.NetworkConfig, sandboxes, noop.NewMeterProvider(), featureFlags)
+	require.NoError(b, err)
 	go func() { assert.NoError(b, tcpFw.Start(b.Context())) }()
 	b.Cleanup(func() {
 		ctx := context.WithoutCancel(b.Context())

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -281,7 +281,10 @@ func doBuild(
 	}()
 	defer sandboxProxy.Close(parentCtx)
 
-	tcpFirewall := tcpfirewall.New(l, networkConfig, sandboxes, noop.NewMeterProvider(), featureFlags)
+	tcpFirewall, err := tcpfirewall.New(l, networkConfig, sandboxes, noop.NewMeterProvider(), featureFlags)
+	if err != nil {
+		return fmt.Errorf("error creating TCP firewall: %w", err)
+	}
 	go tcpFirewall.Start(ctx)
 	defer tcpFirewall.Close(parentCtx)
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -1075,7 +1075,10 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if verbose {
 		fmt.Println("🔧 Starting TCP firewall...")
 	}
-	tcpFw := tcpfirewall.New(l, config.NetworkConfig, sandboxes, tel.MeterProvider, flags)
+	tcpFw, err := tcpfirewall.New(l, config.NetworkConfig, sandboxes, tel.MeterProvider, flags)
+	if err != nil {
+		return fmt.Errorf("error creating TCP firewall: %w", err)
+	}
 	go tcpFw.Start(ctx)
 	defer tcpFw.Close(context.WithoutCancel(ctx))
 

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -198,7 +198,8 @@ func newTestInfra(t *testing.T, ctx context.Context) *testInfra {
 	// Sandbox proxy + TCP firewall
 	sandboxes := sandbox.NewSandboxesMap()
 
-	tcpFw := tcpfirewall.New(l, networkConfig, sandboxes, noop.NewMeterProvider(), flags)
+	tcpFw, err := tcpfirewall.New(l, networkConfig, sandboxes, noop.NewMeterProvider(), flags)
+	require.NoError(t, err)
 	go tcpFw.Start(ctx)
 	ti.closers = append(ti.closers, func(ctx context.Context) { tcpFw.Close(ctx) })
 

--- a/packages/orchestrator/main.go
+++ b/packages/orchestrator/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
@@ -40,13 +41,16 @@ func applyTestFlagOverrides() {
 }
 
 func defaultEgressFactory(_ context.Context, deps *factories.Deps) (*factories.EgressSetup, error) {
-	fw := tcpfirewall.New(
+	fw, err := tcpfirewall.New(
 		deps.Logger,
 		deps.Config.NetworkConfig,
 		deps.Sandboxes,
 		deps.MeterProvider,
 		deps.FeatureFlags,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TCP firewall: %w", err)
+	}
 
 	return &factories.EgressSetup{
 		Proxy: fw,

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -71,6 +71,9 @@ type Config struct {
 	// Comma-separated CIDRs to allow through the predefined firewall deny list.
 	// These are allowed before the private-range deny rules, so they can
 	// reach hosts in the 10.0.0.0/8, 172.16.0.0/12, etc. blocks.
+	// They are also honored by the TCP egress firewall proxy: they take
+	// precedence over user deny rules and exempt domain-resolved IPs from
+	// the always-denied internal ranges.
 	AllowSandboxInternalCIDRs []string `env:"ALLOW_SANDBOX_INTERNAL_CIDRS" envDefault:"" envSeparator:","`
 
 	// TCP firewall ports - separate ports for different traffic types to avoid

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -71,9 +71,6 @@ type Config struct {
 	// Comma-separated CIDRs to allow through the predefined firewall deny list.
 	// These are allowed before the private-range deny rules, so they can
 	// reach hosts in the 10.0.0.0/8, 172.16.0.0/12, etc. blocks.
-	// They are also honored by the TCP egress firewall proxy: they take
-	// precedence over user deny rules and exempt domain-resolved IPs from
-	// the always-denied internal ranges.
 	AllowSandboxInternalCIDRs []string `env:"ALLOW_SANDBOX_INTERNAL_CIDRS" envDefault:"" envSeparator:","`
 
 	// TCP firewall ports - separate ports for different traffic types to avoid

--- a/packages/orchestrator/pkg/tcpfirewall/handlers.go
+++ b/packages/orchestrator/pkg/tcpfirewall/handlers.go
@@ -27,7 +27,7 @@ const (
 )
 
 // domainHandler handles connections with hostname information (HTTP Host header or TLS SNI).
-func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, internalAllowedNets []*net.IPNet) {
 	// Get hostname from tcpproxy's wrapped connection (HTTP Host or TLS SNI).
 	// Hostname can be empty, e.g. for https://1.1.1.1 like requests.
 	var hostname string
@@ -35,7 +35,7 @@ func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int
 		hostname = tc.HostName
 	}
 
-	allowed, matchType, err := isEgressAllowed(sbx, hostname, dstIP)
+	allowed, matchType, err := isEgressAllowed(sbx, hostname, dstIP, internalAllowedNets)
 	if err != nil {
 		logger.Error(ctx, "Egress check failed", zap.Error(err))
 		metrics.RecordError(ctx, ErrorTypeEgressCheck, protocol)
@@ -60,7 +60,7 @@ func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int
 	// After connecting, we verify the connected IP is not internal/private.
 	if matchType == MatchTypeDomain {
 		upstreamAddr := net.JoinHostPort(hostname, fmt.Sprintf("%d", dstPort))
-		proxyWithIPVerification(ctx, conn, upstreamAddr, logger, metrics, protocol)
+		proxyWithIPVerification(ctx, conn, upstreamAddr, logger, metrics, protocol, internalAllowedNets)
 
 		return
 	}
@@ -71,9 +71,9 @@ func domainHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int
 }
 
 // cidrOnlyHandler handles connections without hostname information.
-func cidrOnlyHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func cidrOnlyHandler(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, internalAllowedNets []*net.IPNet) {
 	// No hostname available for CIDR-only handler
-	allowed, matchType, err := isEgressAllowed(sbx, noHostnameValue, dstIP)
+	allowed, matchType, err := isEgressAllowed(sbx, noHostnameValue, dstIP, internalAllowedNets)
 	if err != nil {
 		logger.Error(ctx, "Egress check failed", zap.Error(err))
 		metrics.RecordError(ctx, ErrorTypeEgressCheck, protocol)
@@ -115,7 +115,7 @@ func proxy(ctx context.Context, conn net.Conn, upstreamAddr string, metrics *Met
 //
 // The ControlContext callback is called after DNS resolution but before the TCP connect()
 // syscall, so no TCP handshake occurs to internal IPs.
-func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr string, logger logger.Logger, metrics *Metrics, protocol Protocol) {
+func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr string, logger logger.Logger, metrics *Metrics, protocol Protocol, internalAllowedNets []*net.IPNet) {
 	tracker := metrics.TrackConnection(protocol)
 	defer tracker.Close(ctx)
 
@@ -142,7 +142,7 @@ func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr st
 						return fmt.Errorf("failed to parse IP from resolved address %q", host)
 					}
 
-					if isIPInAlwaysDeniedCIDRs(resolvedIP) {
+					if isIPInAlwaysDeniedCIDRs(resolvedIP, internalAllowedNets) {
 						logger.Warn(ctx, "Blocked connection to internal IP via hostname",
 							zap.String("upstream_addr", addr),
 							zap.String("resolved_ip", resolvedIP.String()))
@@ -164,17 +164,23 @@ func proxyWithIPVerification(ctx context.Context, conn net.Conn, upstreamAddr st
 // isEgressAllowed checks if egress is allowed based on domain and CIDR rules.
 // Returns the allowed status and the match type for metrics.
 // Priority order:
-//  1. Allow domain / Allow CIDR (if either matches → allow)
-//  2. Deny domain / Deny CIDR (if either matches → deny)
-//  3. Default: allow
-func isEgressAllowed(sbx *sandbox.Sandbox, hostname string, ip net.IP) (bool, MatchType, error) {
+//  1. Infra-level internal allowlist (ALLOW_SANDBOX_INTERNAL_CIDRS) → allow.
+//  2. Allow domain / Allow CIDR (if either matches → allow)
+//  3. Deny domain / Deny CIDR (if either matches → deny)
+//  4. Default: allow
+func isEgressAllowed(sbx *sandbox.Sandbox, hostname string, ip net.IP, internalAllowedNets []*net.IPNet) (bool, MatchType, error) {
+	// Priority 1: infra-level whitelisted CIDRs are always allowed.
+	if sandbox_network.IPInNets(ip, internalAllowedNets) {
+		return true, MatchTypeInternal, nil
+	}
+
 	egress := sbx.Config.GetNetworkEgress()
 	if egress == nil {
 		// No egress configuration, allow all traffic.
 		return true, MatchTypeNone, nil
 	}
 
-	// Priority 1: Check allowed domains
+	// Priority 2: Check allowed domains
 	if hostname != noHostnameValue {
 		for _, domain := range egress.GetAllowedDomains() {
 			if matchDomain(hostname, domain) {
@@ -183,7 +189,7 @@ func isEgressAllowed(sbx *sandbox.Sandbox, hostname string, ip net.IP) (bool, Ma
 		}
 	}
 
-	// Priority 1: Check allowed CIDRs
+	// Priority 2: Check allowed CIDRs
 	for _, cidr := range egress.GetAllowedCidrs() {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -195,7 +201,7 @@ func isEgressAllowed(sbx *sandbox.Sandbox, hostname string, ip net.IP) (bool, Ma
 		}
 	}
 
-	// Priority 2: Check denied CIDRs
+	// Priority 3: Check denied CIDRs
 	for _, cidr := range egress.GetDeniedCidrs() {
 		_, ipNet, err := net.ParseCIDR(cidr)
 		if err != nil {
@@ -233,17 +239,11 @@ func matchDomain(hostname, pattern string) bool {
 }
 
 // isIPInAlwaysDeniedCIDRs checks if an IP is within the denied sandbox CIDRs (internal/private ranges).
-func isIPInAlwaysDeniedCIDRs(ip net.IP) bool {
-	for _, cidr := range sandbox_network.DeniedSandboxCIDRs {
-		_, ipNet, err := net.ParseCIDR(cidr)
-		if err != nil {
-			continue
-		}
-
-		if ipNet.Contains(ip) {
-			return true
-		}
+// IPs covered by the infra-level internal allowlist (ALLOW_SANDBOX_INTERNAL_CIDRS) are exempt.
+func isIPInAlwaysDeniedCIDRs(ip net.IP, internalAllowedNets []*net.IPNet) bool {
+	if sandbox_network.IPInNets(ip, internalAllowedNets) {
+		return false
 	}
 
-	return false
+	return sandbox_network.IPInNets(ip, sandbox_network.DeniedSandboxIPNets)
 }

--- a/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
+++ b/packages/orchestrator/pkg/tcpfirewall/handlers_test.go
@@ -132,12 +132,13 @@ func TestMatchDomain(t *testing.T) {
 func TestIsEgressAllowed(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		network   *orchestrator.SandboxNetworkConfig
-		hostname  string
-		ip        net.IP
-		want      bool
-		wantError bool
+		name          string
+		network       *orchestrator.SandboxNetworkConfig
+		hostname      string
+		ip            net.IP
+		internalCIDRs []string
+		want          bool
+		wantError     bool
 	}{
 		// ---------------------------------------------------------------------
 		// Default Allow Behavior
@@ -340,6 +341,55 @@ func TestIsEgressAllowed(t *testing.T) {
 		},
 
 		// ---------------------------------------------------------------------
+		// Infra-level Internal Allowlist (ALLOW_SANDBOX_INTERNAL_CIDRS)
+		// Always wins, even over user deny rules.
+		// ---------------------------------------------------------------------
+		{
+			name: "internal allowlist bypasses user deny all",
+			network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{
+					DeniedCidrs: []string{sandbox_network.AllInternetTrafficCIDR},
+				},
+			},
+			hostname:      "",
+			ip:            net.ParseIP("10.0.11.254"),
+			internalCIDRs: []string{"10.0.11.254/32"},
+			want:          true,
+		},
+		{
+			name: "internal allowlist bypasses specific user deny",
+			network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{
+					DeniedCidrs: []string{"10.0.0.0/8"},
+				},
+			},
+			hostname:      "",
+			ip:            net.ParseIP("10.0.11.254"),
+			internalCIDRs: []string{"10.0.11.254/32"},
+			want:          true,
+		},
+		{
+			name: "IP outside internal allowlist still blocked by user deny",
+			network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{
+					DeniedCidrs: []string{"10.0.0.0/8"},
+				},
+			},
+			hostname:      "",
+			ip:            net.ParseIP("10.0.11.253"),
+			internalCIDRs: []string{"10.0.11.254/32"},
+			want:          false,
+		},
+		{
+			name:          "internal allowlist works with nil egress config",
+			network:       &orchestrator.SandboxNetworkConfig{},
+			hostname:      "",
+			ip:            net.ParseIP("10.0.11.254"),
+			internalCIDRs: []string{"10.0.11.254/32"},
+			want:          true,
+		},
+
+		// ---------------------------------------------------------------------
 		// Error Handling
 		// ---------------------------------------------------------------------
 		{
@@ -390,7 +440,12 @@ func TestIsEgressAllowed(t *testing.T) {
 				},
 			}
 
-			got, _, err := isEgressAllowed(sbx, tt.hostname, tt.ip)
+			internalNets, err := sandbox_network.ParseCIDRs(tt.internalCIDRs)
+			if err != nil {
+				t.Fatalf("failed to parse internal CIDRs: %v", err)
+			}
+
+			got, _, err := isEgressAllowed(sbx, tt.hostname, tt.ip, internalNets)
 
 			if tt.wantError {
 				if err == nil {
@@ -416,35 +471,42 @@ func TestIsEgressAllowed(t *testing.T) {
 func TestAlwaysDeniedCIDRs(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name string
-		ip   string
-		want bool
+		name          string
+		ip            string
+		internalCIDRs []string
+		want          bool
 	}{
 		// IPs in denied CIDRs (internal/private ranges)
-		{"10.0.0.1 is denied", "10.0.0.1", true},
-		{"10.255.255.255 is denied", "10.255.255.255", true},
-		{"192.168.1.1 is denied", "192.168.1.1", true},
-		{"172.16.0.1 is denied", "172.16.0.1", true},
-		{"172.31.255.255 is denied", "172.31.255.255", true},
-		{"169.254.1.1 is denied (link-local)", "169.254.1.1", true},
-		{"127.0.0.1 is denied (loopback)", "127.0.0.1", true},
+		{"10.0.0.1 is denied", "10.0.0.1", nil, true},
+		{"10.255.255.255 is denied", "10.255.255.255", nil, true},
+		{"192.168.1.1 is denied", "192.168.1.1", nil, true},
+		{"172.16.0.1 is denied", "172.16.0.1", nil, true},
+		{"172.31.255.255 is denied", "172.31.255.255", nil, true},
+		{"169.254.1.1 is denied (link-local)", "169.254.1.1", nil, true},
+		{"127.0.0.1 is denied (loopback)", "127.0.0.1", nil, true},
 
 		// IPs NOT in denied CIDRs (public IPs)
-		{"8.8.8.8 is allowed (Google DNS)", "8.8.8.8", false},
-		{"1.1.1.1 is allowed (Cloudflare)", "1.1.1.1", false},
-		{"142.250.80.46 is allowed (Google)", "142.250.80.46", false},
+		{"8.8.8.8 is allowed (Google DNS)", "8.8.8.8", nil, false},
+		{"1.1.1.1 is allowed (Cloudflare)", "1.1.1.1", nil, false},
+		{"142.250.80.46 is allowed (Google)", "142.250.80.46", nil, false},
 
 		// IPv6 denied ranges
-		{"::1 is denied (IPv6 loopback)", "::1", true},
-		{"fc00::1 is denied (IPv6 unique local)", "fc00::1", true},
-		{"fe80::1 is denied (IPv6 link-local)", "fe80::1", true},
+		{"::1 is denied (IPv6 loopback)", "::1", nil, true},
+		{"fc00::1 is denied (IPv6 unique local)", "fc00::1", nil, true},
+		{"fe80::1 is denied (IPv6 link-local)", "fe80::1", nil, true},
 
 		// IPv6 allowed (public)
-		{"2001:4860:4860::8888 is allowed (Google IPv6 DNS)", "2001:4860:4860::8888", false},
+		{"2001:4860:4860::8888 is allowed (Google IPv6 DNS)", "2001:4860:4860::8888", nil, false},
 
 		// Edge cases around CIDR boundaries
-		{"172.15.255.255 is allowed (just before 172.16.0.0/12)", "172.15.255.255", false},
-		{"172.32.0.0 is allowed (just after 172.16.0.0/12)", "172.32.0.0", false},
+		{"172.15.255.255 is allowed (just before 172.16.0.0/12)", "172.15.255.255", nil, false},
+		{"172.32.0.0 is allowed (just after 172.16.0.0/12)", "172.32.0.0", nil, false},
+
+		// Infra-level internal allowlist exemptions
+		{"10.0.11.254 is allowed when whitelisted", "10.0.11.254", []string{"10.0.11.254/32"}, false},
+		{"10.0.11.253 is denied when only 10.0.11.254/32 whitelisted", "10.0.11.253", []string{"10.0.11.254/32"}, true},
+		{"192.168.1.1 is allowed when range whitelisted", "192.168.1.1", []string{"192.168.0.0/16"}, false},
+		{"bare IP whitelist entry is treated as /32", "10.0.11.254", []string{"10.0.11.254"}, false},
 	}
 
 	for _, tt := range tests {
@@ -455,7 +517,12 @@ func TestAlwaysDeniedCIDRs(t *testing.T) {
 				t.Fatalf("Failed to parse IP: %s", tt.ip)
 			}
 
-			got := isIPInAlwaysDeniedCIDRs(ip)
+			internalNets, err := sandbox_network.ParseCIDRs(tt.internalCIDRs)
+			if err != nil {
+				t.Fatalf("failed to parse internal CIDRs: %v", err)
+			}
+
+			got := isIPInAlwaysDeniedCIDRs(ip, internalNets)
 			if got != tt.want {
 				t.Errorf("isIPInDeniedCIDRs(%s) = %v, want %v", tt.ip, got, tt.want)
 			}

--- a/packages/orchestrator/pkg/tcpfirewall/metrics.go
+++ b/packages/orchestrator/pkg/tcpfirewall/metrics.go
@@ -37,7 +37,9 @@ type MatchType string
 const (
 	MatchTypeDomain MatchType = "domain"
 	MatchTypeCIDR   MatchType = "cidr"
-	MatchTypeNone   MatchType = "none"
+	// MatchTypeInternal is an infra-level internal allowlist match (ALLOW_SANDBOX_INTERNAL_CIDRS).
+	MatchTypeInternal MatchType = "internal"
+	MatchTypeNone     MatchType = "none"
 )
 
 // ErrorType represents the type of error that occurred.

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -47,12 +47,10 @@ type Proxy struct {
 	proxy      *tcpproxy.Proxy
 }
 
-func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.Map, meterProvider metric.MeterProvider, featureFlags *featureflags.Client) *Proxy {
+func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.Map, meterProvider metric.MeterProvider, featureFlags *featureflags.Client) (*Proxy, error) {
 	internalAllowedNets, err := sandbox_network.ParseCIDRs(networkConfig.AllowSandboxInternalCIDRs)
 	if err != nil {
-		logger.Error(context.Background(), "failed to parse ALLOW_SANDBOX_INTERNAL_CIDRS for TCP firewall",
-			zap.Strings("cidrs", networkConfig.AllowSandboxInternalCIDRs),
-			zap.Error(err))
+		return nil, fmt.Errorf("error parsing internal allowed CIDRs: %w", err)
 	}
 
 	p := &Proxy{
@@ -75,7 +73,7 @@ func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.
 
 	sandboxes.Subscribe(p)
 
-	return p
+	return p, nil
 }
 
 func (p *Proxy) OnInsert(_ context.Context, _ *sandbox.Sandbox) {}

--- a/packages/orchestrator/pkg/tcpfirewall/proxy.go
+++ b/packages/orchestrator/pkg/tcpfirewall/proxy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/connlimit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 )
 
 var _ sandbox.MapSubscriber = (*Proxy)(nil)
@@ -38,20 +39,32 @@ type Proxy struct {
 	tlsPort   uint16 // For port 443 traffic - TLS SNI inspection
 	otherPort uint16 // For all other ports - CIDR-only, no protocol inspection
 
+	// internalAllowedNets are infra-level whitelisted CIDRs that are always allowed,
+	// even when they fall into the always-denied private ranges or user deny rules.
+	internalAllowedNets []*net.IPNet
+
 	proxyRules []proxyRule
 	proxy      *tcpproxy.Proxy
 }
 
 func New(logger logger.Logger, networkConfig network.Config, sandboxes *sandbox.Map, meterProvider metric.MeterProvider, featureFlags *featureflags.Client) *Proxy {
+	internalAllowedNets, err := sandbox_network.ParseCIDRs(networkConfig.AllowSandboxInternalCIDRs)
+	if err != nil {
+		logger.Error(context.Background(), "failed to parse ALLOW_SANDBOX_INTERNAL_CIDRS for TCP firewall",
+			zap.Strings("cidrs", networkConfig.AllowSandboxInternalCIDRs),
+			zap.Error(err))
+	}
+
 	p := &Proxy{
-		httpPort:     networkConfig.SandboxTCPFirewallHTTPPort,
-		tlsPort:      networkConfig.SandboxTCPFirewallTLSPort,
-		otherPort:    networkConfig.SandboxTCPFirewallOtherPort,
-		logger:       logger,
-		sandboxes:    sandboxes,
-		metrics:      NewMetrics(meterProvider),
-		limiter:      connlimit.NewConnectionLimiter(),
-		featureFlags: featureFlags,
+		httpPort:            networkConfig.SandboxTCPFirewallHTTPPort,
+		tlsPort:             networkConfig.SandboxTCPFirewallTLSPort,
+		otherPort:           networkConfig.SandboxTCPFirewallOtherPort,
+		logger:              logger,
+		sandboxes:           sandboxes,
+		metrics:             NewMetrics(meterProvider),
+		limiter:             connlimit.NewConnectionLimiter(),
+		featureFlags:        featureFlags,
+		internalAllowedNets: internalAllowedNets,
 	}
 
 	p.proxyRules = []proxyRule{
@@ -98,16 +111,16 @@ func (p *Proxy) Start(ctx context.Context) error {
 	otherAddr := fmt.Sprintf("0.0.0.0:%d", p.otherPort)
 
 	// HTTP listener (port 80 traffic): inspect Host header for domain allowlist
-	p.proxy.AddHTTPHostMatchRoute(httpAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
-	p.proxy.AddRoute(httpAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolHTTP, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddHTTPHostMatchRoute(httpAddr, func(_ context.Context, _ string) bool { return true }, p.newConnectionHandler(ctx, domainHandler, ProtocolHTTP))
+	p.proxy.AddRoute(httpAddr, p.newConnectionHandler(ctx, cidrOnlyHandler, ProtocolHTTP))
 
 	// TLS listener (port 443 traffic): inspect SNI for domain allowlist
-	p.proxy.AddSNIMatchRoute(tlsAddr, func(_ context.Context, _ string) bool { return true }, newConnectionHandler(ctx, domainHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
-	p.proxy.AddRoute(tlsAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolTLS, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddSNIMatchRoute(tlsAddr, func(_ context.Context, _ string) bool { return true }, p.newConnectionHandler(ctx, domainHandler, ProtocolTLS))
+	p.proxy.AddRoute(tlsAddr, p.newConnectionHandler(ctx, cidrOnlyHandler, ProtocolTLS))
 
 	// Other listener (all other ports): CIDR-only check, no protocol inspection
 	// This prevents blocking on server-first protocols like SSH
-	p.proxy.AddRoute(otherAddr, newConnectionHandler(ctx, cidrOnlyHandler, ProtocolOther, p.metrics, p.limiter, p.logger, p.sandboxes, p.featureFlags))
+	p.proxy.AddRoute(otherAddr, p.newConnectionHandler(ctx, cidrOnlyHandler, ProtocolOther))
 
 	p.logger.Info(ctx, "TCP firewall proxy started",
 		zap.Uint16("http_port", p.httpPort),
@@ -186,7 +199,7 @@ func (p *Proxy) SupportsBYOP() bool {
 }
 
 // handlerFunc is the signature for connection handlers.
-type handlerFunc func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol)
+type handlerFunc func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, logger logger.Logger, metrics *Metrics, protocol Protocol, internalAllowedNets []*net.IPNet)
 
 var _ tcpproxy.Target = (*connectionHandler)(nil)
 
@@ -194,25 +207,27 @@ var _ tcpproxy.Target = (*connectionHandler)(nil)
 type connectionHandler struct {
 	ctx context.Context //nolint:containedctx // base context for request tracing
 
-	handler      handlerFunc
-	protocol     Protocol
-	metrics      *Metrics
-	limiter      *connlimit.ConnectionLimiter
-	logger       logger.Logger
-	sandboxes    *sandbox.Map
-	featureFlags *featureflags.Client
+	handler             handlerFunc
+	protocol            Protocol
+	metrics             *Metrics
+	limiter             *connlimit.ConnectionLimiter
+	logger              logger.Logger
+	sandboxes           *sandbox.Map
+	featureFlags        *featureflags.Client
+	internalAllowedNets []*net.IPNet
 }
 
-func newConnectionHandler(ctx context.Context, handler handlerFunc, protocol Protocol, metrics *Metrics, limiter *connlimit.ConnectionLimiter, logger logger.Logger, sandboxes *sandbox.Map, featureFlags *featureflags.Client) *connectionHandler {
+func (p *Proxy) newConnectionHandler(ctx context.Context, handler handlerFunc, protocol Protocol) *connectionHandler {
 	return &connectionHandler{
-		ctx:          ctx,
-		handler:      handler,
-		protocol:     protocol,
-		metrics:      metrics,
-		limiter:      limiter,
-		logger:       logger,
-		sandboxes:    sandboxes,
-		featureFlags: featureFlags,
+		ctx:                 ctx,
+		handler:             handler,
+		protocol:            protocol,
+		metrics:             p.metrics,
+		limiter:             p.limiter,
+		logger:              p.logger,
+		sandboxes:           p.sandboxes,
+		featureFlags:        p.featureFlags,
+		internalAllowedNets: p.internalAllowedNets,
 	}
 }
 
@@ -272,7 +287,7 @@ func (t *connectionHandler) HandleConn(conn net.Conn) {
 	// Wrap the handler to release the connection slot when done
 	wrappedHandler := func(ctx context.Context, conn net.Conn, dstIP net.IP, dstPort int, sbx *sandbox.Sandbox, l logger.Logger, metrics *Metrics, protocol Protocol) {
 		defer t.limiter.Release(limiterKey)
-		t.handler(ctx, conn, dstIP, dstPort, sbx, l, metrics, protocol)
+		t.handler(ctx, conn, dstIP, dstPort, sbx, l, metrics, protocol, t.internalAllowedNets)
 	}
 
 	wrappedHandler(ctx, conn, ip, port, sbx, sbxLogger, t.metrics, t.protocol)

--- a/packages/shared/pkg/sandbox-network/byop.go
+++ b/packages/shared/pkg/sandbox-network/byop.go
@@ -200,7 +200,7 @@ func IsIPInDeniedSandboxCIDRs(ip net.IP) bool {
 		return true
 	}
 
-	for _, ipNet := range parsedDeniedSandboxCIDRs {
+	for _, ipNet := range DeniedSandboxIPNets {
 		if ipNet.Contains(ip) {
 			return true
 		}

--- a/packages/shared/pkg/sandbox-network/firewall.go
+++ b/packages/shared/pkg/sandbox-network/firewall.go
@@ -102,6 +102,8 @@ func ParseCIDRs(entries []string) ([]*net.IPNet, error) {
 	nets := make([]*net.IPNet, 0, len(entries))
 
 	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+
 		if ip := net.ParseIP(entry); ip != nil {
 			bits := 8 * net.IPv6len
 			if v4 := ip.To4(); v4 != nil {

--- a/packages/shared/pkg/sandbox-network/firewall.go
+++ b/packages/shared/pkg/sandbox-network/firewall.go
@@ -32,20 +32,8 @@ var DeniedSandboxCIDRs = []string{
 
 var DeniedSandboxSetData = utils.Must(set.AddressStringsToSetData(DeniedSandboxCIDRs))
 
-// parsedDeniedSandboxCIDRs is DeniedSandboxCIDRs pre-parsed for
-// IsIPInDeniedSandboxCIDRs.
-var parsedDeniedSandboxCIDRs = func() []*net.IPNet {
-	out := make([]*net.IPNet, 0, len(DeniedSandboxCIDRs))
-	for _, c := range DeniedSandboxCIDRs {
-		_, ipNet, err := net.ParseCIDR(c)
-		if err != nil {
-			panic(fmt.Sprintf("sandbox_network: invalid CIDR in DeniedSandboxCIDRs: %q: %v", c, err))
-		}
-		out = append(out, ipNet)
-	}
-
-	return out
-}()
+// DeniedSandboxIPNets is the preparsed net.IPNet form of DeniedSandboxCIDRs.
+var DeniedSandboxIPNets = utils.Must(ParseCIDRs(DeniedSandboxCIDRs))
 
 // AddressStringToCIDR converts a string address to the CIDR format.
 // Supports only IPv4 addresses.
@@ -106,6 +94,46 @@ func IsSpecifiedIPOrCIDR(s string) bool {
 	}
 
 	return !ip.IsUnspecified()
+}
+
+// ParseCIDRs converts a list of IPs or CIDRs into net.IPNet values.
+// Bare IPs get a full-length mask (/32 for IPv4, /128 for IPv6).
+func ParseCIDRs(entries []string) ([]*net.IPNet, error) {
+	nets := make([]*net.IPNet, 0, len(entries))
+
+	for _, entry := range entries {
+		if ip := net.ParseIP(entry); ip != nil {
+			bits := 8 * net.IPv6len
+			if v4 := ip.To4(); v4 != nil {
+				ip = v4
+				bits = 8 * net.IPv4len
+			}
+
+			nets = append(nets, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+
+			continue
+		}
+
+		_, ipNet, err := net.ParseCIDR(entry)
+		if err != nil {
+			return nil, fmt.Errorf("invalid CIDR %q: %w", entry, err)
+		}
+
+		nets = append(nets, ipNet)
+	}
+
+	return nets, nil
+}
+
+// IPInNets reports whether the IP is contained in any of the networks.
+func IPInNets(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // ParseAddressesAndDomains separates a list of strings into IP addresses/CIDRs and domain names.

--- a/packages/shared/pkg/sandbox-network/firewall_test.go
+++ b/packages/shared/pkg/sandbox-network/firewall_test.go
@@ -1,6 +1,7 @@
 package sandbox_network
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -70,4 +71,38 @@ func TestAddressStringToCIDR(t *testing.T) {
 			require.Equal(t, tc.expected, result, tc.desc)
 		})
 	}
+}
+
+func TestParseCIDRs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid entries", func(t *testing.T) {
+		t.Parallel()
+		nets, err := ParseCIDRs([]string{"10.0.11.254/32", "192.168.0.0/16", "8.8.8.8", "fc00::/7", "::1"})
+		require.NoError(t, err)
+		require.Len(t, nets, 5)
+
+		require.True(t, IPInNets(net.ParseIP("10.0.11.254"), nets))
+		require.False(t, IPInNets(net.ParseIP("10.0.11.253"), nets))
+		require.True(t, IPInNets(net.ParseIP("192.168.42.1"), nets))
+		require.True(t, IPInNets(net.ParseIP("8.8.8.8"), nets), "bare IPv4 should be treated as /32")
+		require.False(t, IPInNets(net.ParseIP("8.8.8.9"), nets))
+		require.True(t, IPInNets(net.ParseIP("fc00::1"), nets))
+		require.True(t, IPInNets(net.ParseIP("::1"), nets), "bare IPv6 should be treated as /128")
+		require.False(t, IPInNets(net.ParseIP("::2"), nets))
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		t.Parallel()
+		nets, err := ParseCIDRs(nil)
+		require.NoError(t, err)
+		require.Empty(t, nets)
+		require.False(t, IPInNets(net.ParseIP("10.0.11.254"), nets))
+	})
+
+	t.Run("invalid entry", func(t *testing.T) {
+		t.Parallel()
+		_, err := ParseCIDRs([]string{"10.0.11.254/32", "not-a-cidr"})
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Follow up to #2529

The infra-level internal allowlist (`ALLOW_SANDBOX_INTERNAL_CIDRS`) was only applied to the per-slot nftables predefined allow set, so it covered non-TCP traffic but was ignored by the TCP firewall proxy. TCP connections to whitelisted internal IPs were still blocked by user deny rules (e.g. `denyOut` `0.0.0.0/0`), and domain-resolved internal IPs were always hard-blocked with no override.

- parse the allowlist once at proxy startup and plumb it into the connection handlers
- check it at highest priority in isEgressAllowed, mirroring the nftables rule order (predefined allow before user rules); checking it before domain rules also prevents proxy-bound connections from being dialed directly to the Host/SNI domain, bypassing the internal proxy
- exempt whitelisted IPs from the always-denied internal ranges in proxyWithIPVerification
- preparse DeniedSandboxCIDRs into DeniedSandboxIPNets at init instead of re-parsing per connection (panics on malformed entries instead of silently skipping them)
- add MatchTypeInternal metric label for these decisions