### PR TITLE
feat(orchestrator): surface soft-delete reason group on tombstone check

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build/softdelete.go
+++ b/packages/orchestrator/pkg/sandbox/build/softdelete.go
@@ -34,13 +34,15 @@ var softDeleteCheckMetric = utils.Must(meter.Int64Counter(
 
 // recordCheck emits one metric point per check. result distinguishes a read
 // (checked) from an unreadable object (not_found/error); soft_deleted/failed
-// are only meaningful when result==checked.
-func (b *StorageDiff) recordCheck(ctx context.Context, result string, softDeleted, failed bool) {
+// are only meaningful when result==checked. reasonGroup is the soft-delete group
+// (empty for non-tombstoned outcomes).
+func (b *StorageDiff) recordCheck(ctx context.Context, result string, softDeleted, failed bool, reasonGroup string) {
 	softDeleteCheckMetric.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("artifact", string(b.diffType)),
 		attribute.String("result", result),
 		attribute.Bool("soft_deleted", softDeleted),
 		attribute.Bool("failed", failed),
+		attribute.String("reason", reasonGroup),
 	))
 }
 
@@ -87,7 +89,7 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	blob, err := b.persistence.OpenBlob(ctx, path)
 	if err != nil {
 		result := classifyCheckError(err)
-		b.recordCheck(ctx, result, false, false)
+		b.recordCheck(ctx, result, false, false, "")
 		logger.L().Warn(ctx, "storage-index soft-delete check could not open object",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
 			zap.String("result", result), zap.String("object", path), zap.Error(err))
@@ -103,7 +105,7 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		// possibly-tombstoned layer (BlobCustomMetadata used to return no error
 		// here, which silently failed open).
 		if result == checkResultUnsupported && ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag) {
-			b.recordCheck(ctx, result, false, true)
+			b.recordCheck(ctx, result, false, true, "")
 			b.softDeletedPath.Store(&path)
 			logger.L().Error(ctx, "storage-index soft-delete unverifiable; failing closed",
 				logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
@@ -111,7 +113,7 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 
 			return
 		}
-		b.recordCheck(ctx, result, false, false)
+		b.recordCheck(ctx, result, false, false, "")
 		logger.L().Warn(ctx, "storage-index soft-delete check could not read object metadata",
 			logger.WithBuildID(b.buildID), zap.String("artifact", string(b.diffType)),
 			zap.String("result", result),
@@ -125,7 +127,15 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 	enforce := ff.BoolFlag(ctx, featureflags.StorageSoftDeleteEnforceFlag)
 	failed := softDeleted && enforce
 
-	b.recordCheck(ctx, checkResultChecked, softDeleted, failed)
+	// Split "<reason>:<action_id>"; only the bounded reason group is emitted as a
+	// metric dimension to distinguish soft-delete groups without exploding cardinality.
+	reason, actionID := storage.ParseSoftDeleteMarker(marker)
+	var reasonGroup string
+	if softDeleted {
+		reasonGroup = storage.SoftDeleteReasonGroup(reason)
+	}
+
+	b.recordCheck(ctx, checkResultChecked, softDeleted, failed, reasonGroup)
 
 	if !softDeleted {
 		return
@@ -135,6 +145,8 @@ func (b *StorageDiff) softDeleteCheck(ctx context.Context, ff *featureflags.Clie
 		logger.WithBuildID(b.buildID),
 		zap.String("artifact", string(b.diffType)),
 		zap.String("marker", marker),
+		zap.String("reason", reason),
+		zap.String("action_id", actionID),
 		zap.Bool("enforce", enforce),
 	)
 

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -41,6 +41,19 @@ var ErrMetadataUnsupported = errors.New("blob does not support reading custom me
 // ObjectMetadataSoftDeleted is the storage-index soft-delete tombstone key.
 const ObjectMetadataSoftDeleted = storageopts.ObjectMetadataSoftDeleted
 
+// SoftDeleteReasonOther is the fallback soft-delete reason group.
+const SoftDeleteReasonOther = storageopts.SoftDeleteReasonOther
+
+// ParseSoftDeleteMarker splits a soft-delete tombstone value into reason and action ID.
+func ParseSoftDeleteMarker(marker string) (reason, actionID string) {
+	return storageopts.ParseSoftDeleteMarker(marker)
+}
+
+// SoftDeleteReasonGroup normalizes a tombstone reason into a low-cardinality metric dimension.
+func SoftDeleteReasonGroup(reason string) string {
+	return storageopts.SoftDeleteReasonGroup(reason)
+}
+
 type Provider string
 
 const (

--- a/packages/shared/pkg/storage/storageopts/storageopts.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts.go
@@ -5,6 +5,8 @@ package storageopts
 import (
 	"context"
 	"maps"
+	"regexp"
+	"strings"
 )
 
 type ObjectMetadata map[string]string
@@ -31,6 +33,36 @@ const (
 // (not at upload time) to mark a layer for deletion. Value is
 // "<reason>:<action_id>". Consumers fail closed on it behind a feature flag.
 const ObjectMetadataSoftDeleted = "storage-index-soft-deleted"
+
+// SoftDeleteReasonOther is the fallback group used when a tombstone reason is
+// empty or not a simple low-cardinality token.
+const SoftDeleteReasonOther = "other"
+
+// softDeleteReasonPattern bounds what is emitted as a metric dimension so a
+// malformed or high-cardinality reason cannot explode metric series.
+var softDeleteReasonPattern = regexp.MustCompile(`^[a-z0-9_-]{1,32}$`)
+
+// ParseSoftDeleteMarker splits an ObjectMetadataSoftDeleted value of the form
+// "<reason>:<action_id>" into its parts. A marker without a ":" is treated as a
+// bare reason with an empty action ID; either part may be empty.
+func ParseSoftDeleteMarker(marker string) (reason, actionID string) {
+	reason, actionID, found := strings.Cut(marker, ":")
+	if !found {
+		return marker, ""
+	}
+
+	return reason, actionID
+}
+
+// SoftDeleteReasonGroup normalizes a parsed reason into a low-cardinality
+// metric dimension, collapsing empty or unexpected values to SoftDeleteReasonOther.
+func SoftDeleteReasonGroup(reason string) string {
+	if softDeleteReasonPattern.MatchString(reason) {
+		return reason
+	}
+
+	return SoftDeleteReasonOther
+}
 
 // FrameSink fires once per compressed frame with its absolute C-space offset.
 // Best-effort; implementations should return quickly and bound their own I/O.

--- a/packages/shared/pkg/storage/storageopts/storageopts_test.go
+++ b/packages/shared/pkg/storage/storageopts/storageopts_test.go
@@ -1,0 +1,49 @@
+package storageopts
+
+import "testing"
+
+func TestParseSoftDeleteMarker(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		marker     string
+		wantReason string
+		wantAction string
+	}{
+		{"orphaned:abc123", "orphaned", "abc123"},
+		{"orphaned", "orphaned", ""},
+		{"", "", ""},
+		{":abc123", "", "abc123"},
+		{"reason:with:colons", "reason", "with:colons"},
+	}
+
+	for _, c := range cases {
+		reason, action := ParseSoftDeleteMarker(c.marker)
+		if reason != c.wantReason || action != c.wantAction {
+			t.Errorf("ParseSoftDeleteMarker(%q) = (%q, %q), want (%q, %q)", c.marker, reason, action, c.wantReason, c.wantAction)
+		}
+	}
+}
+
+func TestSoftDeleteReasonGroup(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		reason string
+		want   string
+	}{
+		{"orphaned", "orphaned"},
+		{"user_delete", "user_delete"},
+		{"team-expired", "team-expired"},
+		{"", SoftDeleteReasonOther},
+		{"Has Spaces", SoftDeleteReasonOther},
+		{"UPPER", SoftDeleteReasonOther},
+		{"way-too-long-reason-value-that-exceeds-the-cap", SoftDeleteReasonOther},
+	}
+
+	for _, c := range cases {
+		if got := SoftDeleteReasonGroup(c.reason); got != c.want {
+			t.Errorf("SoftDeleteReasonGroup(%q) = %q, want %q", c.reason, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
The storage-index soft-delete tombstone value is `<reason>:<action_id>`, but the orchestrator only logged the raw marker and the check metric had no reason dimension.

This parses the marker and:
- adds a bounded `reason` group dimension to `orchestrator.build.soft_delete_check` (unexpected/high-cardinality values collapse to `other`)
- logs `reason` and `action_id` as separate fields on the soft-deleted log line

No behavior change to enforcement.