### PR TITLE
fix(orchestrator): discard poisoned nftables conn on firewall errors

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/firewall.go
@@ -3,6 +3,7 @@
 package network
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/netip"
@@ -14,8 +15,10 @@ import (
 	"github.com/google/nftables/expr"
 	"github.com/ngrok/firewall_toolkit/pkg/expressions"
 	"github.com/ngrok/firewall_toolkit/pkg/set"
+	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 )
 
@@ -136,7 +139,7 @@ func (fw *Firewall) Close() error {
 // resetConn replaces fw.conn with a fresh netlink connection, discarding
 // buffered messages and any sticky serialization error — nftables.Conn has no
 // API for that (see https://github.com/google/nftables/pull/324).
-func (fw *Firewall) resetConn() error {
+func (fw *Firewall) resetConn(ctx context.Context) error {
 	closeErr := fw.conn.CloseLasting()
 
 	conn, err := nftables.New(nftables.AsLasting())
@@ -148,7 +151,16 @@ func (fw *Firewall) resetConn() error {
 	}
 	fw.conn = conn
 
-	return errors.Join(closeErr, err)
+	resetErr := errors.Join(closeErr, err)
+	if resetErr != nil {
+		logger.L().Error(ctx, "firewall nftables conn reset after apply failure encountered errors",
+			zap.String("tap_interface", fw.tapInterface), zap.Error(resetErr))
+	} else {
+		logger.L().Warn(ctx, "firewall nftables conn reset after apply failure",
+			zap.String("tap_interface", fw.tapInterface))
+	}
+
+	return resetErr
 }
 
 // tapIfaceMatch returns expressions that match packets from the tap interface.
@@ -320,13 +332,13 @@ func (fw *Firewall) bufferUserRules(allowedCIDRs, deniedCIDRs []string) error {
 //
 // On any failure the conn is replaced via resetConn, so a poisoned batch can
 // never leak into a later flush.
-func (fw *Firewall) ApplyRules(byop bool, allowedCIDRs, deniedCIDRs []string) (err error) {
+func (fw *Firewall) ApplyRules(ctx context.Context, byop bool, allowedCIDRs, deniedCIDRs []string) (err error) {
 	fw.mu.Lock()
 	defer fw.mu.Unlock()
 
 	defer func() {
 		if err != nil {
-			err = errors.Join(err, fw.resetConn())
+			err = errors.Join(err, fw.resetConn(ctx))
 		}
 	}()
 

--- a/packages/orchestrator/pkg/sandbox/network/firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/firewall.go
@@ -42,11 +42,17 @@ type Firewall struct {
 	allowedRanges []string
 }
 
-func NewFirewall(tapIf string, orchestratorInternalIP string, extraAllowedCIDRs []string) (*Firewall, error) {
+func NewFirewall(tapIf string, orchestratorInternalIP string, extraAllowedCIDRs []string) (_ *Firewall, err error) {
 	conn, err := nftables.New(nftables.AsLasting())
 	if err != nil {
 		return nil, fmt.Errorf("new nftables conn: %w", err)
 	}
+
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, conn.CloseLasting())
+		}
+	}()
 
 	table := conn.AddTable(&nftables.Table{
 		Name:   tableName,
@@ -125,6 +131,24 @@ func (fw *Firewall) Close() error {
 	}
 
 	return errors.Join(deleteErr, fw.conn.CloseLasting())
+}
+
+// resetConn replaces fw.conn with a fresh netlink connection, discarding
+// buffered messages and any sticky serialization error — nftables.Conn has no
+// API for that (see https://github.com/google/nftables/pull/324).
+func (fw *Firewall) resetConn() error {
+	closeErr := fw.conn.CloseLasting()
+
+	conn, err := nftables.New(nftables.AsLasting())
+	if err != nil {
+		// Fall back to a transient conn, which cannot fail and dials
+		// per-Flush in the calling thread's netns.
+		err = fmt.Errorf("open new lasting nftables conn: %w", err)
+		conn, _ = nftables.New()
+	}
+	fw.conn = conn
+
+	return errors.Join(closeErr, err)
 }
 
 // tapIfaceMatch returns expressions that match packets from the tap interface.
@@ -293,9 +317,18 @@ func (fw *Firewall) bufferUserRules(allowedCIDRs, deniedCIDRs []string) error {
 // holds the new Rule 3 mode with stale user sets. The chain is always rebuilt
 // from scratch; on flush failure the kernel keeps the previous ruleset and no
 // in-memory state can desync from it.
-func (fw *Firewall) ApplyRules(byop bool, allowedCIDRs, deniedCIDRs []string) error {
+//
+// On any failure the conn is replaced via resetConn, so a poisoned batch can
+// never leak into a later flush.
+func (fw *Firewall) ApplyRules(byop bool, allowedCIDRs, deniedCIDRs []string) (err error) {
 	fw.mu.Lock()
 	defer fw.mu.Unlock()
+
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, fw.resetConn())
+		}
+	}()
 
 	fw.conn.FlushChain(fw.filterChain)
 	fw.installRules(byop)

--- a/packages/orchestrator/pkg/sandbox/network/firewall.go
+++ b/packages/orchestrator/pkg/sandbox/network/firewall.go
@@ -144,18 +144,30 @@ func (fw *Firewall) resetConn(ctx context.Context) error {
 
 	conn, err := nftables.New(nftables.AsLasting())
 	if err != nil {
-		// Fall back to a transient conn, which cannot fail and dials
-		// per-Flush in the calling thread's netns.
 		err = fmt.Errorf("open new lasting nftables conn: %w", err)
-		conn, _ = nftables.New()
+
+		// Fall back to a transient conn.
+		var transientErr error
+		conn, transientErr = nftables.New()
+		if transientErr != nil {
+			err = errors.Join(err, fmt.Errorf("open transient nftables conn: %w", transientErr))
+		}
 	}
-	fw.conn = conn
 
 	resetErr := errors.Join(closeErr, err)
-	if resetErr != nil {
+	switch {
+	case conn == nil:
+		// Both the lasting and transient constructors failed. Keep the old
+		// (already closed, possibly poisoned) conn rather than storing nil and
+		// panicking on next use; the firewall is left in a degraded state.
+		logger.L().Error(ctx, "firewall nftables conn reset failed; reusing the old conn",
+			zap.String("tap_interface", fw.tapInterface), zap.Error(resetErr))
+	case resetErr != nil:
+		fw.conn = conn
 		logger.L().Error(ctx, "firewall nftables conn reset after apply failure encountered errors",
 			zap.String("tap_interface", fw.tapInterface), zap.Error(resetErr))
-	} else {
+	default:
+		fw.conn = conn
 		logger.L().Warn(ctx, "firewall nftables conn reset after apply failure",
 			zap.String("tap_interface", fw.tapInterface))
 	}

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -249,7 +249,7 @@ func (s *Slot) CloseFirewall() error {
 }
 
 func (s *Slot) ConfigureInternet(ctx context.Context, network *orchestrator.SandboxNetworkConfig) (e error) {
-	_, span := tracer.Start(ctx, "slot-internet-configure", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "slot-internet-configure", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 	))
 	defer span.End()
@@ -274,7 +274,7 @@ func (s *Slot) ConfigureInternet(ctx context.Context, network *orchestrator.Sand
 	defer n.Close()
 
 	err = n.Do(func(_ ns.NetNS) error {
-		return s.Firewall.ApplyRules(hasBYOP, egress.GetAllowedCidrs(), egress.GetDeniedCidrs())
+		return s.Firewall.ApplyRules(ctx, hasBYOP, egress.GetAllowedCidrs(), egress.GetDeniedCidrs())
 	})
 	if err != nil {
 		return fmt.Errorf("failed execution in network namespace '%s': %w", s.NamespaceID(), err)
@@ -285,7 +285,7 @@ func (s *Slot) ConfigureInternet(ctx context.Context, network *orchestrator.Sand
 
 // UpdateInternet replaces all user firewall rules atomically in a single nftables flush.
 func (s *Slot) UpdateInternet(ctx context.Context, egress *orchestrator.SandboxNetworkEgressConfig) error {
-	_, span := tracer.Start(ctx, "slot-internet-update", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "slot-internet-update", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 	))
 	defer span.End()
@@ -304,7 +304,7 @@ func (s *Slot) UpdateInternet(ctx context.Context, egress *orchestrator.SandboxN
 	s.firewallCustomRules.Store(true)
 
 	err = n.Do(func(_ ns.NetNS) error {
-		return s.Firewall.ApplyRules(hasBYOP, allowedCIDRs, deniedCIDRs)
+		return s.Firewall.ApplyRules(ctx, hasBYOP, allowedCIDRs, deniedCIDRs)
 	})
 	if err != nil {
 		return fmt.Errorf("failed execution in network namespace '%s': %w", s.NamespaceID(), err)
@@ -314,7 +314,7 @@ func (s *Slot) UpdateInternet(ctx context.Context, egress *orchestrator.SandboxN
 }
 
 func (s *Slot) ResetInternet(ctx context.Context) error {
-	_, span := tracer.Start(ctx, "slot-internet-reset", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "slot-internet-reset", trace.WithAttributes(
 		attribute.String("namespace_id", s.NamespaceID()),
 	))
 	defer span.End()
@@ -331,7 +331,7 @@ func (s *Slot) ResetInternet(ctx context.Context) error {
 
 	err = n.Do(func(_ ns.NetNS) error {
 		// Revert BYOP so the next tenant can't inherit non-TCP-only deny rules.
-		return s.Firewall.ApplyRules(false, nil, nil)
+		return s.Firewall.ApplyRules(ctx, false, nil, nil)
 	})
 	if err != nil {
 		return fmt.Errorf("failed execution in network namespace '%s': %w", s.NamespaceID(), err)


### PR DESCRIPTION
A failed buffer or Flush in ApplyRules leaves a partial batch or a sticky   
error on the shared nftables.Conn, which the next Flush replays and         
corrupts the slot firewall. nftables.Conn has no API to clear either, so on 
any failure the conn is replaced via resetConn (transient-conn fallback if  
reopening a lasting one fails). NewFirewall also leaked the lasting socket  
on error paths and now closes it.                                           
                                                                            
resetConn logs the recovery (warn on success, error if it failed) with the  
tap interface and trace context.