### PR TITLE
feat(orchestrator): make build-reserved-disk-space-mb default 256MB

### DIFF
--- a/.github/actions/build-sandbox-template/action.yml
+++ b/.github/actions/build-sandbox-template/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: "Number of frame encode workers"
     required: false
     default: ""
+  disk_size_mb:
+    description: "Base template rootfs disk size in MB. Larger than the create-build default to leave headroom for disk-heavy build steps after the build-reserved-disk-space-mb reservation."
+    required: false
+    default: "2048"
 
 runs:
   using: "composite"
@@ -27,6 +31,7 @@ runs:
         TEMPLATE_ID: "2j6ly824owf4awgai1xo"
         KERNEL_VERSION: "vmlinux-6.1.158-c1a568c"
         FIRECRACKER_VERSION: "v1.14.1_431f1fc"
+        DISK_SIZE_MB: ${{ inputs.disk_size_mb }}
         COMPRESS_ENABLED: ${{ inputs.compress_enabled }}
         COMPRESS_TYPE: ${{ inputs.compress_type }}
         COMPRESS_LEVEL: ${{ inputs.compress_level }}
@@ -50,5 +55,6 @@ runs:
           TEMPLATE_ID=${TEMPLATE_ID} \
           BUILD_ID=${BUILD_ID} \
           KERNEL_VERSION=${KERNEL_VERSION} \
-          FC_VERSION=${FC_VERSION}
+          FC_VERSION=${FC_VERSION} \
+          DISK_SIZE_MB=${DISK_SIZE_MB}
       shell: bash

--- a/packages/orchestrator/Makefile
+++ b/packages/orchestrator/Makefile
@@ -147,6 +147,10 @@ test-docker:
 	@echo "Done"
 
 .PHONY: build-template
+# Disk size (MB) of the base template rootfs. Matches create-build's own
+# default; callers (e.g. integration-test CI) can override to leave headroom
+# for disk-heavy build steps after the build-reserved-disk-space-mb reservation.
+DISK_SIZE_MB ?= 1024
 build-template: fetch-busybox
 	TEMPLATE_BUCKET_NAME=$(TEMPLATE_BUCKET_NAME) \
 	GOOGLE_SERVICE_ACCOUNT_BASE64=$(GOOGLE_SERVICE_ACCOUNT_BASE64) \
@@ -163,7 +167,8 @@ build-template: fetch-busybox
 	-template $(TEMPLATE_ID) \
 	-to-build $(BUILD_ID) \
 	-kernel $(KERNEL_VERSION) \
-	-firecracker $(FIRECRACKER_VERSION)
+	-firecracker $(FIRECRACKER_VERSION) \
+	-disk $(DISK_SIZE_MB)
 
 .PHONY: migrate
 migrate:

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -299,7 +299,7 @@ var (
 
 	// BuildReservedDiskSpaceMB is the amount of disk space in MB reserved for root on the guest filesystem.
 	// Reserved blocks are only usable by root (uid 0), protecting the guest OS from disk-full conditions.
-	BuildReservedDiskSpaceMB = NewIntFlag("build-reserved-disk-space-mb", 0)
+	BuildReservedDiskSpaceMB = NewIntFlag("build-reserved-disk-space-mb", 256)
 
 	// MaxStartingInstancesPerNode limits concurrent sandbox start/resume operations on a single orchestrator node.
 	// Must be > 0.

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -223,7 +223,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, created_at, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 1024, 2494, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 2048, 3727, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version, build.createdAt)
 		} else {
 			err = db.TestsRawSQL(ctx, `
@@ -233,7 +233,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 1024, 2494, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 2048, 3727, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version)
 		}
 		if err != nil {

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -223,7 +223,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, created_at, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 2048, 3727, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version, build.createdAt)
 		} else {
 			err = db.TestsRawSQL(ctx, `
@@ -233,7 +233,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 2048, 3727, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version)
 		}
 		if err != nil {

--- a/tests/integration/seed.go
+++ b/tests/integration/seed.go
@@ -223,7 +223,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, created_at, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 1024, 2494, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version, build.createdAt)
 		} else {
 			err = db.TestsRawSQL(ctx, `
@@ -233,7 +233,7 @@ INSERT INTO env_builds (
 	cluster_node_id, version, updated_at
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, CURRENT_TIMESTAMP)
 `, build.id, "FROM e2bdev/base:latest", dbtypes.BuildStatusUploaded,
-				2, 512, 512, 1982, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
+				2, 512, 1024, 2494, "vmlinux-6.1.158-c1a568c", "v1.14.1_431f1fc", pkg.Version,
 				"integration-test-node", templates.TemplateV1Version)
 		}
 		if err != nil {


### PR DESCRIPTION
This value has been set to 256 in production for a couple of weeks without issues, so promote it to the default for the feature flag. Also bumps the integration-test base template build to 2048MB disk, since the 256MB reservation otherwise leaves create-next-app in TestCommandKillNextApp without enough space.