### PR TITLE
fix(orchestrator): scope rootfs hash to provision default

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -4,13 +4,10 @@ package rootfs
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -40,25 +37,6 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/tem
 //go:embed files
 var files embed.FS
 var fileTemplates = template.Must(template.ParseFS(files, "files/*"))
-
-// filesHash is a stable hash of the embedded rootfs file templates. Folded into
-// the base-layer cache key so a change to any baked unit (e.g. envd.service.tpl)
-// invalidates cached base layers — without it the base hash ignores file content
-// and stale layers keep the old units. Reads on an embed.FS can't fail at runtime
-// (content is baked at compile time), so the errors are safely ignored.
-var filesHash = func() string {
-	entries, _ := fs.ReadDir(files, "files") // sorted by name
-	h := sha256.New()
-	for _, e := range entries {
-		data, _ := files.ReadFile("files/" + e.Name())
-		fmt.Fprintf(h, "%s\x00%x\x00", e.Name(), data)
-	}
-
-	return hex.EncodeToString(h.Sum(nil))
-}()
-
-// FilesHash returns a stable hash over the embedded rootfs file templates.
-func FilesHash() string { return filesHash }
 
 const (
 	BusyBoxPath     = "usr/bin/busybox"

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -41,6 +41,9 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/tem
 var files embed.FS
 var fileTemplates = template.Must(template.ParseFS(files, "files/*"))
 
+// filesHash is a stable hash of the embedded rootfs file templates. It is used
+// only as part of the fallback provision version; explicit provision versions
+// remain the rollout control.
 var filesHash = func() string {
 	entries, _ := fs.ReadDir(files, "files")
 	h := sha256.New()
@@ -52,6 +55,7 @@ var filesHash = func() string {
 	return hex.EncodeToString(h.Sum(nil))
 }()
 
+// FilesHash returns a stable hash over the embedded rootfs file templates.
 func FilesHash() string { return filesHash }
 
 const (

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs.go
@@ -4,10 +4,13 @@ package rootfs
 
 import (
 	"context"
+	"crypto/sha256"
 	"embed"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -37,6 +40,19 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/tem
 //go:embed files
 var files embed.FS
 var fileTemplates = template.Must(template.ParseFS(files, "files/*"))
+
+var filesHash = func() string {
+	entries, _ := fs.ReadDir(files, "files")
+	h := sha256.New()
+	for _, e := range entries {
+		data, _ := files.ReadFile("files/" + e.Name())
+		fmt.Fprintf(h, "%s\x00%x\x00", e.Name(), data)
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}()
+
+func FilesHash() string { return filesHash }
 
 const (
 	BusyBoxPath     = "usr/bin/busybox"

--- a/packages/orchestrator/pkg/template/build/phases/base/hash.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/hash.go
@@ -9,6 +9,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/storage/cache"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
@@ -33,7 +34,7 @@ func (bb *BaseBuilder) Hash(ctx context.Context, _ phases.LayerResult) (string, 
 		baseSource = bb.Config.FromImage
 	}
 
-	provisionVersion := provisionScriptFile
+	provisionVersion := cache.HashKeys(provisionScriptFile, rootfs.FilesHash())
 	if val := bb.featureFlags.IntFlag(
 		ctx,
 		featureflags.BuildProvisionVersion,

--- a/packages/orchestrator/pkg/template/build/phases/base/hash.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/hash.go
@@ -34,6 +34,9 @@ func (bb *BaseBuilder) Hash(ctx context.Context, _ phases.LayerResult) (string, 
 		baseSource = bb.Config.FromImage
 	}
 
+	// For fallback/dev environments, include baked rootfs file contents in the
+	// provision version. In production, BuildProvisionVersion controls rollout
+	// invalidation explicitly.
 	provisionVersion := cache.HashKeys(provisionScriptFile, rootfs.FilesHash())
 	if val := bb.featureFlags.IntFlag(
 		ctx,

--- a/packages/orchestrator/pkg/template/build/phases/base/hash.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/hash.go
@@ -9,7 +9,6 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 
-	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/rootfs"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/storage/cache"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
@@ -57,9 +56,5 @@ func (bb *BaseBuilder) Hash(ctx context.Context, _ phases.LayerResult) (string, 
 		provisionVersion,
 		strconv.FormatInt(bb.Config.DiskSizeMB, 10),
 		baseSource,
-		// Invalidate when a baked rootfs file (e.g. envd.service) changes; the
-		// keys above don't otherwise reflect file content, so stale base layers
-		// would keep old units.
-		rootfs.FilesHash(),
 	), nil
 }


### PR DESCRIPTION
Adjusts the rootfs file hash behavior added in https://github.com/e2b-dev/infra/pull/3043.

The rollout invalidation process should not include the embedded rootfs file hash as an independent base-layer cache-key input. Rollout invalidation is controlled by the provision version instead.

This keeps the embedded rootfs file hash computation, but uses it only as part of the fallback provision version combined with the provision script hash. When the BuildProvisionVersion feature flag is set, that explicit provision version remains the rollout control.