### PR TITLE
feat(orchestrator): soft-delete consumer enforcement for storage index

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+var softDeleteCheckMetric = utils.Must(meter.Int64Counter(
+	"orchestrator.build.soft_delete_check",
+	metric.WithDescription("Storage-index soft-delete checks on data-layer open")))
+
+func (b *StorageDiff) softDeleteErr() error {
+	if b.softDeleted.Load() {
+		return fmt.Errorf("%s %s: %w", b.buildID, b.diffType, storage.ErrObjectSoftDeleted)
+	}
+
+	return nil
+}
+
+// startSoftDeleteCheck runs the check in the background so it never adds latency
+// to the read path. No-op (no GCS access) when the check flag is off.
+func (b *StorageDiff) startSoftDeleteCheck(ctx context.Context) {
+	ff := b.flags
+	if ff == nil || !ff.BoolFlag(ctx, featureflags.StorageSoftDeleteCheckFlag) {
+		return
+	}
+
+	go b.softDeleteCheck(ctx, ff)
+}
+
+func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Client) {
+	// Read the tombstone off the data object this diff actually serves — the
+	// object the storage index prunes — not the header, which a deduped
+	// ancestor layer is never read from.
+	path := b.dataPath.Load()
+	if path == nil {
+		return
+	}
+	blob, err := b.persistence.OpenBlob(ctx, *path, storage.MetadataObjectType)
+	if err != nil {
+		return
+	}
+
+	md, err := storage.BlobCustomMetadata(ctx, blob)
+	if err != nil {
+		return
+	}
+
+	// Indexing a nil map is safe: "" / false.
+	marker, softDeleted := md[storage.ObjectMetadataSoftDeleted]
+	enforce := ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag)
+	failed := softDeleted && enforce
+
+	softDeleteCheckMetric.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("artifact", string(b.diffType)),
+		attribute.Bool("soft_deleted", softDeleted),
+		attribute.Bool("failed", failed),
+	))
+
+	if !softDeleted {
+		return
+	}
+
+	logger.L().Error(ctx, "storage-index soft-deleted layer in use",
+		logger.WithBuildID(b.buildID),
+		zap.String("artifact", string(b.diffType)),
+		zap.String("marker", marker),
+		zap.Bool("enforce", enforce),
+	)
+
+	if failed {
+		b.softDeleted.Store(true)
+	}
+}

--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -52,7 +52,9 @@ func classifyCheckError(err error) string {
 }
 
 func (b *StorageDiff) softDeleteErr() error {
-	if b.softDeleted.Load() {
+	// Fail closed only while the tombstoned path is still the active one: a peer
+	// transition that repointed dataPath makes the old verdict stop matching.
+	if sp := b.softDeletedPath.Load(); sp != nil && sp == b.dataPath.Load() {
 		return fmt.Errorf("%s %s: %w", b.buildID, b.diffType, storage.ErrObjectSoftDeleted)
 	}
 
@@ -119,12 +121,10 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		zap.Bool("enforce", enforce),
 	)
 
-	// Only fail closed if dataPath still points at the object we checked: a
-	// peer transition may have repointed it, in which case a fresh check for
-	// the new object is authoritative and this (stale) one must not latch.
+	// Record the tombstoned path; softDeleteErr enforces only while it is still
+	// the active dataPath, so storing a superseded path here is harmless (it can
+	// never match the current pointer) — no check-then-store race.
 	if failed {
-		if cur := b.dataPath.Load(); cur == path {
-			b.softDeleted.Store(true)
-		}
+		b.softDeletedPath.Store(path)
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -4,6 +4,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -16,9 +17,39 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
+// soft-delete check outcomes, the metric's "result" dimension. They are
+// mutually exclusive: a tombstone hit (checked + soft_deleted) is distinct from
+// the object being unreadable (not_found / error), so a missing object never
+// masquerades as "not soft-deleted".
+const (
+	checkResultChecked  = "checked"   // metadata read; soft_deleted tells the verdict
+	checkResultNotFound = "not_found" // object does not exist (e.g. peer-only or already gone)
+	checkResultError    = "error"     // metadata could not be read (transient/permission)
+)
+
 var softDeleteCheckMetric = utils.Must(meter.Int64Counter(
 	"orchestrator.build.soft_delete_check",
 	metric.WithDescription("Storage-index soft-delete checks on data-layer open")))
+
+// recordCheck emits one metric point per check. result distinguishes a read
+// (checked) from an unreadable object (not_found/error); soft_deleted/failed
+// are only meaningful when result==checked.
+func (b *StorageDiff) recordCheck(ctx context.Context, result string, softDeleted, failed bool) {
+	softDeleteCheckMetric.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("artifact", string(b.diffType)),
+		attribute.String("result", result),
+		attribute.Bool("soft_deleted", softDeleted),
+		attribute.Bool("failed", failed),
+	))
+}
+
+func classifyCheckError(err error) string {
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return checkResultNotFound
+	}
+
+	return checkResultError
+}
 
 func (b *StorageDiff) softDeleteErr() error {
 	if b.softDeleted.Load() {
@@ -49,11 +80,21 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	}
 	blob, err := b.persistence.OpenBlob(ctx, *path, storage.MetadataObjectType)
 	if err != nil {
+		b.recordCheck(ctx, classifyCheckError(err), false, false)
+		logger.L().Warn(ctx, "storage-index soft-delete check could not open object",
+			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
+			zap.String("object", *path), zap.Error(err))
+
 		return
 	}
 
 	md, err := storage.BlobCustomMetadata(ctx, blob)
 	if err != nil {
+		b.recordCheck(ctx, classifyCheckError(err), false, false)
+		logger.L().Warn(ctx, "storage-index soft-delete check could not read object metadata",
+			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
+			zap.String("object", *path), zap.Error(err))
+
 		return
 	}
 
@@ -62,11 +103,7 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	enforce := ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag)
 	failed := softDeleted && enforce
 
-	softDeleteCheckMetric.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("artifact", string(b.diffType)),
-		attribute.Bool("soft_deleted", softDeleted),
-		attribute.Bool("failed", failed),
-	))
+	b.recordCheck(ctx, checkResultChecked, softDeleted, failed)
 
 	if !softDeleted {
 		return

--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -80,19 +80,22 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	}
 	blob, err := b.persistence.OpenBlob(ctx, *path, storage.MetadataObjectType)
 	if err != nil {
-		b.recordCheck(ctx, classifyCheckError(err), false, false)
+		result := classifyCheckError(err)
+		b.recordCheck(ctx, result, false, false)
 		logger.L().Warn(ctx, "storage-index soft-delete check could not open object",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
-			zap.String("object", *path), zap.Error(err))
+			zap.String("result", result), zap.String("object", *path), zap.Error(err))
 
 		return
 	}
 
 	md, err := storage.BlobCustomMetadata(ctx, blob)
 	if err != nil {
-		b.recordCheck(ctx, classifyCheckError(err), false, false)
+		result := classifyCheckError(err)
+		b.recordCheck(ctx, result, false, false)
 		logger.L().Warn(ctx, "storage-index soft-delete check could not read object metadata",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
+			zap.String("result", result),
 			zap.String("object", *path), zap.Error(err))
 
 		return

--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -22,9 +22,10 @@ import (
 // the object being unreadable (not_found / error), so a missing object never
 // masquerades as "not soft-deleted".
 const (
-	checkResultChecked  = "checked"   // metadata read; soft_deleted tells the verdict
-	checkResultNotFound = "not_found" // object does not exist (e.g. peer-only or already gone)
-	checkResultError    = "error"     // metadata could not be read (transient/permission)
+	checkResultChecked     = "checked"     // metadata read; soft_deleted tells the verdict
+	checkResultNotFound    = "not_found"   // object does not exist (e.g. peer-only or already gone)
+	checkResultError       = "error"       // metadata could not be read (transient/permission)
+	checkResultUnsupported = "unsupported" // backend cannot read custom metadata
 )
 
 var softDeleteCheckMetric = utils.Must(meter.Int64Counter(
@@ -44,11 +45,14 @@ func (b *StorageDiff) recordCheck(ctx context.Context, result string, softDelete
 }
 
 func classifyCheckError(err error) string {
-	if errors.Is(err, storage.ErrObjectNotExist) {
+	switch {
+	case errors.Is(err, storage.ErrObjectNotExist):
 		return checkResultNotFound
+	case errors.Is(err, storage.ErrMetadataUnsupported):
+		return checkResultUnsupported
+	default:
+		return checkResultError
 	}
-
-	return checkResultError
 }
 
 func (b *StorageDiff) softDeleteErr() error {
@@ -94,6 +98,19 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	md, err := storage.BlobCustomMetadata(ctx, blob)
 	if err != nil {
 		result := classifyCheckError(err)
+		// A backend that can't read metadata is a deterministic gap, not a
+		// transient one: under enforce, fail closed rather than serve a
+		// possibly-tombstoned layer (BlobCustomMetadata used to return no error
+		// here, which silently failed open).
+		if result == checkResultUnsupported && ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag) {
+			b.recordCheck(ctx, result, false, true)
+			b.softDeletedPath.Store(path)
+			logger.L().Error(ctx, "storage-index soft-delete unverifiable; failing closed",
+				logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
+				zap.String("result", result), zap.String("object", *path), zap.Error(err))
+
+			return
+		}
 		b.recordCheck(ctx, result, false, false)
 		logger.L().Warn(ctx, "storage-index soft-delete check could not read object metadata",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -48,6 +48,12 @@ type StorageDiff struct {
 	buildID           string
 	diffType          DiffType
 	storageObjectType storage.SeekableObjectType
+	// dataPath is the storage object this diff reads from; the soft-delete
+	// check reads the tombstone off it directly (the object that gets pruned),
+	// not the header. It can change on a peer transition (uncompressed probe ->
+	// authoritative compressed object), so it is atomic and the check reruns.
+	dataPath atomic.Pointer[string]
+	flags    *featureflags.Client
 
 	blockSize   int64
 	metrics     blockmetrics.Metrics
@@ -55,6 +61,10 @@ type StorageDiff struct {
 
 	source    atomic.Pointer[source]
 	refreshMu sync.Mutex
+
+	// softDeleted is set once the background check fails the layer (only under
+	// enforcement); when true, reads fail closed.
+	softDeleted atomic.Bool
 }
 
 var _ Diff = (*StorageDiff)(nil)
@@ -82,6 +92,7 @@ func newStorageDiff(
 	upstream storage.Seekable,
 	uncompressedSize int64,
 	initialFT *storage.FullFrameTable,
+	dataPath string,
 	ff *featureflags.Client,
 ) (*StorageDiff, error) {
 	cachePath := GenerateDiffCachePath(basePath, buildID, diffType)
@@ -94,6 +105,7 @@ func newStorageDiff(
 		buildID:           buildID,
 		diffType:          diffType,
 		storageObjectType: storageObjectType,
+		flags:             ff,
 		cachePath:         cachePath,
 		blockSize:         blockSize,
 		metrics:           metrics,
@@ -101,6 +113,7 @@ func newStorageDiff(
 		chunker:           c,
 		cacheKey:          GetDiffStoreKey(buildID, diffType),
 	}
+	d.dataPath.Store(&dataPath)
 	d.source.Store(&source{upstream: upstream, fullDiffFrameTable: initialFT})
 
 	return d, nil
@@ -121,6 +134,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 		upstream  storage.Seekable
 		size      int64
 		initialFT *storage.FullFrameTable
+		dataPath  string
 		err       error
 	)
 	switch {
@@ -128,7 +142,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 		// Open at the entry's CT. Do NOT latch bd.FrameData as the
 		// authoritative full-file FT — it carries only the frames our header
 		// references, not the ancestor's full table.
-		upstream, err = b.openDataFile(ctx, buildID, objType, bd.FrameData.CompressionType())
+		upstream, dataPath, err = b.openDataFile(ctx, buildID, objType, bd.FrameData.CompressionType())
 		if err != nil {
 			return nil, err
 		}
@@ -139,7 +153,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 		// sentinels for storage-loaded headers, so storage paths always hit
 		// CASE=hasEntry). Probe basic-name to detect peer routing; on
 		// miss/transition refresh from storage.
-		upstream, err = b.openDataFile(ctx, buildID, objType, storage.CompressionNone)
+		upstream, dataPath, err = b.openDataFile(ctx, buildID, objType, storage.CompressionNone)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +180,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 				b.SwapHeader(loaded)
 			}
 		}
-		upstream, size, initialFT, err = openFromLoadedHeader(ctx, b.persistence, loaded, b.fileType, objType)
+		upstream, size, initialFT, dataPath, err = openFromLoadedHeader(ctx, b.persistence, loaded, b.fileType, objType)
 		if err != nil {
 			return nil, err
 		}
@@ -183,7 +197,7 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 		initialFT = nil
 	}
 
-	return newStorageDiff(
+	d, err := newStorageDiff(
 		b.store.cachePath,
 		buildID.String(),
 		b.fileType,
@@ -194,18 +208,26 @@ func (b *File) createDiff(ctx context.Context, buildID uuid.UUID) (Diff, error) 
 		upstream,
 		size,
 		initialFT,
+		dataPath,
 		b.store.flags,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	d.startSoftDeleteCheck(context.WithoutCancel(ctx))
+
+	return d, nil
 }
 
-func (b *File) openDataFile(ctx context.Context, buildID uuid.UUID, objType storage.SeekableObjectType, ct storage.CompressionType) (storage.Seekable, error) {
+func (b *File) openDataFile(ctx context.Context, buildID uuid.UUID, objType storage.SeekableObjectType, ct storage.CompressionType) (storage.Seekable, string, error) {
 	path := storage.Paths{BuildID: buildID.String()}.DataFile(string(b.fileType), ct)
 	upstream, err := b.persistence.OpenSeekable(ctx, path, objType)
 	if err != nil {
-		return nil, fmt.Errorf("createDiff: open data file for build %s at %s: %w", buildID, path, err)
+		return nil, "", fmt.Errorf("createDiff: open data file for build %s at %s: %w", buildID, path, err)
 	}
 
-	return upstream, nil
+	return upstream, path, nil
 }
 
 func openFromLoadedHeader(
@@ -214,29 +236,29 @@ func openFromLoadedHeader(
 	loaded *header.Header,
 	fileType DiffType,
 	objType storage.SeekableObjectType,
-) (storage.Seekable, int64, *storage.FullFrameTable, error) {
+) (storage.Seekable, int64, *storage.FullFrameTable, string, error) {
 	buildID := loaded.Metadata.BuildId
 	paths := storage.Paths{BuildID: buildID.String()}
 	if loaded.Metadata.Version < header.MetadataVersionV4 {
 		path := paths.DataFile(string(fileType), storage.CompressionNone)
 		upstream, err := persistence.OpenSeekable(ctx, path, objType)
 		if err != nil {
-			return nil, 0, nil, fmt.Errorf("reopen uncompressed upstream for pre-V4 build %s at %s: %w", buildID, path, err)
+			return nil, 0, nil, "", fmt.Errorf("reopen uncompressed upstream for pre-V4 build %s at %s: %w", buildID, path, err)
 		}
 
-		return upstream, 0, storage.UncompressedFullFrameTable, nil
+		return upstream, 0, storage.UncompressedFullFrameTable, path, nil
 	}
 	size, ft, err := loaded.SelfBuildData()
 	if err != nil {
-		return nil, 0, nil, err
+		return nil, 0, nil, "", err
 	}
 	path := paths.DataFile(string(fileType), ft.Table().CompressionType())
 	upstream, err := persistence.OpenSeekable(ctx, path, objType)
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("reopen upstream for build %s at %s: %w", buildID, path, err)
+		return nil, 0, nil, "", fmt.Errorf("reopen upstream for build %s at %s: %w", buildID, path, err)
 	}
 
-	return upstream, size, ft, nil
+	return upstream, size, ft, path, nil
 }
 
 func storageObjectType(diffType DiffType) (storage.SeekableObjectType, bool) {
@@ -259,6 +281,9 @@ func (b *StorageDiff) Close() error {
 }
 
 func (b *StorageDiff) ReadAt(ctx context.Context, p []byte, off int64, callerFT *storage.FrameTable) (int, error) {
+	if err := b.softDeleteErr(); err != nil {
+		return 0, err
+	}
 	up, ft, err := b.resolve(ctx, callerFT)
 	if err != nil {
 		return 0, err
@@ -274,6 +299,9 @@ func (b *StorageDiff) ReadAt(ctx context.Context, p []byte, off int64, callerFT 
 	if err := b.reloadAfterPeerTransition(ctx); err != nil {
 		return 0, fmt.Errorf("refresh after peer transition: %w", err)
 	}
+	if err := b.softDeleteErr(); err != nil {
+		return 0, err
+	}
 	up, ft, err = b.resolve(ctx, callerFT)
 	if err != nil {
 		return 0, err
@@ -283,6 +311,9 @@ func (b *StorageDiff) ReadAt(ctx context.Context, p []byte, off int64, callerFT 
 }
 
 func (b *StorageDiff) Slice(ctx context.Context, off, length int64, callerFT *storage.FrameTable) ([]byte, error) {
+	if err := b.softDeleteErr(); err != nil {
+		return nil, err
+	}
 	up, ft, err := b.resolve(ctx, callerFT)
 	if err != nil {
 		return nil, err
@@ -297,6 +328,9 @@ func (b *StorageDiff) Slice(ctx context.Context, off, length int64, callerFT *st
 	}
 	if err := b.reloadAfterPeerTransition(ctx); err != nil {
 		return nil, fmt.Errorf("refresh after peer transition: %w", err)
+	}
+	if err := b.softDeleteErr(); err != nil {
+		return nil, err
 	}
 	up, ft, err = b.resolve(ctx, callerFT)
 	if err != nil {
@@ -409,11 +443,19 @@ func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) erro
 	if err != nil {
 		return fmt.Errorf("reloadSourceLocked: load header for build %s: %w", b.buildID, err)
 	}
-	upstream, _, ft, err := openFromLoadedHeader(ctx, b.persistence, loaded, b.diffType, b.storageObjectType)
+	upstream, _, ft, dataPath, err := openFromLoadedHeader(ctx, b.persistence, loaded, b.diffType, b.storageObjectType)
 	if err != nil {
 		return fmt.Errorf("reloadSourceLocked: build %s: %w", b.buildID, err)
 	}
 	b.source.Store(&source{upstream: upstream, fullDiffFrameTable: ft})
+
+	// The authoritative object can differ from the one first opened (e.g. a
+	// peer probe resolving to a compressed object); re-point and recheck the
+	// tombstone so a soft-delete on the real object is not missed.
+	if old := b.dataPath.Load(); old == nil || *old != dataPath {
+		b.dataPath.Store(&dataPath)
+		b.startSoftDeleteCheck(context.WithoutCancel(ctx))
+	}
 
 	return nil
 }

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -472,13 +472,20 @@ func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) erro
 	}
 	b.source.Store(&source{upstream: upstream, fullDiffFrameTable: ft})
 
-	// The authoritative object can differ from the one first opened (e.g. a peer
-	// probe resolving to a compressed object); re-point to the new pointer and
-	// recheck. Enforcement keys on the path pointer, so the old object's verdict
-	// (softDeletedPath) stops matching automatically — no explicit clear, and no
-	// race with a stale check still about to store the superseded path.
-	if old := b.dataPath.Load(); old == nil || *old != dataPath {
+	// Re-point to the new pointer when the authoritative object differs from the
+	// one first opened (e.g. a peer probe resolving to a compressed object).
+	// Enforcement keys on the path pointer, so the old object's verdict
+	// (softDeletedPath) stops matching automatically — no explicit clear, no
+	// race with a stale check about to store the superseded path.
+	old := b.dataPath.Load()
+	pathChanged := old == nil || *old != dataPath
+	if pathChanged {
 		b.dataPath.Store(&dataPath)
+	}
+	// Recheck on any path change, and also on a peer transition even if the path
+	// is unchanged: a peer-served object that wasn't in storage at first open
+	// (not_found) may now exist and carry a tombstone the initial check missed.
+	if pathChanged || cause == refreshCausePeerTransitioned {
 		b.startSoftDeleteCheck(context.WithoutCancel(ctx))
 	}
 

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -62,9 +62,13 @@ type StorageDiff struct {
 	source    atomic.Pointer[source]
 	refreshMu sync.Mutex
 
-	// softDeleted is set once the background check fails the layer (only under
-	// enforcement); when true, reads fail closed.
-	softDeleted atomic.Bool
+	// softDeletedPath holds the dataPath pointer the background check found
+	// tombstoned (only under enforcement); reads fail closed while it equals the
+	// current dataPath. Keying on the path pointer (not a bool) makes the latch
+	// race-free: a stale check that stored a superseded probe path can never
+	// match the current dataPath, and a peer-transition repoint auto-disables
+	// the old verdict without a separate clear.
+	softDeletedPath atomic.Pointer[string]
 }
 
 var _ Diff = (*StorageDiff)(nil)
@@ -468,13 +472,13 @@ func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) erro
 	}
 	b.source.Store(&source{upstream: upstream, fullDiffFrameTable: ft})
 
-	// The authoritative object can differ from the one first opened (e.g. a
-	// peer probe resolving to a compressed object); re-point, clear any verdict
-	// from the old object, and recheck so a soft-delete on the real object is
-	// caught while a stale tombstone on the probe object can't fail us closed.
+	// The authoritative object can differ from the one first opened (e.g. a peer
+	// probe resolving to a compressed object); re-point to the new pointer and
+	// recheck. Enforcement keys on the path pointer, so the old object's verdict
+	// (softDeletedPath) stops matching automatically — no explicit clear, and no
+	// race with a stale check still about to store the superseded path.
 	if old := b.dataPath.Load(); old == nil || *old != dataPath {
 		b.dataPath.Store(&dataPath)
-		b.softDeleted.Store(false)
 		b.startSoftDeleteCheck(context.WithoutCancel(ctx))
 	}
 

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff_test.go
@@ -364,7 +364,7 @@ func TestStorageDiff_ReloadSourceLatchesV3AsUncompressed(t *testing.T) {
 	// caller FT must refresh and latch the V3 header as uncompressed.
 	bootstrap := storage.NewMockSeekable(t)
 	diff, err := newStorageDiff(t.TempDir(), aID.String(), Memfile, storage.MemfileObjectType,
-		testBlockSize, m, provider, bootstrap, int64(payloadSize), nil, &featureflags.Client{})
+		testBlockSize, m, provider, bootstrap, int64(payloadSize), nil, "", &featureflags.Client{})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = diff.Close() })
 

--- a/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
+++ b/packages/orchestrator/pkg/sandbox/template/peerclient/blob.go
@@ -48,6 +48,17 @@ func (b *peerBlob) getBase(ctx context.Context) (storage.Blob, error) {
 	return base, nil
 }
 
+// Metadata reads custom metadata from the base (GCS-backed) blob, never the
+// peer, so the soft-delete marker reflects authoritative storage state.
+func (b *peerBlob) Metadata(ctx context.Context) (storage.ObjectMetadata, error) {
+	base, err := b.getBase(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return storage.BlobCustomMetadata(ctx, base)
+}
+
 func (b *peerBlob) WriteTo(ctx context.Context, dst io.Writer) (int64, error) {
 	res, err := tryPeer(ctx, &b.peerHandle, "peer-blob-write-to", attrOpWriteTo,
 		func(ctx context.Context) (peerAttempt[int64], error) {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -129,6 +129,13 @@ var (
 	SandboxAutoResumeFlag               = NewBoolFlag("sandbox-auto-resume", env.IsDevelopment())
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)
 
+	// StorageSoftDeleteCheckFlag enables reading the storage-index soft-delete
+	// tombstone on header load (one extra GCS Attrs on cold load). Off = no overhead.
+	StorageSoftDeleteCheckFlag = NewBoolFlag("storage-soft-delete-check", false)
+	// StorageSoftDeleteEnforceFlag makes a soft-deleted object fail the read
+	// (fail closed) instead of only emitting a metric + log. Requires the check flag.
+	StorageSoftDeleteEnforceFlag = NewBoolFlag("storage-soft-delete-enforce", false)
+
 	// UseMemFdFlag asks Firecracker to back guest memory with a memfd and
 	// pass the fd over the UFFD socket; the orchestrator then mmaps it
 	// directly instead of using process_vm_readv on pause.

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -31,6 +31,13 @@ var ErrObjectNotExist = errors.New("object does not exist")
 // multiple concurrent writers racing to write the same content-addressed object.
 var ErrObjectRateLimited = errors.New("object access rate limited")
 
+// ErrObjectSoftDeleted means the storage index has marked this object for
+// deletion (soft-delete tombstone in custom metadata) and enforcement is on.
+var ErrObjectSoftDeleted = errors.New("object soft-deleted by storage index")
+
+// ObjectMetadataSoftDeleted is the storage-index soft-delete tombstone key.
+const ObjectMetadataSoftDeleted = storageopts.ObjectMetadataSoftDeleted
+
 type Provider string
 
 const (
@@ -138,6 +145,23 @@ type Blob interface {
 	WriteTo(ctx context.Context, dst io.Writer) (int64, error)
 	Put(ctx context.Context, data []byte, opts ...storageopts.PutOption) error
 	Exists(ctx context.Context) (bool, error)
+}
+
+// MetadataReader is an optional Blob capability: read the object's custom
+// metadata without downloading it. Backends that can't answer cheaply omit it.
+type MetadataReader interface {
+	Metadata(ctx context.Context) (ObjectMetadata, error)
+}
+
+// BlobCustomMetadata returns the blob's custom metadata, or (nil, nil) when the
+// backend doesn't support reading it.
+func BlobCustomMetadata(ctx context.Context, b Blob) (ObjectMetadata, error) {
+	mr, ok := b.(MetadataReader)
+	if !ok {
+		return nil, nil
+	}
+
+	return mr.Metadata(ctx)
 }
 
 type RangeReader interface {

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -35,6 +35,12 @@ var ErrObjectRateLimited = errors.New("object access rate limited")
 // deletion (soft-delete tombstone in custom metadata) and enforcement is on.
 var ErrObjectSoftDeleted = errors.New("object soft-deleted by storage index")
 
+// ErrMetadataUnsupported means the blob's backend cannot read custom metadata
+// (no MetadataReader). It is distinct from "read succeeded, no metadata" so
+// callers (e.g. soft-delete enforcement) can fail closed on an unverifiable
+// backend instead of assuming there is no tombstone.
+var ErrMetadataUnsupported = errors.New("blob does not support reading custom metadata")
+
 // ObjectMetadataSoftDeleted is the storage-index soft-delete tombstone key.
 const ObjectMetadataSoftDeleted = storageopts.ObjectMetadataSoftDeleted
 
@@ -153,12 +159,13 @@ type MetadataReader interface {
 	Metadata(ctx context.Context) (ObjectMetadata, error)
 }
 
-// BlobCustomMetadata returns the blob's custom metadata, or (nil, nil) when the
-// backend doesn't support reading it.
+// BlobCustomMetadata returns the blob's custom metadata, or ErrMetadataUnsupported
+// when the backend can't read it — so callers can distinguish "no tombstone"
+// from "couldn't check" and fail closed under enforcement.
 func BlobCustomMetadata(ctx context.Context, b Blob) (ObjectMetadata, error) {
 	mr, ok := b.(MetadataReader)
 	if !ok {
-		return nil, nil
+		return nil, ErrMetadataUnsupported
 	}
 
 	return mr.Metadata(ctx)

--- a/packages/shared/pkg/storage/storage_cache_blob.go
+++ b/packages/shared/pkg/storage/storage_cache_blob.go
@@ -36,6 +36,12 @@ func (b *cachedBlob) Exists(ctx context.Context) (bool, error) {
 	return b.inner.Exists(ctx)
 }
 
+// Metadata delegates to the inner (backend) blob so custom metadata is read
+// from the authoritative backend, never the local byte cache.
+func (b *cachedBlob) Metadata(ctx context.Context) (ObjectMetadata, error) {
+	return BlobCustomMetadata(ctx, b.inner)
+}
+
 func (b *cachedBlob) WriteTo(ctx context.Context, dst io.Writer) (n int64, e error) {
 	ctx, span := b.tracer.Start(ctx, "read object into writer")
 	defer func() {

--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -264,6 +264,23 @@ func (o *gcpObject) Size(ctx context.Context) (int64, error) {
 	return attrs.Size, nil
 }
 
+// Metadata implements MetadataReader via Attrs (always hits GCS).
+func (o *gcpObject) Metadata(ctx context.Context) (ObjectMetadata, error) {
+	ctx, cancel := context.WithTimeout(ctx, googleOperationTimeout)
+	defer cancel()
+
+	attrs, err := o.handle.Attrs(ctx)
+	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, fmt.Errorf("failed to get GCS object (%q) attributes: %w", o.path, ErrObjectNotExist)
+		}
+
+		return nil, fmt.Errorf("failed to get GCS object (%q) attributes: %w", o.path, err)
+	}
+
+	return ObjectMetadata(attrs.Metadata), nil
+}
+
 func (o *gcpObject) openRangeReader(ctx context.Context, off, length int64) (RangeReader, error) {
 	readCtx, cancel := context.WithCancel(ctx)
 

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -11,6 +11,11 @@ type ObjectMetadata map[string]string
 
 const ObjectMetadataTeamID = "team_id"
 
+// ObjectMetadataSoftDeleted is a mutable tombstone written by the storage index
+// (not at upload time) to mark a layer for deletion. Value is
+// "<reason>:<action_id>". Consumers fail closed on it behind a feature flag.
+const ObjectMetadataSoftDeleted = "storage-index-soft-deleted"
+
 // FrameSink fires once per compressed frame with its absolute C-space offset.
 // Best-effort; implementations should return quickly and bound their own I/O.
 type FrameSink func(ctx context.Context, cOffset int64, compressed []byte)


### PR DESCRIPTION
Background, data-layer check for the storage-index soft-delete tombstone (`storage-index-soft-deleted` custom metadata). On opening a build layer, a background goroutine reads the marker off the request path: a metric fires on every check, a hit is logged, and when the enforce flag is on the layer is marked unusable so subsequent reads fail closed. Both flags (`storage-soft-delete-check` / `-enforce`) default off, so this is inert until the storage index ships and writes a tombstone.
