### PR TITLE
fix(docker-reverse-proxy): fix response body handling in proxy and token acquisition

### DIFF
--- a/packages/docker-reverse-proxy/internal/handlers/store.go
+++ b/packages/docker-reverse-proxy/internal/handlers/store.go
@@ -49,12 +49,16 @@ func NewStore(ctx context.Context) *APIStore {
 	// Custom ModifyResponse function
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == http.StatusUnauthorized {
-			respBody, _ := io.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 			resp.Body.Close()
+			if err != nil {
+				return err
+			}
 			log.Printf("Unauthorized request:[%s] %s\n", resp.Request.Method, respBody)
 			// Restore the body so the reverse proxy can forward it to the client.
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			resp.ContentLength = int64(len(respBody))
+			resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(respBody)))
 		}
 
 		return nil

--- a/packages/docker-reverse-proxy/internal/handlers/store.go
+++ b/packages/docker-reverse-proxy/internal/handlers/store.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -49,10 +50,13 @@ func NewStore(ctx context.Context) *APIStore {
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == http.StatusUnauthorized {
 			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
 			log.Printf("Unauthorized request:[%s] %s\n", resp.Request.Method, respBody)
+			// Restore the body so the reverse proxy can forward it to the client.
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			resp.ContentLength = int64(len(respBody))
 		}
 
-		// You can also modify the response here if needed
 		return nil
 	}
 

--- a/packages/docker-reverse-proxy/internal/handlers/token.go
+++ b/packages/docker-reverse-proxy/internal/handlers/token.go
@@ -139,12 +139,10 @@ func getToken(ctx context.Context, templateID string) (*DockerToken, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body := make([]byte, resp.ContentLength)
-		_, err := resp.Body.Read(body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read body for failed token acquisition (%d) for scope - %s: %w", resp.StatusCode, templateID, err)
 		}
-		defer resp.Body.Close()
 
 		return nil, fmt.Errorf("failed to get token (%d) for scope - %s: %s", resp.StatusCode, templateID, string(body))
 	}


### PR DESCRIPTION
/cc @jakubno @dobrac  @ValentaTomas Would appreciate your review on this change, thanks!

Fix two response body handling issues in the docker-reverse-proxy package.

### 1. `ModifyResponse` consumes response body without restoring it (`store.go`)

The `ModifyResponse` callback reads the entire response body via `io.ReadAll` on
401 Unauthorized responses for logging purposes, but never restores it. Since
`httputil.ReverseProxy` forwards `resp.Body` to the client *after*
`ModifyResponse` returns, the client receives an **empty 401 response body**
with no error details.

**Fix:** Close the consumed body, restore it with `io.NopCloser(bytes.NewReader(...))`,
and update `ContentLength` so the proxy writes the correct `Content-Length` header.

### 2. Potential panic + duplicate defer in `getToken` (`token.go`)

```go
body := make([]byte, resp.ContentLength)  // panics if ContentLength == -1

