### PR TITLE
feat(orch): debug a sandbox guest kernel with resume-build -gdb

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,10 +51,21 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
-const (
-	baseImage = "e2bdev/base:latest"
-	proxyPort = 5007
-)
+const baseImage = "e2bdev/base:latest"
+
+// proxyPort is the sandbox proxy listen port. It defaults to 5007 but can be
+// overridden via PROXY_PORT so create-build can run alongside a live
+// orchestrator (which already holds the default port).
+func proxyPort() uint16 {
+	if v := os.Getenv("PROXY_PORT"); v != "" {
+		if p, err := strconv.ParseUint(v, 10, 16); err == nil {
+			return uint16(p)
+		}
+		log.Printf("warning: ignoring invalid PROXY_PORT=%q, using default 5007", v)
+	}
+
+	return 5007
+}
 
 func main() {
 	templateID := flag.String("template", "local-template", "template id")
@@ -270,7 +282,7 @@ func doBuild(
 
 	sandboxes := sandbox.NewSandboxesMap()
 
-	sandboxProxy, err := proxy.NewSandboxProxy(noop.MeterProvider{}, proxyPort, sandboxes, featureFlags)
+	sandboxProxy, err := proxy.NewSandboxProxy(noop.MeterProvider{}, proxyPort(), sandboxes, featureFlags)
 	if err != nil {
 		return fmt.Errorf("proxy: %w", err)
 	}

--- a/packages/orchestrator/cmd/create-build/proxyport_test.go
+++ b/packages/orchestrator/cmd/create-build/proxyport_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+//nolint:paralleltest // uses t.Setenv, which is incompatible with t.Parallel
+func TestProxyPort(t *testing.T) {
+	t.Setenv("PROXY_PORT", "")
+	if got := proxyPort(); got != 5007 {
+		t.Fatalf("unset: got %d, want 5007", got)
+	}
+
+	t.Setenv("PROXY_PORT", "6007")
+	if got := proxyPort(); got != 6007 {
+		t.Fatalf("valid override: got %d, want 6007", got)
+	}
+
+	t.Setenv("PROXY_PORT", "not-a-port")
+	if got := proxyPort(); got != 5007 {
+		t.Fatalf("invalid: got %d, want 5007 (fallback)", got)
+	}
+}

--- a/packages/orchestrator/cmd/resume-build/fc-debug.gdb
+++ b/packages/orchestrator/cmd/resume-build/fc-debug.gdb
@@ -1,0 +1,106 @@
+# fc-debug.gdb — reusable gdb macros for debugging an e2b guest kernel.
+#
+# Loaded by the init script that `resume-build -gdb` generates (which also does
+# `add-symbol-file <vmlinux.debug> -o <slide>` and `target remote <socket>`); this
+# file only defines macros, so it carries no socket/symbol/slide assumptions and is
+# safe to `source` standalone.
+#
+# Targets Linux 6.1.x on x86_64 (the e2b guest kernel). Field offsets and per-CPU /
+# maple-tree internals are kernel-version specific; the fault-attribution macro is
+# the proven workhorse (it reads handle_mm_fault's own arguments and needs no kernel
+# layout assumptions), the rest are best-effort conveniences.
+
+# fc-faults [N]
+#   Break handle_mm_fault and report the next N guest page faults (default 20) as
+#   comm / pid / faulting-address / VMA-range / VMA-flags. handle_mm_fault's args
+#   give us everything directly (x86_64 SysV: $rdi = struct vm_area_struct *,
+#   $rsi = address), so this works regardless of kernel layout. NULL-guarded.
+#   This is the host-invisible signal: which guest process+VMA faulted, during a
+#   resume, that UFFD/host telemetry cannot attribute.
+define fc-faults
+  if $argc == 0
+    set $_fc_n = 20
+  else
+    set $_fc_n = $arg0
+  end
+  break *handle_mm_fault
+  set $_fc_i = 0
+  while $_fc_i < $_fc_n
+    continue
+    set $_fc_vma = (struct vm_area_struct *)$rdi
+    set $_fc_addr = $rsi
+    if $_fc_vma != 0
+      set $_fc_mm = $_fc_vma->vm_mm
+      if $_fc_mm != 0
+        set $_fc_task = $_fc_mm->owner
+        if $_fc_task != 0
+          printf "FAULT comm=%s pid=%d addr=0x%lx vma=0x%lx-0x%lx flags=0x%lx\n", $_fc_task->comm, $_fc_task->pid, $_fc_addr, $_fc_vma->vm_start, $_fc_vma->vm_end, $_fc_vma->vm_flags
+        end
+      end
+    end
+    set $_fc_i = $_fc_i + 1
+  end
+end
+document fc-faults
+Report the next N guest page faults as comm/pid/addr/VMA. Usage: fc-faults [N=20]
+Sets a breakpoint on handle_mm_fault; call once per debugging session.
+end
+
+# fc-task <task_struct *>
+#   Print the essentials of a task_struct pointer: comm, pid, tgid, and its mm.
+define fc-task
+  set $_t = (struct task_struct *)$arg0
+  if $_t == 0
+    printf "fc-task: NULL task\n"
+  else
+    printf "task=0x%lx comm=%s pid=%d tgid=%d mm=0x%lx\n", $_t, $_t->comm, $_t->pid, $_t->tgid, $_t->mm
+  end
+end
+document fc-task
+Print comm/pid/tgid/mm for a task_struct pointer. Usage: fc-task <task_struct *>
+(e.g. the owner of a VMA reported by fc-faults: fc-task $_fc_task)
+end
+
+# fc-curr [cpu]
+#   Current task on vCPU <cpu> (default 0). "current" is the per-CPU pointer
+#   current_task, normally reached via the GS base: current = *(task **)(gs_base +
+#   &current_task). Firecracker's gdb stub does NOT expose $gs_base (it reports only
+#   GPRs/rip/eflags), so we resolve the per-CPU base from __per_cpu_offset[cpu] instead
+#   — in kernel context gs_base == __per_cpu_offset[smp_processor_id()], and the array
+#   needs no live segment register. Pass the cpu matching the gdb thread you are stopped
+#   on (`info threads`: Thread 1.<n> is vCPU <n-1>); defaults to 0.
+define fc-curr
+  if $argc == 0
+    set $_cpu = 0
+  else
+    set $_cpu = $arg0
+  end
+  set $_pcpu = __per_cpu_offset[$_cpu]
+  set $_cur = *(struct task_struct **)((unsigned long)&current_task + $_pcpu)
+  fc-task $_cur
+end
+document fc-curr
+Print the current task on vCPU <cpu> (default 0), via __per_cpu_offset[cpu] +
+current_task (no $gs_base needed). Usage: fc-curr [cpu]. Linux x86_64 SMP.
+end
+
+# fc-regions
+#   Print the KASLR-randomized direct-map / vmemmap / vmalloc bases, needed to walk
+#   physical<->virtual (__va = phys + page_offset_base) and struct page arrays.
+define fc-regions
+  printf "page_offset_base = 0x%lx\n", page_offset_base
+  printf "vmemmap_base     = 0x%lx\n", vmemmap_base
+  printf "vmalloc_base     = 0x%lx\n", vmalloc_base
+end
+document fc-regions
+Print page_offset_base / vmemmap_base / vmalloc_base (for __va and struct page walks).
+end
+
+# fc-va <phys>
+#   Direct-map virtual address for a guest physical address: phys + page_offset_base.
+define fc-va
+  printf "__va(0x%lx) = 0x%lx\n", $arg0, ((unsigned long)$arg0 + page_offset_base)
+end
+document fc-va
+Compute the direct-map virtual address of a guest physical address. Usage: fc-va <phys>
+end

--- a/packages/orchestrator/cmd/resume-build/gdb-debugging.md
+++ b/packages/orchestrator/cmd/resume-build/gdb-debugging.md
@@ -1,0 +1,104 @@
+# Debugging a sandbox's guest kernel with gdb
+
+`resume-build -gdb` resumes a snapshot under a gdb-enabled Firecracker, holds the
+guest at the kernel entry breakpoint, and hands you a ready gdb session with
+source-level symbols — for inspecting a resumed guest (which process/VMA faulted,
+kernel state) beyond what host/UFFD telemetry exposes.
+
+> Run this only on a **dev node**, never prod. When the snapshot is a real customer
+> template, the **customer-data rules** below are binding.
+
+## Prerequisites
+
+`gdb` on PATH. The two debug artifacts — `firecracker-debug` (Firecracker built
+`--features gdb`) and `vmlinux.debug` (the guest kernel's split DWARF symbols) — are
+**fetched automatically by version**, matched to the snapshot's `FirecrackerVersion`
+/ `KernelVersion` (which `resume-build` prints when it loads the build), from
+`https://storage.googleapis.com/e2b-prod-public-builds`. In the common case you pass
+nothing.
+
+Supplying them yourself is only needed when the fetch can't find them — before the
+fc-versions / fc-kernels pipelines publish them, or for a locally-built kernel/FC.
+Then point `E2B_GDB_ARTIFACTS_URL` at a base that serves them, or pass explicit paths
+with `-gdb-fc` / `-gdb-symbols` (see *Preparing the artifacts*).
+
+## Steps
+
+1. **Copy the build chain** to the dev node's local storage (`copy-build`), as for
+   `resume-prod-snapshot`.
+
+2. **Resume under gdb** (interactive) — the common case needs no extra flags:
+
+   ```bash
+   sudo -E ./resume-build -gdb -from-build <build-id> -no-egress
+   ```
+
+   It prints a **debug-context block** (debug-FC path/version, symbols, gdb socket,
+   generated init-script path, and a ready-to-paste `gdb` line), then drops you at a
+   gdb prompt already connected with symbols loaded.
+
+3. **Scripted / agent mode** — run batch commands instead of an interactive prompt:
+
+   ```bash
+   sudo -E ./resume-build -gdb -from-build <id> -no-egress -gdb-exec 'fc-faults 30'
+   # or: -gdb-script /path/to/commands.gdb
+   ```
+
+The session lasts one resume: Firecracker's stub shuts the VM down on gdb
+disconnect, and `resume-build` then tears down FC/UFFD/NBD/temp. Re-run to debug
+again. (An agent should keep one long-lived gdb subprocess and drive it while
+connected.)
+
+## Preparing the artifacts
+
+Normally you don't — `resume-build` fetches `firecracker-debug` and `vmlinux.debug`
+automatically (see *Prerequisites*). Build them by hand only when the release
+pipelines haven't published them for your version, or to debug a locally-built
+kernel/FC:
+
+- **`firecracker-debug`** — Firecracker built `--features gdb` (release profile):
+  `cargo build --release --features gdb -p firecracker`. Pass with `-gdb-fc`.
+- **`vmlinux.debug`** — the kernel's split DWARF, produced by the fc-kernels build
+  (`vmlinux.bin` + `objcopy --only-keep-debug vmlinux.debug`). Build with the same
+  toolchain as the deployed kernel (gcc 13.x / Ubuntu 24.04) so the symbol addresses
+  match the snapshot. Pass with `-gdb-symbols`.
+
+Then either pass `-gdb-fc` / `-gdb-symbols` explicitly, stage them at the conventional
+local paths (`firecracker-debug` in the FC-version dir, `vmlinux.debug` in the
+kernel-version dir), or set `E2B_GDB_ARTIFACTS_URL` to a base that serves them at
+`firecrackers/<fcver>/<arch>/firecracker-debug` and `kernels/<kver>/<arch>/vmlinux.debug`.
+
+## Macros (`fc-debug.gdb`)
+
+Loaded automatically; targets Linux 6.1.x x86_64.
+
+- `fc-faults [N]` — break `handle_mm_fault` and report the next N guest faults as
+  `comm/pid/addr/VMA` (default 20). The headline tool: attributes each resume page
+  fault to a guest process + VMA. Reads the function's own args, so layout-agnostic.
+- `fc-task <task_struct *>` — comm/pid/tgid/mm for a task pointer (e.g.
+  `fc-task $_fc_task`, the owner from a fault).
+- `fc-curr [cpu]` — the current task on vCPU `cpu` (default 0; `info threads`: Thread
+  1.`<n>` is vCPU `<n-1>`). Resolves per-CPU `current_task` via `__per_cpu_offset[cpu]`,
+  since the FC gdb stub does not expose `$gs_base`.
+- `fc-regions` / `fc-va <phys>` — kernel region bases (`page_offset_base` etc.) and
+  direct-map translation (`__va`, struct-page walks).
+
+## Observer effect
+
+The guest is frozen and resumes deterministically, but debugging perturbs it:
+
+- Prefer **hardware** breakpoints/watchpoints (`hbreak`/`watch`) over software
+  breakpoints — software breakpoints write `int3` into guest text, a guest-visible
+  memory change.
+- To learn the **resident set** without touching the guest, read it from the UFFD
+  prefetch/fault log, not by walking guest memory in gdb (which faults pages in).
+- Single-stepping and repeated `continue` over a fault storm are heavy; scope
+  `fc-faults N` to a small N.
+
+## Customer-data rules (binding for real customer snapshots)
+
+- Always `-no-egress`. Run on a **dev** node only.
+- **System-level diagnostics only.** Do **not** read customer file contents, process
+  command lines/args, environment, or `/home/user`. Attribute faults to
+  process name + VMA range; do not dump customer memory contents.
+- Don't exfiltrate snapshot or guest data off the dev node.

--- a/packages/orchestrator/cmd/resume-build/gdb.go
+++ b/packages/orchestrator/cmd/resume-build/gdb.go
@@ -1,0 +1,466 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// gdbOptions controls the `resume-build -gdb` guest-kernel debugging flow.
+type gdbOptions struct {
+	enabled bool
+
+	// Artifact overrides. By default resume-build fetches the debug artifacts by
+	// version (firecracker-debug and vmlinux.debug) from the release buckets, the
+	// same way create-build fetches the prod kernel/FC. These override the fetch with
+	// a local path: a Firecracker built `--features gdb` and the kernel's split DWARF
+	// symbols (vmlinux.debug).
+	fcBinary string // -gdb-fc
+	symbols  string // -gdb-symbols
+
+	socket   string // -gdb-socket (optional; default: a temp path)
+	execCmds string // -gdb-exec   (scripted mode: gdb commands, newline/';'-separated)
+	script   string // -gdb-script (scripted mode: a gdb command file)
+}
+
+func (o gdbOptions) scripted() bool { return o.execCmds != "" || o.script != "" }
+
+// gdbMode resumes the snapshot with Firecracker's gdb stub armed (held at the entry
+// breakpoint), loads the guest kernel symbols, hands a ready gdb session to the
+// caller, and tears everything down on exit.
+func (r *runner) gdbMode(ctx context.Context, opts gdbOptions) error {
+	// 1. Fail fast, before we touch the sandbox or fetch anything: gdb must be on
+	//    PATH (checked first so we don't download a ~500 MB vmlinux.debug only to
+	//    fall over here), then resolve the debug artifacts — the -gdb-* overrides if
+	//    given, else a local staged copy, else fetch them by version.
+	if _, err := exec.LookPath("gdb"); err != nil {
+		return fmt.Errorf("gdb not found on PATH: %w", err)
+	}
+	fcBinary, symbols, err := r.gdbResolveArtifacts(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	// 2. The kernel image runs at its link-time base — there is no KASLR slide to
+	//    recover. Firecracker boots the uncompressed vmlinux ELF directly (no bzImage
+	//    decompressor), so the image-KASLR relocation never runs and both
+	//    CONFIG_RANDOMIZE_BASE and CONFIG_RANDOMIZE_MEMORY stay inert (gated on a flag
+	//    only the decompressor sets). So we load symbols at offset 0.
+
+	// 3. Stage the gdb-enabled Firecracker binary at the path resume-build resolves
+	//    for this snapshot's FC version, backing up whatever is there and restoring
+	//    it on exit (so the local prod binary is left untouched).
+	fcPath := r.sbxConfig.FirecrackerConfig.FirecrackerPath(r.config)
+	restore, err := stageBinary(fcBinary, fcPath)
+	if err != nil {
+		return fmt.Errorf("stage debug firecracker: %w", err)
+	}
+	defer restore()
+
+	// 4. Arm the stub via the env var (FC inherits resume-build's env; no jailer
+	//    here), and tell the resume path not to wait for envd — the guest never
+	//    boots it while held at the entry breakpoint.
+	socket := opts.socket
+	if socket == "" {
+		socket = filepath.Join(os.TempDir(), fmt.Sprintf("fc-gdb-%d.sock", time.Now().UnixNano()))
+	}
+	_ = os.Remove(socket)
+	if err := os.Setenv("FIRECRACKER_GDB_SOCKET", socket); err != nil {
+		return fmt.Errorf("set FIRECRACKER_GDB_SOCKET: %w", err)
+	}
+	r.sbxConfig.SkipEnvdWait = true
+
+	// 5. Resume concurrently. Firecracker's gdb stub holds the snapshot load open
+	//    until a debugger attaches, so ResumeSandbox does not return until we connect
+	//    gdb. Run it in the background and connect gdb once FC binds the socket; doing
+	//    it the other way around (resume, then connect) deadlocks.
+	runtime := sandbox.RuntimeMetadata{
+		TemplateID:  r.buildID,
+		TeamID:      "local",
+		SandboxID:   fmt.Sprintf("sbx-gdb-%d", time.Now().UnixNano()),
+		ExecutionID: fmt.Sprintf("exec-gdb-%d", time.Now().UnixNano()),
+	}
+	fmt.Println("🚀 Resuming under gdb (guest held at entry breakpoint)...")
+	t0 := time.Now()
+
+	type startResult struct {
+		sbx *sandbox.Sandbox
+		err error
+	}
+	resumeCtx, cancelResume := context.WithCancel(ctx)
+	startCh := make(chan startResult, 1)
+	go func() {
+		sbx, err := r.startSandbox(resumeCtx, runtime, t0, t0.Add(24*time.Hour))
+		startCh <- startResult{sbx: sbx, err: err}
+	}()
+	defer func() {
+		// Unblock ResumeSandbox if it is still waiting (e.g. gdb never connected),
+		// then reclaim the sandbox once it returns.
+		cancelResume()
+		res := <-startCh
+		if res.sbx != nil {
+			fmt.Println("🧹 Cleanup...")
+			res.sbx.Close(context.WithoutCancel(ctx))
+		}
+		_ = os.Remove(socket)
+	}()
+
+	// FC binds the gdb socket while loading the snapshot — before the load blocks on
+	// the debugger — so the socket appears even though startSandbox is still running.
+	// Race the socket wait against the resume result: if the resume fails before the
+	// socket appears, surface that real error instead of a misleading socket timeout.
+	waitCtx, cancelWait := context.WithCancel(ctx)
+	defer cancelWait()
+	socketErr := make(chan error, 1)
+	go func() { socketErr <- waitForSocket(waitCtx, socket, 90*time.Second) }()
+
+	select {
+	case res := <-startCh:
+		startCh <- res // hand back to the deferred cleanup
+		if res.err != nil {
+			return fmt.Errorf("resume: %w", res.err)
+		}
+
+		return fmt.Errorf("resume completed without binding gdb socket %s", socket)
+	case err := <-socketErr:
+		if err != nil {
+			return fmt.Errorf("gdb socket %s never appeared: %w", socket, err)
+		}
+	}
+	fmt.Printf("✅ FC bound gdb socket in %s\n", time.Since(t0))
+
+	// 6. Generate the parameterized init script and print the debug-context block.
+	initScript, err := writeInitScript(symbols, socket)
+	if err != nil {
+		return fmt.Errorf("write gdb init script: %w", err)
+	}
+	defer os.Remove(initScript)
+
+	printGdbContext(fcPath, r.sbxConfig.FirecrackerConfig.FirecrackerVersion, symbols, socket, initScript)
+
+	// 7. Drive gdb. FC's stub shuts the VM down on disconnect, so this is one session
+	//    per invocation; teardown (defer above) reclaims FC/UFFD/NBD/temp.
+	return runGdb(ctx, initScript, opts)
+}
+
+// defaultDebugArtifactsBaseURL is where the fc-versions / fc-kernels release pipelines
+// publish the debug artifacts (firecracker-debug, vmlinux.debug), alongside the prod
+// firecracker/vmlinux that create-build already fetches from here.
+const defaultDebugArtifactsBaseURL = "https://storage.googleapis.com/e2b-prod-public-builds"
+
+// debugArtifactsBaseURL is the base URL to fetch firecracker-debug / vmlinux.debug from.
+// Overridable via E2B_GDB_ARTIFACTS_URL (e.g. to point at a bucket you can read before
+// the artifacts are published to the public one).
+func debugArtifactsBaseURL() string {
+	if u := os.Getenv("E2B_GDB_ARTIFACTS_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+
+	return defaultDebugArtifactsBaseURL
+}
+
+// gdbResolveArtifacts resolves the debug FC binary and the vmlinux.debug symbols. Each
+// is taken from its -gdb-* override if set, else a local staged copy if present, else
+// fetched by version from the release buckets (see debugArtifactsBaseURL) — mirroring
+// how create-build fetches the prod kernel/FC.
+func (r *runner) gdbResolveArtifacts(ctx context.Context, opts gdbOptions) (fcBinary, symbols string, err error) {
+	arch := utils.TargetArch()
+	fcVer := r.sbxConfig.FirecrackerConfig.FirecrackerVersion
+	kernelVer := r.sbxConfig.FirecrackerConfig.KernelVersion
+	fcDir := filepath.Dir(r.sbxConfig.FirecrackerConfig.FirecrackerPath(r.config))
+	kernelDir := filepath.Dir(r.sbxConfig.FirecrackerConfig.HostKernelPath(r.config))
+	base := debugArtifactsBaseURL()
+
+	fcURL, err := url.JoinPath(base, "firecrackers", fcVer, arch, "firecracker-debug")
+	if err != nil {
+		return "", "", fmt.Errorf("firecracker-debug URL: %w", err)
+	}
+	symURL, err := url.JoinPath(base, "kernels", kernelVer, arch, "vmlinux.debug")
+	if err != nil {
+		return "", "", fmt.Errorf("vmlinux.debug URL: %w", err)
+	}
+
+	fcBinary, fcErr := resolveOrFetch(ctx, opts.fcBinary, filepath.Join(fcDir, "firecracker-debug"), fcURL, 0o755)
+	symbols, symErr := resolveOrFetch(ctx, opts.symbols, filepath.Join(kernelDir, "vmlinux.debug"), symURL, 0o644)
+
+	var missing []string
+	if fcErr != nil {
+		missing = append(missing, fmt.Sprintf("firecracker-debug (FC %s): %v", fcVer, fcErr))
+	}
+	if symErr != nil {
+		missing = append(missing, fmt.Sprintf("vmlinux.debug (kernel %s): %v", kernelVer, symErr))
+	}
+	if len(missing) > 0 {
+		return "", "", fmt.Errorf(
+			"could not obtain gdb debug artifacts:\n  - %s\n"+
+				"They are fetched by version from %s. Until the fc-versions/fc-kernels release\n"+
+				"pipelines publish them there, build them (a --features gdb firecracker and a DWARF\n"+
+				"kernel) and pass -gdb-fc / -gdb-symbols, or set E2B_GDB_ARTIFACTS_URL to a base URL\n"+
+				"that serves them",
+			strings.Join(missing, "\n  - "), base)
+	}
+
+	return fcBinary, symbols, nil
+}
+
+// resolveOrFetch returns the override if it is set (erroring if it does not exist),
+// otherwise the local staged path if it already exists, otherwise downloads url to it.
+func resolveOrFetch(ctx context.Context, override, localPath, srcURL string, perm os.FileMode) (string, error) {
+	if override != "" {
+		if fileExists(override) {
+			return override, nil
+		}
+
+		return "", fmt.Errorf("override path %s does not exist", override)
+	}
+	if fileExists(localPath) {
+		return localPath, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o755); err != nil {
+		return "", err
+	}
+	fmt.Printf("⬇ fetching %s from %s ...\n", filepath.Base(localPath), srcURL)
+	if err := download(ctx, srcURL, localPath, perm); err != nil {
+		return "", err
+	}
+
+	return localPath, nil
+}
+
+// download GETs rawURL to path (atomic rename via a .tmp). Mirrors create-build's
+// helper; the debug artifacts live in the same public release buckets.
+func download(ctx context.Context, rawURL, path string, perm os.FileMode) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("invalid download URL %s: %w", rawURL, err)
+	}
+	resp, err := (&http.Client{Timeout: 10 * time.Minute}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("not found (HTTP 404): %s", rawURL)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, rawURL)
+	}
+
+	tmpPath := path + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmpPath)
+
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+
+		return err
+	}
+
+	return nil
+}
+
+// writeInitScript generates the parameterized gdb init script: load the versioned
+// macro library, the symbols (at their link-time addresses — see gdbMode: FC boots the
+// vmlinux ELF directly, so there is no KASLR image slide), and connect to the stub.
+func writeInitScript(symbols, socket string) (string, error) {
+	macroLib, err := macroLibPath()
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp("", "fc-debug-init-*.gdb")
+	if err != nil {
+		return "", err
+	}
+	if _, err := fmt.Fprintf(f, `set pagination off
+set confirm off
+source %s
+# FC boots the uncompressed vmlinux ELF directly, so KASLR never relocates the image:
+# symbols sit at their link-time addresses (offset 0).
+add-symbol-file %s -o 0x0
+target remote %s
+`, macroLib, symbols, socket); err != nil {
+		f.Close()
+		_ = os.Remove(f.Name())
+
+		return "", fmt.Errorf("write gdb init script: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+
+		return "", fmt.Errorf("close gdb init script: %w", err)
+	}
+
+	return f.Name(), nil
+}
+
+// macroLibPath locates the checked-in fc-debug.gdb macro library next to this binary's
+// source. resume-build is run via `go run`/built from cmd/resume-build, so the library
+// sits beside main.go.
+func macroLibPath() (string, error) {
+	exe, err := os.Executable()
+	if err == nil {
+		if p := filepath.Join(filepath.Dir(exe), "fc-debug.gdb"); fileExists(p) {
+			return p, nil
+		}
+	}
+	// Fall back to the source tree (the common `go run ./cmd/resume-build` case).
+	for _, p := range []string{
+		"cmd/resume-build/fc-debug.gdb",
+		"packages/orchestrator/cmd/resume-build/fc-debug.gdb",
+	} {
+		if abs, err := filepath.Abs(p); err == nil && fileExists(abs) {
+			return abs, nil
+		}
+	}
+
+	return "", errors.New("fc-debug.gdb macro library not found (next to the binary or under cmd/resume-build/)")
+}
+
+// printGdbContext prints the debug-context block so the session is drivable any way
+// (interactive, batch, or a long-lived agent-driven gdb subprocess).
+func printGdbContext(fcPath, fcVer, symbols string, socket, initScript string) {
+	fmt.Println("\n──────────────── gdb debug context ────────────────")
+	fmt.Printf("  debug firecracker : %s (version %s)\n", fcPath, fcVer)
+	fmt.Printf("  kernel symbols    : %s (link addresses; FC ELF boot, no KASLR slide)\n", symbols)
+	fmt.Printf("  gdb socket        : %s\n", socket)
+	fmt.Printf("  gdb init script   : %s\n", initScript)
+	fmt.Printf("  attach manually   : gdb -q -x %s\n", initScript)
+	fmt.Println("  macros            : fc-faults [N], fc-curr, fc-task <p>, fc-regions, fc-va <phys>")
+	fmt.Println("────────────────────────────────────────────────────")
+}
+
+// runGdb runs gdb against the generated init script: interactive by default, or
+// batch when -gdb-exec / -gdb-script is given (the agent/CI path).
+func runGdb(ctx context.Context, initScript string, opts gdbOptions) error {
+	var args []string
+	if opts.scripted() {
+		args = append(args, "-batch")
+	} else {
+		args = append(args, "-q")
+	}
+	args = append(args, "-x", initScript)
+	if opts.script != "" {
+		args = append(args, "-x", opts.script)
+	}
+	for _, line := range strings.FieldsFunc(opts.execCmds, func(r rune) bool { return r == '\n' || r == ';' }) {
+		if cmd := strings.TrimSpace(line); cmd != "" {
+			args = append(args, "-ex", cmd)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, "gdb", args...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if !opts.scripted() {
+		fmt.Printf("🐞 launching gdb (VM shuts down on disconnect)...\n\n")
+	}
+
+	return cmd.Run()
+}
+
+// --- small helpers ---
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+
+	return err == nil && !info.IsDir()
+}
+
+func waitForSocket(ctx context.Context, path string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if info, err := os.Stat(path); err == nil && info.Mode()&os.ModeSocket != 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("timeout")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// stageBinary copies src to dst (preserving any existing dst as a backup) and returns
+// a restore func that puts the original back (or removes the staged copy if there was
+// none). The running FC keeps its loaded binary, so restoring after launch is safe.
+func stageBinary(src, dst string) (restore func(), err error) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return nil, err
+	}
+	bak := dst + ".prodbak"
+	// If a backup already exists, a previous run was interrupted before it could
+	// restore — that backup is the real binary, so keep it and overwrite dst (which
+	// currently holds the staged debug binary) rather than backing dst up over it.
+	hadOriginal := fileExists(bak)
+	if !hadOriginal && fileExists(dst) {
+		if err := os.Rename(dst, bak); err != nil {
+			return nil, fmt.Errorf("back up %s: %w", dst, err)
+		}
+		hadOriginal = true
+	}
+	if err := copyFile(src, dst, 0o755); err != nil {
+		if hadOriginal {
+			_ = os.Rename(bak, dst)
+		} else {
+			// No original to restore: drop the partial/truncated copy so a later
+			// run can't resolve and execute a corrupt binary at dst.
+			_ = os.Remove(dst)
+		}
+
+		return nil, err
+	}
+
+	return func() {
+		_ = os.Remove(dst)
+		if hadOriginal {
+			_ = os.Rename(bak, dst)
+		}
+	}, nil
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+
+		return err
+	}
+
+	return out.Close()
+}

--- a/packages/orchestrator/cmd/resume-build/gdb_test.go
+++ b/packages/orchestrator/cmd/resume-build/gdb_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+//nolint:paralleltest // uses t.Setenv, which is incompatible with t.Parallel
+func TestDebugArtifactsBaseURL(t *testing.T) {
+	t.Setenv("E2B_GDB_ARTIFACTS_URL", "")
+	if got := debugArtifactsBaseURL(); got != defaultDebugArtifactsBaseURL {
+		t.Fatalf("default: got %q, want %q", got, defaultDebugArtifactsBaseURL)
+	}
+
+	t.Setenv("E2B_GDB_ARTIFACTS_URL", "http://localhost:8077/")
+	if got, want := debugArtifactsBaseURL(), "http://localhost:8077"; got != want {
+		t.Fatalf("override (trailing slash trimmed): got %q, want %q", got, want)
+	}
+}
+
+func TestResolveOrFetch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	// Resolution paths that must NOT fetch use a fast-failing URL, so a regression
+	// that wrongly fetches surfaces as an error rather than a silent pass.
+	const noFetchURL = "http://127.0.0.1:0/unused"
+
+	t.Run("override returned when present, no fetch", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		override := filepath.Join(dir, "override.bin")
+		if err := os.WriteFile(override, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveOrFetch(ctx, override, filepath.Join(dir, "local"), noFetchURL, 0o644)
+		if err != nil || got != override {
+			t.Fatalf("got %q, err %v; want %q", got, err, override)
+		}
+	})
+
+	t.Run("missing override errors", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		if _, err := resolveOrFetch(ctx, filepath.Join(dir, "nope"), filepath.Join(dir, "local"), noFetchURL, 0o644); err == nil {
+			t.Fatal("expected error for missing override")
+		}
+	})
+
+	t.Run("local staged copy returned, no fetch", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		local := filepath.Join(dir, "local.bin")
+		if err := os.WriteFile(local, []byte("y"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolveOrFetch(ctx, "", local, noFetchURL, 0o644)
+		if err != nil || got != local {
+			t.Fatalf("got %q, err %v; want %q", got, err, local)
+		}
+	})
+
+	t.Run("fetches when absent and creates parent dir", func(t *testing.T) {
+		t.Parallel()
+		const body = "fetched-artifact"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/firecracker-debug" {
+				w.WriteHeader(http.StatusNotFound)
+
+				return
+			}
+			_, _ = w.Write([]byte(body))
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		local := filepath.Join(dir, "sub", "firecracker-debug") // parent does not exist yet
+		got, err := resolveOrFetch(ctx, "", local, srv.URL+"/firecracker-debug", 0o755)
+		if err != nil {
+			t.Fatalf("fetch failed: %v", err)
+		}
+		if got != local {
+			t.Fatalf("got %q, want %q", got, local)
+		}
+		b, err := os.ReadFile(local)
+		if err != nil || string(b) != body {
+			t.Fatalf("content %q err %v; want %q", b, err, body)
+		}
+	})
+
+	t.Run("404 errors", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		dir := t.TempDir()
+		if _, err := resolveOrFetch(ctx, "", filepath.Join(dir, "x"), srv.URL+"/missing", 0o644); err == nil {
+			t.Fatal("expected 404 error")
+		}
+	})
+}

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -82,6 +82,13 @@ func main() {
 	fphBench := flag.Bool("fph-bench", false, "compare pause memfile size with vs without FPH; requires -cmd-pause workload, uses -iterations (default 3), forces FPR on")
 	fphBenchDelay := flag.Duration("fph-bench-delay", 0, "wait this long between workload completion and pause (lets FPR settle)")
 
+	gdbDebug := flag.Bool("gdb", false, "resume under gdb: hold the guest at the kernel entry breakpoint with a gdb-enabled FC and hand over a ready gdb session for source-level guest-kernel debugging")
+	gdbFC := flag.String("gdb-fc", "", "path to a firecracker built --features gdb (default: fetch firecracker-debug by version; set E2B_GDB_ARTIFACTS_URL to override the source)")
+	gdbSymbols := flag.String("gdb-symbols", "", "path to the guest kernel's DWARF symbols, vmlinux.debug (default: fetch vmlinux.debug by version; set E2B_GDB_ARTIFACTS_URL to override the source)")
+	gdbSocket := flag.String("gdb-socket", "", "gdb unix socket path (default: a temp path)")
+	gdbExec := flag.String("gdb-exec", "", "scripted mode: run these gdb commands in batch (newline/';'-separated) instead of an interactive prompt")
+	gdbScript := flag.String("gdb-script", "", "scripted mode: run this gdb command file in batch")
+
 	flag.Parse()
 
 	if *fphTimeoutMs > 0 {
@@ -220,7 +227,16 @@ func main() {
 	}
 	fphBenchOpts := fphBenchOptions{enabled: *fphBench, workload: *cmdPause, iterations: benchIters, delay: *fphBenchDelay}
 
-	err := run(ctx, *fromBuild, *iterations, *coldStart, *noPrefetch, *noEgress, *verbose, *shell, *reboot, pauseOpts, runOpts, fphBenchOpts)
+	gdbOpts := gdbOptions{
+		enabled:  *gdbDebug,
+		fcBinary: *gdbFC,
+		symbols:  *gdbSymbols,
+		socket:   *gdbSocket,
+		execCmds: *gdbExec,
+		script:   *gdbScript,
+	}
+
+	err := run(ctx, *fromBuild, *iterations, *coldStart, *noPrefetch, *noEgress, *verbose, *shell, *reboot, pauseOpts, runOpts, fphBenchOpts, gdbOpts)
 	cancel()
 
 	if err != nil {
@@ -1051,7 +1067,7 @@ func (r *runner) benchmark(ctx context.Context, n int) error {
 	return lastErr
 }
 
-func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefetch, noEgress, verbose, shell, reboot bool, pauseOpts pauseOptions, runOpts runOptions, fphBenchOpts fphBenchOptions) error {
+func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefetch, noEgress, verbose, shell, reboot bool, pauseOpts pauseOptions, runOpts runOptions, fphBenchOpts fphBenchOptions, gdbOpts gdbOptions) error {
 	// Silence other loggers unless verbose mode
 	var l logger.Logger
 	if !verbose {
@@ -1108,6 +1124,15 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	tcpFw := tcpfirewall.New(l, config.NetworkConfig, sandboxes, tel.MeterProvider, flags)
 	go tcpFw.Start(ctx)
 	defer tcpFw.Close(context.WithoutCancel(ctx))
+
+	// gdb mode debugs real customer snapshots. The guest is frozen at the entry
+	// breakpoint and never boots, so it cannot itself open a connection — but force
+	// egress off regardless, so a debugging run can never leave an exfiltration path
+	// open. This makes the runbook's "always -no-egress" mechanical rather than a
+	// manual step the operator can forget.
+	if gdbOpts.enabled {
+		noEgress = true
+	}
 
 	var egressProxy network.EgressProxy = network.NoopEgressProxy{}
 	if noEgress {
@@ -1220,6 +1245,17 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 		config:     config.BuilderConfig,
 		storage:    persistence,
 		sbxConfig:  sbxCfg,
+	}
+
+	if gdbOpts.enabled {
+		// gdb mode holds the guest at the entry breakpoint and never runs a
+		// workload, so it is mutually exclusive with the pause/cmd/bench modes —
+		// reject the combination rather than silently ignoring the other flags.
+		if fphBenchOpts.enabled || runOpts.enabled() || pauseOpts.enabled() || iterations > 0 || reboot || shell {
+			return errors.New("-gdb cannot be combined with -pause/-cmd/-iterations/-reboot/-shell/-fph-bench")
+		}
+
+		return r.gdbMode(ctx, gdbOpts)
 	}
 
 	if fphBenchOpts.enabled {

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -96,6 +96,12 @@ type Config struct {
 
 	FirecrackerConfig fc.Config
 
+	// SkipEnvdWait skips the post-resume wait for envd readiness. Used by the
+	// resume-build gdb debugging flow: the guest is held at a gdb entry
+	// breakpoint and never boots envd, so the readiness wait would otherwise
+	// time out and tear the sandbox down before a debugger can attach.
+	SkipEnvdWait bool
+
 	VolumeMounts []VolumeMountConfig
 
 	MaxSandboxLengthHours int64
@@ -1042,15 +1048,22 @@ func (f *Factory) ResumeSandbox(
 
 	telemetry.ReportEvent(ctx, "initialized FC")
 
-	telemetry.ReportEvent(execCtx, "waiting for envd")
+	if config.SkipEnvdWait {
+		// gdb debugging: the guest is frozen at the entry breakpoint and never
+		// boots envd, so skip the readiness wait (it would time out and tear the
+		// sandbox down). The caller drives the VM via the gdb stub instead.
+		telemetry.ReportEvent(execCtx, "skipping envd wait (gdb mode)")
+	} else {
+		telemetry.ReportEvent(execCtx, "waiting for envd")
 
-	err = sbx.WaitForEnvd(
-		ctx,
-		StartTypeResume,
-		f.GetEnvdTimeout(ctx),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to wait for sandbox start: %w", err)
+		err = sbx.WaitForEnvd(
+			ctx,
+			StartTypeResume,
+			f.GetEnvdTimeout(ctx),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to wait for sandbox start: %w", err)
+		}
 	}
 
 	// A throwaway (e.g. the pause-resume prefetch harvest) is never promoted to a


### PR DESCRIPTION
## Why

Host- and UFFD-side telemetry can't show what happens *inside* a resumed guest — which process/VMA is faulting, kernel state during the resume. This adds a way to attach `gdb` to a resumed sandbox guest with source-level kernel symbols, for diagnosing resume behaviour (page-fault attribution, scheduler/VM state) on a dev node.

## What

`resume-build -gdb` resumes a snapshot under a `--features gdb` Firecracker held at the kernel entry breakpoint, loads the guest kernel's DWARF symbols, and hands over a ready `gdb` session (interactive, or scripted via `-gdb-exec` / `-gdb-script`). Commit-by-commit:

- **`feat(orch): allow skipping the envd readiness wait on resume`** — `Config.SkipEnvdWait` gates the post-resume `WaitForEnvd` in `ResumeSandbox` (the guest is held at the breakpoint and never boots envd).
- **`feat(orch): add fc-debug.gdb guest-kernel debugging macros`** — reusable gdb macros: `fc-faults [N]` (attributes guest page faults to `comm`/`pid`/VMA), `fc-curr`, `fc-task`, `fc-regions`, `fc-va`. Targets Linux 6.1.x x86_64.
- **`feat(orch): add resume-build -gdb …`** — the orchestration: arms `FIRECRACKER_GDB_SOCKET`, stages the debug FC binary, resumes in the background and connects gdb once FC binds the socket (the stub holds the snapshot load open until a debugger attaches — resuming first would deadlock), generates the init script, prints a debug-context block, drives gdb. **Debug artifacts (`firecracker-debug`, `vmlinux.debug`) are fetched by version** from `e2b-prod-public-builds` (override base via `E2B_GDB_ARTIFACTS_URL`; override paths via `-gdb-fc` / `-gdb-symbols`). Symbols load at offset 0 — FC boots the uncompressed `vmlinux` ELF directly, so image KASLR never runs and there's no slide to recover.
- **`docs(orch): add … runbook`** — `gdb-debugging.md` (usage, macros, observer-effect notes, customer-data rules).
- **`feat(orch): honor PROXY_PORT in create-build`** — lets `create-build` run alongside a live orchestrator on an alternate port (needed to build the test snapshot on a node).

> **Depends on** the fc-versions and fc-kernels release pipelines publishing `firecracker-debug-<arch>` and `vmlinux.debug` to the public builds bucket. Until those land, the fetch 404s and you build the artifacts and pass `-gdb-fc` / `-gdb-symbols` (or set `E2B_GDB_ARTIFACTS_URL`). Debug-only `--features gdb` Firecracker must never be promoted to a prod version.

## Validation

- **End-to-end on the dev cluster**: built a DWARF kernel + `--features gdb` FC on the cluster, `create-build` cold-booted the DWARF kernel into a snapshot, then `resume-build -gdb` (no flags) fetched both artifacts by version, recovered a ready session, and produced real fault attribution:
  - `FAULT comm=systemd-journal pid=283 addr=0x7f83… vma=0x7f83…-… flags=0xfb`
  - `fc-curr` → `comm=systemd-journal pid=283 …`; `fc-regions` → `page_offset_base=0xffff888000000000 …`
- **Unit tests**: `debugArtifactsBaseURL`, `resolveOrFetch` (override→local→fetch precedence, 404), `proxyPort` parsing/fallback.
- `golangci-lint` clean; every commit builds and passes tests on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
