### PR TITLE
fix(api): parse the pause body regardless of Content-Length

### DIFF
--- a/packages/api/internal/handlers/sandbox_pause.go
+++ b/packages/api/internal/handlers/sandbox_pause.go
@@ -45,20 +45,15 @@ func (a *APIStore) PostSandboxesSandboxIDPause(c *gin.Context, sandboxID api.San
 
 	// The request body is optional — existing callers send none. Default to a
 	// full memory snapshot; memory:false requests a filesystem-only snapshot.
-	// Only parse when a body is actually present (ContentLength > 0): a zero or
-	// unknown (-1) length means no body, and ParseBody would reject an empty one.
-	filesystemOnly := false
-	if c.Request.ContentLength > 0 {
-		body, bindErr := ginutils.ParseBody[api.PostSandboxesSandboxIDPauseJSONRequestBody](ctx, c)
-		if bindErr != nil {
-			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", bindErr))
+	// ParseOptionalBody tolerates an absent/empty body and parses a present one
+	// regardless of Content-Length (chunked requests report -1 even with a body).
+	body, bindErr := ginutils.ParseOptionalBody[api.PostSandboxesSandboxIDPauseJSONRequestBody](ctx, c)
+	if bindErr != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", bindErr))
 
-			return
-		}
-		if body.Memory != nil && !*body.Memory {
-			filesystemOnly = true
-		}
+		return
 	}
+	filesystemOnly := body.Memory != nil && !*body.Memory
 
 	pause.LogInitiated(ctx, sandboxID, teamID.String(), pause.ReasonRequest)
 

--- a/packages/shared/pkg/ginutils/body.go
+++ b/packages/shared/pkg/ginutils/body.go
@@ -2,6 +2,8 @@ package ginutils
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -16,6 +18,30 @@ func ParseBody[B any](ctx context.Context, c *gin.Context) (body B, err error) {
 		telemetry.ReportCriticalError(ctx, "error when parsing request", err)
 
 		return body, fmt.Errorf("error when parsing request: %w", err)
+	}
+
+	return body, nil
+}
+
+// ParseOptionalBody parses an optional JSON request body. Unlike ParseBody it
+// tolerates an absent or empty body, returning the zero value and no error — and
+// it does so without consulting Content-Length, which is -1 under chunked
+// transfer encoding even when a body is present. A present-but-malformed body
+// still returns an error.
+func ParseOptionalBody[B any](ctx context.Context, c *gin.Context) (body B, err error) {
+	if c.Request == nil || c.Request.Body == nil {
+		return body, nil
+	}
+
+	if decErr := json.NewDecoder(c.Request.Body).Decode(&body); decErr != nil {
+		if errors.Is(decErr, io.EOF) {
+			// Empty body: the caller defaults from the zero value.
+			return body, nil
+		}
+
+		telemetry.ReportCriticalError(ctx, "error when parsing request", decErr)
+
+		return body, fmt.Errorf("error when parsing request: %w", decErr)
 	}
 
 	return body, nil

--- a/packages/shared/pkg/ginutils/body_test.go
+++ b/packages/shared/pkg/ginutils/body_test.go
@@ -1,0 +1,101 @@
+package ginutils
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type optionalBody struct {
+	Memory *bool `json:"memory"`
+}
+
+// newTestContext builds a gin.Context whose request reads from body and reports
+// contentLength (use -1 to emulate chunked transfer encoding).
+func newTestContext(body io.Reader, contentLength int64) *gin.Context {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", body)
+	req.ContentLength = contentLength
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = req
+
+	return c
+}
+
+func TestParseOptionalBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("chunked request with a body is parsed (ContentLength -1)", func(t *testing.T) {
+		t.Parallel()
+
+		// The regression: a chunked client sends a real JSON body but Go reports
+		// ContentLength == -1. Gating on ContentLength > 0 would silently drop it.
+		c := newTestContext(strings.NewReader(`{"memory":false}`), -1)
+
+		body, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.NoError(t, err)
+		require.NotNil(t, body.Memory)
+		assert.False(t, *body.Memory)
+	})
+
+	t.Run("body with Content-Length is parsed", func(t *testing.T) {
+		t.Parallel()
+
+		raw := `{"memory":false}`
+		c := newTestContext(strings.NewReader(raw), int64(len(raw)))
+
+		body, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.NoError(t, err)
+		require.NotNil(t, body.Memory)
+		assert.False(t, *body.Memory)
+	})
+
+	t.Run("empty body yields the zero value", func(t *testing.T) {
+		t.Parallel()
+
+		c := newTestContext(strings.NewReader(""), 0)
+
+		body, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.NoError(t, err)
+		assert.Nil(t, body.Memory, "absent body must default to the zero value")
+	})
+
+	t.Run("empty chunked body yields the zero value (ContentLength -1)", func(t *testing.T) {
+		t.Parallel()
+
+		// This is the case a naive `ContentLength != 0` switch would break:
+		// chunked + no body would attempt to decode an empty stream and 400.
+		c := newTestContext(strings.NewReader(""), -1)
+
+		body, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.NoError(t, err)
+		assert.Nil(t, body.Memory)
+	})
+
+	t.Run("nil body yields the zero value", func(t *testing.T) {
+		t.Parallel()
+
+		c := newTestContext(http.NoBody, 0)
+		c.Request.Body = nil
+
+		body, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.NoError(t, err)
+		assert.Nil(t, body.Memory)
+	})
+
+	t.Run("malformed body returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		c := newTestContext(strings.NewReader(`{"memory":`), -1)
+
+		_, err := ParseOptionalBody[optionalBody](t.Context(), c)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
The pause handler only parsed the optional body when `ContentLength > 0`, so a chunked request (Content-Length reported as -1) carrying `{"memory":false}` had its body silently dropped and was paused as a full memory snapshot — the filesystem-only request was lost. Switching the guard to `!= 0` would instead 400 on a chunked request with no body, since the JSON bind rejects an empty one.

Add ginutils.ParseOptionalBody, which decodes the body when present and treats an absent/empty body as the zero value, without consulting Content-Length, and use it in the pause handler. Unit tests cover chunked-with-body, chunked-empty, Content-Length, nil, empty, and malformed bodies.