### PR TITLE
feat(cfg): add DISABLE_STARTUP_RECLAIM flag

### DIFF
--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -81,6 +81,7 @@ type Config struct {
 
 	ClickhouseConnectionString  string            `env:"CLICKHOUSE_CONNECTION_STRING"`
 	ClickhouseConnectionStrings []string          `env:"CLICKHOUSE_CONNECTION_STRINGS" envSeparator:";"`
+	DisableStartupReclaim       bool              `env:"DISABLE_STARTUP_RECLAIM"`
 	ForceStop                   bool              `env:"FORCE_STOP"`
 	GRPCPort                    uint16            `env:"GRPC_PORT"                     envDefault:"5008"`
 	LaunchDarklyAPIKey          string            `env:"LAUNCH_DARKLY_API_KEY"`

--- a/packages/orchestrator/pkg/cfg/model_test.go
+++ b/packages/orchestrator/pkg/cfg/model_test.go
@@ -79,6 +79,14 @@ func TestParse(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, config.NFSProxyMetrics)
 	})
+
+	t.Run("startup reclaim can be disabled", func(t *testing.T) {
+		t.Setenv("DISABLE_STARTUP_RECLAIM", "true")
+
+		config, err := Parse()
+		require.NoError(t, err)
+		assert.True(t, config.DisableStartupReclaim)
+	})
 }
 
 func TestAdditionalClickhouseEndpoints(t *testing.T) {


### PR DESCRIPTION
Introduce a Config.DisableStartupReclaim field, bound to the DISABLE_STARTUP_RECLAIM environment variable, used to gate the startup resource-reclaim routine.