### PR TITLE
Use FIFREEZE before getting filesystem snapshots

### DIFF
--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -264,6 +264,12 @@ type ServerInterface interface {
 	// Freeze user/pty cgroups before pause. Written directly by envd to avoid Process.Start / shell overhead under load.
 	// (POST /freeze)
 	PostFreeze(w http.ResponseWriter, r *http.Request)
+	// Freeze the guest rootfs (FIFREEZE) before a filesystem-only pause so it is flushed to a consistent on-disk state, closing the sync->pause race. Idempotent. On a successful filesystem-only pause the VM is rebooted, so no thaw is needed; the orchestrator thaws only on the pause-failure path.
+	// (POST /fsfreeze)
+	PostFsfreeze(w http.ResponseWriter, r *http.Request)
+	// Thaw the guest rootfs (FITHAW). Intended ONLY for the orchestrator's pause-failure rollback path, so a frozen filesystem cannot leave the live VM deadlocked. Idempotent.
+	// (POST /fsthaw)
+	PostFsthaw(w http.ResponseWriter, r *http.Request)
 	// Check the health of the service
 	// (GET /health)
 	GetHealth(w http.ResponseWriter, r *http.Request)
@@ -315,6 +321,18 @@ func (_ Unimplemented) PostFilesCompose(w http.ResponseWriter, r *http.Request) 
 // Freeze user/pty cgroups before pause. Written directly by envd to avoid Process.Start / shell overhead under load.
 // (POST /freeze)
 func (_ Unimplemented) PostFreeze(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Freeze the guest rootfs (FIFREEZE) before a filesystem-only pause so it is flushed to a consistent on-disk state, closing the sync->pause race. Idempotent. On a successful filesystem-only pause the VM is rebooted, so no thaw is needed; the orchestrator thaws only on the pause-failure path.
+// (POST /fsfreeze)
+func (_ Unimplemented) PostFsfreeze(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Thaw the guest rootfs (FITHAW). Intended ONLY for the orchestrator's pause-failure rollback path, so a frozen filesystem cannot leave the live VM deadlocked. Idempotent.
+// (POST /fsthaw)
+func (_ Unimplemented) PostFsthaw(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -587,6 +605,46 @@ func (siw *ServerInterfaceWrapper) PostFreeze(w http.ResponseWriter, r *http.Req
 	handler.ServeHTTP(w, r)
 }
 
+// PostFsfreeze operation middleware
+func (siw *ServerInterfaceWrapper) PostFsfreeze(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, AccessTokenAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostFsfreeze(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PostFsthaw operation middleware
+func (siw *ServerInterfaceWrapper) PostFsthaw(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, AccessTokenAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostFsthaw(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetHealth operation middleware
 func (siw *ServerInterfaceWrapper) GetHealth(w http.ResponseWriter, r *http.Request) {
 
@@ -791,6 +849,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/freeze", wrapper.PostFreeze)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/fsfreeze", wrapper.PostFsfreeze)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/fsthaw", wrapper.PostFsthaw)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/health", wrapper.GetHealth)

--- a/packages/envd/internal/api/fsfreeze.go
+++ b/packages/envd/internal/api/fsfreeze.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/e2b-dev/infra/packages/envd/internal/logs"
+)
+
+// rootfsMountpoint is the guest root filesystem — the only persisted filesystem
+// in a filesystem-only snapshot.
+const rootfsMountpoint = "/"
+
+// PostFsfreeze freezes the guest rootfs (FIFREEZE) so it is flushed to a
+// consistent on-disk state before a filesystem-only pause. This closes the
+// sync->pause race: without a memory snapshot, a write acknowledged after the
+// pre-pause sync but before the VM pause would otherwise be lost on the reboot
+// resume. Idempotent: freezing an already-frozen filesystem is a no-op. On a
+// successful filesystem-only pause the VM is rebooted, so no thaw is needed; the
+// orchestrator thaws (PostFsthaw) only on the pause-failure rollback path.
+func (a *API) PostFsfreeze(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	logger := a.logger.With().Str(string(logs.OperationIDKey), logs.AssignOperationID()).Logger()
+
+	if err := a.fsFreezeLock.Acquire(r.Context(), 1); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return
+	}
+	defer a.fsFreezeLock.Release(1)
+
+	if err := a.fsFreezer.Freeze(rootfsMountpoint); err != nil {
+		logger.Error().Err(err).Msg("freeze rootfs")
+		jsonError(w, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// PostFsthaw thaws the guest rootfs (FITHAW). Exists ONLY for the orchestrator's
+// pause-failure rollback path, so a frozen filesystem cannot leave the live VM
+// deadlocked. Idempotent: thawing a filesystem that is not frozen is a no-op.
+func (a *API) PostFsthaw(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	ctx := r.Context()
+	logger := a.logger.With().Str(string(logs.OperationIDKey), logs.AssignOperationID()).Logger()
+
+	// Acquire with WithoutCancel so a cancelled HTTP client can't abandon the
+	// thaw and leave the live VM's filesystem frozen.
+	if err := a.fsFreezeLock.Acquire(context.WithoutCancel(ctx), 1); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+
+		return
+	}
+	defer a.fsFreezeLock.Release(1)
+
+	if err := a.fsFreezer.Thaw(rootfsMountpoint); err != nil {
+		logger.Error().Err(err).Msg("thaw rootfs")
+		jsonError(w, http.StatusInternalServerError, err)
+
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/packages/envd/internal/api/fsfreeze_test.go
+++ b/packages/envd/internal/api/fsfreeze_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/envd/internal/services/cgroups"
+)
+
+type fakeFreezer struct {
+	mu        sync.Mutex
+	frozen    []string
+	thawed    []string
+	freezeErr error
+	thawErr   error
+}
+
+func (f *fakeFreezer) Freeze(mountpoint string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.freezeErr != nil {
+		return f.freezeErr
+	}
+	f.frozen = append(f.frozen, mountpoint)
+
+	return nil
+}
+
+func (f *fakeFreezer) Thaw(mountpoint string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.thawErr != nil {
+		return f.thawErr
+	}
+	f.thawed = append(f.thawed, mountpoint)
+
+	return nil
+}
+
+func newAPIWithFreezer(f *fakeFreezer) *API {
+	api := newAPIWithCgroupManager(cgroups.NewNoopManager())
+	api.fsFreezer = f
+
+	return api
+}
+
+func TestPostFsfreeze(t *testing.T) {
+	t.Parallel()
+
+	t.Run("freezes the rootfs", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeFreezer{}
+		api := newAPIWithFreezer(f)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/fsfreeze", http.NoBody)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		api.PostFsfreeze(rec, req)
+
+		require.Equal(t, http.StatusNoContent, rec.Code)
+		assert.Equal(t, []string{rootfsMountpoint}, f.frozen)
+	})
+
+	t.Run("returns 500 on freeze error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeFreezer{freezeErr: errors.New("FIFREEZE /: io error")}
+		api := newAPIWithFreezer(f)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/fsfreeze", http.NoBody)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		api.PostFsfreeze(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Empty(t, f.frozen)
+	})
+}
+
+func TestPostFsthaw(t *testing.T) {
+	t.Parallel()
+
+	t.Run("thaws the rootfs", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeFreezer{}
+		api := newAPIWithFreezer(f)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/fsthaw", http.NoBody)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		api.PostFsthaw(rec, req)
+
+		require.Equal(t, http.StatusNoContent, rec.Code)
+		assert.Equal(t, []string{rootfsMountpoint}, f.thawed)
+	})
+
+	t.Run("returns 500 on thaw error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeFreezer{thawErr: errors.New("FITHAW /: io error")}
+		api := newAPIWithFreezer(f)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "/fsthaw", http.NoBody)
+		require.NoError(t, err)
+		rec := httptest.NewRecorder()
+		api.PostFsthaw(rec, req)
+
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+		assert.Empty(t, f.thawed)
+	})
+}

--- a/packages/envd/internal/api/store.go
+++ b/packages/envd/internal/api/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/e2b-dev/infra/packages/envd/internal/execcontext"
 	"github.com/e2b-dev/infra/packages/envd/internal/host"
 	"github.com/e2b-dev/infra/packages/envd/internal/services/cgroups"
+	"github.com/e2b-dev/infra/packages/envd/internal/services/fsfreeze"
 	"github.com/e2b-dev/infra/packages/envd/internal/utils"
 )
 
@@ -50,6 +51,11 @@ type API struct {
 	freezeLock    *semaphore.Weighted
 	isMountingNFS atomic.Bool
 	mountedPaths  sync.Map // map[path]lifecycleID - tracks which lifecycle each path was mounted for
+
+	// fsFreezer freezes/thaws the guest rootfs for filesystem-only pauses;
+	// fsFreezeLock serializes /fsfreeze and /fsthaw.
+	fsFreezer    fsfreeze.Freezer
+	fsFreezeLock *semaphore.Weighted
 }
 
 func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.MMDSOpts, isNotFC bool, cgroupManager cgroups.Manager) *API {
@@ -65,6 +71,8 @@ func New(l *zerolog.Logger, defaults *execcontext.Defaults, mmdsChan chan *host.
 		cgroupManager:   cgroupManager,
 		initLock:        semaphore.NewWeighted(1),
 		freezeLock:      semaphore.NewWeighted(1),
+		fsFreezer:       fsfreeze.New(),
+		fsFreezeLock:    semaphore.NewWeighted(1),
 	}
 }
 

--- a/packages/envd/internal/services/fsfreeze/fsfreeze.go
+++ b/packages/envd/internal/services/fsfreeze/fsfreeze.go
@@ -1,0 +1,18 @@
+// Package fsfreeze freezes and thaws a mounted filesystem via the FIFREEZE /
+// FITHAW ioctls. The orchestrator uses it to quiesce the guest rootfs to a
+// consistent, fully-flushed on-disk state before a filesystem-only pause,
+// closing the sync->pause race where a write acknowledged after sync but before
+// pause would otherwise be lost on the reboot resume.
+package fsfreeze
+
+// Freezer freezes and thaws the filesystem mounted at a given path.
+type Freezer interface {
+	// Freeze flushes and suspends all writes to the filesystem containing
+	// mountpoint until Thaw is called. Freezing an already-frozen filesystem is
+	// a no-op (no error).
+	Freeze(mountpoint string) error
+
+	// Thaw resumes writes to the filesystem containing mountpoint. Thawing a
+	// filesystem that is not frozen is a no-op (no error).
+	Thaw(mountpoint string) error
+}

--- a/packages/envd/internal/services/fsfreeze/fsfreeze_linux.go
+++ b/packages/envd/internal/services/fsfreeze/fsfreeze_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+package fsfreeze
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// FIFREEZE / FITHAW ioctl request codes — _IOWR('X', 119/120, int). They are not
+// exported by x/sys/unix. The values are stable on the architectures envd runs
+// on (x86_64, arm64), which use the generic ioctl encoding. FIFREEZE/FITHAW
+// ignore the ioctl argument, so passing 0 is safe.
+const (
+	fiFreeze = 0xC0045877
+	fiThaw   = 0xC0045878
+)
+
+type linuxFreezer struct{}
+
+// New returns a Freezer backed by the FIFREEZE/FITHAW ioctls.
+func New() Freezer {
+	return linuxFreezer{}
+}
+
+func (linuxFreezer) Freeze(mountpoint string) error {
+	f, err := os.Open(mountpoint)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", mountpoint, err)
+	}
+	defer f.Close()
+
+	if err := unix.IoctlSetInt(int(f.Fd()), fiFreeze, 0); err != nil {
+		// EBUSY means the filesystem is already frozen; treat as success so the
+		// call is idempotent.
+		if errors.Is(err, unix.EBUSY) {
+			return nil
+		}
+
+		return fmt.Errorf("FIFREEZE %s: %w", mountpoint, err)
+	}
+
+	return nil
+}
+
+func (linuxFreezer) Thaw(mountpoint string) error {
+	f, err := os.Open(mountpoint)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", mountpoint, err)
+	}
+	defer f.Close()
+
+	if err := unix.IoctlSetInt(int(f.Fd()), fiThaw, 0); err != nil {
+		// EINVAL means the filesystem is not frozen; treat as success so the
+		// call is idempotent.
+		if errors.Is(err, unix.EINVAL) {
+			return nil
+		}
+
+		return fmt.Errorf("FITHAW %s: %w", mountpoint, err)
+	}
+
+	return nil
+}

--- a/packages/envd/internal/services/fsfreeze/fsfreeze_other.go
+++ b/packages/envd/internal/services/fsfreeze/fsfreeze_other.go
@@ -1,0 +1,15 @@
+//go:build !linux
+
+package fsfreeze
+
+// New returns a no-op Freezer on non-Linux platforms; filesystem freezing is a
+// Linux-only kernel feature.
+func New() Freezer {
+	return noopFreezer{}
+}
+
+type noopFreezer struct{}
+
+func (noopFreezer) Freeze(string) error { return nil }
+
+func (noopFreezer) Thaw(string) error { return nil }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.5"
+const Version = "0.6.6"

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -119,6 +119,34 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /fsfreeze:
+    post:
+      summary: Freeze the guest rootfs (FIFREEZE) before a filesystem-only pause so it is flushed to a consistent on-disk state, closing the sync->pause race. Idempotent. On a successful filesystem-only pause the VM is rebooted, so no thaw is needed; the orchestrator thaws only on the pause-failure path.
+      security:
+        - AccessTokenAuth: []
+        - {}
+      responses:
+        "204":
+          description: Rootfs frozen
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          description: Freeze lock is held by another operation
+
+  /fsthaw:
+    post:
+      summary: Thaw the guest rootfs (FITHAW). Intended ONLY for the orchestrator's pause-failure rollback path, so a frozen filesystem cannot leave the live VM deadlocked. Idempotent.
+      security:
+        - AccessTokenAuth: []
+        - {}
+      responses:
+        "204":
+          description: Rootfs thawed
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          description: Freeze lock is held by another operation
+
   /envs:
     get:
       summary: Get the environment variables

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -28,11 +28,14 @@ const (
 	loopDelay = 5 * time.Millisecond
 )
 
-type envdCgroupOp string
+// envdOp is the path segment of a parameterless envd POST endpoint.
+type envdOp string
 
 const (
-	envdCgroupOpFreeze   envdCgroupOp = "freeze"
-	envdCgroupOpUnfreeze envdCgroupOp = "unfreeze"
+	envdOpFreeze   envdOp = "freeze"
+	envdOpUnfreeze envdOp = "unfreeze"
+	envdOpFsfreeze envdOp = "fsfreeze"
+	envdOpFsthaw   envdOp = "fsthaw"
 )
 
 // doRequestWithInfiniteRetries does a request with infinite retries until the context is done.
@@ -97,17 +100,31 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 // user/pty cgroups directly (no Process.Start, no shell). Used pre-pause
 // with a tight, freeze-only timeout.
 func (s *Sandbox) callEnvdFreeze(ctx context.Context, timeout time.Duration) error {
-	return s.callEnvdCgroupOp(ctx, timeout, envdCgroupOpFreeze)
+	return s.callEnvdPostOp(ctx, timeout, envdOpFreeze)
 }
 
 // callEnvdUnfreeze calls envd's native POST /unfreeze endpoint. Reserved for
 // the pause-failure rollback path; the resume thaw runs via /init's deferred
 // unfreeze and does not use this.
 func (s *Sandbox) callEnvdUnfreeze(ctx context.Context, timeout time.Duration) error {
-	return s.callEnvdCgroupOp(ctx, timeout, envdCgroupOpUnfreeze)
+	return s.callEnvdPostOp(ctx, timeout, envdOpUnfreeze)
 }
 
-func (s *Sandbox) callEnvdCgroupOp(ctx context.Context, timeout time.Duration, op envdCgroupOp) error {
+// callEnvdFsfreeze calls envd's native POST /fsfreeze endpoint to freeze the
+// guest rootfs before a filesystem-only pause, flushing it to a consistent
+// on-disk state.
+func (s *Sandbox) callEnvdFsfreeze(ctx context.Context, timeout time.Duration) error {
+	return s.callEnvdPostOp(ctx, timeout, envdOpFsfreeze)
+}
+
+// callEnvdFsthaw calls envd's native POST /fsthaw endpoint. Reserved for the
+// pause-failure rollback path so a frozen rootfs can't leave the live VM
+// deadlocked.
+func (s *Sandbox) callEnvdFsthaw(ctx context.Context, timeout time.Duration) error {
+	return s.callEnvdPostOp(ctx, timeout, envdOpFsthaw)
+}
+
+func (s *Sandbox) callEnvdPostOp(ctx context.Context, timeout time.Duration, op envdOp) error {
 	return s.postEnvd(ctx, timeout, string(op))
 }
 

--- a/packages/orchestrator/pkg/sandbox/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/reclaim.go
@@ -232,6 +232,20 @@ func (s *Sandbox) envdSupportsCgroupFreeze(ctx context.Context) bool {
 	return ok
 }
 
+// envdSupportsFsFreeze reports whether the sandbox's envd exposes the native
+// /fsfreeze and /fsthaw endpoints. Bad version strings log and return false so
+// the filesystem-only pause falls back to a plain guest sync.
+func (s *Sandbox) envdSupportsFsFreeze(ctx context.Context) bool {
+	ok, err := utils.IsGTEVersion(s.Config.Envd.Version, utils.MinEnvdVersionForFsFreeze)
+	if err != nil {
+		logger.L().Warn(ctx, "fsfreeze version gate: bad envd version", logger.WithSandboxID(s.Runtime.SandboxID), zap.String("envd_version", s.Config.Envd.Version), zap.Error(err))
+
+		return false
+	}
+
+	return ok
+}
+
 // envdSupportsHeapCollapse reports whether the sandbox's envd exposes the native
 // /collapse endpoint. Bad version strings log and return false so we never call
 // an unsupported endpoint.

--- a/packages/orchestrator/pkg/sandbox/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/reclaim.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
@@ -170,17 +171,17 @@ func (s *Sandbox) guestSyncTimeout(ctx context.Context) time.Duration {
 	return ramScaledSyncTimeout(s.Config.RamMB)
 }
 
-// guestSync runs sync in the guest via envd so ext4 flushes dirty pages to the
-// virtio disk. Mandatory before a filesystem-only pause: without a memory
-// snapshot the guest page cache is lost, so callers must fail the pause on
-// error instead of persisting a rootfs missing acknowledged writes. Unlike
-// bestEffortReclaim's sync step (LD-flag gated, best-effort), this always runs
-// and always reports failure.
-func (s *Sandbox) guestSync(ctx context.Context) (e error) {
-	syncTimeout := s.guestSyncTimeout(ctx)
+func (s *Sandbox) guestPrepareFsForPause(ctx context.Context, cleanup *Cleanup) (e error) {
+	supportsFsFreeze := s.envdSupportsFsFreeze(ctx)
+	// Use guestSyncTimeout here, as fsfreeze also syncs the disk
+	timeout := s.guestSyncTimeout(ctx)
 	start := time.Now()
 
-	ctx, span := tracer.Start(ctx, "envd-guest-sync")
+	ctx, span := tracer.Start(
+		ctx,
+		"envd-guest-fs-pause",
+		trace.WithAttributes(attribute.Bool("fsfreeze", supportsFsFreeze)),
+	)
 	defer span.End()
 
 	// Record on every exit so slow and timed-out syncs are captured too.
@@ -188,11 +189,44 @@ func (s *Sandbox) guestSync(ctx context.Context) (e error) {
 		guestSyncDurationHistogram.Record(ctx, time.Since(start).Milliseconds(),
 			metric.WithAttributes(
 				attribute.Bool("success", e == nil),
-				attribute.Int64("timeout_ms", syncTimeout.Milliseconds()),
+				attribute.Bool("fsfreeze", supportsFsFreeze),
+				attribute.Int64("timeout_ms", timeout.Milliseconds()),
 			),
 		)
 	}()
 
+	if supportsFsFreeze {
+		// fsfreeze flushes the rootfs AND blocks further writes until thaw,
+		// closing the sync->pause race. FIFREEZE already syncs as part of
+		// freezing, so a separate guest sync would be redundant.
+		// If freezing aborted, thaw so we don't leave the live VM's
+		// filesystem frozen; on success the VM is stopped during rootfs
+		// export, so the frozen state is discarded with it and the thaw is a
+		// harmless no-op.
+		cleanup.Add(ctx, func(ctx context.Context) error {
+			s.bestEffortFsthaw(ctx)
+
+			return nil
+		})
+		if err := s.callEnvdFsfreeze(ctx, timeout); err != nil {
+			return fmt.Errorf("fsfreeze before filesystem-only pause: %w", err)
+		}
+	} else {
+		if err := s.guestSync(ctx, timeout); err != nil {
+			return fmt.Errorf("guest sync before filesystem-only pause: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// guestSync runs sync in the guest via envd so ext4 flushes dirty pages to the
+// virtio disk. Mandatory before a filesystem-only pause: without a memory
+// snapshot the guest page cache is lost, so callers must fail the pause on
+// error instead of persisting a rootfs missing acknowledged writes. Unlike
+// bestEffortReclaim's sync step (LD-flag gated, best-effort), this always runs
+// and always reports failure.
+func (s *Sandbox) guestSync(ctx context.Context, syncTimeout time.Duration) (e error) {
 	rcCtx, cancel := context.WithTimeout(ctx, syncTimeout+reclaimOuterSlack)
 	defer cancel()
 
@@ -348,5 +382,20 @@ func (s *Sandbox) bestEffortUnfreeze(ctx context.Context) {
 
 	if err := s.callEnvdUnfreeze(context.WithoutCancel(ctx), freezeTimeout); err != nil {
 		logger.L().Warn(ctx, "envd unfreeze failed", logger.WithSandboxID(s.Runtime.SandboxID), zap.Error(err))
+	}
+}
+
+// bestEffortFsthaw thaws the guest rootfs via envd's native /fsthaw endpoint.
+// Reserved for the filesystem-only pause error path so an aborted pause can't
+// leave the live VM's filesystem frozen. Gated on envd version; failures are
+// logged. Uses context.WithoutCancel because it runs from cleanup paths whose
+// parent ctx may already be done.
+func (s *Sandbox) bestEffortFsthaw(ctx context.Context) {
+	if !s.envdSupportsFsFreeze(ctx) {
+		return
+	}
+
+	if err := s.callEnvdFsthaw(context.WithoutCancel(ctx), s.guestSyncTimeout(ctx)); err != nil {
+		logger.L().Warn(ctx, "envd fsthaw failed", logger.WithSandboxID(s.Runtime.SandboxID), zap.Error(err))
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1198,13 +1198,13 @@ func (s *Sandbox) Pause(
 
 	if pauseOpts.filesystemSnapshot {
 		// FC never flushes the guest page cache and no memory snapshot will
-		// preserve it, so a failed sync would persist a rootfs missing
-		// acknowledged writes. Mandatory, unlike the best-effort reclaim above.
-		// The unfreeze cleanup is already registered, so failing here can't
-		// leave the live VM frozen.
-		if err := s.guestSync(ctx); err != nil {
-			return nil, fmt.Errorf("guest sync before filesystem-only pause: %w", err)
+		// preserve it, so the rootfs must be quiesced before pause or it would
+		// persist missing acknowledged writes. This is mandatory, unlike the
+		// best-effort reclaim above.
+		if err := s.guestPrepareFsForPause(ctx, cleanup); err != nil {
+			return nil, err
 		}
+
 		// Memory prefetch refers to the memfile, which is not persisted.
 		m.Prefetch = nil
 	}

--- a/packages/shared/pkg/utils/version.go
+++ b/packages/shared/pkg/utils/version.go
@@ -22,6 +22,11 @@ const MinEnvdVersionForCgroupFreeze = "0.6.0"
 // envd that 404s.
 const MinEnvdVersionForHeapCollapse = "0.6.5"
 
+// MinEnvdVersionForFsFreeze is the first envd that exposes the native
+// POST /fsfreeze and /fsthaw endpoints, which quiesce the guest rootfs before a
+// filesystem-only pause. Older envds fall back to a plain guest sync.
+const MinEnvdVersionForFsFreeze = "0.6.6"
+
 func sanitizeVersion(version string) string {
 	if len(version) > 0 && version[0] != 'v' {
 		version = "v" + version

--- a/tests/integration/internal/envd/generated.go
+++ b/tests/integration/internal/envd/generated.go
@@ -340,6 +340,12 @@ type ClientInterface interface {
 	// PostFreeze request
 	PostFreeze(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// PostFsfreeze request
+	PostFsfreeze(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostFsthaw request
+	PostFsthaw(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetHealth request
 	GetHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -429,6 +435,30 @@ func (c *Client) PostFilesCompose(ctx context.Context, body PostFilesComposeJSON
 
 func (c *Client) PostFreeze(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewPostFreezeRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostFsfreeze(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostFsfreezeRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostFsthaw(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostFsthawRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -802,6 +832,60 @@ func NewPostFreezeRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewPostFsfreezeRequest generates requests for PostFsfreeze
+func NewPostFsfreezeRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fsfreeze")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostFsthawRequest generates requests for PostFsthaw
+func NewPostFsthawRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/fsthaw")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetHealthRequest generates requests for GetHealth
 func NewGetHealthRequest(server string) (*http.Request, error) {
 	var err error
@@ -985,6 +1069,12 @@ type ClientWithResponsesInterface interface {
 
 	// PostFreezeWithResponse request
 	PostFreezeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostFreezeResponse, error)
+
+	// PostFsfreezeWithResponse request
+	PostFsfreezeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostFsfreezeResponse, error)
+
+	// PostFsthawWithResponse request
+	PostFsthawWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostFsthawResponse, error)
 
 	// GetHealthWithResponse request
 	GetHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthResponse, error)
@@ -1195,6 +1285,66 @@ func (r PostFreezeResponse) ContentType() string {
 	return ""
 }
 
+type PostFsfreezeResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON500      *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PostFsfreezeResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostFsfreezeResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostFsfreezeResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostFsthawResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON500      *InternalServerError
+}
+
+// Status returns HTTPResponse.Status
+func (r PostFsthawResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostFsthawResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostFsthawResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetHealthResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1373,6 +1523,24 @@ func (c *ClientWithResponses) PostFreezeWithResponse(ctx context.Context, reqEdi
 		return nil, err
 	}
 	return ParsePostFreezeResponse(rsp)
+}
+
+// PostFsfreezeWithResponse request returning *PostFsfreezeResponse
+func (c *ClientWithResponses) PostFsfreezeWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostFsfreezeResponse, error) {
+	rsp, err := c.PostFsfreeze(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostFsfreezeResponse(rsp)
+}
+
+// PostFsthawWithResponse request returning *PostFsthawResponse
+func (c *ClientWithResponses) PostFsthawWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*PostFsthawResponse, error) {
+	rsp, err := c.PostFsthaw(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostFsthawResponse(rsp)
 }
 
 // GetHealthWithResponse request returning *GetHealthResponse
@@ -1656,6 +1824,58 @@ func ParsePostFreezeResponse(rsp *http.Response) (*PostFreezeResponse, error) {
 	}
 
 	response := &PostFreezeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostFsfreezeResponse parses an HTTP response from a PostFsfreezeWithResponse call
+func ParsePostFsfreezeResponse(rsp *http.Response) (*PostFsfreezeResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostFsfreezeResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostFsthawResponse parses an HTTP response from a PostFsthawWithResponse call
+func ParsePostFsthawResponse(rsp *http.Response) (*PostFsthawResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostFsthawResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
### What

Adds envd `POST /fsfreeze` and `POST /fsthaw` endpoints (FIFREEZE/FITHAW ioctls on the guest rootfs) and wires them into the filesystem-only pause path: when the sandbox's envd supports it, the rootfs is **frozen** before the snapshot instead of merely synced. Older envds keep the existing guest-`sync` behavior. Bumps envd to `0.6.6`.

### Why
A filesystem-only pause has no memory snapshot, so the guest page cache is lost on resume — the rootfs must be quiesced to a consistent on-disk state before the VM is paused. A guest `sync` is **point-in-time**: a write acknowledged after `sync` returns but before `process.Pause` lives only in the page cache and is lost on the reboot resume. `FIFREEZE` both
flushes dirty data *and* blocks further writes until thaw, closing that sync→pause race and guaranteeing the persisted rootfs is consistent.

### How
- **envd:** new `/fsfreeze` and `/fsthaw` handlers freeze/thaw the rootfs (`/`) via the FIFREEZE/FITHAW ioctls. Both are idempotent (already-frozen / not-frozen are no-ops) and serialized by a dedicated lock; a Linux ioctl impl with a non-Linux stub.
- **orchestrator:** a version gate (`MinEnvdVersionForFsFreeze = 0.6.6`) selects fsfreeze when supported. Since `FIFREEZE` already syncs as part of freezing, the redundant guest `sync` is skipped in that case. The thaw is registered on the pause's cleanup, so it fires only on the abort path (a failed pause can't leave the live VM frozen); on success the freeze
is held through `process.Pause` and discarded when the VM is stopped during rootfs export. A duration histogram (tagged `fsfreeze` vs sync, plus `success`/`timeout_ms`) measures both paths.