### PR TITLE
fix(orchestrator): add opt-in template build concurrency cap

### DIFF
--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -159,6 +159,18 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 			}
 		}()
 
+		// Queue builds inside the background goroutine so the gRPC handler stays
+		// non-blocking and the node does not oversubscribe build resources.
+		if s.buildLimitEnabled.Load() {
+			if err := s.buildLimiter.Acquire(ctx, 1); err != nil {
+				telemetry.ReportEvent(ctx, "build cancelled while queued for the build limiter")
+				buildInfo.SetFail(builderrors.UnwrapUserError(err))
+
+				return
+			}
+			defer s.buildLimiter.Release(1)
+		}
+
 		res, err := s.builder.Build(ctx, metadata, template, core)
 		_ = core.Sync()
 		if err != nil {

--- a/packages/orchestrator/pkg/template/server/main.go
+++ b/packages/orchestrator/pkg/template/server/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -30,6 +31,12 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
+// buildLimiterRefreshInterval is how often the template build limit is refreshed.
+const buildLimiterRefreshInterval = 30 * time.Second
+
+// buildLimiterUnboundedLimit disables the template build cap.
+const buildLimiterUnboundedLimit = math.MaxInt32
+
 type closeable interface {
 	Close() error
 }
@@ -53,6 +60,11 @@ type ServerStore struct {
 
 	wg           *sync.WaitGroup // wait group for running builds
 	activeBuilds atomic.Int64    // counter for active builds (for debugging)
+
+	// buildLimiter bounds concurrent template builds on this node.
+	buildLimiter *utils.AdjustableSemaphore
+	// buildLimitEnabled gates the limiter acquire path.
+	buildLimitEnabled atomic.Bool
 
 	closers []closeable
 }
@@ -119,6 +131,18 @@ func New(
 		uploads,
 	)
 
+	// Use the service context so the node-wide cap is not team-targeted.
+	flagLimit := featureFlags.IntFlag(ctx, featureflags.MaxConcurrentTemplateBuilds)
+	enabled := flagLimit > 0
+	initialLimit := int64(flagLimit)
+	if !enabled {
+		initialLimit = buildLimiterUnboundedLimit
+	}
+	buildLimiter, err := utils.NewAdjustableSemaphore(initialLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create build limiter: %w", err)
+	}
+
 	store := &ServerStore{
 		logger:            logger,
 		builder:           builder,
@@ -129,10 +153,42 @@ func New(
 		templateStorage:   templatePersistence,
 		buildStorage:      buildPersistence,
 		wg:                &sync.WaitGroup{},
+		buildLimiter:      buildLimiter,
 		closers:           closers,
 	}
+	store.buildLimitEnabled.Store(enabled)
+
+	go store.refreshBuildLimit(ctx)
 
 	return store, nil
+}
+
+// refreshBuildLimit keeps the template build cap in sync with the feature flag.
+func (s *ServerStore) refreshBuildLimit(ctx context.Context) {
+	ticker := time.NewTicker(buildLimiterRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			flagLimit := s.featureFlags.IntFlag(ctx, featureflags.MaxConcurrentTemplateBuilds)
+
+			limit := int64(flagLimit)
+			enabled := flagLimit > 0
+			if !enabled {
+				limit = buildLimiterUnboundedLimit
+			}
+
+			if err := s.buildLimiter.SetLimit(limit); err != nil {
+				s.logger.Error(ctx, "failed to adjust build limiter",
+					zap.Int64("limit", limit), zap.Bool("enabled", enabled), zap.Error(err))
+				continue
+			}
+			s.buildLimitEnabled.Store(enabled)
+		}
+	}
 }
 
 func (s *ServerStore) Close(ctx context.Context) error {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -355,6 +355,10 @@ var (
 	// Must be > 0.
 	MaxStartingInstancesPerNode = NewIntFlag("max-starting-instances-per-node", 3)
 
+	// MaxConcurrentTemplateBuilds limits concurrent template builds on a single
+	// template-manager node. Non-positive values disable the cap.
+	MaxConcurrentTemplateBuilds = NewIntFlag("max-concurrent-template-builds", -1)
+
 	// MaxConcurrentEvictions caps the number of sandbox evictions that can run
 	// in parallel per API instance. Excess items remain expired in the store
 	// and are picked up by the next eviction tick. Must be > 0; non-positive


### PR DESCRIPTION
## Summary

`TemplateCreate` launches one detached goroutine per request with **no concurrency limit**. Each goroutine drives a full template build, extracting an ext4 rootfs and booting a provisioning Firecracker VM, so N simultaneous `TemplateCreate` calls put N rootfs assemblies and N micro-VMs on a single template-manager host at once, with no backpressure or queue. Under a burst (CI fan-out, batch builds, several teams at once) this oversubscribes host disk, I/O, and RAM.

This PR bounds concurrent builds per host with a weighted semaphore, gated by a feature flag.

Fixes #3070.

## What this does

- **Adds `MaxConcurrentTemplateBuilds`** (`max-concurrent-template-builds`, default **-1**) to `flags.go`, alongside the existing `MaxConcurrent*` family. This closes the one heavy concurrent path that lacked a cap (template builds).
- **Acquires the semaphore inside the detached build goroutine** The handler must stay non-blocking so the API's synchronous gRPC trigger returns immediately while blocking it would surface to the caller as a request timeout. Excess builds **queue** (they already report `Building`, which the API status poll tolerates) instead of over-committing the host.
- **Kill switch:** a non-positive value (`<= 0`, e.g. `-1`) disables the cap entirely (unbounded builds), matching the repo's `-1 = unlimited` convention (`TCPFirewallMaxConnectionsPerSandbox`, `SandboxMaxIncomingConnections`).

## Testing

- Built + `go vet` clean (linux/amd64, CGO).
- Validated on a 2-node staging cluster: with the cap set to **2** and 10 builds fired simultaneously, concurrent builds held at **exactly 2** per node (the rest queued as `Building`); with the kill switch (`-1`) a node ran **3** concurrently, confirming the cap is bypassed. 

## Scope / out of scope

This caps build *concurrency*. It deliberately does **not** change build lifecycle/timeout handling. One consequence worth noting for reviewers: queuing makes a build sit in `Building` longer, which interacts with the API's build-status timeout and the build-cache TTL - a build can be marked failed for queuing too long **That's a pre-existing lifecycle gap that this cap amplifies; it should be tracked separately**


