### PR TITLE
feat(orchestrator): startup resource reclaim package

### DIFF
--- a/packages/orchestrator/pkg/sandbox/cgroup/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/cgroup/reclaim.go
@@ -1,0 +1,35 @@
+package cgroup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ReclaimLeaked destroys every sandbox cgroup under root left over from a
+// previous orchestrator run, killing any remaining processes in them. It returns
+// the number of cgroups destroyed and any failures.
+func ReclaimLeaked(ctx context.Context, manager Manager, root string) (int, []error) {
+	if manager == nil {
+		return 0, []error{errors.New("cgroup manager is nil")}
+	}
+
+	names, err := ListSandboxCgroups(root)
+	if err != nil {
+		return 0, []error{err}
+	}
+
+	reclaimed := 0
+	var failures []error
+	for _, name := range names {
+		if err := manager.Destroy(ctx, name); err != nil {
+			failures = append(failures, fmt.Errorf("failed to remove cgroup %s: %w", name, err))
+
+			continue
+		}
+
+		reclaimed++
+	}
+
+	return reclaimed, failures
+}

--- a/packages/orchestrator/pkg/sandbox/nbd/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/reclaim.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package nbd
+
+import (
+	"context"
+	"fmt"
+)
+
+// ReclaimLeaked disconnects every currently-connected NBD device left over from
+// a previous orchestrator run. It returns the number of devices disconnected and
+// any per-device failures.
+func ReclaimLeaked(ctx context.Context) (int, []error) {
+	devices, err := ConnectedDevices()
+	if err != nil {
+		return 0, []error{err}
+	}
+
+	reclaimed := 0
+	var failures []error
+	for _, device := range devices {
+		if err := DisconnectDevice(ctx, device); err != nil {
+			failures = append(failures, fmt.Errorf("failed to disconnect nbd%d: %w", device, err))
+
+			continue
+		}
+
+		reclaimed++
+	}
+
+	return reclaimed, failures
+}

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -107,6 +107,21 @@ func (s *Slot) CreateNetwork(ctx context.Context) (retErr error) {
 		}
 	}()
 
+	// An existing namespace for this index is a stale reclaim anchor from a
+	// failed teardown whose iptables rules, routes and veth may still exist. Run
+	// a full (idempotent) RemoveNetwork to reclaim them; deleting only the
+	// namespace would orphan those rules. On failure the anchor is kept and we
+	// abort so the slot is retried later instead of leaking.
+	available, err := isNamespaceAvailable(s.NamespaceID())
+	if err != nil {
+		return fmt.Errorf("cannot check for stale namespace: %w", err)
+	}
+	if !available {
+		if err = s.RemoveNetwork(); err != nil {
+			return fmt.Errorf("cannot reclaim stale network slot: %w", err)
+		}
+	}
+
 	// Create NS for the sandbox
 	ns, err := netns.NewNamed(s.NamespaceID())
 	if err != nil {
@@ -405,6 +420,18 @@ func (s *Slot) RemoveNetwork() error {
 			"--jump", "REDIRECT", "--to-port", strconv.Itoa(int(s.config.PortmapperPort)),
 		)
 		appendUnlessExpectedAbsentf(&errs, err, isIPTablesNotExist, "error deleting sandbox portmapper redirect rule: %w")
+	}
+
+	// Delete the named namespace only after every host-side (root namespace)
+	// teardown above has succeeded. The /run/netns entry is the anchor that
+	// startup reclaim uses to rediscover a leaked slot, and the host-side
+	// iptables/route/veth state removed above is keyed by the slot index. If any
+	// of that teardown failed, deleting the namespace now would orphan the
+	// remaining state with no way to rediscover and retry it. Preserving the
+	// anchor lets the next teardown attempt (including startup reclaim) finish
+	// the job. CreateNetwork removes a stale anchor before reusing the slot.
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	err = netns.DeleteNamed(s.NamespaceID())

--- a/packages/orchestrator/pkg/sandbox/network/reclaim.go
+++ b/packages/orchestrator/pkg/sandbox/network/reclaim.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package network
+
+import (
+	"fmt"
+)
+
+// ReclaimLeakedSlots tears down network namespaces and slots left over from a
+// previous orchestrator run. It discovers leaked slots by scanning netnsDir:
+// the netns entry is a reliable record of every leaked slot, because it is
+// created before any host-side networking in CreateNetwork and removed last in
+// RemoveNetwork (which preserves it as a rediscovery anchor if host-side
+// teardown fails). It returns the number of slots removed and any failures.
+func ReclaimLeakedSlots(netnsDir string, config Config, egressProxy EgressProxy) (int, []error) {
+	var failures []error
+
+	slots, err := ListSlotNamespaces(netnsDir)
+	if err != nil {
+		failures = append(failures, err)
+	}
+
+	reclaimed := 0
+	for _, idx := range slots {
+		slot, err := NewSlot(fmt.Sprintf("startup-reclaim-%d", idx), idx, config, egressProxy)
+		if err != nil {
+			failures = append(failures, err)
+
+			continue
+		}
+
+		if err := slot.RemoveNetwork(); err != nil {
+			failures = append(failures, fmt.Errorf("failed to remove network slot %d: %w", idx, err))
+
+			continue
+		}
+
+		reclaimed++
+	}
+
+	return reclaimed, failures
+}

--- a/packages/orchestrator/pkg/startupreclaim/firecracker.go
+++ b/packages/orchestrator/pkg/startupreclaim/firecracker.go
@@ -1,0 +1,115 @@
+//go:build linux
+
+package startupreclaim
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+)
+
+// reclaimFirecrackers kills orphaned firecracker process groups by scanning the
+// host process table. The network slots they used are reclaimed separately by
+// the network reclaim.
+func reclaimFirecrackers(ctx context.Context, procDir string) (int, []error) {
+	pids, err := discoverFirecrackerPIDs(procDir)
+	if err != nil {
+		return 0, []error{err}
+	}
+
+	reclaimed := 0
+	var failures []error
+	for _, pid := range pids {
+		pgid, err := syscall.Getpgid(pid)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("failed to get firecracker pgid for pid %d: %w", pid, err))
+
+			continue
+		}
+
+		if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			failures = append(failures, fmt.Errorf("failed to kill firecracker process group %d for pid %d: %w", pgid, pid, err))
+
+			continue
+		}
+
+		reclaimed++
+		logger.L().Warn(ctx, "killed orphaned firecracker process group",
+			zap.Int("pid", pid),
+			zap.Int("pgid", pgid))
+	}
+
+	return reclaimed, failures
+}
+
+// discoverFirecrackerPIDs scans procDir for leftover firecracker processes.
+func discoverFirecrackerPIDs(procDir string) ([]int, error) {
+	entries, err := os.ReadDir(procDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read proc directory: %w", err)
+	}
+
+	pids := make([]int, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		cmdline, err := processCmdline(procDir, pid)
+		if err != nil || !isFirecrackerCmdline(cmdline) {
+			continue
+		}
+
+		pids = append(pids, pid)
+	}
+
+	return pids, nil
+}
+
+func processCmdline(procDir string, pid int) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(procDir, strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		return nil, err
+	}
+
+	data = bytes.TrimRight(data, "\x00")
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	parts := bytes.Split(data, []byte{0})
+	cmdline := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cmdline = append(cmdline, string(part))
+	}
+
+	return cmdline, nil
+}
+
+// firecrackerBinaryName mirrors fc.FirecrackerBinaryName; it is duplicated here
+// to avoid importing the cgo-heavy fc package.
+const firecrackerBinaryName = "firecracker"
+
+func isFirecrackerCmdline(cmdline []string) bool {
+	if len(cmdline) == 0 {
+		return false
+	}
+
+	// Exact basename match so versioned paths match but "firecracker-monitor"
+	// and similar do not.
+	return filepath.Base(cmdline[0]) == firecrackerBinaryName
+}

--- a/packages/orchestrator/pkg/startupreclaim/firecracker_test.go
+++ b/packages/orchestrator/pkg/startupreclaim/firecracker_test.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package startupreclaim
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverFirecrackerPIDs(t *testing.T) {
+	t.Parallel()
+
+	procDir := t.TempDir()
+	createProc(t, procDir, 101, []string{"/fc-versions/v1.7/firecracker", "--api-sock", "/tmp/fc.sock"})
+	createProc(t, procDir, 100, []string{"bash", "-c", "ip netns exec ns-7 /opt/firecracker"})
+	createProc(t, procDir, 200, []string{"bash", "-c", "not firecracker"})
+	// Processes whose basename merely contains "firecracker" must not match, so
+	// helpers like a monitor are never killed.
+	createProc(t, procDir, 300, []string{"/usr/bin/firecracker-monitor", "--watch"})
+	createProc(t, procDir, 400, []string{"/opt/firecrackerd"})
+
+	pids, err := discoverFirecrackerPIDs(procDir)
+	require.NoError(t, err)
+	require.Equal(t, []int{101}, pids)
+}
+
+func TestDiscoverFirecrackerPIDsMissingProcDir(t *testing.T) {
+	t.Parallel()
+
+	_, err := discoverFirecrackerPIDs(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+func createProc(t *testing.T, procDir string, pid int, cmdline []string) {
+	t.Helper()
+
+	pidDir := filepath.Join(procDir, strconv.Itoa(pid))
+	require.NoError(t, os.MkdirAll(pidDir, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte(strings.Join(cmdline, "\x00")+"\x00"), 0o600))
+}

--- a/packages/orchestrator/pkg/startupreclaim/reclaim.go
+++ b/packages/orchestrator/pkg/startupreclaim/reclaim.go
@@ -1,0 +1,158 @@
+//go:build linux
+
+package startupreclaim
+
+import (
+	"context"
+	"os"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/cgroup"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/network"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+const (
+	resourceFirecracker = "firecracker"
+	resourceNBD         = "nbd"
+	resourceNetwork     = "network"
+	resourceCgroup      = "cgroup"
+	resourceFile        = "file"
+
+	procDir = "/proc"
+)
+
+var (
+	meter = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/startupreclaim")
+
+	reclaimedCounter = utils.Must(meter.Int64Counter("orchestrator.startup_reclaim.reclaimed",
+		metric.WithDescription("Startup reclaim resources successfully reclaimed."),
+		metric.WithUnit("{resource}"),
+	))
+	failedCounter = utils.Must(meter.Int64Counter("orchestrator.startup_reclaim.failed",
+		metric.WithDescription("Startup reclaim resource cleanup failures."),
+		metric.WithUnit("{resource}"),
+	))
+)
+
+type Config struct {
+	NetworkConfig network.Config
+	EgressProxy   network.EgressProxy
+	CgroupManager cgroup.Manager
+	StorageConfig storage.Config
+	TempDir       string
+	ProcDir       string
+	NetnsDir      string
+	CgroupRoot    string
+}
+
+type Summary struct {
+	Reclaimed map[string]int
+	Failed    map[string]int
+}
+
+func (s Summary) totalReclaimed() int {
+	return total(s.Reclaimed)
+}
+
+func (s Summary) totalFailed() int {
+	return total(s.Failed)
+}
+
+func total(values map[string]int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+
+	return total
+}
+
+// reclaimer reclaims leaked resources of a single kind. reclaim is best-effort
+// and never fatal, returning the count reclaimed and any failures.
+type reclaimer struct {
+	resource string
+	reclaim  func(ctx context.Context) (int, []error)
+}
+
+func Run(ctx context.Context, config Config) Summary {
+	config = config.withDefaults()
+	summary := Summary{Reclaimed: map[string]int{}, Failed: map[string]int{}}
+
+	// Order matters: firecracker runs first so the VMMs are killed before the
+	// network reclaim tears down the slots they used.
+	reclaimers := []reclaimer{
+		{resourceFirecracker, func(ctx context.Context) (int, []error) {
+			return reclaimFirecrackers(ctx, config.ProcDir)
+		}},
+		{resourceNBD, nbd.ReclaimLeaked},
+		{resourceNetwork, func(context.Context) (int, []error) {
+			return network.ReclaimLeakedSlots(config.NetnsDir, config.NetworkConfig, config.EgressProxy)
+		}},
+		{resourceCgroup, func(ctx context.Context) (int, []error) {
+			return cgroup.ReclaimLeaked(ctx, config.CgroupManager, config.CgroupRoot)
+		}},
+		{resourceFile, func(context.Context) (int, []error) {
+			return storage.ReclaimSandboxFiles(config.TempDir, config.StorageConfig.SandboxCacheDir)
+		}},
+	}
+
+	for _, r := range reclaimers {
+		reclaimed, failures := r.reclaim(ctx)
+		record(ctx, &summary, r.resource, reclaimed, failures)
+	}
+
+	fields := []zap.Field{
+		zap.Any("reclaimed", summary.Reclaimed),
+		zap.Any("failed", summary.Failed),
+		zap.Int("total_reclaimed", summary.totalReclaimed()),
+		zap.Int("total_failed", summary.totalFailed()),
+	}
+	if summary.totalReclaimed() > 0 || summary.totalFailed() > 0 {
+		logger.L().Warn(ctx, "startup resource reclaim completed with leftover resources", fields...)
+	} else {
+		logger.L().Info(ctx, "startup resource reclaim completed cleanly", fields...)
+	}
+
+	return summary
+}
+
+func (c Config) withDefaults() Config {
+	if c.TempDir == "" {
+		c.TempDir = os.TempDir()
+	}
+	if c.ProcDir == "" {
+		c.ProcDir = procDir
+	}
+	if c.NetnsDir == "" {
+		c.NetnsDir = network.NetNamespacesDir
+	}
+	if c.CgroupRoot == "" {
+		c.CgroupRoot = cgroup.RootCgroupPath
+	}
+	if c.EgressProxy == nil {
+		c.EgressProxy = network.NewNoopEgressProxy()
+	}
+
+	return c
+}
+
+func record(ctx context.Context, summary *Summary, resource string, reclaimed int, failures []error) {
+	if reclaimed > 0 {
+		summary.Reclaimed[resource] += reclaimed
+		reclaimedCounter.Add(ctx, int64(reclaimed), metric.WithAttributes(attribute.String("resource_type", resource)))
+	}
+
+	for _, err := range failures {
+		summary.Failed[resource]++
+		failedCounter.Add(ctx, 1, metric.WithAttributes(attribute.String("resource_type", resource)))
+		logger.L().Warn(ctx, "startup resource reclaim failed", zap.String("resource_type", resource), zap.Error(err))
+	}
+}

--- a/packages/shared/pkg/storage/sandbox.go
+++ b/packages/shared/pkg/storage/sandbox.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 )
@@ -67,4 +68,67 @@ func (s *SandboxFiles) SandboxMetricsFifoPath() string {
 
 func (s *SandboxFiles) SandboxCgroupName() string {
 	return fmt.Sprintf("sbx-%s-%s", s.SandboxID, s.randomID)
+}
+
+// SandboxFileGlobs returns glob patterns matching the on-disk files a sandbox
+// creates: firecracker/uffd sockets and the metrics fifo under tempDir, plus
+// the rootfs overlay and link files under sandboxCacheDir. The patterns mirror
+// the path builders above and are the single source of truth used by startup
+// reclaim. sandboxCacheDir may be empty, in which case the cache patterns are
+// omitted.
+func SandboxFileGlobs(tempDir, sandboxCacheDir string) []string {
+	patterns := []string{
+		filepath.Join(tempDir, "fc-*-*.sock"),
+		filepath.Join(tempDir, "uffd-*-*.sock"),
+		filepath.Join(tempDir, "fc-metrics-*-*.fifo"),
+	}
+	if sandboxCacheDir != "" {
+		patterns = append(patterns,
+			filepath.Join(sandboxCacheDir, "rootfs-*-*.cow"),
+			filepath.Join(sandboxCacheDir, "rootfs-*-*.link"),
+		)
+	}
+
+	return patterns
+}
+
+// ReclaimSandboxFiles removes leaked sandbox files matching SandboxFileGlobs,
+// left over from sandboxes that did not shut down cleanly. It returns the number
+// of files removed and any per-file removal failures. Files that no longer exist
+// are treated as already reclaimed.
+func ReclaimSandboxFiles(tempDir, sandboxCacheDir string) (int, []error) {
+	paths, err := matchingSandboxFiles(tempDir, sandboxCacheDir)
+	if err != nil {
+		return 0, []error{err}
+	}
+
+	reclaimed := 0
+	var failures []error
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			failures = append(failures, fmt.Errorf("failed to remove %s: %w", path, err))
+
+			continue
+		}
+
+		reclaimed++
+	}
+
+	return reclaimed, failures
+}
+
+func matchingSandboxFiles(tempDir, sandboxCacheDir string) ([]string, error) {
+	paths := make([]string, 0)
+	for _, pattern := range SandboxFileGlobs(tempDir, sandboxCacheDir) {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to glob %s: %w", pattern, err)
+		}
+
+		paths = append(paths, matches...)
+	}
+
+	slices.Sort(paths)
+
+	return paths, nil
 }

--- a/packages/shared/pkg/storage/sandbox_reclaim_test.go
+++ b/packages/shared/pkg/storage/sandbox_reclaim_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReclaimSandboxFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	cacheDir := t.TempDir()
+	matching := []string{
+		filepath.Join(tmpDir, "fc-sbx-rand.sock"),
+		filepath.Join(tmpDir, "uffd-sbx-rand.sock"),
+		filepath.Join(tmpDir, "fc-metrics-sbx-rand.fifo"),
+		filepath.Join(cacheDir, "rootfs-sbx-rand.cow"),
+		filepath.Join(cacheDir, "rootfs-sbx-rand.link"),
+	}
+	for _, path := range matching {
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	}
+	decoys := []string{
+		filepath.Join(tmpDir, "fc.sock"),
+		filepath.Join(tmpDir, "fc-sbx.sock"),
+		filepath.Join(tmpDir, "uffd-sbx.sock"),
+		filepath.Join(tmpDir, "fc-metrics-sbx.fifo"),
+		filepath.Join(cacheDir, "rootfs-sbx.cow"),
+		filepath.Join(cacheDir, "rootfs-sbx.link"),
+	}
+	for _, path := range decoys {
+		require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	}
+
+	reclaimed, failures := ReclaimSandboxFiles(tmpDir, cacheDir)
+	require.Empty(t, failures)
+	require.Equal(t, len(matching), reclaimed)
+
+	for _, path := range matching {
+		require.NoFileExists(t, path)
+	}
+	for _, path := range decoys {
+		require.FileExists(t, path)
+	}
+}


### PR DESCRIPTION
Add the startupreclaim package, which best-effort reclaims host resources
left behind by sandboxes that did not shut down cleanly: orphaned firecracker
processes (matched to ns-<idx> via /proc netns inode, with cmdline-ancestry
fallback), connected NBD devices, slot network namespaces, sandbox cgroups,
and stale sockets/fifos/overlay files. Failures are logged and counted via
OTel metrics, never fatal.