### PR TITLE
feat(envd): split collapse stats into real migrations vs already-huge

### DIFF
--- a/packages/envd/internal/api/api.gen.go
+++ b/packages/envd/internal/api/api.gen.go
@@ -36,10 +36,13 @@ func (e EntryInfoType) Valid() bool {
 
 // CollapseResult Per-call statistics from a heap collapse
 type CollapseResult struct {
+	// AlreadyHuge Chunks MADV_COLLAPSE accepted but were already hugepages (no work)
+	AlreadyHuge *int `json:"alreadyHuge,omitempty"`
+
 	// Chunks 2 MiB chunks attempted
 	Chunks *int `json:"chunks,omitempty"`
 
-	// Collapsed Chunks collapsed into a hugepage
+	// Collapsed Chunks whose base pages were actually migrated into a new hugepage (real work)
 	Collapsed *int `json:"collapsed,omitempty"`
 
 	// ElapsedMs Wall-clock time spent collapsing, in milliseconds

--- a/packages/envd/internal/api/collapse.go
+++ b/packages/envd/internal/api/collapse.go
@@ -36,16 +36,18 @@ func (a *API) PostCollapse(w http.ResponseWriter, r *http.Request) {
 		Int("regions", stats.Regions).
 		Int("chunks", stats.Chunks).
 		Int("collapsed", stats.Collapsed).
+		Int("already_huge", stats.AlreadyHuge).
 		Int("skipped", stats.Skipped).
 		Int64("elapsed_ms", elapsedMs).
 		Msg("collapsed envd heap")
 
 	result := CollapseResult{
-		Regions:   &stats.Regions,
-		Chunks:    &stats.Chunks,
-		Collapsed: &stats.Collapsed,
-		Skipped:   &stats.Skipped,
-		ElapsedMs: &elapsedMs,
+		Regions:     &stats.Regions,
+		Chunks:      &stats.Chunks,
+		Collapsed:   &stats.Collapsed,
+		AlreadyHuge: &stats.AlreadyHuge,
+		Skipped:     &stats.Skipped,
+		ElapsedMs:   &elapsedMs,
 	}
 
 	w.Header().Set("Cache-Control", "no-store")

--- a/packages/envd/internal/services/memory/collapse.go
+++ b/packages/envd/internal/services/memory/collapse.go
@@ -8,9 +8,17 @@
 package memory
 
 // Stats summarizes a CollapseSelf run.
+//
+// MADV_COLLAPSE returns success both when it migrates scattered base pages into
+// a new hugepage and when the window was already a hugepage (a no-op), so the
+// raw success count overstates real work. We split it with the process's
+// AnonHugePages delta: Collapsed counts windows actually migrated this run,
+// AlreadyHuge counts windows that were already huge. Invariant:
+// Chunks = Collapsed + AlreadyHuge + Skipped.
 type Stats struct {
-	Regions   int // anonymous read-write regions scanned
-	Chunks    int // 2 MiB chunks attempted
-	Collapsed int // chunks collapsed into a hugepage
-	Skipped   int // chunks that could not be collapsed (empty or ineligible)
+	Regions     int // anonymous read-write regions scanned
+	Chunks      int // 2 MiB chunks attempted = Collapsed + AlreadyHuge + Skipped
+	Collapsed   int // chunks whose base pages were actually migrated into a new hugepage (real work)
+	AlreadyHuge int // chunks MADV_COLLAPSE accepted but were already hugepages (no work)
+	Skipped     int // chunks that could not be collapsed (empty or ineligible)
 }

--- a/packages/envd/internal/services/memory/collapse_linux.go
+++ b/packages/envd/internal/services/memory/collapse_linux.go
@@ -65,23 +65,33 @@ func CollapseSelf(ctx context.Context) (Stats, error) {
 	}
 	after, okAfter := anonHugePagesBytes()
 
-	// Attribute madvise successes to real migrations (AnonHugePages grew) vs
-	// already-huge no-ops. MADV_COLLAPSE is synchronous, so the delta reflects
-	// exactly the hugepages this run created. If smaps_rollup is unreadable, fall
-	// back to the pre-split meaning (all successes counted as Collapsed) rather
-	// than misreporting real work as no-ops.
-	if okBefore && okAfter && after >= before {
-		// Clamp: background THP activity could inflate the delta past what our
-		// madvise calls actually achieved.
-		migrated := min(int((after-before)/hugePageSize), successes)
-		s.Collapsed = migrated
-		s.AlreadyHuge = successes - migrated
-	} else {
-		s.Collapsed = successes
-	}
+	// Attribute madvise successes to real migrations vs already-huge no-ops
+	// using the AnonHugePages delta. MADV_COLLAPSE is synchronous, so the delta
+	// reflects exactly the hugepages this run created.
+	s.Collapsed, s.AlreadyHuge = splitCollapsed(successes, before, after, okBefore && okAfter)
 
 	// nil on a complete run; the cancellation error if the caller gave up.
 	return s, ctx.Err()
+}
+
+// splitCollapsed attributes MADV_COLLAPSE successes to real migrations vs
+// already-huge no-ops using the AnonHugePages byte delta across the collapse.
+// collapsed = windows whose pages were actually migrated this run (the delta in
+// 2 MiB hugepages), alreadyHuge = the rest.
+//
+// When the delta could not be measured (measured=false, e.g. smaps_rollup
+// unreadable) or AnonHugePages went backwards (after < before, e.g. concurrent
+// THP teardown), it falls back to the pre-split meaning — all successes counted
+// as collapsed — so a missing or noisy reading never misreports real work as a
+// no-op. The migrated count is clamped to successes, since background THP
+// activity could otherwise inflate the delta past what these madvise calls did.
+func splitCollapsed(successes int, before, after uint64, measured bool) (collapsed, alreadyHuge int) {
+	if !measured || after < before {
+		return successes, 0
+	}
+	migrated := min(int((after-before)/hugePageSize), successes)
+
+	return migrated, successes - migrated
 }
 
 // anonHugePagesBytes reads AnonHugePages from /proc/self/smaps_rollup. The bool

--- a/packages/envd/internal/services/memory/collapse_linux.go
+++ b/packages/envd/internal/services/memory/collapse_linux.go
@@ -3,8 +3,12 @@
 package memory
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/prometheus/procfs"
 	"golang.org/x/sys/unix"
@@ -41,6 +45,11 @@ func CollapseSelf(ctx context.Context) (Stats, error) {
 	}
 
 	var s Stats
+	// successes = windows where MADV_COLLAPSE returned 0. That conflates real
+	// migrations with already-huge no-ops; we split them below via the
+	// AnonHugePages delta.
+	var successes int
+	before, okBefore := anonHugePagesBytes()
 	for _, r := range anonRWRegions(maps) {
 		// Caller gave up (timeout/disconnect): stop issuing madvise calls and
 		// return the progress made so far. Reported uniformly via ctx.Err()
@@ -51,12 +60,59 @@ func CollapseSelf(ctx context.Context) (Stats, error) {
 		s.Regions++
 		rs := collapseRange(ctx, r.start, r.end)
 		s.Chunks += rs.Chunks
-		s.Collapsed += rs.Collapsed
+		successes += rs.Collapsed
 		s.Skipped += rs.Skipped
+	}
+	after, okAfter := anonHugePagesBytes()
+
+	// Attribute madvise successes to real migrations (AnonHugePages grew) vs
+	// already-huge no-ops. MADV_COLLAPSE is synchronous, so the delta reflects
+	// exactly the hugepages this run created. If smaps_rollup is unreadable, fall
+	// back to the pre-split meaning (all successes counted as Collapsed) rather
+	// than misreporting real work as no-ops.
+	if okBefore && okAfter && after >= before {
+		// Clamp: background THP activity could inflate the delta past what our
+		// madvise calls actually achieved.
+		migrated := min(int((after-before)/hugePageSize), successes)
+		s.Collapsed = migrated
+		s.AlreadyHuge = successes - migrated
+	} else {
+		s.Collapsed = successes
 	}
 
 	// nil on a complete run; the cancellation error if the caller gave up.
 	return s, ctx.Err()
+}
+
+// anonHugePagesBytes reads AnonHugePages from /proc/self/smaps_rollup. The bool
+// is false when the field can't be read (no smaps_rollup / CONFIG_PROC_PAGE_MONITOR),
+// so callers can fall back instead of treating a missing read as zero hugepages.
+func anonHugePagesBytes() (uint64, bool) {
+	f, err := os.Open("/proc/self/smaps_rollup")
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.HasPrefix(line, "AnonHugePages:") {
+			continue
+		}
+		fields := strings.Fields(line) // ["AnonHugePages:", "<kB>", "kB"]
+		if len(fields) < 2 {
+			return 0, false
+		}
+		kb, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			return 0, false
+		}
+
+		return kb * 1024, true
+	}
+
+	return 0, false
 }
 
 // anonRWRegions selects the anonymous (no backing file) read-write mappings from

--- a/packages/envd/internal/services/memory/collapse_test.go
+++ b/packages/envd/internal/services/memory/collapse_test.go
@@ -87,5 +87,39 @@ func TestCollapseSelf(t *testing.T) {
 	s, err := CollapseSelf(context.Background())
 	require.NoError(t, err)
 	assert.Positive(t, s.Regions)
-	assert.Equal(t, s.Chunks, s.Collapsed+s.Skipped)
+	assert.Equal(t, s.Chunks, s.Collapsed+s.AlreadyHuge+s.Skipped)
+}
+
+// TestSplitCollapsed covers the pure attribution of MADV_COLLAPSE successes into
+// real migrations vs already-huge no-ops from the AnonHugePages byte delta.
+func TestSplitCollapsed(t *testing.T) {
+	t.Parallel()
+
+	const hp = hugePageSize
+	cases := []struct {
+		name                           string
+		successes                      int
+		before, after                  uint64
+		measured                       bool
+		wantCollapsed, wantAlreadyHuge int
+	}{
+		{"all migrated", 10, 0, 10 * hp, true, 10, 0},
+		{"partial migrated", 10, 5 * hp, 8 * hp, true, 3, 7},
+		{"none migrated, all already huge", 10, 4 * hp, 4 * hp, true, 0, 10},
+		{"delta clamped to successes", 10, 0, 20 * hp, true, 10, 0},
+		{"unmeasured falls back to all collapsed", 10, 0, 0, false, 10, 0},
+		{"delta went backwards falls back", 10, 8 * hp, 4 * hp, true, 10, 0},
+		{"no successes", 0, 0, 4 * hp, true, 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			collapsed, alreadyHuge := splitCollapsed(tc.successes, tc.before, tc.after, tc.measured)
+			assert.Equal(t, tc.wantCollapsed, collapsed, "collapsed")
+			assert.Equal(t, tc.wantAlreadyHuge, alreadyHuge, "alreadyHuge")
+			// The split always partitions the successes.
+			assert.Equal(t, tc.successes, collapsed+alreadyHuge, "collapsed+alreadyHuge must equal successes")
+		})
+	}
 }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.5"
+const Version = "0.6.6"

--- a/packages/envd/spec/envd.yaml
+++ b/packages/envd/spec/envd.yaml
@@ -452,7 +452,10 @@ components:
           description: 2 MiB chunks attempted
         collapsed:
           type: integer
-          description: Chunks collapsed into a hugepage
+          description: Chunks whose base pages were actually migrated into a new hugepage (real work)
+        alreadyHuge:
+          type: integer
+          description: Chunks MADV_COLLAPSE accepted but were already hugepages (no work)
         skipped:
           type: integer
           description: Chunks that could not be collapsed (empty or ineligible)

--- a/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
+++ b/packages/orchestrator/pkg/sandbox/envd/envd.gen.go
@@ -30,10 +30,13 @@ func (e EntryInfoType) Valid() bool {
 
 // CollapseResult Per-call statistics from a heap collapse
 type CollapseResult struct {
+	// AlreadyHuge Chunks MADV_COLLAPSE accepted but were already hugepages (no work)
+	AlreadyHuge int `json:"alreadyHuge,omitempty"`
+
 	// Chunks 2 MiB chunks attempted
 	Chunks int `json:"chunks,omitempty"`
 
-	// Collapsed Chunks collapsed into a hugepage
+	// Collapsed Chunks whose base pages were actually migrated into a new hugepage (real work)
 	Collapsed int `json:"collapsed,omitempty"`
 
 	// ElapsedMs Wall-clock time spent collapsing, in milliseconds

--- a/packages/orchestrator/pkg/sandbox/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/reclaim.go
@@ -286,15 +286,18 @@ func (s *Sandbox) bestEffortCollapse(ctx context.Context) {
 		return
 	}
 
-	// Chunk-level efficacy: attempts = collapsed + skipped, successful = collapsed.
-	// One counter split by result so attempts (sum) and successes (collapsed) are
-	// both queryable.
+	// Chunk-level efficacy split three ways so the dashboard can separate real
+	// work from no-ops: attempts = collapsed + already_huge + skipped, where
+	// collapsed = pages actually migrated this pause, already_huge = windows that
+	// were already hugepages (MADV_COLLAPSE succeeded but did nothing).
 	envdCollapseChunks.Add(ctx, int64(stats.Collapsed), metric.WithAttributes(attribute.String("result", "collapsed")))
+	envdCollapseChunks.Add(ctx, int64(stats.AlreadyHuge), metric.WithAttributes(attribute.String("result", "already_huge")))
 	envdCollapseChunks.Add(ctx, int64(stats.Skipped), metric.WithAttributes(attribute.String("result", "skipped")))
 	span.SetAttributes(
 		attribute.Int("collapse.regions", stats.Regions),
 		attribute.Int("collapse.chunks", stats.Chunks),
 		attribute.Int("collapse.collapsed", stats.Collapsed),
+		attribute.Int("collapse.already_huge", stats.AlreadyHuge),
 		attribute.Int("collapse.skipped", stats.Skipped),
 	)
 
@@ -303,6 +306,7 @@ func (s *Sandbox) bestEffortCollapse(ctx context.Context) {
 		zap.Int("regions", stats.Regions),
 		zap.Int("chunks", stats.Chunks),
 		zap.Int("collapsed", stats.Collapsed),
+		zap.Int("already_huge", stats.AlreadyHuge),
 		zap.Int("skipped", stats.Skipped),
 		zap.Int64("duration_ms", elapsedMs),
 	)

--- a/tests/integration/internal/envd/generated.go
+++ b/tests/integration/internal/envd/generated.go
@@ -39,10 +39,13 @@ func (e EntryInfoType) Valid() bool {
 
 // CollapseResult Per-call statistics from a heap collapse
 type CollapseResult struct {
+	// AlreadyHuge Chunks MADV_COLLAPSE accepted but were already hugepages (no work)
+	AlreadyHuge *int `json:"alreadyHuge,omitempty"`
+
 	// Chunks 2 MiB chunks attempted
 	Chunks *int `json:"chunks,omitempty"`
 
-	// Collapsed Chunks collapsed into a hugepage
+	// Collapsed Chunks whose base pages were actually migrated into a new hugepage (real work)
 	Collapsed *int `json:"collapsed,omitempty"`
 
 	// ElapsedMs Wall-clock time spent collapsing, in milliseconds


### PR DESCRIPTION
## Why

The pre-pause envd heap collapse records `MADV_COLLAPSE` successes as `collapsed`. But `MADV_COLLAPSE` returns success **both** when it actually migrates scattered base pages into a new hugepage **and** when the window was already a hugepage (a no-op). So the raw `collapsed` count overstates real work, and the collapse-duration/efficacy metrics are diluted by no-op re-collapses (e.g. re-pausing an already-collapsed, resumed sandbox).

## What

- Split the count using the process's **`AnonHugePages` delta** (`/proc/self/smaps_rollup`) across the collapse:
  - `collapsed` now counts only windows **actually migrated** this run.
  - new `already_huge` counts windows that were already huge.
  - invariant: `chunks = collapsed + already_huge + skipped`.
- Fall back to the pre-split meaning (all successes → `collapsed`) when `smaps_rollup` is unreadable, so a missing read never misreports real work as no-ops.
- Plumb `alreadyHuge` through the `/collapse` response (spec + regenerated envd server and orchestrator client) and emit it from the orchestrator as a third `result` bucket (`collapsed | already_huge | skipped`).
- Bump envd `0.6.5 → 0.6.6` (additive response field; version gate stays at 0.6.5).

## Validation

Verified on the dev cluster through the real API/orchestrator. First pause of a freshly-scattered envd heap: `collapsed=379, already_huge=2` (434 ms). Repeat pauses of the resumed (already-collapsed) sandbox: `collapsed≈20, already_huge≈360` (~30 ms). The split correctly attributes real work, and `collapsed` now correlates with collapse duration where the raw success count did not. Lint + unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)