### PR TITLE
feat(api): add bin-pack placement strategy for sandbox scheduling

### DIFF
--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -319,6 +319,8 @@ func getBestOfKConfig(ctx context.Context, featureFlagsClient *featureflags.Clie
 
 	tooManyStarting := featureFlagsClient.BoolFlag(ctx, featureflags.BestOfKTooManyStartingFlag)
 
+	binPack := featureFlagsClient.BoolFlag(ctx, featureflags.BestOfKBinPackFlag)
+
 	// Convert percentage to decimal
 	alpha := float64(alphaPercent) / 100.0
 	maxOvercommit := float64(maxOvercommitPercent) / 100.0
@@ -329,5 +331,6 @@ func getBestOfKConfig(ctx context.Context, featureFlagsClient *featureflags.Clie
 		Alpha:           alpha,
 		CanFit:          canFit,
 		TooManyStarting: tooManyStarting,
+		BinPack:         binPack,
 	}
 }

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K.go
@@ -24,6 +24,9 @@ type BestOfKConfig struct {
 	TooManyStarting bool
 	// CanFit determines whether to skip the node CanFit check
 	CanFit bool
+	// BinPack enables bin-packing mode: fill one node before using the next.
+	// When false (default), sandboxes are spread evenly across nodes.
+	BinPack bool
 }
 
 // DefaultBestOfKConfig returns the default placement configuration
@@ -61,7 +64,15 @@ func (b *BestOfK) Score(node *nodemanager.Node, resources nodemanager.SandboxRes
 
 	cpuRequested := float64(resources.CPUs)
 
-	return (cpuRequested + float64(reserved) + config.Alpha*usageAvg) / totalCapacity
+	spreadScore := (cpuRequested + float64(reserved) + config.Alpha*usageAvg) / totalCapacity
+
+	if config.BinPack {
+		// Invert: prefer nodes with higher load (lower score = better).
+		// A node at 90% capacity scores lower (better) than one at 10%.
+		return 1.0 - spreadScore
+	}
+
+	return spreadScore
 }
 
 // CanFit checks if the node can fit a new VM with the given quota

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
@@ -424,3 +424,69 @@ func TestBestOfK_PowerOfKChoices(t *testing.T) {
 		assert.GreaterOrEqual(t, earlyNodeCount, lateNodeCount)
 	}
 }
+
+func TestBestOfK_Score_BinPackPrefersLoadedNodes(t *testing.T) {
+	t.Parallel()
+	config := DefaultBestOfKConfig()
+	config.BinPack = true
+	algo := NewBestOfK(config).(*BestOfK)
+
+	// nodeLight has low load, nodeHeavy has high load
+	nodeLight := nodemanager.NewTestNode("light", api.NodeStatusReady, 1, 8)
+	nodeHeavy := nodemanager.NewTestNode("heavy", api.NodeStatusReady, 6, 8)
+
+	resources := nodemanager.SandboxResources{CPUs: 1, MiBMemory: 512}
+
+	scoreLight := algo.Score(nodeLight, resources, config)
+	scoreHeavy := algo.Score(nodeHeavy, resources, config)
+
+	// In bin-pack mode, the heavier node should get a LOWER score (= better)
+	assert.Less(t, scoreHeavy, scoreLight,
+		"bin-pack mode should prefer the more loaded node (lower score)")
+}
+
+func TestBestOfK_Score_SpreadPrefersLightNodes(t *testing.T) {
+	t.Parallel()
+	config := DefaultBestOfKConfig()
+	config.BinPack = false // explicit spread (default)
+	algo := NewBestOfK(config).(*BestOfK)
+
+	nodeLight := nodemanager.NewTestNode("light", api.NodeStatusReady, 1, 8)
+	nodeHeavy := nodemanager.NewTestNode("heavy", api.NodeStatusReady, 6, 8)
+
+	resources := nodemanager.SandboxResources{CPUs: 1, MiBMemory: 512}
+
+	scoreLight := algo.Score(nodeLight, resources, config)
+	scoreHeavy := algo.Score(nodeHeavy, resources, config)
+
+	// In spread mode, the lighter node should get a LOWER score (= better)
+	assert.Less(t, scoreLight, scoreHeavy,
+		"spread mode should prefer the less loaded node (lower score)")
+}
+
+func TestBestOfK_ChooseNode_BinPackFillsOneFirst(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	config := BestOfKConfig{
+		R:       10,
+		Alpha:   0.5,
+		K:       100, // sample all nodes to make the test deterministic
+		BinPack: true,
+	}
+	algo := NewBestOfK(config).(*BestOfK)
+
+	// Three nodes: empty, half-full, almost-full
+	nodeEmpty := nodemanager.NewTestNode("empty", api.NodeStatusReady, 0, 8)
+	nodeHalf := nodemanager.NewTestNode("half", api.NodeStatusReady, 4, 8)
+	nodeAlmost := nodemanager.NewTestNode("almost", api.NodeStatusReady, 7, 8)
+
+	nodes := []*nodemanager.Node{nodeEmpty, nodeHalf, nodeAlmost}
+	resources := nodemanager.SandboxResources{CPUs: 1, MiBMemory: 512}
+
+	selected, err := algo.chooseNode(ctx, nodes, nil, resources, machineinfo.MachineInfo{}, false, nil)
+	require.NoError(t, err)
+
+	// Should pick the most loaded node that can still fit
+	assert.Equal(t, "almost", selected.ID,
+		"bin-pack should choose the most loaded node")
+}

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -126,6 +126,7 @@ var (
 	UseNFSCacheForBuildingTemplatesFlag = NewBoolFlag("use-nfs-for-building-templates", env.IsDevelopment())
 	BestOfKCanFitFlag                   = NewBoolFlag("best-of-k-can-fit", true)
 	BestOfKTooManyStartingFlag          = NewBoolFlag("best-of-k-too-many-starting", false)
+	BestOfKBinPackFlag                  = NewBoolFlag("best-of-k-bin-pack", false)
 	EdgeProvidedSandboxMetricsFlag      = NewBoolFlag("edge-provided-sandbox-metrics", false)
 	CreateStorageCacheSpansFlag         = NewBoolFlag("create-storage-cache-spans", env.IsDevelopment())
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)


### PR DESCRIPTION
fix https://github.com/e2b-dev/infra/issues/3104
/cc @jakubno Would appreciate your review on this change, thanks!
### Description:

Add a configurable bin-pack placement mode to the BestOfK sandbox scheduling algorithm, controlled by the best-of-k-bin-pack feature flag (default off).

Problem: The current spread strategy distributes sandboxes evenly across all nodes, which is ideal when nodes are plentiful but wastes resources when nodes are scarce — partially loaded nodes cannot be reclaimed or scaled down.

Solution: When best-of-k-bin-pack is enabled, the scoring function is inverted so that nodes with higher utilization are preferred. This fills one node before moving to the next, maximizing single-node density and enabling idle nodes to be drained or scaled down.

BinPack = false (default): spread — prefer least-loaded nodes (existing behavior, unchanged)
BinPack = true: bin-pack — prefer most-loaded nodes that can still fit the sandbox
The flag is read every 30s via the existing updateBestOfKConfig loop, so switching between strategies requires no restart.

### Changes:

flags.go: add BestOfKBinPackFlag
placement_best_of_K.go: add BinPack field to BestOfKConfig, invert score when enabled
orchestrator.go: wire the flag into config
placement_best_of_K_test.go: add 3 tests covering bin-pack preference, spread preference, and end-to-end node selection