### PR TITLE
fix(orchestrator): bump min envd for cgroup freeze to 0.6.3

### DIFF
--- a/packages/shared/pkg/utils/version.go
+++ b/packages/shared/pkg/utils/version.go
@@ -8,11 +8,11 @@ import (
 
 const MinEnvdVersionForSnapshot = "0.5.0"
 
-// MinEnvdVersionForCgroupFreeze is the first envd that exposes a native
-// POST /freeze endpoint and thaws cgroups on /init. We require both so the
-// orchestrator can avoid shell-based freezes (slow under load) and so the
-// sandbox doesn't end up permanently frozen after resume on older envds.
-const MinEnvdVersionForCgroupFreeze = "0.6.0"
+// MinEnvdVersionForCgroupFreeze is the first envd we trust to freeze user
+// cgroups across pause/resume. /freeze plus /init thaw landed in 0.6.0, but
+// 0.6.0-0.6.2 also froze the socat cgroup, breaking port forwarding (fixed
+// in 0.6.3 by #2923), so we gate on 0.6.3.
+const MinEnvdVersionForCgroupFreeze = "0.6.3"
 
 // MinEnvdVersionForHeapCollapse is the first envd that exposes a native
 // POST /collapse endpoint, which compacts envd's own anonymous heap into 2 MiB


### PR DESCRIPTION
envd 0.6.0-0.6.2 also froze the socat cgroup across pause/resume, which broke port forwarding (fixed in 0.6.3 by #2923). Raise the version gate so the orchestrator only freezes user cgroups on envds that exclude socat; older sandboxes skip the freeze entirely.