### PR TITLE
fix(orchestrator): read V3 ancestors as uncompressed instead of failing

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/build.go
+++ b/packages/orchestrator/pkg/sandbox/build/build.go
@@ -464,6 +464,22 @@ func (b *File) refreshAncestorAndOpenUpstream(ctx context.Context, buildID uuid.
 		}
 	}
 
+	// Pre-V4 ancestor headers (old template builds) carry no Builds map at
+	// all: their data file is stored uncompressed at the basic path. Latch
+	// that authoritatively — failing the self-entry lookup here breaks every
+	// V4 snapshot that still maps pages to a V3-era ancestor (sandbox resume
+	// then EIOs on first uncached read).
+	if loaded.Metadata.Version < header.MetadataVersionV4 {
+		upstream, err := b.openUpstream(ctx, buildID, objType, storage.CompressionNone)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+
+		// Size 0: createDiff falls back to upstream.Size, matching the
+		// pre-refresh behavior for V3 builds.
+		return upstream, 0, storage.UncompressedFullFrameTable, nil
+	}
+
 	// A finalized V4+ storage header always carries a self entry
 	// (build_upload_v4 populates it before publish). A missing self entry here
 	// means a routed OpenBlob hit a peer's in-flight header — which shouldn't

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -251,10 +251,13 @@ func (b *StorageDiff) reloadSource(ctx context.Context, cause string) error {
 // Fail loudly; the read path will retry when the peer transitions and the
 // storage-authoritative header is available.
 //
-// V3 never reaches reloadSourceLocked: getBuild's V3 branch latches an
-// authoritative empty &{} FT at construction, so resolve short-circuits and
-// reloadSource is never called; V3 builds aren't peer-routed so
-// PeerTransitionedError never fires against them either.
+// A V3 *current* header never reaches reloadSourceLocked (createDiff's
+// default branch latches an authoritative uncompressed FT at construction),
+// but a V3 *ancestor* of a V4+ header can: the V4 header carries no Builds
+// entry for it (appendAncestorBuilds skips V3 ancestors), so the latch is
+// empty and the first read funnels here. Pre-V4 headers have no Builds map,
+// so they are latched as authoritatively uncompressed instead of failing the
+// self-entry lookup.
 func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) error {
 	bid, err := uuid.Parse(b.buildID)
 	if err != nil {
@@ -263,6 +266,16 @@ func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) erro
 	loaded, err := refreshBuildHeader(ctx, b.persistence, bid, b.diffType, cause)
 	if err != nil {
 		return fmt.Errorf("reloadSourceLocked: load header for build %s (cause=%s): %w", b.buildID, cause, err)
+	}
+	if loaded.Metadata.Version < header.MetadataVersionV4 {
+		newPath := storage.Paths{BuildID: b.buildID}.DataFile(string(b.diffType), storage.CompressionNone)
+		newObj, openErr := b.persistence.OpenSeekable(ctx, newPath, b.storageObjectType)
+		if openErr != nil {
+			return fmt.Errorf("reloadSourceLocked: reopen uncompressed upstream for pre-V4 build %s at %s (cause=%s): %w", b.buildID, newPath, cause, openErr)
+		}
+		b.source.Store(&source{upstream: newObj, fullDiffFrameTable: storage.UncompressedFullFrameTable})
+
+		return nil
 	}
 	_, ft, err := loaded.SelfBuildData()
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -287,6 +287,65 @@ func TestStorageDiff_SkipsHeaderRefreshWhenPeerActive(t *testing.T) {
 	require.Equal(t, payload[:readLen], got)
 }
 
+// A V4 snapshot header can map pages to a V3-era ancestor it carries no
+// Builds entry for (appendAncestorBuilds skips V3 ancestors). The proactive
+// refresh then loads the ancestor's own V3 header — which has no Builds map
+// at all — and must latch it as authoritatively uncompressed instead of
+// failing the self-entry lookup, which made every resume of a pre-V4
+// template EIO on its first uncached read.
+func TestStorageDiff_V3AncestorFallsBackToUncompressed(t *testing.T) {
+	t.Parallel()
+
+	const payloadSize = 256 * 1024
+	readLen := testBlockSize
+
+	aID := uuid.New()
+	payload := bytes.Repeat([]byte("v3-ancestor-data-"), payloadSize/len("v3-ancestor-data-")+1)[:payloadSize]
+
+	// A's storage header is V3 (NewTemplateMetadata default): no Builds map.
+	aMeta := header.NewTemplateMetadata(aID, uint64(testBlockSize), uint64(payloadSize))
+	aHeader, err := header.NewHeader(aMeta, []header.BuildMap{{
+		Offset: 0, Length: uint64(payloadSize), BuildId: aID, BuildStorageOffset: 0,
+	}})
+	require.NoError(t, err)
+	aHeaderBytes, err := header.SerializeHeader(aHeader)
+	require.NoError(t, err)
+
+	// Current header: V4, maps to A, no Builds entry for A.
+	bHeader := buildHeader(t, uuid.New(), payloadSize, aID)
+
+	aPaths := storage.Paths{BuildID: aID.String()}
+	provider := storage.NewMockStorageProvider(t)
+
+	headerBlob := storage.NewMockBlob(t)
+	headerBlob.EXPECT().
+		WriteTo(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, w io.Writer) (int64, error) {
+			return io.Copy(w, bytes.NewReader(aHeaderBytes))
+		}).Once()
+	provider.EXPECT().
+		OpenBlob(mock.Anything, aPaths.HeaderFile(storage.MemfileName), mock.Anything).
+		Return(headerBlob, nil).Once()
+
+	// The fallback must open the *uncompressed* data path and serve raw bytes.
+	rawSeekable := storage.NewMockSeekable(t)
+	rawSeekable.EXPECT().
+		Size(mock.Anything).
+		Return(int64(payloadSize), nil).Once()
+	rawSeekable.EXPECT().
+		OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, off, length int64, _ *storage.FrameTable) (io.ReadCloser, error) {
+			end := min(off+length, int64(len(payload)))
+
+			return io.NopCloser(bytes.NewReader(payload[off:end])), nil
+		})
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionNone), mock.Anything).
+		Return(rawSeekable, nil).Once()
+
+	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider, readLen))
+}
+
 // runRead wires up a File over a fresh DiffStore + noop metrics and returns
 // the first `n` bytes read from offset 0.
 func runRead(t *testing.T, h *header.Header, provider storage.StorageProvider, n int64) []byte {

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -346,6 +346,70 @@ func TestStorageDiff_V3AncestorFallsBackToUncompressed(t *testing.T) {
 	require.Equal(t, payload[:readLen], runRead(t, bHeader, provider, readLen))
 }
 
+// Same V3 fallback on the read-time refresh path: a StorageDiff with no
+// latched FT and no caller FT funnels through reloadSource, which must latch
+// a pre-V4 header as authoritatively uncompressed rather than failing the
+// self-entry lookup.
+func TestStorageDiff_ReloadSourceLatchesV3AsUncompressed(t *testing.T) {
+	t.Parallel()
+
+	const payloadSize = 64 * 1024
+	readLen := testBlockSize
+
+	aID := uuid.New()
+	payload := bytes.Repeat([]byte("v3-reload-data-"), payloadSize/len("v3-reload-data-")+1)[:payloadSize]
+
+	aMeta := header.NewTemplateMetadata(aID, uint64(testBlockSize), uint64(payloadSize))
+	aHeader, err := header.NewHeader(aMeta, []header.BuildMap{{
+		Offset: 0, Length: uint64(payloadSize), BuildId: aID, BuildStorageOffset: 0,
+	}})
+	require.NoError(t, err)
+	aHeaderBytes, err := header.SerializeHeader(aHeader)
+	require.NoError(t, err)
+
+	aPaths := storage.Paths{BuildID: aID.String()}
+	provider := storage.NewMockStorageProvider(t)
+
+	headerBlob := storage.NewMockBlob(t)
+	headerBlob.EXPECT().
+		WriteTo(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, w io.Writer) (int64, error) {
+			return io.Copy(w, bytes.NewReader(aHeaderBytes))
+		}).Once()
+	provider.EXPECT().
+		OpenBlob(mock.Anything, aPaths.HeaderFile(storage.MemfileName), mock.Anything).
+		Return(headerBlob, nil).Once()
+
+	rawSeekable := storage.NewMockSeekable(t)
+	rawSeekable.EXPECT().
+		OpenRangeReader(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, off, length int64, _ *storage.FrameTable) (io.ReadCloser, error) {
+			end := min(off+length, int64(len(payload)))
+
+			return io.NopCloser(bytes.NewReader(payload[off:end])), nil
+		})
+	provider.EXPECT().
+		OpenSeekable(mock.Anything, aPaths.DataFile(storage.MemfileName, storage.CompressionNone), mock.Anything).
+		Return(rawSeekable, nil).Once()
+
+	m, err := blockmetrics.NewMetrics(noop.NewMeterProvider())
+	require.NoError(t, err)
+
+	// Bootstrap with no latched FT (initialFT nil) — the first read with a nil
+	// caller FT must refresh and latch the V3 header as uncompressed.
+	bootstrap := storage.NewMockSeekable(t)
+	diff, err := newStorageDiff(t.TempDir(), aID.String(), Memfile, storage.MemfileObjectType,
+		testBlockSize, m, provider, nil, bootstrap, int64(payloadSize), nil, &featureflags.Client{})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = diff.Close() })
+
+	buf := make([]byte, readLen)
+	n, err := diff.ReadAt(t.Context(), buf, 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, int(readLen), n)
+	require.Equal(t, payload[:readLen], buf)
+}
+
 // runRead wires up a File over a fresh DiffStore + noop metrics and returns
 // the first `n` bytes read from offset 0.
 func runRead(t *testing.T, h *header.Header, provider storage.StorageProvider, n int64) []byte {


### PR DESCRIPTION
Since #2919, `createDiff`/`reloadSource` handle an ancestor build missing from a V4+ header's `Builds` map by loading the ancestor's own header and requiring a self entry (`SelfBuildData`). Pre-V4 ancestor headers have no `Builds` map at all — `appendAncestorBuilds` deliberately skips them on upload — so the lookup fails, `planRead` errors, the guest gets EIO from NBD, and envd init returns 400. On staging this kills every resume of pre-V4-era templates: ~650 creates/h failing with INTERNAL since the `ed6f90a` deploy (previously 0), observable as the disappearance of the 1 GiB snapshot cohort and all pause-path rootfs uploads.

Fix: when the refreshed ancestor header is pre-V4, latch it as authoritatively uncompressed (`UncompressedFullFrameTable`, data at the basic path, size from storage) in both refresh paths — same semantics the read path had before #2919. V4+ headers keep the strict self-entry requirement (a missing self entry there still indicates a peer's in-flight header and must fail loudly).

Regression test: V4 header mapping to a V3 ancestor with no Builds entry now reads raw bytes from the uncompressed path.