### PR TITLE
chore(client-proxy): mark enable autoresume to true by default

### DIFF
--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -128,7 +128,7 @@ var (
 	BestOfKTooManyStartingFlag          = NewBoolFlag("best-of-k-too-many-starting", false)
 	EdgeProvidedSandboxMetricsFlag      = NewBoolFlag("edge-provided-sandbox-metrics", false)
 	CreateStorageCacheSpansFlag         = NewBoolFlag("create-storage-cache-spans", env.IsDevelopment())
-	SandboxAutoResumeFlag               = NewBoolFlag("sandbox-auto-resume", env.IsDevelopment())
+	SandboxAutoResumeFlag               = NewBoolFlag("sandbox-auto-resume", true)
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)
 
 	// StorageSoftDeleteCheckFlag enables reading the storage-index soft-delete


### PR DESCRIPTION
Turn the flag to true by default - it's the default we use in our deployments