### PR TITLE
refactor(orchestrator): fold soft-delete dataPath into source

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -58,7 +58,7 @@ func classifyCheckError(err error) string {
 func (b *StorageDiff) softDeleteErr() error {
 	// Fail closed only while the tombstoned path is still the active one: a peer
 	// transition that repointed dataPath makes the old verdict stop matching.
-	if sp := b.softDeletedPath.Load(); sp != nil && sp == b.dataPath.Load() {
+	if sp := b.softDeletedPath.Load(); sp != nil && *sp == b.source.Load().dataPath {
 		return fmt.Errorf("%s %s: %w", b.buildID, b.diffType, storage.ErrObjectSoftDeleted)
 	}
 
@@ -80,17 +80,17 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	// Read the tombstone off the data object this diff actually serves — the
 	// object the storage index prunes — not the header, which a deduped
 	// ancestor layer is never read from.
-	path := b.dataPath.Load()
-	if path == nil {
+	path := b.source.Load().dataPath
+	if path == "" {
 		return
 	}
-	blob, err := b.persistence.OpenBlob(ctx, *path, storage.MetadataObjectType)
+	blob, err := b.persistence.OpenBlob(ctx, path, storage.MetadataObjectType)
 	if err != nil {
 		result := classifyCheckError(err)
 		b.recordCheck(ctx, result, false, false)
 		logger.L().Warn(ctx, "storage-index soft-delete check could not open object",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
-			zap.String("result", result), zap.String("object", *path), zap.Error(err))
+			zap.String("result", result), zap.String("object", path), zap.Error(err))
 
 		return
 	}
@@ -104,10 +104,10 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		// here, which silently failed open).
 		if result == checkResultUnsupported && ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag) {
 			b.recordCheck(ctx, result, false, true)
-			b.softDeletedPath.Store(path)
+			b.softDeletedPath.Store(&path)
 			logger.L().Error(ctx, "storage-index soft-delete unverifiable; failing closed",
 				logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
-				zap.String("result", result), zap.String("object", *path), zap.Error(err))
+				zap.String("result", result), zap.String("object", path), zap.Error(err))
 
 			return
 		}
@@ -115,7 +115,7 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		logger.L().Warn(ctx, "storage-index soft-delete check could not read object metadata",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
 			zap.String("result", result),
-			zap.String("object", *path), zap.Error(err))
+			zap.String("object", path), zap.Error(err))
 
 		return
 	}
@@ -138,10 +138,10 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		zap.Bool("enforce", enforce),
 	)
 
-	// Record the tombstoned path; softDeleteErr enforces only while it is still
-	// the active dataPath, so storing a superseded path here is harmless (it can
-	// never match the current pointer) — no check-then-store race.
+	// Record the tombstoned path; softDeleteErr enforces only while it still
+	// equals the active source's dataPath, so recording a superseded path here is
+	// harmless (it can never match the live value) — no check-then-store race.
 	if failed {
-		b.softDeletedPath.Store(path)
+		b.softDeletedPath.Store(&path)
 	}
 }

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -311,21 +311,29 @@ func (b *StorageDiff) ReadAt(ctx context.Context, p []byte, off int64, callerFT 
 	if !errors.As(err, &transErr) {
 		return n, err
 	}
-	if err := waitTransitionBackoff(ctx, transErr); err != nil {
-		return 0, err
-	}
-	if err := b.reloadAfterPeerTransition(ctx); err != nil {
-		return 0, fmt.Errorf("refresh after peer transition: %w", err)
-	}
-	if err := b.softDeleteErr(); err != nil {
-		return 0, err
-	}
-	up, ft, err = b.resolve(ctx, callerFT)
+	up, ft, err = b.recoverFromPeerTransition(ctx, transErr, callerFT)
 	if err != nil {
 		return 0, err
 	}
 
 	return b.chunker.ReadAt(ctx, p, off, up, ft)
+}
+
+// recoverFromPeerTransition handles a PeerTransitionedError surfaced by a read:
+// back off, reload the source, re-check the soft-delete latch (the source's
+// dataPath may have changed during the reload), and re-resolve the upstream/FT.
+func (b *StorageDiff) recoverFromPeerTransition(ctx context.Context, transErr *storage.PeerTransitionedError, callerFT *storage.FrameTable) (storage.RangeOpener, *storage.FrameTable, error) {
+	if err := waitTransitionBackoff(ctx, transErr); err != nil {
+		return nil, nil, err
+	}
+	if err := b.reloadAfterPeerTransition(ctx); err != nil {
+		return nil, nil, fmt.Errorf("refresh after peer transition: %w", err)
+	}
+	if err := b.softDeleteErr(); err != nil {
+		return nil, nil, err
+	}
+
+	return b.resolve(ctx, callerFT)
 }
 
 func (b *StorageDiff) Slice(ctx context.Context, off, length int64, callerFT *storage.FrameTable) ([]byte, error) {
@@ -341,16 +349,7 @@ func (b *StorageDiff) Slice(ctx context.Context, off, length int64, callerFT *st
 	if !errors.As(err, &transErr) {
 		return out, err
 	}
-	if err := waitTransitionBackoff(ctx, transErr); err != nil {
-		return nil, err
-	}
-	if err := b.reloadAfterPeerTransition(ctx); err != nil {
-		return nil, fmt.Errorf("refresh after peer transition: %w", err)
-	}
-	if err := b.softDeleteErr(); err != nil {
-		return nil, err
-	}
-	up, ft, err = b.resolve(ctx, callerFT)
+	up, ft, err = b.recoverFromPeerTransition(ctx, transErr, callerFT)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/orchestrator/pkg/sandbox/build/storage_diff.go
+++ b/packages/orchestrator/pkg/sandbox/build/storage_diff.go
@@ -33,6 +33,12 @@ const (
 type source struct {
 	upstream           storage.RangeOpener
 	fullDiffFrameTable *storage.FullFrameTable
+	// dataPath is the storage object upstream reads from; the soft-delete check
+	// reads the tombstone off it directly (the object that gets pruned), not the
+	// header. Empty when there is no storage path to check. It travels with the
+	// upstream it was opened from, so a peer transition (uncompressed probe ->
+	// authoritative compressed object) swaps both atomically.
+	dataPath string
 }
 
 func isPeerRouted(v any) bool {
@@ -48,12 +54,7 @@ type StorageDiff struct {
 	buildID           string
 	diffType          DiffType
 	storageObjectType storage.SeekableObjectType
-	// dataPath is the storage object this diff reads from; the soft-delete
-	// check reads the tombstone off it directly (the object that gets pruned),
-	// not the header. It can change on a peer transition (uncompressed probe ->
-	// authoritative compressed object), so it is atomic and the check reruns.
-	dataPath atomic.Pointer[string]
-	flags    *featureflags.Client
+	flags             *featureflags.Client
 
 	blockSize   int64
 	metrics     blockmetrics.Metrics
@@ -62,12 +63,12 @@ type StorageDiff struct {
 	source    atomic.Pointer[source]
 	refreshMu sync.Mutex
 
-	// softDeletedPath holds the dataPath pointer the background check found
+	// softDeletedPath holds the storage path the background check found
 	// tombstoned (only under enforcement); reads fail closed while it equals the
-	// current dataPath. Keying on the path pointer (not a bool) makes the latch
-	// race-free: a stale check that stored a superseded probe path can never
-	// match the current dataPath, and a peer-transition repoint auto-disables
-	// the old verdict without a separate clear.
+	// current source's dataPath. Comparing by path value (not a bool) makes the
+	// latch race-free: a stale check that recorded a superseded probe path can
+	// never match the live dataPath, and a peer-transition repoint to a different
+	// object auto-disables the old verdict without a separate clear.
 	softDeletedPath atomic.Pointer[string]
 }
 
@@ -117,8 +118,7 @@ func newStorageDiff(
 		chunker:           c,
 		cacheKey:          GetDiffStoreKey(buildID, diffType),
 	}
-	d.dataPath.Store(&dataPath)
-	d.source.Store(&source{upstream: upstream, fullDiffFrameTable: initialFT})
+	d.source.Store(&source{upstream: upstream, fullDiffFrameTable: initialFT, dataPath: dataPath})
 
 	return d, nil
 }
@@ -470,18 +470,9 @@ func (b *StorageDiff) reloadSourceLocked(ctx context.Context, cause string) erro
 	if err != nil {
 		return fmt.Errorf("reloadSourceLocked: build %s: %w", b.buildID, err)
 	}
-	b.source.Store(&source{upstream: upstream, fullDiffFrameTable: ft})
+	pathChanged := b.source.Load().dataPath != dataPath
+	b.source.Store(&source{upstream: upstream, fullDiffFrameTable: ft, dataPath: dataPath})
 
-	// Re-point to the new pointer when the authoritative object differs from the
-	// one first opened (e.g. a peer probe resolving to a compressed object).
-	// Enforcement keys on the path pointer, so the old object's verdict
-	// (softDeletedPath) stops matching automatically — no explicit clear, no
-	// race with a stale check about to store the superseded path.
-	old := b.dataPath.Load()
-	pathChanged := old == nil || *old != dataPath
-	if pathChanged {
-		b.dataPath.Store(&dataPath)
-	}
 	// Recheck on any path change, and also on a peer transition even if the path
 	// is unchanged: a peer-served object that wasn't in storage at first open
 	// (not_found) may now exist and carry a tombstone the initial check missed.


### PR DESCRIPTION
Two small follow-up refactors to the soft-delete consumer (#3034), now that it's merged.

1. **Fold `dataPath` into `source`.** The data object's path was a second `atomic.Pointer[string]` kept in lockstep with `source`, and the tombstone latch keyed on pointer identity. The path is just routing state
(where `upstream` reads from), so move it into the `source` struct — `{upstream, ft, dataPath}` now swap as one atomic — and match the latch by path value. This drops a redundant atomic, removes the source/path
desync window, and deletes the "only re-store the pointer when the value changed" branch in `reloadSourceLocked` (that conditional was already doing value comparison to make pointer identity behave).

2. **Extract `recoverFromPeerTransition`.** `ReadAt` and `Slice` had identical post-`PeerTransitionedError` recovery (back off → reload → re-check soft-delete latch → re-resolve). Pull it into one helper.
