### PR TITLE
fix(orchestrator): harden shutdown network cleanup

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/firewall.go
@@ -3,6 +3,7 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
@@ -114,7 +115,16 @@ func (fw *Firewall) Close() error {
 	fw.mu.Lock()
 	defer fw.mu.Unlock()
 
-	return fw.conn.CloseLasting()
+	fw.conn.DelTable(&nftables.Table{
+		Name:   tableName,
+		Family: nftables.TableFamilyINet,
+	})
+	deleteErr := fw.conn.Flush()
+	if errors.Is(deleteErr, unix.ENOENT) {
+		deleteErr = nil
+	}
+
+	return errors.Join(deleteErr, fw.conn.CloseLasting())
 }
 
 // tapIfaceMatch returns expressions that match packets from the tap interface.

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 	"runtime"
 	"strconv"
 
@@ -14,11 +15,67 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
-func (s *Slot) CreateNetwork(ctx context.Context) error {
+type notExistError interface {
+	IsNotExist() bool
+}
+
+type multiUnwrapError interface {
+	Unwrap() []error
+}
+
+func ignoreExpectedAbsent(err error, isExpected func(error) bool) bool {
+	if err == nil {
+		return true
+	}
+
+	var joined multiUnwrapError
+	if errors.As(err, &joined) {
+		for _, child := range joined.Unwrap() {
+			if !ignoreExpectedAbsent(child, isExpected) {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	return isExpected(err)
+}
+
+func isIPTablesNotExist(err error) bool {
+	var notExist notExistError
+
+	return errors.As(err, &notExist) && notExist.IsNotExist()
+}
+
+func isRouteNotExist(err error) bool {
+	return errors.Is(err, unix.ESRCH) || errors.Is(err, unix.ENOENT)
+}
+
+func isLinkNotExist(err error) bool {
+	var linkNotFound netlink.LinkNotFoundError
+
+	return errors.As(err, &linkNotFound) || errors.Is(err, unix.ENODEV) || errors.Is(err, unix.ENOENT)
+}
+
+func isNamespaceNotExist(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, unix.ENOENT)
+}
+
+func appendUnlessExpectedAbsentf(errs *[]error, err error, isExpected func(error) bool, format string) {
+	if ignoreExpectedAbsent(err, isExpected) {
+		return
+	}
+
+	*errs = append(*errs, fmt.Errorf(format, err))
+}
+
+func (s *Slot) CreateNetwork(ctx context.Context) (retErr error) {
 	// Prevent thread changes so we can safely manipulate with namespaces
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
@@ -29,10 +86,19 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 		return fmt.Errorf("cannot get current (host) namespace: %w", err)
 	}
 
+	cleanupNeeded := false
 	defer func() {
-		err = netns.Set(hostNS)
-		if err != nil {
-			logger.L().Error(ctx, "error resetting network namespace back to the host namespace", zap.Error(err))
+		restoreErr := netns.Set(hostNS)
+		if restoreErr != nil {
+			logger.L().Error(ctx, "error resetting network namespace back to the host namespace", zap.Error(restoreErr))
+		}
+
+		if retErr != nil && cleanupNeeded {
+			if restoreErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("error resetting network namespace back to the host namespace before cleanup: %w", restoreErr))
+			} else if cleanupErr := s.RemoveNetwork(); cleanupErr != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("error cleaning up partially created network: %w", cleanupErr))
+			}
 		}
 
 		err = hostNS.Close()
@@ -46,6 +112,7 @@ func (s *Slot) CreateNetwork(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("cannot create new namespace: %w", err)
 	}
+	cleanupNeeded = true
 
 	defer ns.Close()
 
@@ -273,20 +340,14 @@ func (s *Slot) RemoveNetwork() error {
 	} else {
 		// Delete host forwarding rules
 		err = tables.Delete("filter", "FORWARD", "-i", s.VethName(), "-o", defaultGateway, "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule to default gateway: %w", err))
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting host forwarding rule to default gateway: %w")
 
 		err = tables.Delete("filter", "FORWARD", "-i", defaultGateway, "-o", s.VethName(), "-j", "ACCEPT")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host forwarding rule from default gateway: %w", err))
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting host forwarding rule from default gateway: %w")
 
 		// Delete host postrouting rules
 		err = tables.Delete("nat", "POSTROUTING", "-s", s.HostCIDR(), "-o", defaultGateway, "-j", "MASQUERADE")
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting host postrouting rule: %w", err))
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting host postrouting rule: %w")
 
 		// Delete hyperloop proxy redirect rule
 		err = tables.Delete(
@@ -294,15 +355,11 @@ func (s *Slot) RemoveNetwork() error {
 			"-p", "tcp", "-d", s.config.OrchestratorInSandboxIPAddress, "--dport", "80",
 			"-j", "REDIRECT", "--to-port", s.hyperloopPort,
 		)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting sandbox hyperloop proxy redirect rule: %w", err))
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting sandbox hyperloop proxy redirect rule: %w")
 
 		// Delete changes made by egress proxy
 		err = s.egressProxy.OnSlotDelete(s, tables)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "%w")
 	}
 
 	// Delete routing from host to FC namespace
@@ -310,9 +367,7 @@ func (s *Slot) RemoveNetwork() error {
 		Gw:  s.VpeerIP(),
 		Dst: s.HostNet(),
 	})
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting route from host to FC: %w", err))
-	}
+	appendUnlessExpectedAbsentf(&errs, err, isRouteNotExist, "error deleting route from host to FC: %w")
 
 	// Delete veth device
 	// We explicitly delete the veth device from the host namespace because even though deleting
@@ -320,38 +375,32 @@ func (s *Slot) RemoveNetwork() error {
 	// the same name immediately after deleting the namespace.
 	veth, err := netlink.LinkByName(s.VethName())
 	if err != nil {
-		errs = append(errs, fmt.Errorf("error finding veth: %w", err))
+		appendUnlessExpectedAbsentf(&errs, err, isLinkNotExist, "error finding veth: %w")
 	} else {
 		err = netlink.LinkDel(veth)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("error deleting veth device: %w", err))
-		}
+		appendUnlessExpectedAbsentf(&errs, err, isLinkNotExist, "error deleting veth device: %w")
 	}
 
-	// Delete NFS proxy redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.NFSProxyPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox NFS proxy redirect rule: %w", err))
-	}
+	if tables != nil {
+		// Delete NFS proxy redirect rule
+		err = tables.Delete("nat", "PREROUTING",
+			"--in-interface", s.VethName(), "--protocol", "tcp",
+			"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "2049",
+			"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.NFSProxyPort)),
+		)
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting sandbox NFS proxy redirect rule: %w")
 
-	// Delete portmapper redirect rule
-	err = tables.Delete("nat", "PREROUTING",
-		"--in-interface", s.VethName(), "--protocol", "tcp",
-		"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
-		"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.PortmapperPort)),
-	)
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting sandbox portmapper redirect rule: %w", err))
+		// Delete portmapper redirect rule
+		err = tables.Delete("nat", "PREROUTING",
+			"--in-interface", s.VethName(), "--protocol", "tcp",
+			"--destination", s.config.OrchestratorInSandboxIPAddress, "--dport", "111",
+			"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.PortmapperPort)),
+		)
+		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting sandbox portmapper redirect rule: %w")
 	}
 
 	err = netns.DeleteNamed(s.NamespaceID())
-	if err != nil {
-		errs = append(errs, fmt.Errorf("error deleting namespace: %w", err))
-	}
+	appendUnlessExpectedAbsentf(&errs, err, isNamespaceNotExist, "error deleting namespace: %w")
 
 	return errors.Join(errs...)
 }

--- a/packages/orchestrator/pkg/sandbox/network/network_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/network_test.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package network
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+type fakeNotExistError struct {
+	notExist bool
+}
+
+func (e fakeNotExistError) Error() string {
+	return "fake iptables error"
+}
+
+func (e fakeNotExistError) IsNotExist() bool {
+	return e.notExist
+}
+
+func TestIgnoreExpectedAbsentHandlesWrappedAndJoinedErrors(t *testing.T) {
+	t.Parallel()
+
+	wrapped := fmt.Errorf("wrapped: %w", fakeNotExistError{notExist: true})
+	joined := errors.Join(wrapped, fakeNotExistError{notExist: true})
+
+	require.True(t, ignoreExpectedAbsent(joined, isIPTablesNotExist))
+	require.False(t, ignoreExpectedAbsent(errors.Join(joined, errors.New("boom")), isIPTablesNotExist))
+	require.False(t, ignoreExpectedAbsent(fakeNotExistError{notExist: false}, isIPTablesNotExist))
+}
+
+func TestExpectedAbsentClassifiers(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isRouteNotExist(fmt.Errorf("route delete failed: %w", unix.ESRCH)))
+	require.False(t, isRouteNotExist(unix.EPERM))
+
+	require.True(t, isLinkNotExist(fmt.Errorf("link delete failed: %w", unix.ENODEV)))
+	require.False(t, isLinkNotExist(unix.EPERM))
+
+	require.True(t, isNamespaceNotExist(&os.PathError{Op: "remove", Path: "/var/run/netns/missing", Err: unix.ENOENT}))
+	require.False(t, isNamespaceNotExist(unix.EPERM))
+}

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -156,21 +156,19 @@ func (p *Pool) Populate(ctx context.Context) {
 			}
 
 			select {
-			case <-p.done:
-				if err := p.cleanup(context.WithoutCancel(ctx), slot); err != nil {
-					logger.L().Error(ctx, "[network slot pool]: failed to cleanup created slot while closing", zap.Error(err), zap.Int("slot_index", slot.Idx))
-				}
-
-				return
-			case <-ctx.Done():
-				if err := p.cleanup(context.WithoutCancel(ctx), slot); err != nil {
-					logger.L().Error(ctx, "[network slot pool]: failed to cleanup created slot after context cancellation", zap.Error(err), zap.Int("slot_index", slot.Idx))
-				}
-
-				return
 			case p.newSlots <- slot:
 				newSlotsAvailableCounter.Add(ctx, 1)
+
+				continue
+			case <-p.done:
+			case <-ctx.Done():
 			}
+
+			if err := p.cleanup(context.WithoutCancel(ctx), slot); err != nil {
+				logger.L().Error(ctx, "[network slot pool]: failed to cleanup created slot while closing", zap.Error(err), zap.Int("slot_index", slot.Idx))
+			}
+
+			return
 		}
 	}
 }
@@ -204,8 +202,11 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 
 	err := slot.ConfigureInternet(ctx, network)
 	if err != nil {
-		// Return the slot to the pool if configuring internet fails
-		p.recycleAcquiredSlot(ctx, slot)
+		// Return the slot to the pool if configuring internet fails. The slot
+		// was never handed out, so nobody listens for its release notification.
+		if rerr := p.ReturnAsync(context.WithoutCancel(ctx), slot, func(context.Context, string) {}, 0); rerr != nil {
+			logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(rerr), zap.Int("slot_index", slot.Idx))
+		}
 
 		return nil, fmt.Errorf("error setting slot internet access: %w", err)
 	}
@@ -213,34 +214,10 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 	return slot, nil
 }
 
-// recycleAcquiredSlot recycles a slot whose acquisition failed, in the
-// background when Close can wait for it, inline otherwise: Close cannot
-// observe goroutines started after the pool closed, and the process may
-// exit right after Close returns, leaking the slot.
-func (p *Pool) recycleAcquiredSlot(ctx context.Context, slot *Slot) {
-	recycleSlot := func() {
-		if returnErr := p.recycle(context.WithoutCancel(ctx), slot); returnErr != nil {
-			logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(returnErr), zap.Int("slot_index", slot.Idx))
-		}
-	}
-
-	if !p.tryTrackReturn() {
-		recycleSlot()
-
-		return
-	}
-
-	go func() {
-		defer p.returnsWG.Done()
-
-		recycleSlot()
-	}()
-}
-
-// Return recycles a slot that was used by a sandbox. It waits returnDelay
+// returnSlot recycles a slot that was used by a sandbox. It waits returnDelay
 // before making the slot reusable to let inflight requests on the previous
 // sandbox drain.
-func (p *Pool) Return(ctx context.Context, slot *Slot, releasedFn ReleaseNotify, returnDelay time.Duration) error {
+func (p *Pool) returnSlot(ctx context.Context, slot *Slot, releasedFn ReleaseNotify, returnDelay time.Duration) error {
 	notifyNetworkRelease := sync.OnceFunc(func() {
 		releasedFn(ctx, slot.HostIPString())
 	})
@@ -251,17 +228,9 @@ func (p *Pool) Return(ctx context.Context, slot *Slot, releasedFn ReleaseNotify,
 	// still fall through and clean up the slot to avoid leaking it.
 	select {
 	case <-ctx.Done():
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return errors.Join(ctx.Err(), fmt.Errorf("cleanup slot '%d' on cancelled context: %w", slot.Idx, cerr))
-		}
-
-		return ctx.Err()
+		return p.cleanupWith(ctx, slot, ctx.Err())
 	case <-p.done:
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closed pool: %w", slot.Idx, cerr))
-		}
-
-		return ErrClosed
+		return p.cleanupWith(ctx, slot, ErrClosed)
 	case <-time.After(returnDelay):
 	}
 
@@ -292,13 +261,13 @@ func (p *Pool) tryTrackReturn() bool {
 // pool. If the pool is already closed the slot is cleaned up synchronously.
 func (p *Pool) ReturnAsync(ctx context.Context, slot *Slot, releasedFn ReleaseNotify, returnDelay time.Duration) error {
 	if !p.tryTrackReturn() {
-		return p.Return(ctx, slot, releasedFn, returnDelay)
+		return p.returnSlot(ctx, slot, releasedFn, returnDelay)
 	}
 
 	go func() {
 		defer p.returnsWG.Done()
 
-		err := p.Return(ctx, slot, releasedFn, returnDelay)
+		err := p.returnSlot(ctx, slot, releasedFn, returnDelay)
 		switch {
 		case err == nil:
 		case errors.Is(err, ErrClosed), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
@@ -315,63 +284,53 @@ func (p *Pool) ReturnAsync(ctx context.Context, slot *Slot, releasedFn ReleaseNo
 // recycle resets the slot's internet configuration and puts it back into the
 // reused pool, or cleans it up if the pool is full or closed.
 func (p *Pool) recycle(ctx context.Context, slot *Slot) error {
-	err := slot.ResetInternet(ctx)
-	if err != nil {
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return fmt.Errorf("reset internet: %w; cleanup: %w", err, cerr)
-		}
-
-		return fmt.Errorf("error resetting slot internet access: %w", err)
+	if err := slot.ResetInternet(ctx); err != nil {
+		return p.cleanupWith(ctx, slot, fmt.Errorf("error resetting slot internet access: %w", err))
 	}
 
-	// RLock only guards the closed flag and the reusedSlots send. It is
-	// released before cleanup() so Close()'s Lock() is never pinned by a
-	// slow RemoveNetwork syscall (iptables, netlink) running in a
-	// concurrent Return.
+	reused, cause := p.tryReuse(ctx, slot)
+	if reused {
+		return nil
+	}
+
+	// cause is nil when the pool is simply full.
+	return p.cleanupWith(ctx, slot, cause)
+}
+
+// tryReuse attempts to push the slot into the reused pool. The RLock pairs
+// with Close's Lock so a send can never race the drain; cleanup stays
+// outside the lock so Close is never pinned by slow iptables/netlink
+// teardown.
+func (p *Pool) tryReuse(ctx context.Context, slot *Slot) (reused bool, cause error) {
 	p.closeMu.RLock()
+	defer p.closeMu.RUnlock()
 
 	if p.closed {
-		p.closeMu.RUnlock()
-
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closed pool: %w", slot.Idx, cerr))
-		}
-
-		return ErrClosed
+		return false, ErrClosed
 	}
 
 	select {
 	case <-ctx.Done():
-		p.closeMu.RUnlock()
-
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return errors.Join(ctx.Err(), fmt.Errorf("cleanup slot '%d' on cancelled context: %w", slot.Idx, cerr))
-		}
-
-		return ctx.Err()
+		return false, ctx.Err()
 	case <-p.done:
-		p.closeMu.RUnlock()
-
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return errors.Join(ErrClosed, fmt.Errorf("cleanup slot '%d' on closing pool: %w", slot.Idx, cerr))
-		}
-
-		return ErrClosed
+		return false, ErrClosed
 	case p.reusedSlots <- slot:
 		returnedSlotCounter.Add(ctx, 1)
 		reusableSlotsAvailableCounter.Add(ctx, 1)
-		p.closeMu.RUnlock()
 
-		return nil
+		return true, nil
 	default:
-		p.closeMu.RUnlock()
-
-		if cerr := p.cleanup(ctx, slot); cerr != nil {
-			return fmt.Errorf("failed to return slot '%d': %w", slot.Idx, cerr)
-		}
-
-		return nil
+		return false, nil
 	}
+}
+
+// cleanupWith tears the slot down and attaches any cleanup error to cause.
+func (p *Pool) cleanupWith(ctx context.Context, slot *Slot, cause error) error {
+	if cerr := p.cleanup(ctx, slot); cerr != nil {
+		return errors.Join(cause, fmt.Errorf("cleanup slot '%d': %w", slot.Idx, cerr))
+	}
+
+	return cause
 }
 
 func (p *Pool) cleanup(ctx context.Context, slot *Slot) error {

--- a/packages/orchestrator/pkg/sandbox/network/pool.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool.go
@@ -99,6 +99,10 @@ type Pool struct {
 	newSlots    chan *Slot
 	reusedSlots chan *Slot
 
+	// returnsWG tracks in-flight asynchronous slot returns; Close waits for
+	// it before draining the pool.
+	returnsWG sync.WaitGroup
+
 	slotStorage Storage
 }
 
@@ -108,15 +112,13 @@ func NewPool(newSlotsPoolSize, reusedSlotsPoolSize int, slotStorage Storage, con
 	newSlots := make(chan *Slot, newSlotsPoolSize-1)
 	reusedSlots := make(chan *Slot, reusedSlotsPoolSize)
 
-	pool := &Pool{
+	return &Pool{
 		config:      config,
 		done:        make(chan struct{}),
 		newSlots:    newSlots,
 		reusedSlots: reusedSlots,
 		slotStorage: slotStorage,
 	}
-
-	return pool
 }
 
 func (p *Pool) createNetworkSlot(ctx context.Context) (*Slot, error) {
@@ -153,8 +155,22 @@ func (p *Pool) Populate(ctx context.Context) {
 				continue
 			}
 
-			newSlotsAvailableCounter.Add(ctx, 1)
-			p.newSlots <- slot
+			select {
+			case <-p.done:
+				if err := p.cleanup(context.WithoutCancel(ctx), slot); err != nil {
+					logger.L().Error(ctx, "[network slot pool]: failed to cleanup created slot while closing", zap.Error(err), zap.Int("slot_index", slot.Idx))
+				}
+
+				return
+			case <-ctx.Done():
+				if err := p.cleanup(context.WithoutCancel(ctx), slot); err != nil {
+					logger.L().Error(ctx, "[network slot pool]: failed to cleanup created slot after context cancellation", zap.Error(err), zap.Int("slot_index", slot.Idx))
+				}
+
+				return
+			case p.newSlots <- slot:
+				newSlotsAvailableCounter.Add(ctx, 1)
+			}
 		}
 	}
 }
@@ -189,16 +205,36 @@ func (p *Pool) Get(ctx context.Context, network *orchestrator.SandboxNetworkConf
 	err := slot.ConfigureInternet(ctx, network)
 	if err != nil {
 		// Return the slot to the pool if configuring internet fails
-		go func() {
-			if returnErr := p.recycle(context.WithoutCancel(ctx), slot); returnErr != nil {
-				logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(returnErr), zap.Int("slot_index", slot.Idx))
-			}
-		}()
+		p.recycleAcquiredSlot(ctx, slot)
 
 		return nil, fmt.Errorf("error setting slot internet access: %w", err)
 	}
 
 	return slot, nil
+}
+
+// recycleAcquiredSlot recycles a slot whose acquisition failed, in the
+// background when Close can wait for it, inline otherwise: Close cannot
+// observe goroutines started after the pool closed, and the process may
+// exit right after Close returns, leaking the slot.
+func (p *Pool) recycleAcquiredSlot(ctx context.Context, slot *Slot) {
+	recycleSlot := func() {
+		if returnErr := p.recycle(context.WithoutCancel(ctx), slot); returnErr != nil {
+			logger.L().Error(ctx, "failed to return slot to the pool", zap.Error(returnErr), zap.Int("slot_index", slot.Idx))
+		}
+	}
+
+	if !p.tryTrackReturn() {
+		recycleSlot()
+
+		return
+	}
+
+	go func() {
+		defer p.returnsWG.Done()
+
+		recycleSlot()
+	}()
 }
 
 // Return recycles a slot that was used by a sandbox. It waits returnDelay
@@ -233,6 +269,47 @@ func (p *Pool) Return(ctx context.Context, slot *Slot, releasedFn ReleaseNotify,
 	notifyNetworkRelease()
 
 	return p.recycle(ctx, slot)
+}
+
+// tryTrackReturn registers an in-flight slot return so Close can wait for
+// it. It reports false when the pool is already closed and the caller must
+// process the slot inline.
+func (p *Pool) tryTrackReturn() bool {
+	p.closeMu.RLock()
+	defer p.closeMu.RUnlock()
+
+	if p.closed {
+		return false
+	}
+
+	p.returnsWG.Add(1)
+
+	return true
+}
+
+// ReturnAsync recycles a slot in the background, logging errors instead of
+// returning them. Close waits for all in-flight returns before draining the
+// pool. If the pool is already closed the slot is cleaned up synchronously.
+func (p *Pool) ReturnAsync(ctx context.Context, slot *Slot, releasedFn ReleaseNotify, returnDelay time.Duration) error {
+	if !p.tryTrackReturn() {
+		return p.Return(ctx, slot, releasedFn, returnDelay)
+	}
+
+	go func() {
+		defer p.returnsWG.Done()
+
+		err := p.Return(ctx, slot, releasedFn, returnDelay)
+		switch {
+		case err == nil:
+		case errors.Is(err, ErrClosed), errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+			// Expected when the pool closes or the context ends mid-return.
+			logger.L().Warn(ctx, "network slot returned during pool shutdown", zap.Error(err), zap.Int("slot_index", slot.Idx))
+		default:
+			logger.L().Error(ctx, "failed to return network slot to pool", zap.Error(err), zap.Int("slot_index", slot.Idx))
+		}
+	}()
+
+	return nil
 }
 
 // recycle resets the slot's internet configuration and puts it back into the
@@ -325,6 +402,10 @@ func (p *Pool) Close(ctx context.Context) error {
 	p.closeMu.Lock()
 	p.closed = true
 	p.closeMu.Unlock()
+
+	// Wait for in-flight asynchronous returns: each either cleans its slot
+	// up itself or has already pushed it into reusedSlots, drained below.
+	p.returnsWG.Wait()
 
 	var errs []error
 

--- a/packages/orchestrator/pkg/sandbox/network/pool_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +112,86 @@ func TestReturn_AfterCloseCleansUpLocally(t *testing.T) {
 
 	assert.Equal(t, int64(1), after-before, "Return after Close must invoke Storage.Release via cleanup")
 	require.ErrorIs(t, err, ErrClosed)
+}
+
+func TestReturnAsync_DoesNotBlockOnReturnDelay(t *testing.T) {
+	t.Parallel()
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, 4, storage, Config{})
+	close(pool.newSlots)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		_ = pool.ReturnAsync(t.Context(), newTestSlot(1), noopRelease, time.Hour)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("ReturnAsync blocked on the return delay")
+	}
+
+	// Close short-circuits the hour-long delay into the cleanup path and
+	// must not return before the slot is released.
+	require.NoError(t, pool.Close(t.Context()))
+	assert.Equal(t, int64(1), storage.released.Load(), "Close returned before the in-flight return released the slot")
+}
+
+// Every slot handed to ReturnAsync must be released by the time Close
+// returns, whether cleaned up in flight or drained from reusedSlots.
+func TestClose_WaitsForInFlightAsyncReturns(t *testing.T) {
+	t.Parallel()
+
+	const slots = 8
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, slots, storage, Config{})
+	close(pool.newSlots)
+
+	for i := range slots {
+		require.NoError(t, pool.ReturnAsync(t.Context(), newTestSlot(i+1), noopRelease, 10*time.Millisecond))
+	}
+
+	// Close error ignored: cleanup()'s netlink/iptables teardown may fail
+	// in the test environment; the release count is the leak signal.
+	_ = pool.Close(t.Context())
+
+	assert.Equal(t, int64(slots), storage.released.Load(), "Close returned before all in-flight returns released their slots")
+}
+
+// After Close, ReturnAsync cannot register with Close's wait, so it must
+// clean the slot up inline before returning.
+func TestReturnAsync_AfterCloseCleansUpSynchronously(t *testing.T) {
+	t.Parallel()
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, 4, storage, Config{})
+	close(pool.newSlots)
+
+	require.NoError(t, pool.Close(t.Context()))
+
+	err := pool.ReturnAsync(t.Context(), newTestSlot(1), noopRelease, time.Hour)
+	require.ErrorIs(t, err, ErrClosed)
+	assert.Equal(t, int64(1), storage.released.Load(), "ReturnAsync after Close must release the slot before returning")
+}
+
+// After Close, recycleAcquiredSlot cannot register with Close's wait, so
+// it must recycle inline instead of starting a goroutine Close (and process
+// exit) cannot observe.
+func TestRecycleAcquiredSlot_AfterCloseCleansUpInline(t *testing.T) {
+	t.Parallel()
+
+	storage := &fakeStorage{}
+	pool := NewPool(2, 4, storage, Config{})
+	close(pool.newSlots)
+
+	require.NoError(t, pool.Close(t.Context()))
+
+	pool.recycleAcquiredSlot(t.Context(), newTestSlot(1))
+	assert.Equal(t, int64(1), storage.released.Load(), "recycleAcquiredSlot after Close must release the slot before returning")
 }
 
 func TestReturn_AfterClose_CleanupFailure_PreservesErrClosed(t *testing.T) {

--- a/packages/orchestrator/pkg/sandbox/network/pool_test.go
+++ b/packages/orchestrator/pkg/sandbox/network/pool_test.go
@@ -42,8 +42,8 @@ func newTestSlot(idx int) *Slot {
 	return &Slot{Idx: idx + testSlotIdxOffset, egressProxy: NoopEgressProxy{}}
 }
 
-// noopRelease satisfies Pool.Return's ReleaseNotify parameter without doing
-// anything. Tests cover Return's cleanup path and don't care about the
+// noopRelease satisfies returnSlot's ReleaseNotify parameter without doing
+// anything. Tests cover the cleanup path and don't care about the
 // network-release notification.
 func noopRelease(context.Context, string) {}
 
@@ -75,7 +75,7 @@ func TestReturn_NoPanicDuringClose(t *testing.T) {
 				<-start
 
 				for i := range iters {
-					_ = pool.Return(t.Context(), newTestSlot(w*iters+i+1), noopRelease, 0)
+					_ = pool.returnSlot(t.Context(), newTestSlot(w*iters+i+1), noopRelease, 0)
 				}
 			})
 		}
@@ -107,7 +107,7 @@ func TestReturn_AfterCloseCleansUpLocally(t *testing.T) {
 	require.NoError(t, pool.Close(t.Context()))
 
 	before := storage.released.Load()
-	err := pool.Return(t.Context(), newTestSlot(1), noopRelease, 0)
+	err := pool.returnSlot(t.Context(), newTestSlot(1), noopRelease, 0)
 	after := storage.released.Load()
 
 	assert.Equal(t, int64(1), after-before, "Return after Close must invoke Storage.Release via cleanup")
@@ -178,22 +178,6 @@ func TestReturnAsync_AfterCloseCleansUpSynchronously(t *testing.T) {
 	assert.Equal(t, int64(1), storage.released.Load(), "ReturnAsync after Close must release the slot before returning")
 }
 
-// After Close, recycleAcquiredSlot cannot register with Close's wait, so
-// it must recycle inline instead of starting a goroutine Close (and process
-// exit) cannot observe.
-func TestRecycleAcquiredSlot_AfterCloseCleansUpInline(t *testing.T) {
-	t.Parallel()
-
-	storage := &fakeStorage{}
-	pool := NewPool(2, 4, storage, Config{})
-	close(pool.newSlots)
-
-	require.NoError(t, pool.Close(t.Context()))
-
-	pool.recycleAcquiredSlot(t.Context(), newTestSlot(1))
-	assert.Equal(t, int64(1), storage.released.Load(), "recycleAcquiredSlot after Close must release the slot before returning")
-}
-
 func TestReturn_AfterClose_CleanupFailure_PreservesErrClosed(t *testing.T) {
 	t.Parallel()
 
@@ -204,7 +188,7 @@ func TestReturn_AfterClose_CleanupFailure_PreservesErrClosed(t *testing.T) {
 
 	require.NoError(t, pool.Close(t.Context()))
 
-	err := pool.Return(t.Context(), newTestSlot(1), noopRelease, 0)
+	err := pool.returnSlot(t.Context(), newTestSlot(1), noopRelease, 0)
 	require.ErrorIs(t, err, ErrClosed)
 	require.ErrorIs(t, err, boom)
 }

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1441,15 +1441,9 @@ func getNetworkSlot(
 			ctx, span := tracer.Start(ctx, "clean network-slot")
 			defer span.End()
 
-			// We can run this cleanup asynchronously, as it is not important for the sandbox lifecycle
-			go func(ctx context.Context) {
-				returnErr := networkPool.Return(ctx, slot, networkReleased, network.ReturnDelay)
-				if returnErr != nil {
-					logger.L().Error(ctx, "failed to return network slot", zap.Error(returnErr))
-				}
-			}(context.WithoutCancel(ctx))
-
-			return nil
+			// Async so sandbox cleanup doesn't block on the return delay or
+			// network teardown; the pool's Close waits for in-flight returns.
+			return networkPool.ReturnAsync(ctx, slot, networkReleased, network.ReturnDelay)
 		})
 
 		return slot, nil


### PR DESCRIPTION
Return network slots synchronously during sandbox cleanup instead of fire-and-forget goroutines, guard firewall teardown against missing iptables state, and preserve ErrClosed when returning slots to a closed pool.