### PR TITLE
fix(dashboard-api): set Ory external_id only after the bootstrap commit

### DIFF
--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -691,6 +691,12 @@ func TestBootstrapOIDCUser_ExternalIDFailureKeepsUserProvisioned(t *testing.T) {
 	if _, err := testDB.AuthDB.Read.GetDefaultTeamByUserID(ctx, userIdentity.UserID); err != nil {
 		t.Fatalf("expected default team to survive external_id failure: %v", err)
 	}
+
+	// The billing event must be emitted before the external_id backfill, otherwise
+	// a PATCH failure leaves the committed team billing-orphaned.
+	if len(sink.requests) != 1 {
+		t.Fatalf("expected one billing provisioning call despite external_id failure, got %d", len(sink.requests))
+	}
 }
 
 // A user provisioned by a prior bootstrap whose external_id PATCH failed re-runs

--- a/packages/dashboard-api/internal/handlers/team_handlers_test.go
+++ b/packages/dashboard-api/internal/handlers/team_handlers_test.go
@@ -635,6 +635,122 @@ func TestBootstrapOIDCUser_PopulatesOryExternalID(t *testing.T) {
 	}
 }
 
+// failingUserProfiles fails the Ory external_id PATCH to simulate the IdP being
+// unavailable after the bootstrap transaction has already committed.
+type failingUserProfiles struct {
+	handlerTestUserProfiles
+
+	externalIDCalls int
+}
+
+func (f *failingUserProfiles) SetIdentityExternalID(context.Context, string, uuid.UUID) error {
+	f.externalIDCalls++
+
+	return errors.New("ory unavailable")
+}
+
+// A failed external_id PATCH must not roll back the committed user/identity/team.
+// The PATCH now runs after the transaction commits, so the user stays provisioned
+// and the next login can backfill external_id rather than being stranded.
+func TestBootstrapOIDCUser_ExternalIDFailureKeepsUserProvisioned(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	sink := &fakeTeamProvisionSink{}
+	profiles := &failingUserProfiles{}
+
+	store := &APIStore{
+		config:            cfg.Config{OryIssuerURL: "https://ory.example.test"},
+		db:                testDB.SqlcClient,
+		authDB:            testDB.AuthDB,
+		teamProvisionSink: sink,
+		userProfiles:      profiles,
+	}
+
+	input := oidcUserBootstrapInput{
+		OIDCIssuer:    "https://ory.example.test",
+		OIDCUserID:    uuid.NewString(),
+		OIDCUserEmail: "ada@example.test",
+	}
+
+	if _, err := store.bootstrapOIDCUser(ctx, input); err == nil {
+		t.Fatal("expected bootstrap to fail when external_id patch fails")
+	}
+	if profiles.externalIDCalls != 1 {
+		t.Fatalf("expected one external id attempt, got %d", profiles.externalIDCalls)
+	}
+
+	userIdentity, err := testDB.AuthDB.Read.GetUserIdentity(ctx, authqueries.GetUserIdentityParams{
+		OidcIss: input.OIDCIssuer,
+		OidcSub: input.OIDCUserID,
+	})
+	if err != nil {
+		t.Fatalf("expected user identity to survive external_id failure: %v", err)
+	}
+	if _, err := testDB.AuthDB.Read.GetDefaultTeamByUserID(ctx, userIdentity.UserID); err != nil {
+		t.Fatalf("expected default team to survive external_id failure: %v", err)
+	}
+}
+
+// A user provisioned by a prior bootstrap whose external_id PATCH failed re-runs
+// here on the next login; the existing-team path re-asserts the PATCH and
+// backfills external_id without creating a duplicate team.
+func TestBootstrapOIDCUser_ReRunBackfillsExternalID(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	sink := &fakeTeamProvisionSink{}
+
+	store := &APIStore{
+		config:            cfg.Config{OryIssuerURL: "https://ory.example.test"},
+		db:                testDB.SqlcClient,
+		authDB:            testDB.AuthDB,
+		teamProvisionSink: sink,
+		userProfiles:      &failingUserProfiles{},
+	}
+
+	input := oidcUserBootstrapInput{
+		OIDCIssuer:    "https://ory.example.test",
+		OIDCUserID:    uuid.NewString(),
+		OIDCUserEmail: "ada@example.test",
+	}
+
+	if _, err := store.bootstrapOIDCUser(ctx, input); err == nil {
+		t.Fatal("expected first bootstrap to fail on external_id patch")
+	}
+
+	userIdentity, err := testDB.AuthDB.Read.GetUserIdentity(ctx, authqueries.GetUserIdentityParams{
+		OidcIss: input.OIDCIssuer,
+		OidcSub: input.OIDCUserID,
+	})
+	if err != nil {
+		t.Fatalf("expected user identity from first bootstrap: %v", err)
+	}
+	existingTeam, err := testDB.AuthDB.Read.GetDefaultTeamByUserID(ctx, userIdentity.UserID)
+	if err != nil {
+		t.Fatalf("expected default team from first bootstrap: %v", err)
+	}
+
+	recording := &recordingUserProfiles{}
+	store.userProfiles = recording
+
+	secondTeam, err := store.bootstrapOIDCUser(ctx, input)
+	if err != nil {
+		t.Fatalf("expected re-run bootstrap to succeed: %v", err)
+	}
+	if secondTeam.ID != existingTeam.ID {
+		t.Fatalf("expected re-run to reuse existing team %s, got %s", existingTeam.ID, secondTeam.ID)
+	}
+	if recording.externalIDCalls != 1 {
+		t.Fatalf("expected re-run to backfill external_id once, got %d", recording.externalIDCalls)
+	}
+	if recording.externalID != userIdentity.UserID {
+		t.Fatalf("expected external id %s, got %s", userIdentity.UserID, recording.externalID)
+	}
+}
+
 func TestBootstrapOIDCUser_ConcurrentRequestsSingleIdentityAndTeam(t *testing.T) {
 	t.Parallel()
 

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -163,14 +163,6 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		}
 	}
 
-	// Populate the Ory identity's external_id with the canonical public.users id
-	// now that the user row exists. Runs before any team is created and before
-	// the user lock is taken, so an Ory failure rolls the user/identity back and
-	// no orphan team is left behind.
-	if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
-		return provisionedTeam{}, err
-	}
-
 	// Serialize bootstrap for a user even when they have no team memberships yet.
 	if _, err := authTxDB.LockPublicUserForUpdate(ctx, profile.UserID); err != nil {
 		return provisionedTeam{}, fmt.Errorf("lock public user: %w", err)
@@ -180,6 +172,15 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 	if err == nil {
 		if err := tx.Commit(ctx); err != nil {
 			return provisionedTeam{}, fmt.Errorf("commit existing user bootstrap transaction: %w", err)
+		}
+
+		// Backfill the Ory identity's external_id only after the user/identity/team
+		// are durably committed, so a failed PATCH never outlives a rolled-back
+		// transaction. This is also the recovery path: a user whose external_id was
+		// never set (e.g. a prior bootstrap whose PATCH failed after commit) re-runs
+		// here and the PATCH is re-asserted. setOIDCIdentityExternalID is idempotent.
+		if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
+			return provisionedTeam{}, err
 		}
 
 		if time.Since(existingTeam.CreatedAt) < bootstrapProvisionRetryAge {
@@ -229,6 +230,14 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 
 	if err := tx.Commit(ctx); err != nil {
 		return provisionedTeam{}, fmt.Errorf("commit user bootstrap transaction: %w", err)
+	}
+
+	// Backfill external_id only after the user/identity/team are durably committed.
+	// A PATCH failure here is recoverable: external_id stays unset, the dashboard
+	// re-runs bootstrap on the next login and re-asserts it via the existing-team
+	// path above.
+	if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
+		return provisionedTeam{}, err
 	}
 
 	req := teamprovision.TeamBillingProvisionRequestedV1{

--- a/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
+++ b/packages/dashboard-api/internal/handlers/utils_team_provisioning.go
@@ -174,15 +174,6 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 			return provisionedTeam{}, fmt.Errorf("commit existing user bootstrap transaction: %w", err)
 		}
 
-		// Backfill the Ory identity's external_id only after the user/identity/team
-		// are durably committed, so a failed PATCH never outlives a rolled-back
-		// transaction. This is also the recovery path: a user whose external_id was
-		// never set (e.g. a prior bootstrap whose PATCH failed after commit) re-runs
-		// here and the PATCH is re-asserted. setOIDCIdentityExternalID is idempotent.
-		if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
-			return provisionedTeam{}, err
-		}
-
 		if time.Since(existingTeam.CreatedAt) < bootstrapProvisionRetryAge {
 			req := teamprovision.TeamBillingProvisionRequestedV1{
 				TeamID:         existingTeam.ID,
@@ -193,6 +184,15 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 				Reason:         teamprovision.ReasonDefaultSignupTeam,
 			}
 			_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
+		}
+
+		// Backfill the Ory identity's external_id only after the user/identity/team
+		// are durably committed, so a failed PATCH never outlives a rolled-back
+		// transaction. This is also the recovery path: a user whose external_id was
+		// never set (e.g. a prior bootstrap whose PATCH failed after commit) re-runs
+		// here and the PATCH is re-asserted. setOIDCIdentityExternalID is idempotent.
+		if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
+			return provisionedTeam{}, err
 		}
 
 		return provisionedTeam{
@@ -232,14 +232,11 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		return provisionedTeam{}, fmt.Errorf("commit user bootstrap transaction: %w", err)
 	}
 
-	// Backfill external_id only after the user/identity/team are durably committed.
-	// A PATCH failure here is recoverable: external_id stays unset, the dashboard
-	// re-runs bootstrap on the next login and re-asserts it via the existing-team
-	// path above.
-	if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
-		return provisionedTeam{}, err
-	}
-
+	// Emit the billing event before the external_id backfill: ProvisionTeam is
+	// fire-and-forget, but setOIDCIdentityExternalID returns early on failure, and
+	// the existing-team recovery path only re-fires ProvisionTeam within
+	// bootstrapProvisionRetryAge of team creation. Provisioning first guarantees the
+	// freshly committed team is never left billing-orphaned by an Ory PATCH failure.
 	req := teamprovision.TeamBillingProvisionRequestedV1{
 		TeamID:         team.ID,
 		TeamName:       team.Name,
@@ -249,6 +246,14 @@ func (s *APIStore) bootstrapUserWithIdentity(ctx context.Context, profile bootst
 		Reason:         teamprovision.ReasonDefaultSignupTeam,
 	}
 	_ = s.teamProvisionSink.ProvisionTeam(ctx, req)
+
+	// Backfill external_id only after the user/identity/team are durably committed.
+	// A PATCH failure here is recoverable: external_id stays unset, the dashboard
+	// re-runs bootstrap on the next login and re-asserts it via the existing-team
+	// path above.
+	if err := s.setOIDCIdentityExternalID(ctx, identity, profile.UserID); err != nil {
+		return provisionedTeam{}, err
+	}
 
 	return provisionedTeam{
 		ID:            team.ID,


### PR DESCRIPTION
## Summary

If the commit (or any step after the PATCH) fails, the DB rolls back but **Ory keeps `external_id`**. The dashboard treats a present `external_id` as "fully provisioned", so the affected user ends up with a valid-looking Ory session and **no e2b user or team** — permanently, since re-login never re-runs bootstrap.

## Fix

Move `setOIDCIdentityExternalID` to run **after** `tx.Commit()`, in **both** return paths of `bootstrapUserWithIdentity`:

- **New-team path** — PATCH only once the user/identity/team are durably committed.
- **Existing-team path** — PATCH here too, because this is the **recovery path**: a user whose PATCH failed on a prior bootstrap re-enters here and the (idempotent) PATCH is re-asserted.

The PATCH uses RFC 6902 `add`, so re-assertion is a safe no-op-equivalent and never creates a duplicate team.