### PR TITLE
Speed  up guest cold boot

### DIFF
--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -17,7 +17,10 @@ const (
 
 	// caExtraPath is where the injected cert is persisted on the NBD-backed
 	// filesystem so that running update-ca-certificates later re-includes it
-	// when rebuilding the bundle.
+	// when rebuilding the bundle. Note: a fast cold boot (filesystem-only
+	// reboot) seeds the tmpfs bundle from a build-time tar and skips
+	// update-ca-certificates, so this persisted cert is NOT auto-merged at boot;
+	// /init re-installs the current proxy CA before the sandbox is routable.
 	caExtraPath = "/usr/local/share/ca-certificates/e2b-ca.crt"
 )
 

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -3,7 +3,15 @@
 
 [Unit]
 Description=Env Daemon Service
-After=multi-user.target
+# Start as early as possible on cold boot: envd only needs journald's socket
+# and a writable rootfs; networking is configured by the kernel (ip=) before
+# userspace. Default dependencies would gate it on sysinit/basic.target
+# (~0.5s), and the previous After=multi-user.target on chrony-wait (~8s).
+DefaultDependencies=no
+After=systemd-journald.socket systemd-remount-fs.service
+Wants=systemd-journald.socket
+Conflicts=shutdown.target
+Before=shutdown.target
 # Disable rate limiting; retry forever
 StartLimitIntervalSec=0
 
@@ -14,8 +22,20 @@ User=root
 Group=root
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
-ExecStartPre=/bin/sh -c 'mountpoint -q /etc/ssl/certs || (mkdir -p /run/e2b/certs && mount --bind /run/e2b/certs /etc/ssl/certs) && ([ -s /etc/ssl/certs/ca-certificates.crt ] || update-ca-certificates)'
-ExecStart=/bin/bash -l -c "/usr/bin/envd"
+# Seed the tmpfs from the tar packed at build time (one sequential read);
+# fall back to copying the cert dir, then to regenerating the bundle.
+#
+# Contract: seeding from the tar gives a complete ca-certificates.crt, so
+# update-ca-certificates is skipped (its scattered rootfs reads are the cost we
+# avoid). It therefore does NOT re-merge a persisted egress-proxy CA
+# (/usr/local/share/ca-certificates/e2b-ca.crt) into the bundle at boot. That CA
+# is (re)installed by envd's POST /init for the current proxy, which runs before
+# the orchestrator marks the sandbox running/routable — so the egress CA is
+# guaranteed present for the sandbox's routable lifetime. The only gap is guest
+# units that auto-start and egress over TLS before /init; that is accepted
+# (revisit if a template needs boot-time egress).
+ExecStartPre=/bin/sh -c 'mountpoint -q /etc/ssl/certs || { mkdir -p /run/e2b/certs && { tar -C /run/e2b/certs -xf /usr/local/share/e2b/ssl-certs.tar 2>/dev/null || cp -a /etc/ssl/certs/. /run/e2b/certs/ 2>/dev/null; }; mount --bind /run/e2b/certs /etc/ssl/certs; } && ([ -s /etc/ssl/certs/ca-certificates.crt ] || update-ca-certificates)'
+ExecStart=/usr/bin/envd
 Nice=-20
 IOSchedulingClass=realtime
 IOSchedulingPriority=4

--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -22,12 +22,16 @@ User=root
 Group=root
 Environment=GOTRACEBACK=all
 LimitCORE=infinity
-# Seed the tmpfs from the tar packed at build time (one sequential read);
-# fall back to copying the cert dir, then to regenerating the bundle.
+# Seed the tmpfs from the tar packed as the build's last guest step — after all
+# build steps, start_cmd, and ready_cmd, with update-ca-certificates run first
+# (one sequential read); fall back to copying the cert dir, then to regenerating.
 #
-# Contract: seeding from the tar gives a complete ca-certificates.crt, so
-# update-ca-certificates is skipped (its scattered rootfs reads are the cost we
-# avoid). It therefore does NOT re-merge a persisted egress-proxy CA
+# Contract: the tar is the regenerated trust store captured at the end of the
+# build, so it equals what update-ca-certificates would produce at boot —
+# including CAs added in user layers or start/ready, registered or not. Seeding
+# from it gives a complete ca-certificates.crt, so update-ca-certificates is
+# skipped on cold boot (its scattered rootfs reads are the cost we avoid). It
+# therefore does NOT re-merge a persisted egress-proxy CA
 # (/usr/local/share/ca-certificates/e2b-ca.crt) into the bundle at boot. That CA
 # is (re)installed by envd's POST /init for the current proxy, which runs before
 # the orchestrator marks the sandbox running/routable — so the egress CA is

--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -112,15 +112,6 @@ echo "Disable slow boot units not needed in the sandbox"
 systemctl mask systemd-binfmt.service
 systemctl mask e2scrub_reap.service
 
-echo "Pre-packing CA certificates for fast boot"
-# Single contiguous file: seeding the /etc/ssl/certs tmpfs from one tar is one
-# sequential read instead of ~150 scattered small reads on the lazily-fetched
-# rootfs (see envd.service ExecStartPre). -h dereferences symlinks so the real
-# cert contents are packed: /etc/ssl/certs is mostly hash-named symlinks into
-# /usr/share/ca-certificates, which would otherwise still fault the rootfs.
-mkdir -p /usr/local/share/e2b
-tar -C /etc/ssl/certs -chf /usr/local/share/e2b/ssl-certs.tar .
-
 # Clean machine-id from Docker
 rm -rf /etc/machine-id
 

--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -95,6 +95,26 @@ echo "Disable system first boot wizard"
 # and Linux boot was stuck in wizard until envd wait timeout
 systemctl mask systemd-firstboot.service
 
+echo "Disable chrony-wait"
+# chrony-wait blocks multi-user.target until the first clock sync (~8s);
+# chrony still syncs in the background, nothing needs to wait for it.
+systemctl mask chrony-wait.service
+
+echo "Disable slow boot units not needed in the sandbox"
+# binfmt registrations (foreign-arch exec) take ~1s of CPU early in boot and
+# compete with envd start; e2scrub is for LVM-backed ext4 only.
+systemctl mask systemd-binfmt.service
+systemctl mask e2scrub_reap.service
+
+echo "Pre-packing CA certificates for fast boot"
+# Single contiguous file: seeding the /etc/ssl/certs tmpfs from one tar is one
+# sequential read instead of ~150 scattered small reads on the lazily-fetched
+# rootfs (see envd.service ExecStartPre). -h dereferences symlinks so the real
+# cert contents are packed: /etc/ssl/certs is mostly hash-named symlinks into
+# /usr/share/ca-certificates, which would otherwise still fault the rootfs.
+mkdir -p /usr/local/share/e2b
+tar -C /etc/ssl/certs -chf /usr/local/share/e2b/ssl-certs.tar .
+
 # Clean machine-id from Docker
 rm -rf /etc/machine-id
 

--- a/packages/orchestrator/pkg/template/build/phases/base/provision.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/provision.sh
@@ -59,6 +59,12 @@ echo "Setting up chrony"
 mkdir -p /etc/chrony
 cat <<EOF >/etc/chrony/chrony.conf
 refclock PHC /dev/ptp0 poll 2 dpoll 2
+# Step (jump) the clock instead of slewing when the offset exceeds 1s, but only
+# for the first 3 updates after chronyd starts. chronyd restarts on every cold
+# boot/reboot, so this corrects a large boot-time offset fast (TLS needs a
+# correct clock) without risking a backward jump under a running workload.
+# Needed because chrony-wait is masked, so boot no longer blocks on first sync.
+makestep 1.0 3
 EOF
 
 # Add a proxy config, as some environments expects it there (e.g. timemaster in Node Dockerimage)

--- a/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
@@ -88,7 +88,10 @@ func (ppb *PostProcessingBuilder) Metadata() phases.PhaseMeta {
 }
 
 func (ppb *PostProcessingBuilder) Hash(_ context.Context, sourceLayer phases.LayerResult) (string, error) {
-	return cache.HashKeys(sourceLayer.Hash, "config-run-cmd"), nil
+	// Include the configure script and the cert-bundle command so changes to
+	// either invalidate the cached finalize layer, mirroring how the base layer
+	// hashes provision.sh.
+	return cache.HashKeys(sourceLayer.Hash, "config-run-cmd", configureScriptFile, packCertBundleCmd), nil
 }
 
 func (ppb *PostProcessingBuilder) Layer(
@@ -228,6 +231,16 @@ func (ppb *PostProcessingBuilder) postProcessingFn(userLogger logger.Logger) lay
 
 		defer func() {
 			if e != nil {
+				return
+			}
+
+			// Pack the CA cert bundle as the build's final guest step — after the
+			// configuration script, start_cmd, and ready_cmd have all run — so the
+			// tar that envd.service seeds the boot-time cert tmpfs from reflects the
+			// final trust store. Runs before the sync below so it is flushed to disk.
+			if err := packCertBundle(ctx, userLogger, ppb.proxy, sbx.Runtime.SandboxID); err != nil {
+				e = err
+
 				return
 			}
 

--- a/packages/orchestrator/pkg/template/build/phases/finalize/configure.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/configure.go
@@ -25,6 +25,52 @@ const configurationTimeout = 5 * time.Minute
 var configureScriptFile string
 var ConfigureScriptTemplate = tt.Must(tt.New("provisioning-finish-script").Parse(configureScriptFile))
 
+// packCertBundleCmd regenerates the system trust store and packs it into a
+// single contiguous tar. It is run as the build's last guest step — after all
+// build steps, start_cmd, and ready_cmd — so the tar equals the trust store the
+// guest would otherwise regenerate at boot (update-ca-certificates merges certs
+// dropped under /usr/local/share/ca-certificates even if the user never ran it).
+// envd.service seeds /etc/ssl/certs from this tar and skips update-ca-certificates
+// on cold boot, trading the regen's scattered rootfs reads for one sequential
+// read. -h dereferences the hash-named symlinks so the real cert contents are
+// packed instead of links that would still fault the lazily-fetched rootfs.
+const packCertBundleCmd = `set -e
+if command -v update-ca-certificates >/dev/null 2>&1; then
+	update-ca-certificates
+fi
+mkdir -p /usr/local/share/e2b
+tar -C /etc/ssl/certs -chf /usr/local/share/e2b/ssl-certs.tar .
+`
+
+// packCertBundle runs packCertBundleCmd in the guest as root.
+func packCertBundle(
+	ctx context.Context,
+	userLogger logger.Logger,
+	proxy *proxy.SandboxProxy,
+	sandboxID string,
+) error {
+	ctx, span := tracer.Start(ctx, "pack cert bundle")
+	defer span.End()
+
+	err := sandboxtools.RunCommandWithLogger(
+		ctx,
+		proxy,
+		userLogger,
+		zapcore.DebugLevel,
+		"certs",
+		sandboxID,
+		packCertBundleCmd,
+		metadata.Context{
+			User: "root",
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error packing CA cert bundle: %w", err)
+	}
+
+	return nil
+}
+
 type ConfigurationParams struct {
 	EnvID      string
 	TemplateID string


### PR DESCRIPTION
### What
Trims guest boot time so a filesystem-only (reboot) resume comes up fast. Applies to newly built templates only. Locally ~9.5 s → ~0.5 s on a 1-vCPU sandbox (warm cache).

- **envd.service:** start envd as early as possible — `DefaultDependencies=no`, ordered only after `systemd-journald.socket` + `systemd-remount-fs` (was `After=multi-user.target`); seed the `/etc/ssl/certs` tmpfs from a build-time tar (one sequential read instead of ~150 scattered ones); exec envd directly instead of via `bash -l -c`.
- **provision.sh:** mask `chrony-wait` (the ~8 s `multi-user.target` gate), `systemd-binfmt` (~1 s early-boot CPU + bimodal tail on 1 vCPU), and `e2scrub_reap` (LVM-only); pre-pack the CA certs into the tar consumed by envd.service; add `makestep 1.0 3` to chrony.

### Why
For fs-only snapshots, resume cold-boots a fresh VM from the rootfs, so **guest boot time is the resume latency**. The original boot was dominated by `envd.service` waiting on `multi-user.target`, which `chrony-wait` held for ~8 s on the first clock sync; `systemd-binfmt` and the scattered cert reads added more. Starting envd off the critical path and dropping
the boot-time clock gate removes most of it. Since `chrony-wait` no longer blocks boot, `makestep 1.0 3` ensures the clock is still hard-corrected fast in the background (TLS validation depends on a correct clock) without jumping it backward under a running workload.

### How
envd starts off `multi-user.target` and only orders after journald's socket + a writable rootfs (networking is configured by the kernel `ip=` before userspace); shutdown ordering is preserved explicitly (`Conflicts`/`Before=shutdown.target`). The cert tmpfs is seeded from `/usr/local/share/e2b/ssl-certs.tar` packed during provisioning, with fallbacks to copying
the cert dir and then regenerating the bundle. The masked units are inert in the sandbox. chrony still syncs in the background; `makestep` only steps (vs slews) when the offset exceeds 1 s, for the first 3 updates after each boot.