### PR TITLE
chore(envd): truncate promote commit SHA to 7 chars

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -39,10 +39,11 @@ endif
 .PHONY: promote
 promote:
 	$(if $(ENVD_COMMIT_SHA),,$(error ENVD_COMMIT_SHA is required))
+	$(eval ENVD_COMMIT_SHA_SHORT := $(shell printf '%.7s' "$(ENVD_COMMIT_SHA)"))
 ifeq ($(PROVIDER),aws)
-	aws s3 cp "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA)" "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+	aws s3 cp "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA_SHORT)" "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/envd" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
-	gsutil -h "Cache-Control:no-cache, max-age=0" cp "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA)" "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd"
+	gsutil -h "Cache-Control:no-cache, max-age=0" cp "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd.$(ENVD_COMMIT_SHA_SHORT)" "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/envd"
 endif
 
 build:


### PR DESCRIPTION
The build workflow names the envd artifact envd.<sha> using the 7-char short SHA. Promoting with a full SHA fails the copy since no such object exists, which makes promoting inconvenient. Truncate ENVD_COMMIT_SHA to 7 chars so any >=7-char SHA resolves to the uploaded artifact.