### PR TITLE
fix(orch): let the collapse timeout flag exceed the HTTP client cap

### DIFF
--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -120,7 +120,9 @@ func (s *Sandbox) callEnvdCollapse(ctx context.Context, timeout time.Duration) (
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	resp, err := s.doEnvdPost(ctx, "collapse")
+	// Uncapped client: collapse's budget is the configurable timeout above,
+	// which may exceed sandboxHttpClient's fixed 10s cap.
+	resp, err := s.doEnvdPost(ctx, &collapseHttpClient, "collapse")
 	if err != nil {
 		return envd.CollapseResult{}, err
 	}
@@ -146,7 +148,9 @@ func (s *Sandbox) postEnvd(ctx context.Context, timeout time.Duration, path stri
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	resp, err := s.doEnvdPost(ctx, path)
+	// Shared client: the cgroup ops use a tight, fixed deadline well under the
+	// client's 10s cap, so they keep its backstop.
+	resp, err := s.doEnvdPost(ctx, &sandboxHttpClient, path)
 	if err != nil {
 		return err
 	}
@@ -161,13 +165,15 @@ func (s *Sandbox) postEnvd(ctx context.Context, timeout time.Duration, path stri
 	return nil
 }
 
-// doEnvdPost builds and sends an authenticated POST to envd's /<path> endpoint.
-// The caller owns the returned response and must close its body. Status handling
-// is left to the caller because the endpoints disagree on success: /collapse
-// returns 200 with a body, while the cgroup ops return 204 No Content. The
-// deadline must live on ctx (callers set it via context.WithTimeout) so it
-// stays in force while the caller reads the body.
-func (s *Sandbox) doEnvdPost(ctx context.Context, path string) (*http.Response, error) {
+// doEnvdPost builds and sends an authenticated POST to envd's /<path> endpoint
+// on the given client. The caller owns the returned response and must close its
+// body. Status handling is left to the caller because the endpoints disagree on
+// success: /collapse returns 200 with a body, while the cgroup ops return 204 No
+// Content. The deadline must live on ctx (callers set it via context.WithTimeout)
+// so it stays in force while the caller reads the body. The client is a
+// parameter so /collapse can use an uncapped client (its budget may exceed the
+// shared client's fixed timeout) while the cgroup ops keep the shared one.
+func (s *Sandbox) doEnvdPost(ctx context.Context, client *http.Client, path string) (*http.Response, error) {
 	address := fmt.Sprintf("http://%s:%d/%s", s.Slot.HostIPString(), consts.DefaultEnvdServerPort, path)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, address, nil)
 	if err != nil {
@@ -177,7 +183,7 @@ func (s *Sandbox) doEnvdPost(ctx context.Context, path string) (*http.Response, 
 		req.Header.Set("X-Access-Token", *s.Config.Envd.AccessToken)
 	}
 
-	resp, err := sandboxHttpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s request: %w", path, err)
 	}

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -76,6 +76,17 @@ var sandboxHttpClient = http.Client{
 	Transport: SandboxHttpTransport,
 }
 
+// collapseHttpClient issues the pre-pause POST /collapse, whose deadline is the
+// per-call request context (the LD-configurable collapse-envd-heap-timeout-ms).
+// It deliberately has no http.Client.Timeout: a fixed client cap would silently
+// truncate any budget above it, which is exactly the value /collapse needs to be
+// able to raise. The context always bounds the call, including the body read, so
+// no client-level timeout is needed. The cgroup ops (/freeze, /unfreeze) keep the
+// shared sandboxHttpClient — their fixed 2s deadline is well under its cap.
+var collapseHttpClient = http.Client{
+	Transport: SandboxHttpTransport,
+}
+
 type Config struct {
 	// TODO: Remove when the rootfs path is constant.
 	// Only used for v1 rootfs paths format.


### PR DESCRIPTION
Follow-up to the merged envd-heap-collapse work (#2997), addressing the post-merge Cursor Bugbot review comment about the HTTP client timeout cap ([r3419101889](https://github.com/e2b-dev/infra/pull/2997#discussion_r3419101889)).

## Why

`bestEffortCollapse` bounds the pre-pause `POST /collapse` call with the LD-configurable `collapse-envd-heap-timeout-ms`, but the shared `sandboxHttpClient` has a fixed `Timeout: 10 * time.Second`. Any flag value above 10 s could never take effect — the client aborted the request first and the collapse was reported failed despite the larger budget. The flag could only ever *lower* the effective timeout, never raise it.

## What

Send only `/collapse` through a dedicated `envdPostClient` with no client-level timeout, relying on the per-call request context it already sets via `context.WithTimeout`. The context bounds the whole exchange (including the body read), so the configured budget is honored rather than truncated.

`doEnvdPost` now takes the client as a parameter:
- `/collapse` → `envdPostClient` (uncapped; its budget may legitimately exceed 10 s).
- `/freeze`, `/unfreeze` → keep the shared `sandboxHttpClient` and its 10 s cap. Their fixed 2 s deadline is always well under the cap, and the cap is a useful backstop there — so the change is scoped to exactly the endpoint that needs it.

## Validation

`go build` clean (CGO, linux/amd64); `pkg/sandbox` tests pass (incl. the existing envd HTTP-client tests); `golangci-lint` reports 0 issues.

## Note

An earlier version of this PR also carried an envd-side change for [r3419101892](https://github.com/e2b-dev/infra/pull/2997#discussion_r3419101892) (returning partial stats on cancellation). It was dropped: on the orchestrator's own timeout the client aborts and never reads envd's response, so that change was only log-noise reduction on a path that's virtually never hit. See the reply on that thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
