### PR TITLE
feat(api): add templateID filter to GET /v2/sandboxes

### DIFF
--- a/packages/api/internal/api/api.gen.go
+++ b/packages/api/internal/api/api.gen.go
@@ -1623,6 +1623,9 @@ type GetV2SandboxesParams struct {
 	// State Filter sandboxes by one or more states
 	State *[]SandboxState `form:"state,omitempty" json:"state,omitempty"`
 
+	// TemplateID Filter sandboxes by the template ID they were created from
+	TemplateID *string `form:"templateID,omitempty" json:"templateID,omitempty"`
+
 	// NextToken Cursor to start the list from
 	NextToken *PaginationNextToken `form:"nextToken,omitempty" json:"nextToken,omitempty"`
 
@@ -5365,6 +5368,18 @@ func NewGetV2SandboxesRequest(server string, params *GetV2SandboxesParams) (*htt
 		if params.State != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "state", *params.State, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.TemplateID != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "templateID", *params.TemplateID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {
@@ -13016,6 +13031,14 @@ func (siw *ServerInterfaceWrapper) GetV2Sandboxes(c *gin.Context) {
 		return
 	}
 
+	// ------------- Optional query parameter "templateID" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "templateID", c.Request.URL.Query(), &params.TemplateID, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter templateID: %w", err), http.StatusBadRequest)
+		return
+	}
+
 	// ------------- Optional query parameter "nextToken" -------------
 
 	err = runtime.BindQueryParameterWithOptions("form", true, false, "nextToken", c.Request.URL.Query(), &params.NextToken, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
@@ -13620,15 +13643,15 @@ var swaggerSpec = []string{
 	"CywW7aUScIKyNGI4RBFNrqydEHOkRoBK9pgmDoXjJdHf+mqRH1XbX7BY3JdjeRzQCz1sX/+zWoXlXHYL",
 	"3S7o1w9DKwouXwDyTfdd91xuFoTDY3fzI9COOaUfwJHybOnMuqs7ItLASb2KCd54EtfpcnnAsLMLPL9v",
 	"XLhRkQCuz79+9NNwELpJF3s8YmtLnP5190eubjFuelOXL3S6RCwhiHEUM65LowAkeuV5l5ruV8uHdi69",
-	"cZ3jkZDLSP2gNM7n5HZ7KQXy5J++tmZr7ZULssnc6PCRZ5rP9VmaDbsupjtD15wb//pAtmHJazE7VkCp",
-	"NwEGCbg2m7csGU8mSPVGUxKxG52rQDfAnCByG0RZ2AzbtZkxD7AgW4Ikgkp6TZDIploGoRjLYIFYAiuP",
-	"iRB4rm9hiqU2iBWCebAoLSvGt8ckmSsC3333l83G2Tpper/urma/fEnYO5BJlx7HrP+lwtfdx3ir8HX3",
-	"qbuhDSReajsNvEu7GFuLWWwvgdweE+Qg6o8dFfQgi2hm1S9hR49CDh1xH0OjPLzU8XhxHg8sRQAig2TI",
-	"0wozeUr8+k2ThrGiPvHmUfSJN4+lT5gFWA5rF/K0VIsf/zV5Da1ZlMWkZ5ojZFv7jBn5p4c3iOm5BlvC",
-	"IrCj1Xfzp+BndrM96ttq3pUDyM++nON+kJq29ow3+6BLz7qfhMYk3IFRNtFnHWYv959G/HPYzvZ3/Y/+",
-	"T7WasVI3Mnj51Qw7WJmz6+n5TquEDfaNFq5jwovtxs+JWuLEcgg2Bok95FnvPBZLscmGXtCoP0OBZfFr",
-	"e+wZj0Z7o4WUqdjb3sYpnZDd6QSn6cjp/73IblMkevleyTVa/hEy8bh/w7FtSXWu5YYp3boiy9Jvxpmf",
-	"/50rH5d3/x0AAP//",
+	"cZ3jkZDLSP2gNM5Rvy2USO3oUP29RDdKwtjn2y2XZ+mas1th+Uz8fy81SZ78G9zWtLG9klI22T0dhvZM",
+	"E8s+S/tl1w15Z+iacytkH8g2LHkt9s8KKPUmwDIC93fzqCbjyQSp3mhKInajkyboBpgTRG6DKAubYbs2",
+	"e+oBFmRLkERQSa8JEtlUM3AUYxksEEtg5TERAs/1dVCx1Ab5RjAPFqVlxfj2mCRzReC77/6y2YBfJ1/w",
+	"193VDKkvmYMHMunSK531P5n4uvsYjya+7j51f7iBxEuRqYGXehdja8GT7bWY24OTHET9scOTHmQRzaz6",
+	"Jf7pUcihIwBlaLiJlzoeL+DkgaUIQGSQDHla8S5PiV+/adIwVtQn3jyKPvHmsfQJswDLYe1CnpZq8eM/",
+	"a6+hNYuymPTMt4Rsa58xI//08AYxPddgS1gEdrT6bv4U/MxutkehXc27cgD52Zdz3A9SXNee8WZflulZ",
+	"95PQmIQ7MMqarOswe7n/NOKfw3a2v+t/9H8z1oyVupHBy69m2MHKnF1PzwdjJWywj8VwHRNebDd+TtQS",
+	"sJZDsDFa7SHPeuexWIrNevSCRv0ZCiyLX9tjz3g02hstpEzF3vY2TumE7E4nOE1HTv/vVZ+igNtbOelp",
+	"+UdICeT+Dce2JdW5lhumdOuKLEu/maiC/O9c+bi8++8AAAD//w==",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/packages/api/internal/handlers/sandboxes_list.go
+++ b/packages/api/internal/handlers/sandboxes_list.go
@@ -35,6 +35,7 @@ func (a *APIStore) getPausedSandboxes(
 	teamID uuid.UUID,
 	runningSandboxesIDs []string,
 	metadataFilter *map[string]string,
+	templateID *string,
 	queryLimit int32,
 	cursorTime time.Time,
 	cursorID string,
@@ -53,6 +54,7 @@ func (a *APIStore) getPausedSandboxes(
 		Limit:      dbLimit,
 		TeamID:     teamID,
 		Metadata:   queryMetadata,
+		BaseEnvID:  templateID,
 		CursorTime: pgtype.Timestamptz{Time: cursorTime, Valid: true},
 		CursorID:   cursorID,
 	})
@@ -176,6 +178,12 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 		return
 	}
 
+	// Normalize the template filter: treat an empty string the same as no filter
+	templateFilter := params.TemplateID
+	if templateFilter != nil && *templateFilter == "" {
+		templateFilter = nil
+	}
+
 	// Get sandboxes with pagination
 	sandboxes := make([]utils.PaginatedSandbox, 0)
 
@@ -200,6 +208,9 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 		// Filter based on metadata
 		runningSandboxList = utils.FilterSandboxesOnMetadata(runningSandboxList, metadataFilter)
 
+		// Filter based on template
+		runningSandboxList = utils.FilterSandboxesOnTemplate(runningSandboxList, templateFilter)
+
 		// Set the total (before we apply the limit, but already with all filters)
 		c.Header("X-Total-Running", strconv.Itoa(len(runningSandboxList)))
 
@@ -219,7 +230,7 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 			runningSandboxesIDs = append(runningSandboxesIDs, info.SandboxID)
 		}
 
-		pausedSandboxList, err := a.getPausedSandboxes(ctx, team.ID, runningSandboxesIDs, metadataFilter, pagination.QueryLimit(), pagination.CursorTime(), pagination.CursorID())
+		pausedSandboxList, err := a.getPausedSandboxes(ctx, team.ID, runningSandboxesIDs, metadataFilter, templateFilter, pagination.QueryLimit(), pagination.CursorTime(), pagination.CursorID())
 		if err != nil {
 			logger.L().Error(ctx, "Error getting paused sandboxes", zap.Error(err))
 			a.sendAPIStoreError(c, http.StatusInternalServerError, "Error getting paused sandboxes")
@@ -229,6 +240,7 @@ func (a *APIStore) GetV2Sandboxes(c *gin.Context, params api.GetV2SandboxesParam
 
 		pausingSandboxList := instanceInfoToPaginatedSandboxes(pausingSandboxes)
 		pausingSandboxList = utils.FilterSandboxesOnMetadata(pausingSandboxList, metadataFilter)
+		pausingSandboxList = utils.FilterSandboxesOnTemplate(pausingSandboxList, templateFilter)
 		pausingSandboxList = utils.FilterBasedOnCursor(pausingSandboxList, pagination.CursorTime(), pagination.CursorID())
 
 		sandboxes = append(sandboxes, pausedSandboxList...)

--- a/packages/api/internal/utils/sandboxes_list.go
+++ b/packages/api/internal/utils/sandboxes_list.go
@@ -137,6 +137,26 @@ func FilterSandboxesOnMetadata(sandboxes []PaginatedSandbox, metadata *map[strin
 	return sandboxes
 }
 
+func FilterSandboxesOnTemplate(sandboxes []PaginatedSandbox, templateID *string) []PaginatedSandbox {
+	if templateID == nil || *templateID == "" {
+		return sandboxes
+	}
+
+	// Filter instances to match the template ID
+	n := 0
+	for _, sbx := range sandboxes {
+		if sbx.TemplateID == *templateID {
+			sandboxes[n] = sbx
+			n++
+		}
+	}
+
+	// Trim slice
+	sandboxes = sandboxes[:n]
+
+	return sandboxes
+}
+
 func parseFilters(query string) (map[string]string, error) {
 	query, err := url.QueryUnescape(query)
 	if err != nil {

--- a/packages/api/internal/utils/sandboxes_list_test.go
+++ b/packages/api/internal/utils/sandboxes_list_test.go
@@ -5,7 +5,65 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/api/internal/api"
 )
+
+func sandboxWithTemplate(sandboxID, templateID string) PaginatedSandbox {
+	return PaginatedSandbox{
+		ListedSandbox: api.ListedSandbox{
+			SandboxID:  sandboxID,
+			TemplateID: templateID,
+		},
+	}
+}
+
+func TestFilterSandboxesOnTemplate(t *testing.T) {
+	t.Parallel()
+
+	sandboxes := []PaginatedSandbox{
+		sandboxWithTemplate("sbx-1", "tmpl-a"),
+		sandboxWithTemplate("sbx-2", "tmpl-b"),
+		sandboxWithTemplate("sbx-3", "tmpl-a"),
+	}
+
+	t.Run("nil filter returns all", func(t *testing.T) {
+		t.Parallel()
+
+		input := append([]PaginatedSandbox(nil), sandboxes...)
+		actual := FilterSandboxesOnTemplate(input, nil)
+		assert.Len(t, actual, 3)
+	})
+
+	t.Run("empty string filter returns all", func(t *testing.T) {
+		t.Parallel()
+
+		empty := ""
+		input := append([]PaginatedSandbox(nil), sandboxes...)
+		actual := FilterSandboxesOnTemplate(input, &empty)
+		assert.Len(t, actual, 3)
+	})
+
+	t.Run("matching template returns subset", func(t *testing.T) {
+		t.Parallel()
+
+		templateID := "tmpl-a"
+		input := append([]PaginatedSandbox(nil), sandboxes...)
+		actual := FilterSandboxesOnTemplate(input, &templateID)
+		require.Len(t, actual, 2)
+		assert.Equal(t, "sbx-1", actual[0].SandboxID)
+		assert.Equal(t, "sbx-3", actual[1].SandboxID)
+	})
+
+	t.Run("no match returns empty", func(t *testing.T) {
+		t.Parallel()
+
+		templateID := "tmpl-missing"
+		input := append([]PaginatedSandbox(nil), sandboxes...)
+		actual := FilterSandboxesOnTemplate(input, &templateID)
+		assert.Empty(t, actual)
+	})
+}
 
 func TestParseFilters(t *testing.T) {
 	t.Parallel()

--- a/packages/db/pkg/tests/snapshots/snapshot_latest_assignment_test.go
+++ b/packages/db/pkg/tests/snapshots/snapshot_latest_assignment_test.go
@@ -119,6 +119,52 @@ func TestGetSnapshotsWithCursor_ReturnsLatestAssignment(t *testing.T) {
 		"GetSnapshotsWithCursor should return the build from the latest assignment")
 }
 
+// TestGetSnapshotsWithCursor_FiltersByBaseEnvID verifies that passing BaseEnvID filters
+// snapshots to only those created from that base template, and that a nil filter returns all.
+func TestGetSnapshotsWithCursor_FiltersByBaseEnvID(t *testing.T) {
+	t.Parallel()
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	baseTemplateA := testutils.CreateTestTemplate(t, db, teamID)
+	baseTemplateB := testutils.CreateTestTemplate(t, db, teamID)
+
+	// One snapshot from base template A, one from base template B
+	sandboxA := "sandbox-" + uuid.New().String()
+	testutils.UpsertTestSnapshot(t, ctx, db, "snapshot-template-"+uuid.New().String(), sandboxA, teamID, baseTemplateA)
+
+	sandboxB := "sandbox-" + uuid.New().String()
+	testutils.UpsertTestSnapshot(t, ctx, db, "snapshot-template-"+uuid.New().String(), sandboxB, teamID, baseTemplateB)
+
+	cursorTime := pgtype.Timestamptz{Time: time.Now().Add(time.Hour), Valid: true}
+
+	// No filter: both snapshots are returned
+	all, err := db.SqlcClient.GetSnapshotsWithCursor(ctx, queries.GetSnapshotsWithCursorParams{
+		TeamID:     teamID,
+		Metadata:   types.JSONBStringMap{},
+		CursorID:   "",
+		CursorTime: cursorTime,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, all, 2, "nil BaseEnvID filter should return all snapshots")
+
+	// Filter by base template A: only sandboxA is returned
+	filtered, err := db.SqlcClient.GetSnapshotsWithCursor(ctx, queries.GetSnapshotsWithCursorParams{
+		TeamID:     teamID,
+		Metadata:   types.JSONBStringMap{},
+		BaseEnvID:  &baseTemplateA,
+		CursorID:   "",
+		CursorTime: cursorTime,
+		Limit:      10,
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered, 1, "BaseEnvID filter should return only matching snapshots")
+	assert.Equal(t, sandboxA, filtered[0].Snapshot.SandboxID)
+	assert.Equal(t, baseTemplateA, filtered[0].Snapshot.BaseEnvID)
+}
+
 // TestGetLastSnapshot_BuildSharedWithOtherTemplate verifies that when a build is assigned
 // to multiple templates, GetLastSnapshot still returns the correct build for this template.
 func TestGetLastSnapshot_BuildSharedWithOtherTemplate(t *testing.T) {

--- a/packages/db/queries/get_snapshots_with_cursor.sql
+++ b/packages/db/queries/get_snapshots_with_cursor.sql
@@ -30,6 +30,7 @@ WHERE
     s.team_id = @team_id
     -- The order here is important, we want started_at descending, but sandbox_id ascending
     AND s.metadata @> @metadata
+    AND (sqlc.narg('base_env_id')::text IS NULL OR s.base_env_id = sqlc.narg('base_env_id'))
     AND (s.sandbox_started_at, @cursor_id::text) < (@cursor_time, s.sandbox_id)
 ORDER BY s.sandbox_started_at DESC, s.sandbox_id ASC
 LIMIT $1;

--- a/packages/db/queries/get_snapshots_with_cursor.sql.go
+++ b/packages/db/queries/get_snapshots_with_cursor.sql.go
@@ -46,7 +46,8 @@ WHERE
     s.team_id = $2
     -- The order here is important, we want started_at descending, but sandbox_id ascending
     AND s.metadata @> $3
-    AND (s.sandbox_started_at, $4::text) < ($5, s.sandbox_id)
+    AND ($4::text IS NULL OR s.base_env_id = $4)
+    AND (s.sandbox_started_at, $5::text) < ($6, s.sandbox_id)
 ORDER BY s.sandbox_started_at DESC, s.sandbox_id ASC
 LIMIT $1
 `
@@ -55,6 +56,7 @@ type GetSnapshotsWithCursorParams struct {
 	Limit      int32
 	TeamID     uuid.UUID
 	Metadata   types.JSONBStringMap
+	BaseEnvID  *string
 	CursorID   string
 	CursorTime pgtype.Timestamptz
 }
@@ -76,6 +78,7 @@ func (q *Queries) GetSnapshotsWithCursor(ctx context.Context, arg GetSnapshotsWi
 		arg.Limit,
 		arg.TeamID,
 		arg.Metadata,
+		arg.BaseEnvID,
 		arg.CursorID,
 		arg.CursorTime,
 	)

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -2161,6 +2161,12 @@ paths:
               $ref: "#/components/schemas/SandboxState"
           style: form
           explode: false
+        - name: templateID
+          in: query
+          description: Filter sandboxes by the template ID they were created from
+          required: false
+          schema:
+            type: string
         - $ref: "#/components/parameters/paginationNextToken"
         - $ref: "#/components/parameters/paginationLimit"
       responses:

--- a/tests/integration/internal/api/generated.go
+++ b/tests/integration/internal/api/generated.go
@@ -1618,6 +1618,9 @@ type GetV2SandboxesParams struct {
 	// State Filter sandboxes by one or more states
 	State *[]SandboxState `form:"state,omitempty" json:"state,omitempty"`
 
+	// TemplateID Filter sandboxes by the template ID they were created from
+	TemplateID *string `form:"templateID,omitempty" json:"templateID,omitempty"`
+
 	// NextToken Cursor to start the list from
 	NextToken *PaginationNextToken `form:"nextToken,omitempty" json:"nextToken,omitempty"`
 
@@ -5360,6 +5363,18 @@ func NewGetV2SandboxesRequest(server string, params *GetV2SandboxesParams) (*htt
 		if params.State != nil {
 
 			if queryFrag, err := runtime.StyleParamWithOptions("form", false, "state", *params.State, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "array", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.TemplateID != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "templateID", *params.TemplateID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "string", Format: ""}); err != nil {
 				return nil, err
 			} else {
 				for _, qp := range strings.Split(queryFrag, "&") {

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_list_test.go
@@ -77,6 +77,58 @@ func TestSandboxListWithFilter(t *testing.T) {
 	assert.Equal(t, sbx.SandboxID, (*listResponse.JSON200)[0].SandboxID)
 }
 
+func TestSandboxListFilterByTemplate(t *testing.T) {
+	t.Parallel()
+	c := setup.GetAPIClient()
+
+	// Scope the test to our own sandboxes via unique metadata.
+	metadataKey := "uniqueIdentifier"
+	metadataValue := id.Generate()
+	metadataString := fmt.Sprintf("%s=%s", metadataKey, metadataValue)
+
+	// One running and one paused sandbox, both from the default template.
+	running := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
+	paused := utils.SetupSandboxWithCleanup(t, c, utils.WithMetadata(api.SandboxMetadata{metadataKey: metadataValue}))
+	pauseSandbox(t, c, paused.SandboxID)
+
+	templateID := setup.SandboxTemplateID
+
+	// Filter by the real template: both sandboxes are returned.
+	listResponse, err := c.GetV2SandboxesWithResponse(t.Context(), &api.GetV2SandboxesParams{
+		State:      &[]api.SandboxState{api.Running, api.Paused},
+		Metadata:   &metadataString,
+		TemplateID: &templateID,
+	}, setup.WithAPIKey())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, listResponse.StatusCode(), string(listResponse.Body))
+
+	sandboxIds := sharedUtils.Map(*listResponse.JSON200, func(s api.ListedSandbox) string {
+		return s.SandboxID
+	})
+	assert.Contains(t, sandboxIds, running.SandboxID)
+	assert.Contains(t, sandboxIds, paused.SandboxID)
+	for _, s := range *listResponse.JSON200 {
+		assert.Equal(t, templateID, s.TemplateID)
+	}
+
+	// X-Total-Running counts only the running sandbox for this template.
+	totalHeader := listResponse.HTTPResponse.Header.Get("X-Total-Running")
+	total, err := strconv.Atoi(totalHeader)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total)
+
+	// Filter by a non-existent template: nothing matches.
+	bogusTemplateID := "template-does-not-exist-" + id.Generate()
+	emptyResponse, err := c.GetV2SandboxesWithResponse(t.Context(), &api.GetV2SandboxesParams{
+		State:      &[]api.SandboxState{api.Running, api.Paused},
+		Metadata:   &metadataString,
+		TemplateID: &bogusTemplateID,
+	}, setup.WithAPIKey())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, emptyResponse.StatusCode())
+	assert.Empty(t, *emptyResponse.JSON200)
+}
+
 func TestSandboxListRunning(t *testing.T) {
 	t.Parallel()
 	c := setup.GetAPIClient()


### PR DESCRIPTION
Adds an optional `templateID` query parameter to `GET /v2/sandboxes` so callers can filter sandboxes by the template they were created from, server-side, instead of fetching the full list and filtering client-side. Running and pausing sandboxes are filtered in-memory (before the `X-Total-Running` header is computed), while paused sandboxes are filtered in SQL via `get_snapshots_with_cursor` so pagination and limits stay correct. The change includes a new `FilterSandboxesOnTemplate` helper, unit tests, a DB test for the `base_env_id` filter, an integration test covering running + paused + bogus-template cases, and regenerated API clients/spec. Scoped to the v2 endpoint only; v1 `/sandboxes` is unchanged.