### PR TITLE
Return 503 for unavailable sandbox upstreams

### DIFF
--- a/packages/api/internal/handlers/sandbox_resume.go
+++ b/packages/api/internal/handlers/sandbox_resume.go
@@ -124,8 +124,12 @@ func (a *APIStore) PostSandboxesSandboxIDResume(c *gin.Context, sandboxID api.Sa
 	lastSnapshot, err := a.snapshotCache.Get(ctx, sandboxID)
 	if err != nil {
 		if errors.Is(err, snapshotcache.ErrSnapshotNotFound) {
-			logger.L().Debug(ctx, "Snapshot not found", logger.WithSandboxID(sandboxID))
-			a.sendAPIStoreError(c, http.StatusNotFound, utils.SandboxNotFoundMsg(sandboxID))
+			logger.L().Warn(ctx, "snapshot not found while resuming sandbox",
+				logger.WithSandboxID(sandboxID),
+				logger.WithTeamID(teamID.String()),
+				zap.Error(err),
+			)
+			a.sendAPIStoreError(c, http.StatusNotFound, utils.SandboxSnapshotNotFoundMsg(sandboxID))
 
 			return
 		}
@@ -193,6 +197,19 @@ func (a *APIStore) buildResumeSandboxData(sandboxID string, autoPauseOverride *b
 	return func(ctx context.Context) (orchestrator.SandboxMetadata, *api.APIError) {
 		lastSnapshot, err := a.snapshotCache.Get(ctx, sandboxID)
 		if err != nil {
+			if errors.Is(err, snapshotcache.ErrSnapshotNotFound) {
+				logger.L().Warn(ctx, "snapshot disappeared while starting resumed sandbox",
+					logger.WithSandboxID(sandboxID),
+					zap.Error(err),
+				)
+
+				return orchestrator.SandboxMetadata{}, &api.APIError{
+					Code:      http.StatusNotFound,
+					ClientMsg: utils.SandboxSnapshotNotFoundMsg(sandboxID),
+					Err:       fmt.Errorf("snapshot not found for sandbox '%s': %w", sandboxID, err),
+				}
+			}
+
 			return orchestrator.SandboxMetadata{}, &api.APIError{
 				Code:      http.StatusInternalServerError,
 				ClientMsg: "Error when getting snapshot",

--- a/packages/api/internal/utils/messages.go
+++ b/packages/api/internal/utils/messages.go
@@ -10,6 +10,10 @@ func SandboxNotFoundMsg(sandboxID string) string {
 	return fmt.Sprintf("Sandbox %q doesn't exist or you don't have access to it", sandboxID)
 }
 
+func SandboxSnapshotNotFoundMsg(sandboxID string) string {
+	return fmt.Sprintf("Snapshot for sandbox %q was not found", sandboxID)
+}
+
 func SandboxChangingStateMsg(sandboxID string, state sandbox.State) string {
 	switch state {
 	case sandbox.StateKilling:

--- a/packages/api/internal/utils/messages_test.go
+++ b/packages/api/internal/utils/messages_test.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSandboxSnapshotNotFoundMsg(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, `Snapshot for sandbox "sbx_123" was not found`, SandboxSnapshotNotFoundMsg("sbx_123"))
+}

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"go.uber.org/zap"
@@ -162,7 +163,16 @@ func newProxyClient(
 				return
 			}
 
-			http.Error(w, "Failed to route request to sandbox", http.StatusBadGateway)
+			statusCode := upstreamErrorStatus(err)
+			if statusCode == http.StatusServiceUnavailable {
+				t.RequestLogger.Warn(ctx, "sandbox upstream unavailable",
+					zap.Error(err),
+					zap.Int("status_code", statusCode),
+					zap.Uint64("sandbox_port", t.SandboxPort),
+				)
+			}
+
+			http.Error(w, "Failed to route request to sandbox", statusCode)
 		},
 		ModifyResponse: func(r *http.Response) error {
 			ctx := r.Request.Context()
@@ -190,6 +200,30 @@ func newProxyClient(
 	}
 
 	return pc
+}
+
+func upstreamErrorStatus(err error) int {
+	if err == nil {
+		return http.StatusBadGateway
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return http.StatusBadGateway
+	}
+
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return http.StatusServiceUnavailable
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return http.StatusServiceUnavailable
+	}
+
+	return http.StatusBadGateway
 }
 
 func (p *ProxyClient) getDestination(r *http.Request) (*Destination, bool) {

--- a/packages/shared/pkg/proxy/pool/client.go
+++ b/packages/shared/pkg/proxy/pool/client.go
@@ -220,6 +220,9 @@ func upstreamErrorStatus(err error) int {
 
 	var netErr net.Error
 	if errors.As(err, &netErr) {
+		if netErr.Timeout() {
+			return http.StatusGatewayTimeout
+		}
 		return http.StatusServiceUnavailable
 	}
 

--- a/packages/shared/pkg/proxy/pool/client_test.go
+++ b/packages/shared/pkg/proxy/pool/client_test.go
@@ -35,6 +35,11 @@ func TestUpstreamErrorStatus(t *testing.T) {
 			want: http.StatusServiceUnavailable,
 		},
 		{
+			name: "timeout",
+			err:  &net.DNSError{Err: "i/o timeout", IsTimeout: true},
+			want: http.StatusGatewayTimeout,
+		},
+		{
 			name: "client canceled",
 			err:  context.Canceled,
 			want: http.StatusBadGateway,

--- a/packages/shared/pkg/proxy/pool/client_test.go
+++ b/packages/shared/pkg/proxy/pool/client_test.go
@@ -1,0 +1,56 @@
+package pool
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpstreamErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "connection refused",
+			err:  syscall.ECONNREFUSED,
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "wrapped connection reset",
+			err:  errors.Join(errors.New("proxy read failed"), syscall.ECONNRESET),
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "net error",
+			err:  &net.DNSError{Err: "lookup failed"},
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "client canceled",
+			err:  context.Canceled,
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "unknown error",
+			err:  errors.New("malformed upstream response"),
+			want: http.StatusBadGateway,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, upstreamErrorStatus(tt.err))
+		})
+	}
+}

--- a/packages/shared/pkg/proxy/proxy_test.go
+++ b/packages/shared/pkg/proxy/proxy_test.go
@@ -728,6 +728,40 @@ func TestProxyReuseConnectionsWhenBackendChangesFails(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, resp2.StatusCode, "status code should be 502")
 }
 
+func TestProxyReturnsServiceUnavailableForClosedUpstreamPort(t *testing.T) {
+	t.Parallel()
+
+	var lisCfg net.ListenConfig
+	listener, err := lisCfg.Listen(t.Context(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	backendURL, err := url.Parse(fmt.Sprintf("http://%s", listener.Addr().String()))
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+
+	getDestination := func(*http.Request) (*pool.Destination, error) {
+		return &pool.Destination{
+			Url:           backendURL,
+			SandboxId:     "test-sandbox",
+			RequestLogger: logger.NewNopLogger(),
+			ConnectionKey: "closed-upstream",
+			SandboxPort:   49983,
+		}, nil
+	}
+
+	proxy, port, err := newTestProxy(t, getDestination)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		proxy.Close()
+	})
+
+	resp, err := httpGet(t, fmt.Sprintf("http://127.0.0.1:%d/hello", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "status code should be 503")
+}
+
 func TestProxyDoesNotReuseConnectionsWhenBackendChanges(t *testing.T) {
 	t.Parallel()
 	// Create first backend


### PR DESCRIPTION
## Summary

* classify sandbox upstream dial and transport failures as 503 instead of always returning 502
* add structured logging for unavailable upstreams with status code and sandbox port
* keep the existing closed-port and stale-connection behavior intact
* return a specific snapshot-missing message when resume cannot find the cached snapshot

Fixes part of e2b-dev/infra#2730.

## Checks

* gofmt on touched Go files with Go 1.26.3
* git diff --check
* PATH=/tmp/codex-go1.26.3/go/bin:$PATH go test ./packages/shared/pkg/proxy/... ./packages/api/internal/utils

## Notes

The shared proxy and utils tests passed. A heavier compile of ./packages/api/internal/handlers could not complete locally because the machine ran out of disk while downloading the handler dependency graph. The failure was disk space, not a test assertion.