### PR TITLE
fix(orchestrator): keep dedup empty-pages telemetry scan-only

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/cache.go
+++ b/packages/orchestrator/pkg/sandbox/block/cache.go
@@ -336,7 +336,7 @@ func (c *Cache) Dedup(
 	if err != nil {
 		return nil, nil, err
 	}
-	recordDedupAttrs(ctx, plan, compareDur, time.Since(writeStart))
+	recordDedupAttrs(ctx, plan, int64(plan.pageEmpty.GetCardinality()), compareDur, time.Since(writeStart))
 
 	return cache, &header.DiffMetadata{
 		Dirty:     plan.pageDirty,

--- a/packages/orchestrator/pkg/sandbox/block/dedup.go
+++ b/packages/orchestrator/pkg/sandbox/block/dedup.go
@@ -460,10 +460,12 @@ func parentKeyGroups(pages []dedupPageInfo) [][]int {
 	return groups
 }
 
-func recordDedupAttrs(ctx context.Context, plan *dedupPlan, compareDur, writeDur time.Duration) {
+// recordDedupAttrs takes emptyPages explicitly because the memfd path merges
+// the whole-VM inputEmpty bitmap into plan.pageEmpty in place before this
+// runs; the caller captures the scan-only count first.
+func recordDedupAttrs(ctx context.Context, plan *dedupPlan, emptyPages int64, compareDur, writeDur time.Duration) {
 	totalPages := plan.exportedSize / header.PageSize
 	uniquePages := int64(plan.pageDirty.GetCardinality())
-	emptyPages := int64(plan.pageEmpty.GetCardinality())
 	dedupedPages := totalPages - uniquePages - emptyPages
 	ratio := 0.0
 	if totalPages > 0 {

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -291,21 +291,20 @@ func (d *DedupedMemfdCache) runDedup(
 		return
 	}
 
-	// Clone before merging inputEmpty: plan.pageEmpty must stay scan-only so
-	// recordDedupAttrs reports content-detected zeros, not whole-VM empties.
-	metaEmpty := plan.pageEmpty
+	// Capture the scan-only zero count before inputEmpty is merged in place:
+	// dedup.empty_pages must report content-detected zeros, not whole-VM
+	// empties (cloning the bitmap to preserve it would be too expensive).
+	scanEmptyPages := int64(plan.pageEmpty.GetCardinality())
 	if inputEmpty != nil {
-		metaEmpty = plan.pageEmpty.Clone()
 		ratio := uint64(blockSize / header.PageSize)
 		for start, end := range inputEmpty.Ranges() {
-			metaEmpty.AddRange(uint64(start)*ratio, end*ratio)
+			plan.pageEmpty.AddRange(uint64(start)*ratio, end*ratio)
 		}
 	}
-	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: metaEmpty, BlockSize: header.PageSize}
-	// Whole-VM empty set recorded in the header (scan zeros + inputEmpty);
-	// dedup.empty_pages stays the scan-only count.
+	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: plan.pageEmpty, BlockSize: header.PageSize}
+	// Whole-VM empty set recorded in the header (scan zeros + inputEmpty).
 	telemetry.SetAttributes(ctx,
-		attribute.Int64("dedup.header_empty_pages", int64(metaEmpty.GetCardinality())))
+		attribute.Int64("dedup.header_empty_pages", int64(plan.pageEmpty.GetCardinality())))
 	logSetOnceErr(ctx, "dedup metaOut", metaOut.SetValue(meta))
 
 	writeStart := time.Now()
@@ -315,7 +314,7 @@ func (d *DedupedMemfdCache) runDedup(
 		logger.L().Warn(ctx, "close memfd after dedup drain", zap.Error(closeErr))
 	}
 
-	recordDedupAttrs(ctx, plan, compareDur, writeDur)
+	recordDedupAttrs(ctx, plan, scanEmptyPages, compareDur, writeDur)
 	logSetOnceErr(ctx, "dedup done", d.done.SetResult(cache, err))
 }
 

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -290,13 +290,17 @@ func (d *DedupedMemfdCache) runDedup(
 		return
 	}
 
-	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: plan.pageEmpty, BlockSize: header.PageSize}
+	// Clone before merging inputEmpty: plan.pageEmpty must stay scan-only so
+	// recordDedupAttrs reports content-detected zeros, not whole-VM empties.
+	metaEmpty := plan.pageEmpty
 	if inputEmpty != nil {
+		metaEmpty = plan.pageEmpty.Clone()
 		ratio := uint64(blockSize / header.PageSize)
 		for start, end := range inputEmpty.Ranges() {
-			meta.Empty.AddRange(uint64(start)*ratio, end*ratio)
+			metaEmpty.AddRange(uint64(start)*ratio, end*ratio)
 		}
 	}
+	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: metaEmpty, BlockSize: header.PageSize}
 	logSetOnceErr(ctx, "dedup metaOut", metaOut.SetValue(meta))
 
 	writeStart := time.Now()

--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
@@ -301,6 +302,10 @@ func (d *DedupedMemfdCache) runDedup(
 		}
 	}
 	meta := &header.DiffMetadata{Dirty: plan.pageDirty, Empty: metaEmpty, BlockSize: header.PageSize}
+	// Whole-VM empty set recorded in the header (scan zeros + inputEmpty);
+	// dedup.empty_pages stays the scan-only count.
+	telemetry.SetAttributes(ctx,
+		attribute.Int64("dedup.header_empty_pages", int64(metaEmpty.GetCardinality())))
 	logSetOnceErr(ctx, "dedup metaOut", metaOut.SetValue(meta))
 
 	writeStart := time.Now()


### PR DESCRIPTION
With `use-memfd` + `memfile-diff-dedup` enabled, `dedup.deduped_pages` reports large negative values (≈ −68k observed on staging). `runDedup` builds the diff metadata with `Empty: plan.pageEmpty` (same bitmap) and then merges the block-granular `inputEmpty` ranges into it before `recordDedupAttrs` reads the plan, so `dedup.empty_pages` counts whole-VM empties instead of the scan's content-detected zeros and `deduped = total - unique - empty` goes negative, making `dedup.ratio` unusable for tuning the new dedup budget.

Clone the bitmap for the metadata merge; the plan keeps the scan-only set.