### PR TITLE
fix(orchestrator): export dirty-page stall counter from process start

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -122,9 +122,10 @@ func monitorDirtyPageThrottle() {
 	ticker := time.NewTicker(dirtyPollInterval)
 	defer ticker.Stop()
 	for range ticker.C {
-		if n := countBalanceDirtyThreads(); n > 0 {
-			balanceDirtyPageThreads.Add(context.Background(), int64(n))
-		}
+		// Add even when 0 so the counter exports from process start —
+		// otherwise a node that never stalls has no series at all and
+		// dashboards can't tell "no stalls" from "no metric".
+		balanceDirtyPageThreads.Add(context.Background(), int64(countBalanceDirtyThreads()))
 	}
 }
 


### PR DESCRIPTION
`orchestrator_host_balance_dirty_pages_threads_total` has zero series on staging because the poller only calls Add while threads are stalled in balance_dirty_pages. A fleet that never stalls exports nothing, so the dirty-page-throttle dashboard shows "No data" and cannot distinguish healthy from broken. Add the sampled count unconditionally (1/s, including 0) so the series exists from process start.

Companion to e2b-dev/monitoring#102.