### PR TITLE
feat(orchestrator): tag envd-init meters with start_type

### DIFF
--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -226,7 +226,7 @@ func (s *Sandbox) convertMounts(mounts []VolumeMountConfig) []envd.VolumeMount {
 	return results
 }
 
-func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
+func (s *Sandbox) initEnvd(ctx context.Context, startType StartType) (e error) {
 	ctx, span := tracer.Start(ctx, "envd-init", trace.WithAttributes(telemetry.WithEnvdVersion(s.Config.Envd.Version)))
 	defer func() {
 		if e != nil {
@@ -236,7 +236,7 @@ func (s *Sandbox) initEnvd(ctx context.Context) (e error) {
 		span.End()
 	}()
 
-	attributes := []attribute.KeyValue{telemetry.WithEnvdVersion(s.Config.Envd.Version), attribute.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds())}
+	attributes := []attribute.KeyValue{telemetry.WithEnvdVersion(s.Config.Envd.Version), attribute.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()), attribute.String("start_type", string(startType))}
 	attributesFail := append(attributes, attribute.Bool("success", false))
 	attributesSuccess := append(attributes, attribute.Bool("success", true))
 

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -57,8 +57,8 @@ var (
 	uffdStartupBytesHistogram       = utils.Must(telemetry.GetHistogram(meter, telemetry.UffdStartupBytesHistogramName))
 )
 
-// Sandbox start types recorded on the orchestrator.sandbox.uffd.startup.*
-// metrics via the start_type attribute.
+// Sandbox start types recorded on sandbox start/init metrics via the
+// start_type attribute.
 type StartType string
 
 const (

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1757,6 +1757,7 @@ func (s *Sandbox) WaitForEnvd(
 				telemetry.WithEnvdVersion(s.Config.Envd.Version),
 				attribute.Int64("timeout_ms", s.internalConfig.EnvdInitRequestTimeout.Milliseconds()),
 				attribute.Bool("success", e == nil),
+				attribute.String("start_type", string(startType)),
 			))
 
 			// Record the demand-fault working set the guest needed to reach this
@@ -1803,7 +1804,7 @@ func (s *Sandbox) WaitForEnvd(
 		}
 	}()
 
-	if err := s.initEnvd(ctx); err != nil {
+	if err := s.initEnvd(ctx, startType); err != nil {
 		return fmt.Errorf("failed to init new envd: %w", err)
 	}
 


### PR DESCRIPTION
Add a start_type attribute (create/resume/reboot) to the two core envd-init meters orchestrator.sandbox.envd.init.calls and orchestrator.sandbox.envd.init.duration so create, resume, and reboot starts can be distinguished in Grafana. The value already flows into WaitForEnvd; thread it through to initEnvd and the duration histogram.