### PR TITLE
fix(storage): drop 30s WithTimeout from S3 StoreFile (BYOC-58)

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -168,9 +168,14 @@ func (o *awsObject) StoreFile(ctx context.Context, path string, opts ...PutOptio
 		return nil, [32]byte{}, errors.New("compressed uploads are not supported on AWS (builds target GCP only)")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
-	defer cancel()
-
+	// Inherit the caller's context for the multipart upload. The AWS SDK's
+	// manager.Uploader reuses the same ctx for CreateMultipartUpload, every
+	// UploadPart (Concurrency=8, PartSize=10MB), and the final Complete/Abort —
+	// a tight static timeout here would cancel an in-flight multi-GB snapshot
+	// upload and surface as "S3: UploadPart ... StatusCode: 0, canceled,
+	// context deadline exceeded". The caller (pkg/server/sandboxes.go) already
+	// scopes a per-attempt deadline (uploadTimeout = 20m) with retry budget on
+	// top, matching the GCP path which also inherits the caller's ctx.
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, [32]byte{}, fmt.Errorf("failed to open file %s: %w", path, err)


### PR DESCRIPTION
> Linear: [BYOC-58](https://linear.app)

## Symptom

BYOC AWS deployments fail to upload sandbox snapshots with:

```
error uploading snapshot: upload multipart failed, upload id: <…>,
cause: operation error S3: UploadPart, https response error
StatusCode: 0, RequestID: , HostID: , canceled, context deadline exceeded
```

`StatusCode: 0` means no HTTP response was ever received — the request was killed client-side. The same workload on GCS Object Storage succeeds.

## Root cause

`packages/shared/pkg/storage/storage_aws.go:171` wrapped the caller's `ctx` in `context.WithTimeout(ctx, awsWriteTimeout)` where `awsWriteTimeout = 30 * time.Second`.

```go
func (o *awsObject) StoreFile(ctx context.Context, ...) (...) {
    ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout) // ← 30s ceiling
    defer cancel()
    ...
    uploader := manager.NewUploader(o.client, func(u *manager.Uploader) {
        u.PartSize    = 10 * 1024 * 1024  // 10 MB
        u.Concurrency = 8
    })
    _, err = uploader.Upload(ctx, ...) // single ctx for whole multipart
}
```

The AWS SDK's `manager.Uploader` **stores the ctx once and reuses it everywhere** (per [aws-sdk-go-v2/feature/s3/manager/upload.go](https://github.com/aws/aws-sdk-go-v2/blob/main/feature/s3/manager/upload.go)):

```go
i := uploader{in: input, cfg: u, ctx: ctx}
// ...
resp, err := u.cfg.S3.CreateMultipartUpload(u.ctx, ...)
resp, err := u.cfg.S3.UploadPart(u.ctx, ...)         // every part
```

So 30 s caps the **entire** multipart upload — not per-part. When ctx fires, all 8 concurrent `UploadPart` goroutines cancel simultaneously, and the SDK's follow-up `AbortMultipartUpload` reuses the same already-dead ctx (known upstream bug [aws-sdk-go-v2#3341](https://github.com/aws/aws-sdk-go-v2/issues/3341)), which orphans the multipart parts in the bucket.

### Why GCS doesn't see this

`packages/shared/pkg/storage/storage_google.go:424` — `gcpObject.StoreFile` does **not** wrap `ctx` in `WithTimeout`. It inherits the caller's deadline only. (The `googleOperationTimeout = 5s` constant wraps small attr/metadata operations, not the upload.)

### What the caller already provides

`packages/orchestrator/pkg/server/sandboxes.go:49-54, 789`:

```go
uploadTimeout      = 20 * time.Minute  // per attempt
uploadTotalBudget  = 2 * time.Hour     // overall retry window
// ...
uploadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), uploadTimeout)
```

So the architecture **already** scopes the per-attempt deadline at 20 min, with up to 2 h of retry budget on top. On GCS this works. On AWS, the storage layer silently overrode 20 min → 30 s, guaranteed to fail for any multi-GB snapshot.

### Throughput math

Best case: 8 concurrent × ~80 MB/s/conn × 30 s ≈ 19 GB theoretical max. In practice (TLS handshake, S3 server-side queueing, slow-start) the practical ceiling is ~1–3 GB. Snapshots are routinely 4–8 GB → predictable failure.

## Fix

Remove the `context.WithTimeout(ctx, awsWriteTimeout)` wrap from `(o *awsObject) StoreFile`. Inherit the caller's `uploadCtx` (20 min) instead, matching the GCS path.

```diff
- ctx, cancel := context.WithTimeout(ctx, awsWriteTimeout)
- defer cancel()
+ // (comment explaining the symmetric contract with GCS)
```

The `awsWriteTimeout` constant is intentionally kept for `Put()` (`storage_aws.go:222`), which handles small byte-slice uploads where 30 s is appropriate.

## Best-practice verification

Per AWS SDK Go v2 docs and community guidance ([aws-sdk-go#3386](https://github.com/aws/aws-sdk-go/issues/3386), [aws-sdk-js#1704](https://github.com/aws/aws-sdk-js/issues/1704), [tus/tusd#1172](https://github.com/tus/tusd/issues/1172)):

- The `ctx` passed to `manager.Uploader.Upload` must have a deadline that **covers the entire upload**, not a tight static one.
- The SDK's own per-attempt retries handle transient per-part failures; a wrapping deadline only adds a hard ceiling on the cumulative wall-clock time.
- Recommended pattern is either (a) inherit the caller's deadline unchanged (what GCS does, what we'll do) or (b) size proportionally to file size.

## Follow-ups (not in this PR)

1. **S3 lifecycle rule to auto-abort incomplete multipart uploads** after 1–3 days. Defends against the orphaned-parts bug in [aws-sdk-go-v2#3341](https://github.com/aws/aws-sdk-go-v2/issues/3341) and recovers storage cost from past BYOC-58 failures.
2. **Migrate from deprecated `feature/s3/manager` to `feature/s3/transfermanager`** ([discussion #3306](https://github.com/aws/aws-sdk-go-v2/discussions/3306)). Orthogonal to this bug, but worth doing.

## Test plan

- [ ] Deploy to a BYOC AWS dev env.
- [ ] Trigger a snapshot upload for a sandbox with a ≥ 2 GB memfile.
- [ ] Confirm `S3: UploadPart … context deadline exceeded` no longer appears in logs.
- [ ] Confirm the upload either succeeds or fails for a real network/S3 reason (not a client-side cancel).
- [ ] Confirm `Put()` for small payloads (e.g. manifest writes) still uses the 30 s ceiling (unchanged).
- [ ] Smoke-test snapshot upload on GCP — must be a no-op behavior change.

## Marked as draft

So we can verify the fix on BYOC dev before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)