### PR TITLE
Trace template build timeout sources

### DIFF
--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -10,6 +10,8 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
@@ -182,9 +184,19 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 	// Wrap context as a user error if no user error already exists
 	defer func() {
 		if ctx.Err() != nil {
+			childSpan.AddEvent("build context done", trace.WithAttributes(contextTraceAttributes(ctx, startTime)...))
 			e = errors.Join(e, ctx.Err())
 		}
+
 		e = builderrors.WrapContextAsUserError(e)
+		if e != nil {
+			childSpan.RecordError(e, trace.WithAttributes(
+				telemetry.WithTemplateID(cfg.TemplateID),
+				telemetry.WithBuildID(paths.BuildID),
+				telemetry.WithTeamID(cfg.TeamID),
+			))
+			childSpan.SetStatus(codes.Error, e.Error())
+		}
 	}()
 
 	if isV1Build {
@@ -215,10 +227,60 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 	uploadErrGroup := &errgroup.Group{}
 	defer func() {
 		// Wait for all template layers to be uploaded even if the build fails
-		err := uploadErrGroup.Wait()
-		if err != nil {
-			e = errors.Join(e, fmt.Errorf("error uploading template layers: %w", err))
+		waitCtx := context.WithoutCancel(ctx)
+		waitCtx, waitSpan := tracer.Start(waitCtx, "wait-for-template-layer-uploads", trace.WithAttributes(
+			telemetry.WithTemplateID(cfg.TemplateID),
+			telemetry.WithBuildID(paths.BuildID),
+			telemetry.WithTeamID(cfg.TeamID),
+			attribute.Bool("build_context_done_at_wait_start", ctx.Err() != nil),
+		))
+		waitStart := time.Now()
+
+		if ctx.Err() != nil {
+			attrs := contextTraceAttributes(ctx, startTime)
+			waitSpan.AddEvent("build context done before upload wait", trace.WithAttributes(attrs...))
+			b.logger.Warn(waitCtx, "build context done before waiting for template layer uploads",
+				append(contextLogFields(ctx, startTime),
+					logger.WithTemplateID(cfg.TemplateID),
+					logger.WithBuildID(paths.BuildID),
+					logger.WithTeamID(cfg.TeamID),
+				)...,
+			)
 		}
+
+		err := uploadErrGroup.Wait()
+		waitDuration := time.Since(waitStart)
+		waitAttrs := append(contextTraceAttributes(ctx, startTime),
+			attribute.Bool("upload_wait_error", err != nil),
+			attribute.Bool("build_context_done_after_upload_wait", ctx.Err() != nil),
+		)
+		waitSpan.SetAttributes(waitAttrs...)
+		if err != nil {
+			waitSpan.RecordError(err, trace.WithAttributes(waitAttrs...))
+			waitSpan.SetStatus(codes.Error, err.Error())
+			b.logger.Error(waitCtx, "template layer upload wait failed",
+				append(contextLogFields(ctx, startTime),
+					logger.WithTemplateID(cfg.TemplateID),
+					logger.WithBuildID(paths.BuildID),
+					logger.WithTeamID(cfg.TeamID),
+					zap.Duration("upload_wait_duration", waitDuration),
+					zap.Error(err),
+				)...,
+			)
+			e = errors.Join(e, fmt.Errorf("error uploading template layers: %w", err))
+		} else if ctx.Err() != nil {
+			waitSpan.AddEvent("upload wait completed after build context done", trace.WithAttributes(waitAttrs...))
+			b.logger.Warn(waitCtx, "template layer upload wait completed after build context was done",
+				append(contextLogFields(ctx, startTime),
+					logger.WithTemplateID(cfg.TemplateID),
+					logger.WithBuildID(paths.BuildID),
+					logger.WithTeamID(cfg.TeamID),
+					zap.Duration("upload_wait_duration", waitDuration),
+				)...,
+			)
+		}
+
+		waitSpan.End()
 	}()
 
 	buildContext := buildcontext.BuildContext{
@@ -446,4 +508,45 @@ func getRootfsSize(
 	}
 
 	return h.Metadata.Size, nil
+}
+
+func contextTraceAttributes(ctx context.Context, startTime time.Time, extra ...attribute.KeyValue) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Int64("build.elapsed_ms", time.Since(startTime).Milliseconds()),
+		attribute.Bool("build.context_done", ctx.Err() != nil),
+	}
+	if err := ctx.Err(); err != nil {
+		attrs = append(attrs, attribute.String("build.context_err", err.Error()))
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		attrs = append(attrs, attribute.String("build.context_cause", cause.Error()))
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		attrs = append(attrs,
+			attribute.String("build.context_deadline", deadline.Format(time.RFC3339Nano)),
+			attribute.Int64("build.context_deadline_remaining_ms", time.Until(deadline).Milliseconds()),
+		)
+	}
+
+	return append(attrs, extra...)
+}
+
+func contextLogFields(ctx context.Context, startTime time.Time) []zap.Field {
+	fields := []zap.Field{
+		zap.Duration("build_elapsed", time.Since(startTime)),
+	}
+	if err := ctx.Err(); err != nil {
+		fields = append(fields, zap.String("context_err", err.Error()))
+	}
+	if cause := context.Cause(ctx); cause != nil {
+		fields = append(fields, zap.String("context_cause", cause.Error()))
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		fields = append(fields,
+			zap.Time("context_deadline", deadline),
+			zap.Duration("context_deadline_remaining", time.Until(deadline)),
+		)
+	}
+
+	return fields
 }

--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -230,8 +230,7 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 	uploadErrGroup := &errgroup.Group{}
 	defer func() {
 		// Wait for all template layers to be uploaded even if the build fails
-		waitCtx := context.WithoutCancel(ctx)
-		waitCtx, waitSpan := tracer.Start(waitCtx, "wait-for-template-layer-uploads", trace.WithAttributes(
+		_, waitSpan := tracer.Start(ctx, "wait-for-template-layer-uploads", trace.WithAttributes(
 			telemetry.WithTemplateID(cfg.TemplateID),
 			telemetry.WithBuildID(paths.BuildID),
 			telemetry.WithTeamID(cfg.TeamID),
@@ -242,7 +241,7 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 		if err != nil {
 			waitSpan.RecordError(err)
 			waitSpan.SetStatus(codes.Error, err.Error())
-			b.logger.Error(waitCtx, "template layer upload wait failed",
+			b.logger.Error(ctx, "template layer upload wait failed",
 				logger.WithTemplateID(cfg.TemplateID),
 				logger.WithBuildID(paths.BuildID),
 				logger.WithTeamID(cfg.TeamID),

--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -186,7 +186,6 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 		if ctx.Err() != nil {
 			childSpan.AddEvent("build context done", trace.WithAttributes(
 				attribute.String("context.err", ctx.Err().Error()),
-				attribute.String("context.cause", context.Cause(ctx).Error()),
 			))
 			e = errors.Join(e, ctx.Err())
 		}
@@ -253,7 +252,6 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 		if ctx.Err() != nil {
 			waitSpan.AddEvent("build context done while waiting for uploads", trace.WithAttributes(
 				attribute.String("context.err", ctx.Err().Error()),
-				attribute.String("context.cause", context.Cause(ctx).Error()),
 			))
 		}
 	}()

--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -235,55 +235,28 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 			telemetry.WithTemplateID(cfg.TemplateID),
 			telemetry.WithBuildID(paths.BuildID),
 			telemetry.WithTeamID(cfg.TeamID),
-			attribute.Bool("build_context_done_at_wait_start", ctx.Err() != nil),
 		))
-		waitStart := time.Now()
-
-		if ctx.Err() != nil {
-			waitSpan.AddEvent("build context done before upload wait", trace.WithAttributes(
-				attribute.String("context.err", ctx.Err().Error()),
-				attribute.String("context.cause", context.Cause(ctx).Error()),
-			))
-			b.logger.Warn(waitCtx, "build context done before waiting for template layer uploads",
-				logger.WithTemplateID(cfg.TemplateID),
-				logger.WithBuildID(paths.BuildID),
-				logger.WithTeamID(cfg.TeamID),
-				zap.String("context_err", ctx.Err().Error()),
-				zap.String("context_cause", context.Cause(ctx).Error()),
-			)
-		}
+		defer waitSpan.End()
 
 		err := uploadErrGroup.Wait()
-		waitDuration := time.Since(waitStart)
-		waitAttrs := []attribute.KeyValue{
-			attribute.Bool("upload_wait_error", err != nil),
-			attribute.Bool("build_context_done_after_upload_wait", ctx.Err() != nil),
-		}
-		waitSpan.SetAttributes(waitAttrs...)
 		if err != nil {
-			waitSpan.RecordError(err, trace.WithAttributes(waitAttrs...))
+			waitSpan.RecordError(err)
 			waitSpan.SetStatus(codes.Error, err.Error())
 			b.logger.Error(waitCtx, "template layer upload wait failed",
 				logger.WithTemplateID(cfg.TemplateID),
 				logger.WithBuildID(paths.BuildID),
 				logger.WithTeamID(cfg.TeamID),
-				zap.Duration("upload_wait_duration", waitDuration),
 				zap.Error(err),
 			)
 			e = errors.Join(e, fmt.Errorf("error uploading template layers: %w", err))
-		} else if ctx.Err() != nil {
-			waitSpan.AddEvent("upload wait completed after build context done", trace.WithAttributes(waitAttrs...))
-			b.logger.Warn(waitCtx, "template layer upload wait completed after build context was done",
-				logger.WithTemplateID(cfg.TemplateID),
-				logger.WithBuildID(paths.BuildID),
-				logger.WithTeamID(cfg.TeamID),
-				zap.Duration("upload_wait_duration", waitDuration),
-				zap.String("context_err", ctx.Err().Error()),
-				zap.String("context_cause", context.Cause(ctx).Error()),
-			)
 		}
 
-		waitSpan.End()
+		if ctx.Err() != nil {
+			waitSpan.AddEvent("build context done while waiting for uploads", trace.WithAttributes(
+				attribute.String("context.err", ctx.Err().Error()),
+				attribute.String("context.cause", context.Cause(ctx).Error()),
+			))
+		}
 	}()
 
 	buildContext := buildcontext.BuildContext{

--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -184,7 +184,10 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 	// Wrap context as a user error if no user error already exists
 	defer func() {
 		if ctx.Err() != nil {
-			childSpan.AddEvent("build context done", trace.WithAttributes(contextTraceAttributes(ctx, startTime)...))
+			childSpan.AddEvent("build context done", trace.WithAttributes(
+				attribute.String("context.err", ctx.Err().Error()),
+				attribute.String("context.cause", context.Cause(ctx).Error()),
+			))
 			e = errors.Join(e, ctx.Err())
 		}
 
@@ -237,46 +240,46 @@ func (b *Builder) Build(ctx context.Context, paths storage.Paths, cfg config.Tem
 		waitStart := time.Now()
 
 		if ctx.Err() != nil {
-			attrs := contextTraceAttributes(ctx, startTime)
-			waitSpan.AddEvent("build context done before upload wait", trace.WithAttributes(attrs...))
+			waitSpan.AddEvent("build context done before upload wait", trace.WithAttributes(
+				attribute.String("context.err", ctx.Err().Error()),
+				attribute.String("context.cause", context.Cause(ctx).Error()),
+			))
 			b.logger.Warn(waitCtx, "build context done before waiting for template layer uploads",
-				append(contextLogFields(ctx, startTime),
-					logger.WithTemplateID(cfg.TemplateID),
-					logger.WithBuildID(paths.BuildID),
-					logger.WithTeamID(cfg.TeamID),
-				)...,
+				logger.WithTemplateID(cfg.TemplateID),
+				logger.WithBuildID(paths.BuildID),
+				logger.WithTeamID(cfg.TeamID),
+				zap.String("context_err", ctx.Err().Error()),
+				zap.String("context_cause", context.Cause(ctx).Error()),
 			)
 		}
 
 		err := uploadErrGroup.Wait()
 		waitDuration := time.Since(waitStart)
-		waitAttrs := append(contextTraceAttributes(ctx, startTime),
+		waitAttrs := []attribute.KeyValue{
 			attribute.Bool("upload_wait_error", err != nil),
 			attribute.Bool("build_context_done_after_upload_wait", ctx.Err() != nil),
-		)
+		}
 		waitSpan.SetAttributes(waitAttrs...)
 		if err != nil {
 			waitSpan.RecordError(err, trace.WithAttributes(waitAttrs...))
 			waitSpan.SetStatus(codes.Error, err.Error())
 			b.logger.Error(waitCtx, "template layer upload wait failed",
-				append(contextLogFields(ctx, startTime),
-					logger.WithTemplateID(cfg.TemplateID),
-					logger.WithBuildID(paths.BuildID),
-					logger.WithTeamID(cfg.TeamID),
-					zap.Duration("upload_wait_duration", waitDuration),
-					zap.Error(err),
-				)...,
+				logger.WithTemplateID(cfg.TemplateID),
+				logger.WithBuildID(paths.BuildID),
+				logger.WithTeamID(cfg.TeamID),
+				zap.Duration("upload_wait_duration", waitDuration),
+				zap.Error(err),
 			)
 			e = errors.Join(e, fmt.Errorf("error uploading template layers: %w", err))
 		} else if ctx.Err() != nil {
 			waitSpan.AddEvent("upload wait completed after build context done", trace.WithAttributes(waitAttrs...))
 			b.logger.Warn(waitCtx, "template layer upload wait completed after build context was done",
-				append(contextLogFields(ctx, startTime),
-					logger.WithTemplateID(cfg.TemplateID),
-					logger.WithBuildID(paths.BuildID),
-					logger.WithTeamID(cfg.TeamID),
-					zap.Duration("upload_wait_duration", waitDuration),
-				)...,
+				logger.WithTemplateID(cfg.TemplateID),
+				logger.WithBuildID(paths.BuildID),
+				logger.WithTeamID(cfg.TeamID),
+				zap.Duration("upload_wait_duration", waitDuration),
+				zap.String("context_err", ctx.Err().Error()),
+				zap.String("context_cause", context.Cause(ctx).Error()),
 			)
 		}
 
@@ -508,45 +511,4 @@ func getRootfsSize(
 	}
 
 	return h.Metadata.Size, nil
-}
-
-func contextTraceAttributes(ctx context.Context, startTime time.Time, extra ...attribute.KeyValue) []attribute.KeyValue {
-	attrs := []attribute.KeyValue{
-		attribute.Int64("build.elapsed_ms", time.Since(startTime).Milliseconds()),
-		attribute.Bool("build.context_done", ctx.Err() != nil),
-	}
-	if err := ctx.Err(); err != nil {
-		attrs = append(attrs, attribute.String("build.context_err", err.Error()))
-	}
-	if cause := context.Cause(ctx); cause != nil {
-		attrs = append(attrs, attribute.String("build.context_cause", cause.Error()))
-	}
-	if deadline, ok := ctx.Deadline(); ok {
-		attrs = append(attrs,
-			attribute.String("build.context_deadline", deadline.Format(time.RFC3339Nano)),
-			attribute.Int64("build.context_deadline_remaining_ms", time.Until(deadline).Milliseconds()),
-		)
-	}
-
-	return append(attrs, extra...)
-}
-
-func contextLogFields(ctx context.Context, startTime time.Time) []zap.Field {
-	fields := []zap.Field{
-		zap.Duration("build_elapsed", time.Since(startTime)),
-	}
-	if err := ctx.Err(); err != nil {
-		fields = append(fields, zap.String("context_err", err.Error()))
-	}
-	if cause := context.Cause(ctx); cause != nil {
-		fields = append(fields, zap.String("context_cause", cause.Error()))
-	}
-	if deadline, ok := ctx.Deadline(); ok {
-		fields = append(fields,
-			zap.Time("context_deadline", deadline),
-			zap.Duration("context_deadline_remaining", time.Until(deadline)),
-		)
-	}
-
-	return fields
 }

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/proxy"
@@ -21,6 +24,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/layer")
@@ -298,8 +302,29 @@ func (lb *LayerExecutor) PauseAndUpload(
 
 	lb.UploadErrGroup.Go(func() (uploadErr error) {
 		ctx := context.WithoutCancel(ctx)
-		ctx, span := tracer.Start(ctx, "upload snapshot")
-		defer span.End()
+		ctx, span := tracer.Start(ctx, "upload snapshot", trace.WithAttributes(
+			telemetry.WithTemplateID(lb.Config.TemplateID),
+			telemetry.WithBuildID(lb.Template.BuildID),
+			telemetry.WithTeamID(lb.Config.TeamID),
+			attribute.String("layer.build_id", meta.Template.BuildID),
+			attribute.String("layer.hash", hash),
+		))
+		defer func() {
+			if uploadErr != nil {
+				span.RecordError(uploadErr)
+				span.SetStatus(codes.Error, uploadErr.Error())
+				lb.logger.Error(ctx, "template layer snapshot upload failed",
+					logger.WithTemplateID(lb.Config.TemplateID),
+					logger.WithBuildID(lb.Template.BuildID),
+					logger.WithTeamID(lb.Config.TeamID),
+					zap.String("layer_build_id", meta.Template.BuildID),
+					zap.String("layer_hash", hash),
+					zap.Error(uploadErr),
+				)
+			}
+
+			span.End()
+		}()
 
 		// Signal even on error so child layers waiting on this build can abort.
 		defer func() { upload.Finish(ctx, uploadErr) }()


### PR DESCRIPTION
## Summary
- record context-deadline details when template builds are collapsed to `build timed out`
- add a dedicated span around async template layer upload waits
- annotate snapshot upload spans with template/build/team/layer identifiers and record upload failures

## Verification
- `gofmt`
- `go test ./pkg/template/build/metrics`

Linux orchestrator package compile was not runnable locally on macOS because the userfaultfd/cgo path requires a Linux C toolchain.