### PR TITLE
refactor(orchestrator): introduce StartType type for sandbox start types

### DIFF
--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -59,10 +59,12 @@ var (
 
 // Sandbox start types recorded on the orchestrator.sandbox.uffd.startup.*
 // metrics via the start_type attribute.
+type StartType string
+
 const (
-	StartTypeCreate = "create" // cold boot (template build)
-	StartTypeResume = "resume" // resume from a snapshot (the common runtime path)
-	StartTypeReboot = "reboot" // cold boot from a snapshot rootfs (filesystem-only resume)
+	StartTypeCreate StartType = "create" // cold boot (template build)
+	StartTypeResume StartType = "resume" // resume from a snapshot (the common runtime path)
+	StartTypeReboot StartType = "reboot" // cold boot from a snapshot rootfs (filesystem-only resume)
 )
 
 var SandboxHttpTransport = otelhttp.NewTransport(
@@ -1735,7 +1737,7 @@ func (s *Sandbox) WaitForExit(ctx context.Context) error {
 
 func (s *Sandbox) WaitForEnvd(
 	ctx context.Context,
-	startType string,
+	startType StartType,
 	timeout time.Duration,
 ) (e error) {
 	start := time.Now()
@@ -1768,7 +1770,7 @@ func (s *Sandbox) WaitForEnvd(
 			s.startupStatsOnce.Do(func() {
 				stats := s.memory.ServeStats()
 				startupAttrs := metric.WithAttributes(
-					attribute.String("start_type", startType),
+					attribute.String("start_type", string(startType)),
 					attribute.Bool("success", e == nil),
 				)
 				uffdStartupPagesHistogram.Record(ctx, stats.Pages, startupAttrs)


### PR DESCRIPTION
The start type was passed around as a plain string, which let any string flow into WaitForEnvd and the start_type metric attribute. Promoting it to a dedicated StartType type makes the accepted values explicit, lets the compiler catch typos and invalid values at the call site, and keeps the metric label values consistent.