### PR TITLE
Fix upload metadata path races

### DIFF
--- a/packages/envd/internal/api/upload.go
+++ b/packages/envd/internal/api/upload.go
@@ -108,7 +108,7 @@ func processFile(r *http.Request, path string, part io.Reader, uid, gid int, met
 	defer file.Close()
 
 	if !hasBeenChowned {
-		err = os.Chown(path, uid, gid)
+		err = file.Chown(uid, gid)
 		if err != nil {
 			err := fmt.Errorf("error changing file ownership: %w", err)
 

--- a/packages/envd/internal/api/upload.go
+++ b/packages/envd/internal/api/upload.go
@@ -136,7 +136,7 @@ func processFile(r *http.Request, path string, part io.Reader, uid, gid int, met
 	// overwriting a file replaces its full metadata set: keys absent from
 	// this request are cleared (O_TRUNC truncates the body but preserves
 	// xattrs from a prior upload).
-	if err := filesystem.WriteMetadata(path, metadata); err != nil {
+	if err := filesystem.WriteMetadata(file, metadata); err != nil {
 		switch {
 		case filesystem.IsXattrUnsupported(err):
 			// Filesystem doesn't support xattrs. ext4 (the sandbox rootfs)

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.6"
+const Version = "0.6.7"

--- a/packages/shared/pkg/filesystem/xattr.go
+++ b/packages/shared/pkg/filesystem/xattr.go
@@ -3,6 +3,7 @@ package filesystem
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"syscall"
 	"unicode/utf8"
@@ -127,19 +128,18 @@ func ReadMetadata(path string) (map[string]string, error) {
 // WriteMetadata replaces the file's user-defined metadata with the given
 // key/value pairs. Any existing xattrs under MetadataXattrPrefix that are
 // absent from metadata are removed, and the supplied keys are written via
-// xattr.Set. Passing a nil/empty map therefore clears all metadata, so that
+// xattr.FSet. Passing a nil/empty map therefore clears all metadata, so that
 // overwriting a file (which preserves xattrs across O_TRUNC) does not leak
 // stale metadata from a previous upload.
 //
-// Safe to call before or after chown — `user.*` xattrs are preserved across
-// ownership changes, and envd runs as root inside the VM so the kernel
-// write-permission check is satisfied regardless of file ownership.
-func WriteMetadata(path string, metadata map[string]string) error {
+// It addresses the file through an already-open descriptor, avoiding path races
+// with concurrent renames.
+func WriteMetadata(file *os.File, metadata map[string]string) error {
 	if err := ValidateMetadata(metadata); err != nil {
 		return err
 	}
 
-	existing, err := xattr.List(path)
+	existing, err := xattr.FList(file)
 	if err != nil {
 		return err
 	}
@@ -152,13 +152,13 @@ func WriteMetadata(path string, metadata map[string]string) error {
 		if _, keep := metadata[key]; keep {
 			continue
 		}
-		if err := xattr.Remove(path, name); err != nil && !errors.Is(err, xattr.ENOATTR) {
+		if err := xattr.FRemove(file, name); err != nil && !errors.Is(err, xattr.ENOATTR) {
 			return err
 		}
 	}
 
 	for k, v := range metadata {
-		if err := xattr.Set(path, MetadataXattrPrefix+k, []byte(v)); err != nil {
+		if err := xattr.FSet(file, MetadataXattrPrefix+k, []byte(v)); err != nil {
 			return err
 		}
 	}

--- a/packages/shared/pkg/filesystem/xattr_metadata_test.go
+++ b/packages/shared/pkg/filesystem/xattr_metadata_test.go
@@ -17,7 +17,7 @@ func TestWriteAndReadMetadata(t *testing.T) {
 	}
 
 	want := map[string]string{"author": "mish", "purpose": "upload"}
-	if err := WriteMetadata(path, want); err != nil {
+	if err := writeMetadataForTest(path, want); err != nil {
 		if IsXattrUnsupported(err) {
 			t.Skipf("filesystem does not support xattrs: %v", err)
 		}
@@ -166,7 +166,7 @@ func TestWriteMetadataReplacesFullSet(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	if err := WriteMetadata(path, map[string]string{"author": "mish", "purpose": "upload"}); err != nil {
+	if err := writeMetadataForTest(path, map[string]string{"author": "mish", "purpose": "upload"}); err != nil {
 		if IsXattrUnsupported(err) {
 			t.Skipf("filesystem does not support xattrs: %v", err)
 		}
@@ -180,7 +180,7 @@ func TestWriteMetadataReplacesFullSet(t *testing.T) {
 
 	// Non-empty call replaces the full set: "purpose" is dropped because
 	// it's not in the new map.
-	if err := WriteMetadata(path, map[string]string{"author": "alice"}); err != nil {
+	if err := writeMetadataForTest(path, map[string]string{"author": "alice"}); err != nil {
 		t.Fatalf("WriteMetadata replace: %v", err)
 	}
 	got, err := ReadMetadata(path)
@@ -192,7 +192,7 @@ func TestWriteMetadataReplacesFullSet(t *testing.T) {
 	}
 
 	// Empty/nil call clears all e2b metadata.
-	if err := WriteMetadata(path, nil); err != nil {
+	if err := writeMetadataForTest(path, nil); err != nil {
 		t.Fatalf("WriteMetadata nil: %v", err)
 	}
 	got, err = ReadMetadata(path)
@@ -207,4 +207,47 @@ func TestWriteMetadataReplacesFullSet(t *testing.T) {
 	if _, err := xattr.Get(path, "user.foreign"); err != nil {
 		t.Errorf("foreign xattr was removed: %v", err)
 	}
+}
+
+func TestWriteMetadataSurvivesRename(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	renamed := filepath.Join(dir, "renamed")
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("open file: %v", err)
+	}
+	defer file.Close()
+
+	if err := os.Rename(path, renamed); err != nil {
+		t.Fatalf("rename file: %v", err)
+	}
+
+	want := map[string]string{"author": "mish"}
+	if err := WriteMetadata(file, want); err != nil {
+		if IsXattrUnsupported(err) {
+			t.Skipf("filesystem does not support xattrs: %v", err)
+		}
+		t.Fatalf("WriteMetadata: %v", err)
+	}
+
+	got, err := ReadMetadata(renamed)
+	if err != nil {
+		t.Fatalf("ReadMetadata: %v", err)
+	}
+	if got["author"] != want["author"] {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func writeMetadataForTest(path string, metadata map[string]string) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return WriteMetadata(file, metadata)
 }


### PR DESCRIPTION
Writes upload metadata through the already-open file handle instead of looking the path up again after the body is persisted. This keeps metadata replacement semantics while avoiding ENOENT failures if the upload path changes before xattrs are written. Adds a regression test for metadata writes after rename.