### PR TITLE
Fix NBD release retry loop ignoring context cancel

### DIFF
--- a/packages/orchestrator/pkg/sandbox/nbd/pool.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/pool.go
@@ -333,10 +333,12 @@ func (d *DevicePool) ReleaseDevice(ctx context.Context, idx DeviceSlot, opts ...
 			logger.L().Error(ctx, "error releasing device", zap.Int("attempt", attempt), zap.Error(err))
 		}
 
+		timer := time.NewTimer(500 * time.Millisecond)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-timer.C:
 		}
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/nbd/pool.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/pool.go
@@ -333,7 +333,11 @@ func (d *DevicePool) ReleaseDevice(ctx context.Context, idx DeviceSlot, opts ...
 			logger.L().Error(ctx, "error releasing device", zap.Int("attempt", attempt), zap.Error(err))
 		}
 
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
Replace blocking time.Sleep with select + time.After in infinite retry loop of ReleaseDevice.
Now the loop correctly respects context cancellation, preventing process hang during graceful shutdown and timeout.