### PR TITLE
feat(orchestrator): upload metadata.json last as completion marker

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -99,10 +99,6 @@ func (u *Upload) runV3(ctx context.Context) error {
 		return uploadBlobWithMetrics(egCtx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), uploadFileSnap, meta)
 	})
 
-	eg.Go(func() error {
-		return uploadBlobWithMetrics(egCtx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
-	})
-
 	if err := eg.Wait(); err != nil {
 		return err
 	}
@@ -140,7 +136,10 @@ func (u *Upload) runV3(ctx context.Context) error {
 		}
 	}
 
-	return nil
+	// metadata.json is the completion marker: upload it only after every other
+	// object (data, headers, snapfile) has landed, so its presence proves the
+	// build is fully uploaded.
+	return uploadBlobWithMetrics(ctx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
 }
 
 // finalizeV3 returns a shallow copy of src with IncompletePendingUpload cleared,

--- a/packages/orchestrator/pkg/sandbox/build_upload_v4.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v4.go
@@ -64,11 +64,14 @@ func (u *Upload) runV4(ctx context.Context) error {
 		return uploadBlobWithMetrics(ctx, u.store, u.paths.Snapfile(), storage.SnapfileObjectType, u.snap.Snapfile.Path(), uploadFileSnap, meta)
 	})
 
-	eg.Go(func() error {
-		return uploadBlobWithMetrics(ctx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
-	})
+	if err := eg.Wait(); err != nil {
+		return err
+	}
 
-	return eg.Wait()
+	// metadata.json is the completion marker: upload it only after every other
+	// object (data, headers, snapfile) has landed, so its presence proves the
+	// build is fully uploaded.
+	return uploadBlobWithMetrics(ctx, u.store, u.paths.Metadata(), storage.MetadataObjectType, u.snap.Metafile.Path(), uploadFileMeta, meta)
 }
 
 func (u *Upload) uploadFramed(


### PR DESCRIPTION
## What
Upload `metadata.json` as the final object in the build upload (v3 and v4 paths), after all data files, headers, and the snapfile have been written.

## Why
Its presence then proves the build is fully uploaded. A consumer (e.g. the storage index) can treat a build missing `metadata.json` as incomplete — such as a crashed mid-upload — instead of risking action on a partial object set. GCS object writes are individually atomic, so "all others succeeded, then metadata.json" is a reliable commit marker.