### PR TITLE
feat(dashboard-api): populate Ory identity external_id on admin bootstrap

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -409,6 +409,10 @@ func (handlerTestUserProfiles) GetTeamCreatorContext(context.Context, uuid.UUID)
 	return nil, nil
 }
 
+func (handlerTestUserProfiles) SetIdentityExternalID(context.Context, string, uuid.UUID) error {
+	return nil
+}
+
 func (handlerTestUserProfiles) PrepareDeleteUser(context.Context, uuid.UUID) (userprofile.DeleteUserHandle, error) {
 	return nil, nil
 }
@@ -509,6 +513,7 @@ func TestBootstrapAuthProviderUser_CreatesIdentityAndDefaultTeam(t *testing.T) {
 		db:                testDB.SqlcClient,
 		authDB:            testDB.AuthDB,
 		teamProvisionSink: sink,
+		userProfiles:      newHandlerTestUserProfiles(),
 	}
 
 	input := oidcUserBootstrapInput{
@@ -567,6 +572,69 @@ func TestBootstrapAuthProviderUser_CreatesIdentityAndDefaultTeam(t *testing.T) {
 	}
 }
 
+type recordingUserProfiles struct {
+	handlerTestUserProfiles
+
+	externalIDSubject string
+	externalID        uuid.UUID
+	externalIDCalls   int
+}
+
+func (r *recordingUserProfiles) SetIdentityExternalID(_ context.Context, subject string, externalID uuid.UUID) error {
+	r.externalIDSubject = subject
+	r.externalID = externalID
+	r.externalIDCalls++
+
+	return nil
+}
+
+func TestBootstrapOIDCUser_PopulatesOryExternalID(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	sink := &fakeTeamProvisionSink{}
+	profiles := &recordingUserProfiles{}
+
+	store := &APIStore{
+		config: cfg.Config{
+			OryIssuerURL: "https://ory.example.test",
+		},
+		db:                testDB.SqlcClient,
+		authDB:            testDB.AuthDB,
+		teamProvisionSink: sink,
+		userProfiles:      profiles,
+	}
+
+	input := oidcUserBootstrapInput{
+		OIDCIssuer:    "https://ory.example.test",
+		OIDCUserID:    uuid.NewString(),
+		OIDCUserEmail: "ada@example.test",
+	}
+
+	if _, err := store.bootstrapOIDCUser(ctx, input); err != nil {
+		t.Fatalf("expected bootstrap to succeed: %v", err)
+	}
+
+	userIdentity, err := testDB.AuthDB.Read.GetUserIdentity(ctx, authqueries.GetUserIdentityParams{
+		OidcIss: input.OIDCIssuer,
+		OidcSub: input.OIDCUserID,
+	})
+	if err != nil {
+		t.Fatalf("expected user identity to be created: %v", err)
+	}
+
+	if profiles.externalIDCalls != 1 {
+		t.Fatalf("expected one external id update, got %d", profiles.externalIDCalls)
+	}
+	if profiles.externalIDSubject != input.OIDCUserID {
+		t.Fatalf("expected external id set on subject %q, got %q", input.OIDCUserID, profiles.externalIDSubject)
+	}
+	if profiles.externalID != userIdentity.UserID {
+		t.Fatalf("expected external id %s, got %s", userIdentity.UserID, profiles.externalID)
+	}
+}
+
 func TestBootstrapOIDCUser_ConcurrentRequestsSingleIdentityAndTeam(t *testing.T) {
 	t.Parallel()
 
@@ -591,6 +659,7 @@ func TestBootstrapOIDCUser_ConcurrentRequestsSingleIdentityAndTeam(t *testing.T)
 		db:                testDB.SqlcClient,
 		authDB:            testDB.AuthDB,
 		teamProvisionSink: sink,
+		userProfiles:      newHandlerTestUserProfiles(),
 	}
 
 	input := oidcUserBootstrapInput{
@@ -703,6 +772,7 @@ func TestBootstrapOIDCUser_OryIssuerWithoutJWTConfigIsAccepted(t *testing.T) {
 		db:                testDB.SqlcClient,
 		authDB:            testDB.AuthDB,
 		teamProvisionSink: sink,
+		userProfiles:      newHandlerTestUserProfiles(),
 	}
 
 	team, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
@@ -741,6 +811,7 @@ func TestBootstrapOIDCUser_OryModeRejectsNonOryJWTIssuer(t *testing.T) {
 		db:                testDB.SqlcClient,
 		authDB:            testDB.AuthDB,
 		teamProvisionSink: sink,
+		userProfiles:      newHandlerTestUserProfiles(),
 	}
 
 	_, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{
@@ -777,6 +848,7 @@ func TestBootstrapOIDCUser_UnknownIssuerReturnsBadRequest(t *testing.T) {
 		db:                testDB.SqlcClient,
 		authDB:            testDB.AuthDB,
 		teamProvisionSink: sink,
+		userProfiles:      newHandlerTestUserProfiles(),
 	}
 
 	_, err := store.bootstrapOIDCUser(ctx, oidcUserBootstrapInput{

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -163,6 +163,14 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		}
 	}
 
+	// Populate the Ory identity's external_id with the canonical public.users id
+	// now that the user row exists. Runs before any team is created and before
+	// the user lock is taken, so an Ory failure rolls the user/identity back and
+	// no orphan team is left behind.
+	if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
+		return provisionedTeam{}, err
+	}
+
 	// Serialize bootstrap for a user even when they have no team memberships yet.
 	if _, err := authTxDB.LockPublicUserForUpdate(ctx, profile.UserID); err != nil {
 		return provisionedTeam{}, fmt.Errorf("lock public user: %w", err)
@@ -241,6 +249,20 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		IsBlocked:     team.IsBlocked,
 		BlockedReason: team.BlockedReason,
 	}, nil
+}
+
+// setOIDCIdentityExternalID stores the canonical public.users id on the Ory
+// identity. It is a no-op for non-OIDC bootstrap (identity == nil).
+func (s *APIStore) setOIDCIdentityExternalID(ctx context.Context, identity *bootstrapUserIdentity, userID uuid.UUID) error {
+	if identity == nil {
+		return nil
+	}
+
+	if err := s.userProfiles.SetIdentityExternalID(ctx, identity.Subject, userID); err != nil {
+		return fmt.Errorf("set ory identity external id: %w", err)
+	}
+
+	return nil
 }
 
 func (s *APIStore) createTeam(ctx context.Context, userID uuid.UUID, name string) (provisionedTeam, error) {

--- a/packages/dashboard-api/internal/userprofile/ory.go
+++ b/packages/dashboard-api/internal/userprofile/ory.go
@@ -179,6 +179,34 @@ func (p *oryProvider) GetTeamCreatorContext(ctx context.Context, userID uuid.UUI
 	return creatorContextFromOryIdentity(identities[0]), nil
 }
 
+func (p *oryProvider) SetIdentityExternalID(ctx context.Context, subject string, externalID uuid.UUID) error {
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return errors.New("ory identity subject is required")
+	}
+	if externalID == uuid.Nil {
+		return errors.New("external id is required")
+	}
+
+	// "add" (not "replace") so the patch succeeds even when the identity has no
+	// external_id yet: Ory serializes external_id with omitempty, so an unset
+	// value is absent from the document and RFC 6902 "replace" would fail with a
+	// path-not-found error. "add" creates the member if missing and replaces it
+	// if present, making the operation idempotent across re-bootstraps.
+	patch := []ory.JsonPatch{{Op: "add", Path: "/external_id", Value: externalID.String()}}
+	_, resp, err := p.identities.PatchIdentityExecute(
+		p.identities.PatchIdentity(p.authCtx(ctx), subject).JsonPatch(patch),
+	)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	if err != nil {
+		return fmt.Errorf("ory patch identity external id: %w", err)
+	}
+
+	return nil
+}
+
 func (p *oryProvider) PrepareDeleteUser(ctx context.Context, userID uuid.UUID) (DeleteUserHandle, error) {
 	if userID == uuid.Nil {
 		return nil, errors.New("user id is required")

--- a/packages/dashboard-api/internal/userprofile/ory_test.go
+++ b/packages/dashboard-api/internal/userprofile/ory_test.go
@@ -1,14 +1,93 @@
 package userprofile
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/google/uuid"
 	ory "github.com/ory/client-go"
 
+	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
 	sharedteamprovision "github.com/e2b-dev/infra/packages/shared/pkg/teamprovision"
 )
+
+type stubIdentityResolver struct{}
+
+func (stubIdentityResolver) GetUserIdentitiesByUserIDs(context.Context, authqueries.GetUserIdentitiesByUserIDsParams) ([]authqueries.GetUserIdentitiesByUserIDsRow, error) {
+	return nil, nil
+}
+
+func (stubIdentityResolver) GetUserIdentitiesBySubjects(context.Context, authqueries.GetUserIdentitiesBySubjectsParams) ([]authqueries.GetUserIdentitiesBySubjectsRow, error) {
+	return nil, nil
+}
+
+func TestOryProvider_SetIdentityExternalID(t *testing.T) {
+	t.Parallel()
+
+	subject := uuid.NewString()
+	externalID := uuid.New()
+
+	var gotPatch []ory.JsonPatch
+	var gotPath, gotMethod string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotPatch)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"` + subject + `","schema_id":"default","schema_url":"","state":"active","traits":{}}`))
+	}))
+	defer server.Close()
+
+	provider, err := NewOryProvider(OryConfig{
+		HTTPClient: server.Client(),
+		SDKURL:     server.URL,
+		Token:      "test-token",
+		Issuer:     "https://ory.example.test",
+		Resolver:   stubIdentityResolver{},
+	})
+	if err != nil {
+		t.Fatalf("failed to build ory provider: %v", err)
+	}
+
+	if err := provider.SetIdentityExternalID(t.Context(), subject, externalID); err != nil {
+		t.Fatalf("SetIdentityExternalID returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodPatch {
+		t.Fatalf("expected PATCH, got %s", gotMethod)
+	}
+	if want := "/admin/identities/" + subject; gotPath != want {
+		t.Fatalf("expected path %q, got %q", want, gotPath)
+	}
+	if len(gotPatch) != 1 {
+		t.Fatalf("expected one json patch op, got %d", len(gotPatch))
+	}
+	if gotPatch[0].Op != "add" || gotPatch[0].Path != "/external_id" {
+		t.Fatalf("unexpected patch op/path: %+v", gotPatch[0])
+	}
+	if value, _ := gotPatch[0].Value.(string); value != externalID.String() {
+		t.Fatalf("expected external id %q, got %v", externalID.String(), gotPatch[0].Value)
+	}
+}
+
+func TestOryProvider_SetIdentityExternalIDValidatesInput(t *testing.T) {
+	t.Parallel()
+
+	provider := &oryProvider{}
+
+	if err := provider.SetIdentityExternalID(t.Context(), "  ", uuid.New()); err == nil {
+		t.Fatal("expected error for blank subject")
+	}
+	if err := provider.SetIdentityExternalID(t.Context(), uuid.NewString(), uuid.Nil); err == nil {
+		t.Fatal("expected error for nil external id")
+	}
+}
 
 func TestProfileFromOryIdentity(t *testing.T) {
 	t.Parallel()

--- a/packages/dashboard-api/internal/userprofile/provider.go
+++ b/packages/dashboard-api/internal/userprofile/provider.go
@@ -25,6 +25,9 @@ type Provider interface {
 	GetProfilesByUserID(ctx context.Context, userIDs []uuid.UUID) (map[uuid.UUID]Profile, error)
 	FindProfilesByEmail(ctx context.Context, email string) ([]Profile, error)
 	GetTeamCreatorContext(ctx context.Context, userID uuid.UUID) (*sharedteamprovision.CreatorContextV1, error)
+	// SetIdentityExternalID stores the canonical user UUID on the external
+	// identity (Ory external_id) so the IdP can back-reference our user.
+	SetIdentityExternalID(ctx context.Context, subject string, externalID uuid.UUID) error
 	// PrepareDeleteUser resolves the external identity references for the
 	// given user so they can be removed after the database rows are gone.
 	PrepareDeleteUser(ctx context.Context, userID uuid.UUID) (DeleteUserHandle, error)


### PR DESCRIPTION
## What

During OIDC admin user bootstrap, set the Ory identity's `external_id` to the canonical `public.users.id` UUID after the user row has been committed.

## Details

- Added `SetIdentityExternalID(ctx, subject, externalID)` to the `userprofile.Provider` interface.
- Implemented it on `oryProvider` via Ory `PatchIdentity` (JSON patch `replace /external_id`).
- `bootstrapUserWithIdentity` calls the setter after each commit (existing-team and new-team paths), only for OIDC bootstrap (identity present). If the Ory update fails, bootstrap hard-fails and returns the error.