### PR TITLE
fix(orchestrator): seed legacy-ancestor in pending diff headers

### DIFF
--- a/packages/shared/pkg/storage/header/diff_test.go
+++ b/packages/shared/pkg/storage/header/diff_test.go
@@ -3,7 +3,11 @@ package header
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 func TestIsZero(t *testing.T) {
@@ -21,4 +25,52 @@ func TestIsZero(t *testing.T) {
 	buf = make([]byte, RootfsBlockSize)
 	buf[RootfsBlockSize-2] = 0xFF
 	assert.False(t, IsZero(buf), "non-zero just before the last sampled byte")
+}
+
+// newDiffHeader must carry forward ancestors the source knows about and
+// backfill the uncompressed sentinel for ones it lacks, so a legacy ancestor
+// resolves via GetBuildFrameData (no doomed proactive header load) while the
+// still-unuploaded self build stays absent.
+func TestNewDiffHeaderBackfillsAncestors(t *testing.T) {
+	t.Parallel()
+
+	const bs = 4096
+	self := uuid.New()
+	knownAncestor := uuid.New()
+	legacyAncestor := uuid.New()
+
+	mapping := []BuildMap{
+		{Offset: 0, Length: bs, BuildId: self, BuildStorageOffset: 0},
+		{Offset: bs, Length: bs, BuildId: knownAncestor, BuildStorageOffset: 0},
+		{Offset: 2 * bs, Length: bs, BuildId: legacyAncestor, BuildStorageOffset: 0},
+		{Offset: 3 * bs, Length: bs, BuildId: uuid.Nil, BuildStorageOffset: 0},
+	}
+
+	// Parent header carries only knownAncestor; legacyAncestor predates per-build
+	// headers and is absent from the source.
+	sourceBuilds := map[uuid.UUID]BuildData{knownAncestor: {Size: 123}}
+
+	meta := &Metadata{Version: MetadataVersionV4, BlockSize: bs, Size: 4 * bs, BuildId: self, BaseBuildId: legacyAncestor}
+	h, err := newDiffHeader(meta, mapping, sourceBuilds)
+	require.NoError(t, err)
+
+	// Self is excluded: its data isn't uploaded yet.
+	_, hasSelf := h.Builds[self]
+	require.False(t, hasSelf)
+
+	// Known ancestor carried forward verbatim (not clobbered by the sentinel).
+	require.Equal(t, BuildData{Size: 123}, h.Builds[knownAncestor])
+
+	// Legacy ancestor gets the uncompressed sentinel, so GetBuildFrameData
+	// returns a non-nil table and the read path never proactively refreshes it.
+	bd, hasLegacy := h.Builds[legacyAncestor]
+	require.True(t, hasLegacy)
+	require.Equal(t, BuildData{}, bd)
+	require.Equal(t, storage.UncompressedFrameTable, h.GetBuildFrameData(legacyAncestor))
+
+	// Empty (uuid.Nil) regions don't create entries.
+	_, hasNil := h.Builds[uuid.Nil]
+	require.False(t, hasNil)
+
+	require.True(t, h.IncompletePendingUpload)
 }

--- a/packages/shared/pkg/storage/header/header.go
+++ b/packages/shared/pkg/storage/header/header.go
@@ -109,14 +109,23 @@ func newDiffHeader(metadata *Metadata, mapping []BuildMap, sourceBuilds map[uuid
 		return nil, err
 	}
 
-	if sourceBuilds != nil {
-		// h.Mapping.Builds() is already deduped at NewMapping construction;
-		// no need for an oversized temp set keyed by len(mapping).
-		h.Builds = make(map[uuid.UUID]BuildData, len(sourceBuilds))
-		for _, id := range h.Mapping.Builds() {
-			if bd, ok := sourceBuilds[id]; ok {
-				h.Builds[id] = bd
-			}
+	// Carry every still-referenced ancestor forward, backfilling the uncompressed
+	// sentinel (zero BuildData) for the ones the source lacks — the same gap
+	// LoadHeader closes for stored headers. Without it a legacy (pre-header)
+	// ancestor is absent from Builds, so the read path issues a doomed proactive
+	// header load for it before falling back to uncompressed. Self is left out: a
+	// pending header carries no self entry by design (its data is still local and
+	// served from the cache), and the finalized header swapped in at upload
+	// carries the real self entry — never a zero sentinel.
+	h.Builds = make(map[uuid.UUID]BuildData, len(h.Mapping.Builds()))
+	for _, id := range h.Mapping.Builds() {
+		if id == metadata.BuildId || id == uuid.Nil {
+			continue
+		}
+		if bd, ok := sourceBuilds[id]; ok {
+			h.Builds[id] = bd
+		} else {
+			h.Builds[id] = BuildData{}
 		}
 	}
 


### PR DESCRIPTION
After the legacy header fix was deployed, I started [seeing](https://e2bfoxtrot.grafana.net/a/grafana-metricsdrilldown-app/drilldown?actionView=breakdown&var-filters=deployment_environment%7C%3D%7Ce2b-foxtrot&layout=grid&filters-rule=&filters-prefix=&filters-suffix=&search_txt=frame&var-metrics-reducer-sort-by=default&filters-recent=&var-ds=grafanacloud-prom&var-metrics_filters=deployment_environment%7C%3D%7Ce2b-foxtrot&var-labelsWingman=%28none%29&var-other_metric_filters=&metric=orchestrator_storage_diff_frame_table_refresh_total&var-groupby=$__all&from=2026-06-22T03:45:12.000Z&to=now&timezone=browser) a few failed header "proactive" refreshes. This PR removes them.

A same-orch resume reads the pending diff header cached by AddSnapshot before the async upload swaps in the finalized one. That header only carried ancestor Builds entries inherited from its parent, so a legacy (pre-header) ancestor was absent — driving createDiff's proactive branch into a doomed header load (404, tolerated as uncompressed) and a misleading frame_table_refresh{cause=proactive,result=failure} metric plus a wasted GCS GET on the resume hot path.

newDiffHeader now backfills the uncompressed sentinel for every mapped ancestor the source lacks (excluding self) — the same gap LoadHeader closes for stored headers — so legacy ancestors resolve locally with no storage round-trip. No behavior change for modern chains, the durable upload, scheduling, or the existing publish swap.