### PR TITLE
docs: fix AWS self-host prerequisites and env template reference

### DIFF
--- a/self-host.md
+++ b/self-host.md
@@ -112,16 +112,15 @@ Now, you should see the right quota options in `All Quotas` and be able to reque
     ```sh
     aws configure --profile <your-profile>
     ```
-- [gsutil](https://cloud.google.com/storage/docs/gsutil_install) (for copying public Firecracker builds)
 - AWS account
 
 ### Steps
 
-1. Create `.env.prod`, `.env.staging`, or `.env.dev` from [`.env.template`](.env.template). Make sure to fill in the AWS-specific values:
+1. Create `.env.prod`, `.env.staging`, or `.env.dev` from [`.env.aws.template`](.env.aws.template). Make sure to fill in the AWS-specific values:
     - `PROVIDER=aws`
     - `AWS_PROFILE` - your AWS CLI profile name
     - `AWS_ACCOUNT_ID` - your AWS account ID
-    - `AWS_REGION` - the AWS region to deploy to (must support bare metal instances for Firecracker)
+    - `AWS_REGION` - the AWS region to deploy to (must support nested virtualization for Firecracker)
     - `PREFIX` - name prefix for all resources (e.g. `e2b-`)
     - `DOMAIN_NAME` - your domain managed by Cloudflare
     - `TERRAFORM_ENVIRONMENT` - one of `prod`, `staging`, `dev`


### PR DESCRIPTION
Three corrections to the **AWS** section of `self-host.md`, each verified against the Terraform/Makefile sources:

### 1. Remove `gsutil` from prerequisites
The AWS path of `make copy-public-builds` reads the public builds via the AWS CLI's S3-compatible endpoint, not gsutil:
```sh
aws s3 cp s3://e2b-prod-public-builds/kernels/ ./.kernels/ --recursive --no-sign-request --endpoint-url https://storage.googleapis.com
```
Every `gsutil` call in the build/upload Makefiles (`Makefile`, `packages/orchestrator/Makefile`, `packages/envd/Makefile`) sits in the GCP (`else`) branch of an `ifeq ($(PROVIDER),aws)` guard, so gsutil is never invoked when `PROVIDER=aws`. The AWS CLI is already listed as a prerequisite.

### 2. Fix the env template link
The file is `.env.aws.template`; `.env.template` does not exist in the repo.

### 3. `AWS_REGION` note: nested virtualization, not bare metal
The client/build node pools launch **m8i** instances with the `nested_virtualization` CPU option (`iac/provider-aws/modules/nodepool-client/main.tf`), not `*.metal`. This also matches the wording already used in the **AWS Architecture** section further down the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)