### PR TITLE
feat(dashboard-api): LD-gated ClickHouse read switcher

### DIFF
--- a/packages/dashboard-api/internal/cfg/model.go
+++ b/packages/dashboard-api/internal/cfg/model.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Config struct {
-	Port                       int                 `env:"PORT"                                         envDefault:"3010"`
-	PostgresConnectionString   string              `env:"POSTGRES_CONNECTION_STRING,required,notEmpty"`
-	ClickhouseConnectionString string              `env:"CLICKHOUSE_CONNECTION_STRING"`
-	AdminToken                 string              `env:"ADMIN_TOKEN,required,notEmpty"`
-	AuthProvider               auth.ProviderConfig `env:"AUTH_PROVIDER_CONFIG"`
+	Port                        int                 `env:"PORT"                                         envDefault:"3010"`
+	PostgresConnectionString    string              `env:"POSTGRES_CONNECTION_STRING,required,notEmpty"`
+	ClickhouseConnectionString  string              `env:"CLICKHOUSE_CONNECTION_STRING"`
+	ClickhouseConnectionStrings []string            `env:"CLICKHOUSE_CONNECTION_STRINGS" envSeparator:";"`
+	AdminToken                  string              `env:"ADMIN_TOKEN,required,notEmpty"`
+	AuthProvider                auth.ProviderConfig `env:"AUTH_PROVIDER_CONFIG"`
 
 	AuthDBConnectionString            string `env:"AUTH_DB_CONNECTION_STRING"`
 	AuthDBReadReplicaConnectionString string `env:"AUTH_DB_READ_REPLICA_CONNECTION_STRING"`
@@ -30,6 +31,8 @@ type Config struct {
 	OrySDKURL          string `env:"ORY_SDK_URL"`
 	OryProjectAPIToken string `env:"ORY_PROJECT_API_TOKEN,unset"`
 	OryIssuerURL       string `env:"ORY_ISSUER_URL"`
+
+	DomainName string `env:"DOMAIN_NAME" envDefault:""`
 }
 
 type FailureCondition string

--- a/packages/dashboard-api/internal/cfg/model.go
+++ b/packages/dashboard-api/internal/cfg/model.go
@@ -14,7 +14,7 @@ type Config struct {
 	Port                        int                 `env:"PORT"                                         envDefault:"3010"`
 	PostgresConnectionString    string              `env:"POSTGRES_CONNECTION_STRING,required,notEmpty"`
 	ClickhouseConnectionString  string              `env:"CLICKHOUSE_CONNECTION_STRING"`
-	ClickhouseConnectionStrings []string            `env:"CLICKHOUSE_CONNECTION_STRINGS" envSeparator:";"`
+	ClickhouseConnectionStrings []string            `env:"CLICKHOUSE_CONNECTION_STRINGS"                envSeparator:";"`
 	AdminToken                  string              `env:"ADMIN_TOKEN,required,notEmpty"`
 	AuthProvider                auth.ProviderConfig `env:"AUTH_PROVIDER_CONFIG"`
 

--- a/packages/dashboard-api/main.go
+++ b/packages/dashboard-api/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/pkg/pool"
 	e2benv "github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/factories"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/httpserver"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sharedmiddleware "github.com/e2b-dev/infra/packages/shared/pkg/middleware"
@@ -146,18 +147,30 @@ func run() int {
 	}
 	defer authDB.Close()
 
-	var clickhouseClient clickhouse.Clickhouse
-	if config.ClickhouseConnectionString == "" {
-		clickhouseClient = clickhouse.NewNoopClient()
-	} else {
-		clickhouseClient, err = clickhouse.New(config.ClickhouseConnectionString)
-		if err != nil {
-			l.Error(ctx, "Initializing ClickHouse client", zap.Error(err))
+	// Initialize feature flags client for ClickHouse endpoint switching
+	featureFlags, err := featureflags.NewClient()
+	if err != nil {
+		l.Error(ctx, "Initializing feature flags client", zap.Error(err))
 
-			return 1
-		}
-		defer clickhouseClient.Close(ctx)
+		return 1
 	}
+	defer featureFlags.Close(ctx)
+	featureFlags.SetServiceName(serviceName)
+	featureFlags.SetDeploymentName(config.DomainName)
+
+	clickhouseClient, err := clickhouse.NewSwitchingClient(
+		ctx,
+		featureFlags,
+		config.ClickhouseConnectionString,
+		config.ClickhouseConnectionStrings,
+		clickhouse.WithAllowNoopDefault(true),
+	)
+	if err != nil {
+		l.Error(ctx, "initializing ClickHouse switching client", zap.Error(err))
+
+		return 1
+	}
+	defer clickhouseClient.Close(ctx)
 
 	redisClient, err := factories.NewRedisClient(ctx, factories.RedisConfig{
 		RedisURL:         config.RedisURL,


### PR DESCRIPTION
## What

Migrate `dashboard-api` to the LD-gated ClickHouse switching client, mirroring the `api` service (introduced in #3061). Replaces the single fixed-DSN client with `clickhouse.NewSwitchingClient`, gated on the `clickhouse-read-endpoint` flag, so dashboard-api reads can shift to the Aiven alternate in lock-step with `api`.

## Why

`dashboard-api` was the only ClickHouse reader still hardwired to the single (legacy) DSN with no flag awareness — it would not follow the `clickhouse-read-endpoint` cutover. This brings it in line with `api`, `data-exporter`, `argus-api`, `bot-detection`, etc.

## Changes

- `internal/cfg/model.go`: add `ClickhouseConnectionStrings` (alternates, `;`-separated) and `DomainName`.
- `main.go`: build a feature-flags client, `SetServiceName` + `SetDeploymentName(config.DomainName)` (same deployment context as `api`, so both resolve to the same endpoint), and construct `NewSwitchingClient(..., WithAllowNoopDefault(true))`. The noop-default preserves the prior empty-DSN behavior.

## Notes

- Requires the matching Terraform change to set `CLICKHOUSE_CONNECTION_STRINGS` + `DOMAIN_NAME` on the dashboard-api job (separate PR in the terraform repo).
- `go build` / `go vet` / `gofmt` clean.