### PR TITLE
feat(orchestrator): run startup reclaim on boot 

### DIFF
--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	blockmetrics "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/metrics"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/cgroup"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
@@ -485,7 +486,7 @@ func printLocalFileSizes(basePath, buildID string) {
 
 func setupKernel(ctx context.Context, dir, version string) error {
 	arch := utils.TargetArch()
-	dstPath := filepath.Join(dir, version, arch, "vmlinux.bin")
+	dstPath := filepath.Join(dir, version, arch, artifact.KernelFileName)
 
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 		return fmt.Errorf("mkdir kernel dir: %w", err)
@@ -498,7 +499,7 @@ func setupKernel(ctx context.Context, dir, version string) error {
 	}
 
 	// Try arch-specific URL first: {version}/{arch}/vmlinux.bin
-	archURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/kernels/", version, arch, "vmlinux.bin")
+	archURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/kernels/", version, arch, artifact.KernelFileName)
 	if err != nil {
 		return fmt.Errorf("invalid kernel URL: %w", err)
 	}
@@ -516,7 +517,7 @@ func setupKernel(ctx context.Context, dir, version string) error {
 		return fmt.Errorf("kernel %s not found for %s (no legacy fallback for non-amd64)", version, arch)
 	}
 
-	legacyURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/kernels/", version, "vmlinux.bin")
+	legacyURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/kernels/", version, artifact.KernelFileName)
 	if err != nil {
 		return fmt.Errorf("invalid kernel legacy URL: %w", err)
 	}
@@ -528,7 +529,7 @@ func setupKernel(ctx context.Context, dir, version string) error {
 
 func setupFC(ctx context.Context, dir, version string) error {
 	arch := utils.TargetArch()
-	dstPath := filepath.Join(dir, version, arch, "firecracker")
+	dstPath := filepath.Join(dir, version, arch, artifact.FirecrackerBinaryName)
 
 	if err := os.MkdirAll(filepath.Dir(dstPath), 0o755); err != nil {
 		return fmt.Errorf("mkdir firecracker dir: %w", err)
@@ -541,7 +542,7 @@ func setupFC(ctx context.Context, dir, version string) error {
 	}
 
 	// Download from GCS bucket with {version}/{arch}/firecracker path
-	fcURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/firecrackers/", version, arch, "firecracker")
+	fcURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/firecrackers/", version, arch, artifact.FirecrackerBinaryName)
 	if err != nil {
 		return fmt.Errorf("invalid Firecracker URL: %w", err)
 	}
@@ -559,7 +560,7 @@ func setupFC(ctx context.Context, dir, version string) error {
 		return fmt.Errorf("firecracker %s not found for %s (no legacy fallback for non-amd64)", version, arch)
 	}
 
-	legacyURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/firecrackers/", version, "firecracker")
+	legacyURL, err := url.JoinPath("https://storage.googleapis.com/e2b-prod-public-builds/firecrackers/", version, artifact.FirecrackerBinaryName)
 	if err != nil {
 		return fmt.Errorf("invalid Firecracker legacy URL: %w", err)
 	}

--- a/packages/orchestrator/cmd/inspect-build/main.go
+++ b/packages/orchestrator/cmd/inspect-build/main.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/cmd/internal/cmdutil"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
@@ -72,7 +73,7 @@ func main() {
 	if *memfile {
 		artifactName = "memfile"
 	} else {
-		artifactName = "rootfs.ext4"
+		artifactName = artifact.RootfsFileName
 	}
 
 	ctx := context.Background()

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/proxy"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	blockmetrics "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block/metrics"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/cgroup"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/fc"
@@ -362,8 +363,8 @@ func setupEnvVars(t *testing.T, dataDir, envdPath string) {
 
 func downloadKernel(t *testing.T, dataDir string) {
 	t.Helper()
-	dst := filepath.Join(dataDir, "kernels", featureflags.DefaultKernelVersion, "vmlinux.bin")
-	url := fmt.Sprintf("https://storage.googleapis.com/e2b-prod-public-builds/kernels/%s/vmlinux.bin", featureflags.DefaultKernelVersion)
+	dst := filepath.Join(dataDir, "kernels", featureflags.DefaultKernelVersion, artifact.KernelFileName)
+	url := fmt.Sprintf("https://storage.googleapis.com/e2b-prod-public-builds/kernels/%s/%s", featureflags.DefaultKernelVersion, artifact.KernelFileName)
 	downloadFile(t, url, dst, 0o644)
 }
 
@@ -376,10 +377,10 @@ func downloadFC(t *testing.T, dataDir, version string) {
 	// TODO: Drop this work-around once we remove support for Firecracker v1.10
 	assetName := "firecracker-amd64"
 	if strings.HasPrefix(version, "v1.10") {
-		assetName = "firecracker"
+		assetName = artifact.FirecrackerBinaryName
 	}
 
-	dst := filepath.Join(dataDir, "fc-versions", version, "firecracker")
+	dst := filepath.Join(dataDir, "fc-versions", version, artifact.FirecrackerBinaryName)
 	url := fmt.Sprintf("https://github.com/e2b-dev/fc-versions/releases/download/%s/%s", version, assetName)
 	downloadFile(t, url, dst, 0o755)
 }

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -622,6 +622,10 @@ func run(config cfg.Config, opts Options) (success bool) {
 		closers = append(closers, closer{"egress proxy", egressSetup.Close})
 	}
 
+	// Must run before newStorage below: reclaim deletes leaked ns-* from
+	// /run/netns, and NewStorageLocal snapshots the remaining namespaces as
+	// foreign at construction. Running it after would mark reclaimed indices
+	// foreign and leave them unusable for this process.
 	if slices.Contains(services, cfg.Orchestrator) && !config.DisableStartupReclaim {
 		startupreclaim.Run(ctx, startupreclaim.Config{
 			NetworkConfig: config.NetworkConfig,

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -51,6 +51,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/server"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/service"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/service/machineinfo"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/startupreclaim"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/constants"
 	tmplserver "github.com/e2b-dev/infra/packages/orchestrator/pkg/template/server"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/volumes"
@@ -619,6 +620,15 @@ func run(config cfg.Config, opts Options) (success bool) {
 	}
 	if egressSetup.Close != nil {
 		closers = append(closers, closer{"egress proxy", egressSetup.Close})
+	}
+
+	if slices.Contains(services, cfg.Orchestrator) && !config.DisableStartupReclaim {
+		startupreclaim.Run(ctx, startupreclaim.Config{
+			NetworkConfig: config.NetworkConfig,
+			EgressProxy:   egressSetup.Proxy,
+			CgroupManager: cgroupManager,
+			StorageConfig: config.StorageConfig,
+		})
 	}
 
 	// device pool

--- a/packages/orchestrator/pkg/sandbox/artifact/names.go
+++ b/packages/orchestrator/pkg/sandbox/artifact/names.go
@@ -1,0 +1,7 @@
+package artifact
+
+const (
+	FirecrackerBinaryName = "firecracker"
+	KernelFileName        = "vmlinux.bin"
+	RootfsFileName        = "rootfs.ext4"
+)

--- a/packages/orchestrator/pkg/sandbox/fc/config.go
+++ b/packages/orchestrator/pkg/sandbox/fc/config.go
@@ -8,18 +8,17 @@ import (
 	"path/filepath"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 const (
-	SandboxKernelFile = "vmlinux.bin"
-
-	FirecrackerBinaryName = "firecracker"
+	SandboxKernelFile     = artifact.KernelFileName
+	FirecrackerBinaryName = artifact.FirecrackerBinaryName
+	SandboxRootfsFile     = artifact.RootfsFileName
 
 	envsDisk     = "/mnt/disks/fc-envs/v1"
 	buildDirName = "builds"
-
-	SandboxRootfsFile = "rootfs.ext4"
 
 	rootfsDriveID = "rootfs"
 
@@ -40,7 +39,7 @@ func (t Config) SandboxKernelDir() string {
 func (t Config) HostKernelPath(config cfg.BuilderConfig) string {
 	// Prefer arch-prefixed path ({version}/{arch}/vmlinux.bin) for multi-arch support.
 	// Fall back to legacy flat path ({version}/vmlinux.bin) for existing production nodes.
-	archPath := filepath.Join(config.HostKernelsDir, t.KernelVersion, utils.TargetArch(), SandboxKernelFile)
+	archPath := filepath.Join(config.HostKernelsDir, t.KernelVersion, utils.TargetArch(), artifact.KernelFileName)
 	if _, err := os.Stat(archPath); err == nil {
 		return archPath
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -49,14 +48,14 @@ func (t Config) HostKernelPath(config cfg.BuilderConfig) string {
 		return archPath
 	}
 
-	return filepath.Join(config.HostKernelsDir, t.KernelVersion, SandboxKernelFile)
+	return filepath.Join(config.HostKernelsDir, t.KernelVersion, artifact.KernelFileName)
 }
 
 func (t Config) FirecrackerPath(config cfg.BuilderConfig) string {
 	// Prefer arch-prefixed path ({version}/{arch}/firecracker) for multi-arch support.
 	// Fall back to legacy flat path ({version}/firecracker) for existing production nodes
 	// that haven't migrated to the arch-prefixed layout yet.
-	archPath := filepath.Join(config.FirecrackerVersionsDir, t.FirecrackerVersion, utils.TargetArch(), FirecrackerBinaryName)
+	archPath := filepath.Join(config.FirecrackerVersionsDir, t.FirecrackerVersion, utils.TargetArch(), artifact.FirecrackerBinaryName)
 	if _, err := os.Stat(archPath); err == nil {
 		return archPath
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -65,7 +64,7 @@ func (t Config) FirecrackerPath(config cfg.BuilderConfig) string {
 		return archPath
 	}
 
-	return filepath.Join(config.FirecrackerVersionsDir, t.FirecrackerVersion, FirecrackerBinaryName)
+	return filepath.Join(config.FirecrackerVersionsDir, t.FirecrackerVersion, artifact.FirecrackerBinaryName)
 }
 
 type RootfsPaths struct {

--- a/packages/orchestrator/pkg/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/pkg/sandbox/fc/script_builder.go
@@ -9,6 +9,7 @@ import (
 	txtTemplate "text/template"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
@@ -94,12 +95,12 @@ func (sb *StartScriptBuilder) buildArgs(
 		// Kernel
 		HostKernelPath:    versions.HostKernelPath(sb.builderConfig),
 		SandboxKernelDir:  versions.SandboxKernelDir(),
-		SandboxKernelFile: SandboxKernelFile,
+		SandboxKernelFile: artifact.KernelFileName,
 
 		// Rootfs
 		HostRootfsPath:             files.SandboxCacheRootfsLinkPath(sb.builderConfig.StorageConfig),
 		DeprecatedSandboxRootfsDir: rootfsPaths.DeprecatedSandboxRootfsDir(),
-		SandboxRootfsFile:          SandboxRootfsFile,
+		SandboxRootfsFile:          artifact.RootfsFileName,
 
 		// FC
 		NamespaceID:       namespaceID,

--- a/packages/orchestrator/pkg/startupreclaim/firecracker.go
+++ b/packages/orchestrator/pkg/startupreclaim/firecracker.go
@@ -14,6 +14,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/artifact"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -100,10 +101,6 @@ func processCmdline(procDir string, pid int) ([]string, error) {
 	return cmdline, nil
 }
 
-// firecrackerBinaryName mirrors fc.FirecrackerBinaryName; it is duplicated here
-// to avoid importing the cgo-heavy fc package.
-const firecrackerBinaryName = "firecracker"
-
 func isFirecrackerCmdline(cmdline []string) bool {
 	if len(cmdline) == 0 {
 		return false
@@ -111,5 +108,5 @@ func isFirecrackerCmdline(cmdline []string) bool {
 
 	// Exact basename match so versioned paths match but "firecracker-monitor"
 	// and similar do not.
-	return filepath.Base(cmdline[0]) == firecrackerBinaryName
+	return filepath.Base(cmdline[0]) == artifact.FirecrackerBinaryName
 }

--- a/packages/orchestrator/pkg/startupreclaim/reclaim.go
+++ b/packages/orchestrator/pkg/startupreclaim/reclaim.go
@@ -84,6 +84,16 @@ type reclaimer struct {
 
 func Run(ctx context.Context, config Config) Summary {
 	config = config.withDefaults()
+
+	// No egress proxy wired: slots are still torn down, but the egress firewall
+	// cleanup (OnSlotDelete) is skipped and those iptables rules may leak. Log it
+	// instead of substituting silently; callers with no egress firewall can pass
+	// network.NewNoopEgressProxy() to opt in quietly.
+	if config.EgressProxy == nil {
+		logger.L().Error(ctx, "startup reclaim: no egress proxy provided; egress firewall cleanup will be skipped for reclaimed slots")
+		config.EgressProxy = network.NewNoopEgressProxy()
+	}
+
 	summary := Summary{Reclaimed: map[string]int{}, Failed: map[string]int{}}
 
 	// Order matters: firecracker runs first so the VMMs are killed before the
@@ -136,9 +146,6 @@ func (c Config) withDefaults() Config {
 	}
 	if c.CgroupRoot == "" {
 		c.CgroupRoot = cgroup.RootCgroupPath
-	}
-	if c.EgressProxy == nil {
-		c.EgressProxy = network.NewNoopEgressProxy()
 	}
 
 	return c


### PR DESCRIPTION
Invoke startupreclaim.Run during orchestrator startup, after egress/cgroup
setup and before the NBD and network pools are initialized, so that leaked
ns-<idx> namespaces are torn down rather than skipped. Gated by the
DISABLE_STARTUP_RECLAIM flag.

fix(orchestrator): log missing egress proxy in startup reclaim instead of defaulting silently
docs(orchestrator): document reclaim-before-storage ordering requirement
refactor(orchestrator): share sandbox artifact names