### PR TITLE
fix(orchestrator): order envd.service after systemd-tmpfiles-setup

### DIFF
--- a/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/files/envd.service.tpl
@@ -8,10 +8,15 @@ Description=Env Daemon Service
 # userspace. Default dependencies would gate it on sysinit/basic.target
 # (~0.5s), and the previous After=multi-user.target on chrony-wait (~8s).
 DefaultDependencies=no
-# local-fs.target keeps envd from answering /init before /tmp (a systemd-managed
-# tmpfs) is mounted: updateEnvd stages an update binary in /tmp during early
-# boot, and without this ordering the upload can race tmp.mount and fail ENOENT.
-After=systemd-journald.socket systemd-remount-fs.service local-fs.target
+# Order after /tmp is finalized so envd doesn't answer before it's safe to stage
+# files there: updateEnvd uploads an update binary to /tmp during early boot.
+# On our base images (Ubuntu/Debian) /tmp is a plain rootfs dir, not a tmpfs
+# mount, and systemd-tmpfiles-setup.service runs `systemd-tmpfiles --remove`
+# with a `D /tmp` rule that wipes /tmp's contents at boot. That service is only
+# ordered After=local-fs.target, so gating envd on local-fs.target alone leaves
+# them unordered and the upload races the wipe (chmod/mv then fail ENOENT).
+# Ordering after systemd-tmpfiles-setup.service closes that race.
+After=systemd-journald.socket systemd-remount-fs.service local-fs.target systemd-tmpfiles-setup.service
 Wants=systemd-journald.socket
 Conflicts=shutdown.target
 Before=shutdown.target

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -107,9 +107,10 @@ func TestAdditionalOCILayers(t *testing.T) {
 		// envd can answer the build's upload before the wipe, and the staged
 		// /tmp/envd_updated is deleted, so the follow-up chmod/mv fails with ENOENT.
 		envdAfter := ""
-		for _, line := range strings.Split(actualFiles["etc/systemd/system/envd.service"], "\n") {
+		for line := range strings.SplitSeq(actualFiles["etc/systemd/system/envd.service"], "\n") {
 			if strings.HasPrefix(line, "After=") {
 				envdAfter = line
+
 				break
 			}
 		}

--- a/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
+++ b/packages/orchestrator/pkg/template/build/core/rootfs/rootfs_test.go
@@ -100,6 +100,23 @@ func TestAdditionalOCILayers(t *testing.T) {
 		// verify that systemd is configured to retry envd forever
 		assert.Contains(t, actualFiles["etc/systemd/system/envd.service"], "StartLimitIntervalSec=0")
 
+		// Regression guard: envd must be ordered after systemd-tmpfiles-setup.service.
+		// updateEnvd stages its replacement binary in /tmp during early boot, and on
+		// our Ubuntu/Debian base images systemd-tmpfiles-setup.service wipes /tmp's
+		// contents at boot (`D /tmp` rule run with --remove). Without this ordering
+		// envd can answer the build's upload before the wipe, and the staged
+		// /tmp/envd_updated is deleted, so the follow-up chmod/mv fails with ENOENT.
+		envdAfter := ""
+		for _, line := range strings.Split(actualFiles["etc/systemd/system/envd.service"], "\n") {
+			if strings.HasPrefix(line, "After=") {
+				envdAfter = line
+				break
+			}
+		}
+		require.NotEmpty(t, envdAfter, "envd.service must declare an After= ordering")
+		assert.Contains(t, envdAfter, "systemd-tmpfiles-setup.service",
+			"envd.service After= must order envd after the boot-time /tmp wipe")
+
 		// ensure that both files have identical content
 		disabledContent := strings.TrimSpace(`
 [Service]


### PR DESCRIPTION
## What

Add `systemd-tmpfiles-setup.service` to `envd.service`'s `After=` ordering.

## Why

Template builds hot-update envd via `updateEnvdInSandbox`, which stages the new binary at `/tmp/envd_updated`, then `chmod`/`mv`s it into place. In production this fails with:

```
error building step N: update envd: failed to replace envd binary: exit status 1
[update-envd-replace] [stderr]: chmod: cannot access '/tmp/envd_updated': No such file or directory
[update-envd-replace] [stderr]: mv: cannot stat '/tmp/envd_updated': No such file or directory
```

(and earlier as `error writing file metadata: xattr.list /tmp/envd_updated: no such file or directory`)

### Root cause

On our Ubuntu/Debian base images `/tmp` is **not** a tmpfs mount — it's a plain `1777` directory on the rootfs (`tmp.mount` ships only as a disabled template in `/usr/share/systemd/`, and fstab is unconfigured). At boot, `systemd-tmpfiles-setup.service` runs `systemd-tmpfiles --create --remove --boot`, and `/usr/lib/tmpfiles.d/tmp.conf` contains `D /tmp 1777 root root 30d` — the `D` type with `--remove` **wipes `/tmp`'s contents at boot**.

#3020 made envd start very early (`DefaultDependencies=no`), and #3043 ordered it only `After=local-fs.target`. But `systemd-tmpfiles-setup.service` is *also* `After=local-fs.target`, so the two were **unordered** relative to each other. When envd answered the build's upload before the wipe ran, the staged file was deleted underneath it.

Ordering envd after `systemd-tmpfiles-setup.service` ensures the boot-time `/tmp` wipe has completed before envd answers requests, closing the race. The early-start cold-boot win from `#3020` is preserved (`systemd-tmpfiles-setup.service` runs `Before=sysinit.target`, so the added wait is minimal).

### Deterministic reproducer

```bash
docker run --rm ubuntu:24.04 bash -c '
  export DEBIAN_FRONTEND=noninteractive
  apt-get -qq update >/dev/null 2>&1
  apt-get -qq install -y --no-install-recommends systemd >/dev/null 2>&1
  echo data > /tmp/envd_updated
  systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
  chmod +x /tmp/envd_updated   # -> No such file or directory
  mv -f /tmp/envd_updated /usr/bin/envd
'
```

## Notes

- Changing an embedded rootfs file shifts `rootfs.FilesHash()`, so base layers rebuild and the fix propagates to newly built templates.
- `local-fs.target` is kept in `After=` (still relevant if a base image ever enables a real `tmp.mount`, which is ordered before `local-fs.target`).