### PR TITLE
feat(orchestrator): track sandbox lifecycles

### DIFF
--- a/packages/orchestrator/pkg/sandbox/map.go
+++ b/packages/orchestrator/pkg/sandbox/map.go
@@ -25,14 +25,33 @@ type MapSubscriber interface {
 	OnNetworkRelease(ctx context.Context, sbx *Sandbox)
 }
 
-// Map holds sandboxes that are live (running) together with a IP-to-sandbox index
-// The two maps are managed independently.
+// Map tracks sandboxes in three indexes, managed independently:
 //
-// AssignNetwork/NetworkReleased manage the IP map,
-// MarkRunning/MarkStopping manage the live set.
+//   - live: keyed by sandboxID, holds the current routable lifecycle per
+//     sandbox from MarkRunning until MarkStopping. It serves the API/proxy
+//     lookup paths (Get, Items, Count).
+//   - lifecycles: keyed by sandboxID/lifecycleID, holds every lifecycle whose
+//     cleanup is still outstanding, from MarkRunning until MarkStopped in
+//     Close. During checkpoint/resume an old lifecycle can still be cleaning
+//     up while a new lifecycle with the same sandboxID is already live, so a
+//     sandboxID can map to multiple lifecycle entries. Shutdown uses this set
+//     (WaitLifecycles, LifecycleItems) to wait for cleanup to finish, not
+//     just for sandboxes to stop being routable.
+//   - network: an IP-to-sandbox index managed by AssignNetwork and
+//     NetworkReleased, serving GetByHostPort lookups.
+//
+// Invariant: live is a subset of lifecycles; MarkRunning inserts into both.
+// The live and lifecycles maps could later be merged into a single registry
+// keyed by sandboxID/lifecycleID with a running/stopping state per entry;
+// they are kept separate for now to stay close to the pre-existing live-map
+// shape.
 type Map struct {
-	live    *smap.Map[*Sandbox]
-	network *smap.Map[*Sandbox]
+	live       *smap.Map[*Sandbox]
+	lifecycles *smap.Map[*Sandbox]
+	network    *smap.Map[*Sandbox]
+
+	lifecycleMu      sync.Mutex
+	lifecycleChanged chan struct{}
 
 	subs     []MapSubscriber
 	subsLock sync.RWMutex
@@ -40,9 +59,15 @@ type Map struct {
 
 func NewSandboxesMap() *Map {
 	return &Map{
-		live:    smap.New[*Sandbox](),
-		network: smap.New[*Sandbox](),
+		live:             smap.New[*Sandbox](),
+		lifecycles:       smap.New[*Sandbox](),
+		network:          smap.New[*Sandbox](),
+		lifecycleChanged: make(chan struct{}),
 	}
+}
+
+func sandboxLifecycleKey(sandboxID, lifecycleID string) string {
+	return fmt.Sprintf("%s/%s", sandboxID, lifecycleID)
 }
 
 func (m *Map) Subscribe(subscriber MapSubscriber) {
@@ -73,6 +98,36 @@ func (m *Map) Get(sandboxID string) (*Sandbox, bool) {
 	return m.live.Get(sandboxID)
 }
 
+func (m *Map) LifecycleItems() []*Sandbox {
+	items := m.lifecycles.Items()
+	sandboxes := make([]*Sandbox, 0, len(items))
+	for _, sbx := range items {
+		sandboxes = append(sandboxes, sbx)
+	}
+
+	return sandboxes
+}
+
+func (m *Map) WaitLifecycles(ctx context.Context) error {
+	for {
+		m.lifecycleMu.Lock()
+		if m.lifecycles.Count() == 0 {
+			m.lifecycleMu.Unlock()
+
+			return nil
+		}
+
+		changed := m.lifecycleChanged
+		m.lifecycleMu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for sandbox lifecycle cleanup: %w", ctx.Err())
+		case <-changed:
+		}
+	}
+}
+
 // GetByHostPort looks up a sandbox by its host IP address parsed from hostPort.
 func (m *Map) GetByHostPort(hostPort string) (*Sandbox, error) {
 	reqIP, _, err := net.SplitHostPort(hostPort)
@@ -100,11 +155,26 @@ func (m *Map) AssignNetwork(ctx context.Context, sbx *Sandbox) {
 	)
 }
 
+func (m *Map) trackLifecycle(ctx context.Context, sbx *Sandbox) {
+	m.lifecycleMu.Lock()
+	m.lifecycles.Insert(sandboxLifecycleKey(sbx.Runtime.SandboxID, sbx.LifecycleID), sbx)
+	m.notifyLifecycleChangeLocked()
+	m.lifecycleMu.Unlock()
+
+	logger.L().Info(ctx, "sandbox lifecycle tracked",
+		logger.WithSandboxID(sbx.Runtime.SandboxID),
+		logger.WithLifecycleID(sbx.LifecycleID),
+		logger.WithSandboxIP(sbx.Slot.HostIPString()),
+	)
+}
+
 // MarkRunning makes the sandbox visible to Get/Items/Count and notifies OnInsert subscribers.
 func (m *Map) MarkRunning(ctx context.Context, sbx *Sandbox) {
 	if !m.live.InsertIfAbsent(sbx.Runtime.SandboxID, sbx) {
 		return
 	}
+
+	m.trackLifecycle(ctx, sbx)
 
 	m.trigger(ctx, func(ctx context.Context, s MapSubscriber) {
 		s.OnInsert(ctx, sbx)
@@ -148,6 +218,24 @@ func (m *Map) MarkStopping(ctx context.Context, sandboxID, lifecycleID string) b
 	})
 
 	return stopped
+}
+
+func (m *Map) MarkStopped(ctx context.Context, sbx *Sandbox) {
+	m.lifecycleMu.Lock()
+	m.lifecycles.Remove(sandboxLifecycleKey(sbx.Runtime.SandboxID, sbx.LifecycleID))
+	m.notifyLifecycleChangeLocked()
+	m.lifecycleMu.Unlock()
+
+	logger.L().Info(ctx, "sandbox lifecycle stopped",
+		logger.WithSandboxID(sbx.Runtime.SandboxID),
+		logger.WithLifecycleID(sbx.LifecycleID),
+		logger.WithSandboxIP(sbx.Slot.HostIPString()),
+	)
+}
+
+func (m *Map) notifyLifecycleChangeLocked() {
+	close(m.lifecycleChanged)
+	m.lifecycleChanged = make(chan struct{})
 }
 
 // NetworkReleased unregisters a sandbox's IP and notifies OnNetworkRelease

--- a/packages/orchestrator/pkg/sandbox/map_test.go
+++ b/packages/orchestrator/pkg/sandbox/map_test.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
+)
+
+func TestMapMarkRunningTracksLifecycle(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	sbx := testMapSandbox(t, "lifecycle-1")
+
+	sandboxes.MarkRunning(t.Context(), sbx)
+	require.Len(t, sandboxes.Items(), 1)
+	require.Len(t, sandboxes.LifecycleItems(), 1)
+}
+
+func TestMapLifecycleItemsRemainAfterMarkStopping(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	sbx := testMapSandbox(t, "lifecycle-1")
+
+	sandboxes.MarkRunning(t.Context(), sbx)
+	require.Len(t, sandboxes.Items(), 1)
+	require.Len(t, sandboxes.LifecycleItems(), 1)
+
+	marked := sandboxes.MarkStopping(t.Context(), sbx.Runtime.SandboxID, sbx.LifecycleID)
+	require.True(t, marked)
+	require.Empty(t, sandboxes.Items())
+	require.Len(t, sandboxes.LifecycleItems(), 1)
+
+	sandboxes.MarkStopped(t.Context(), sbx)
+	require.Empty(t, sandboxes.LifecycleItems())
+}
+
+func TestSandboxCloseMarksLifecycleStopped(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	sbx := testMapSandbox(t, "lifecycle-1")
+	sbx.cleanup = NewCleanup()
+	sbx.sandboxes = sandboxes
+
+	sandboxes.MarkRunning(t.Context(), sbx)
+	require.Len(t, sandboxes.LifecycleItems(), 1)
+
+	require.NoError(t, sbx.Close(t.Context()))
+	require.Empty(t, sandboxes.LifecycleItems())
+}
+
+func TestMapLifecycleItemsAllowDuplicateSandboxIDs(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	oldSbx := testMapSandbox(t, "lifecycle-old")
+	newSbx := testMapSandbox(t, "lifecycle-new")
+
+	sandboxes.MarkRunning(t.Context(), oldSbx)
+	require.True(t, sandboxes.MarkStopping(t.Context(), oldSbx.Runtime.SandboxID, oldSbx.LifecycleID))
+	sandboxes.MarkRunning(t.Context(), newSbx)
+
+	require.Len(t, sandboxes.LifecycleItems(), 2)
+}
+
+func TestMapWaitLifecyclesReturnsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+
+	require.NoError(t, sandboxes.WaitLifecycles(t.Context()))
+}
+
+func TestMapWaitLifecyclesWaitsUntilStopped(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	sbx := testMapSandbox(t, "lifecycle-1")
+	sandboxes.MarkRunning(t.Context(), sbx)
+
+	waitCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sandboxes.WaitLifecycles(waitCtx)
+	}()
+
+	select {
+	case err := <-done:
+		require.Failf(t, "WaitLifecycles returned before lifecycle stopped", "err: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	sandboxes.MarkStopped(t.Context(), sbx)
+	require.NoError(t, <-done)
+}
+
+func TestMapWaitLifecyclesReturnsContextError(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := NewSandboxesMap()
+	sbx := testMapSandbox(t, "lifecycle-1")
+	sandboxes.MarkRunning(t.Context(), sbx)
+
+	waitCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.ErrorIs(t, sandboxes.WaitLifecycles(waitCtx), context.Canceled)
+}
+
+func TestMapConcurrentMarkStoppingAndStoppedDoesNotResurrectLifecycle(t *testing.T) {
+	t.Parallel()
+
+	for range 1000 {
+		sandboxes := NewSandboxesMap()
+		sbx := testMapSandbox(t, "lifecycle-1")
+		sandboxes.MarkRunning(t.Context(), sbx)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			<-start
+			sandboxes.MarkStopping(t.Context(), sbx.Runtime.SandboxID, sbx.LifecycleID)
+		}()
+
+		go func() {
+			defer wg.Done()
+			<-start
+			sandboxes.MarkStopped(t.Context(), sbx)
+		}()
+
+		close(start)
+		wg.Wait()
+
+		require.Empty(t, sandboxes.LifecycleItems())
+	}
+}
+
+func testMapSandbox(t *testing.T, lifecycleID string) *Sandbox {
+	t.Helper()
+
+	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{})
+	require.NoError(t, err)
+
+	return &Sandbox{
+		LifecycleID: lifecycleID,
+		Metadata: &Metadata{
+			Config:  NewConfig(Config{}),
+			Runtime: RuntimeMetadata{SandboxID: "sandbox-1"},
+		},
+		Resources: &Resources{Slot: slot},
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -247,6 +247,8 @@ type Sandbox struct {
 	files   *storage.SandboxFiles
 	cleanup *Cleanup
 
+	sandboxes *Map
+
 	featureFlags *featureflags.Client
 
 	process      *fc.Process
@@ -500,10 +502,11 @@ func (f *Factory) CreateSandbox(
 		Metadata:     metadata,
 		cgroupHandle: cgroupHandle,
 
-		Template: template,
-		config:   f.config,
-		files:    sandboxFiles,
-		process:  fcHandle,
+		Template:  template,
+		config:    f.config,
+		files:     sandboxFiles,
+		process:   fcHandle,
+		sandboxes: f.Sandboxes,
 
 		cleanup:      cleanup,
 		featureFlags: f.featureFlags,
@@ -845,10 +848,11 @@ func (f *Factory) ResumeSandbox(
 		Metadata:     metadata,
 		cgroupHandle: cgroupHandle,
 
-		Template: t,
-		config:   f.config,
-		files:    sandboxFiles,
-		process:  fcHandle,
+		Template:  t,
+		config:    f.config,
+		files:     sandboxFiles,
+		process:   fcHandle,
+		sandboxes: f.Sandboxes,
 
 		cleanup:      cleanup,
 		featureFlags: f.featureFlags,
@@ -988,6 +992,10 @@ func (s *Sandbox) Wait(ctx context.Context) error {
 
 func (s *Sandbox) Close(ctx context.Context) error {
 	err := s.cleanup.Run(ctx)
+	if s.sandboxes != nil {
+		s.sandboxes.MarkStopped(context.WithoutCancel(ctx), s)
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to cleanup sandbox: %w", err)
 	}


### PR DESCRIPTION
Track sandbox lifecycle entries in the sandbox map so shutdown can observe live sandboxes, and mark sandboxes stopped on Close so the map reflects reality even when cleanup partially fails.