### PR TITLE
fix(orchestrator): stop balloon hinting round when pre-pause drain fails

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/client.go
+++ b/packages/orchestrator/pkg/sandbox/fc/client.go
@@ -483,6 +483,25 @@ func (c *apiClient) startBalloonHinting(ctx context.Context, acknowledgeOnStop b
 	return nil
 }
 
+// stopBalloonHinting ends the current hinting run: FC sets host_cmd to DONE
+// synchronously on its event-loop thread, after which any hint descriptors
+// still queued are acked without being discarded.
+func (c *apiClient) stopBalloonHinting(ctx context.Context) error {
+	params := operations.StopBalloonHintingParams{Context: ctx}
+	_, err := c.client.Operations.StopBalloonHinting(&params)
+	if err != nil {
+		// Same 204-vs-spec quirk as startBalloonHinting.
+		var apiErr *openapiruntime.APIError
+		if errors.As(err, &apiErr) && apiErr.IsSuccess() {
+			return nil
+		}
+
+		return fmt.Errorf("error stopping balloon hinting: %w", err)
+	}
+
+	return nil
+}
+
 func (c *apiClient) describeBalloonHinting(ctx context.Context) (hostCmd int64, err error) {
 	params := operations.DescribeBalloonHintingParams{Context: ctx}
 	res, err := c.client.Operations.DescribeBalloonHinting(&params)

--- a/packages/orchestrator/pkg/sandbox/fc/process.go
+++ b/packages/orchestrator/pkg/sandbox/fc/process.go
@@ -758,6 +758,22 @@ func (p *Process) DrainBalloon(ctx context.Context) error {
 			outcome = "describe-failed"
 		}
 
+		// The round is still active: pausing the VM only stops vCPUs, FC's
+		// event loop keeps processing queued hint descriptors — each one a
+		// discard mutating guest memory after the pause, racing the snapshot.
+		// Stop the round so the backlog is acked without discards; FC applies
+		// the stop synchronously on the same thread that processes the queue,
+		// so no discard can land once this returns. Fresh context: ctx is
+		// typically already expired here.
+		stopCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 3*time.Second)
+		defer cancel()
+		if stopErr := p.client.stopBalloonHinting(stopCtx); stopErr != nil {
+			outcome += "-stop-failed"
+
+			return errors.Join(err, fmt.Errorf("stop balloon hinting after failed drain: %w", stopErr))
+		}
+		outcome += "-stopped"
+
 		return err
 	}
 


### PR DESCRIPTION
## Investigation context (EN-978)

While investigating the resume failures we confirmed (against the FC fork and the v6.1 guest balloon driver) that **pausing the VM does not stop the balloon**: `pause_vm` stops vCPUs only, FC's event loop keeps running (it serves the snapshot/pagemap API calls), and any free-page-hint descriptors still queued are processed *after* the pause — each one a `MADV_REMOVE` that punches holes in the memfd while the snapshot pipeline samples bitmaps and reads memory.

`DrainBalloon` made this worse: on drain timeout it logged and continued, leaving the hint round active with a backlog. There is also a protocol-level hazard (guest's balloon shrinker may return hinted blocks to its allocator under the memory pressure the hint round itself creates, so a queued hint can be stale and its discard destroys live guest data + its WP-async dirty evidence) — demonstrated in tests on a real userfaultfd in the companion test PR. That part ultimately needs an FC-side fix (don't discard on hints, or reconcile against pagemap).

**Not 100% confirmed as the EN-978 root cause** — this mechanism is dedup-flag-independent, while the failure rate appeared to track the dedup ramp; see PR with repro tests for the open questions and decisive data cuts.

## Fix

On any drain failure (timeout/describe error), call the fork's `StopFreePageHinting`: FC sets `host_cmd=DONE` synchronously on the same thread that processes the queue, after which remaining descriptors are acked **without** discards. Span outcome becomes `timeout-stopped` / `timeout-stop-failed` for observability.

Open question for review: if the stop itself fails we still continue the pause (existing behavior). Arguably the pause should abort then.