### PR TITLE
fix: handle `InvalidObjectState` error for archived S3 objects

### DIFF
--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -255,6 +255,12 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 			return nil, status.Errorf(codes.FailedPrecondition, "sandbox files for '%s' not found", req.GetSandbox().GetSandboxId())
 		}
 
+		if errors.Is(err, storage.ErrObjectArchived) {
+			telemetry.ReportError(ctx, "sandbox files archived", err, telemetry.WithSandboxID(req.GetSandbox().GetSandboxId()))
+
+			return nil, status.Errorf(codes.FailedPrecondition, "sandbox files for '%s' are archived and not directly accessible, please rebuild the template", req.GetSandbox().GetSandboxId())
+		}
+
 		err = errors.Join(err, context.Cause(ctx))
 		telemetry.ReportCriticalError(ctx, "failed to create sandbox", err)
 		logger.L().Error(ctx, "failed to create sandbox", zap.Error(err),

--- a/packages/shared/pkg/storage/metrics.go
+++ b/packages/shared/pkg/storage/metrics.go
@@ -38,6 +38,9 @@ const (
 	OutcomeErrIO        = "err_io"
 	OutcomeErrTimeout   = "err_timeout"
 	OutcomeTransitioned = "transitioned"
+	// OutcomeArchived means the object exists but is in an archived storage
+	// class that does not allow direct reads.
+	OutcomeArchived = "archived"
 	// OutcomeContended is a writeback skipped because another goroutine held the
 	// NFS chunk lock — normal cache dedup, nothing written.
 	OutcomeContended = "contended"
@@ -80,6 +83,8 @@ func Outcome(err error) string {
 		return OutcomeOK
 	case errors.Is(err, ErrObjectNotExist), errors.Is(err, fs.ErrNotExist):
 		return OutcomeNotFound
+	case errors.Is(err, ErrObjectArchived):
+		return OutcomeArchived
 	case errors.Is(err, context.Canceled):
 		return OutcomeErrCanceled
 	case errors.Is(err, context.DeadlineExceeded):

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -24,6 +24,11 @@ var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/shared/pkg/storage")
 
 var ErrObjectNotExist = errors.New("object does not exist")
 
+// ErrObjectArchived means the object exists but is stored in an archived
+// storage class (e.g. GLACIER, ARCHIVE, COLD_ARCHIVE) that does not allow
+// direct reads. The object must be restored or rebuilt before it can be used.
+var ErrObjectArchived = errors.New("object is archived and not accessible")
+
 // ErrObjectRateLimited means per-object mutation rate limiting —
 // multiple concurrent writers racing to write the same content-addressed object.
 var ErrObjectRateLimited = errors.New("object access rate limited")

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -168,6 +168,11 @@ func (o *awsObject) WriteTo(ctx context.Context, dst io.Writer) (n int64, err er
 			return 0, ErrObjectNotExist
 		}
 
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
+		}
+
 		return 0, err
 	}
 
@@ -277,6 +282,11 @@ func (o *awsObject) OpenRangeReader(ctx context.Context, off, length int64, fram
 			return nil, SourceAWS, ErrObjectNotExist
 		}
 
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return nil, SourceAWS, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
+		}
+
 		return nil, SourceAWS, fmt.Errorf("failed to create S3 range reader for %q: %w", o.path, err)
 	}
 
@@ -297,6 +307,11 @@ func (o *awsObject) Size(ctx context.Context) (_ int64, err error) {
 		var nfd *types.NotFound
 		if errors.As(err, &nsk) || errors.As(err, &nfd) {
 			return 0, ErrObjectNotExist
+		}
+
+		var ios *types.InvalidObjectState
+		if errors.As(err, &ios) {
+			return 0, fmt.Errorf("object %q is in storage class that does not allow direct reads: %w", o.path, ErrObjectArchived)
 		}
 
 		return 0, err


### PR DESCRIPTION
## Summary

When objects are transitioned to archived storage classes (e.g. `GLACIER`, `ARCHIVE_FR`, `COLD_ARCHIVE`) via lifecycle rules, S3-compatible backends return an `InvalidObjectState` error on `GetObject`/`HeadObject` instead of the usual `NoSuchKey`. Previously this was unhandled, causing sandbox creation to fail with a generic "Internal" gRPC error.

## Changes

### `packages/shared/pkg/storage/storage.go`
- Added `ErrObjectArchived` sentinel error for archived/inaccessible objects

### `packages/shared/pkg/storage/storage_aws.go`
- `WriteTo()`: handle `types.InvalidObjectState` → `ErrObjectArchived`
- `OpenRangeReader()`: handle `types.InvalidObjectState` → `ErrObjectArchived`
- `Size()`: handle `types.InvalidObjectState` → `ErrObjectArchived`

### `packages/shared/pkg/storage/metrics.go`
- Added `OutcomeArchived` constant for metrics tracking
- `Outcome()` function now maps `ErrObjectArchived` to the `"archived"` outcome

### `packages/orchestrator/pkg/server/sandboxes.go`
- `Create()`: check for `ErrObjectArchived` and return `FailedPrecondition` with a clear message telling users to rebuild the template

## Testing

- Verified compilation of both `shared/pkg/storage` and `orchestrator/pkg/server` packages
- The `InvalidObjectState` error type is part of the AWS SDK v2 (`github.com/aws/aws-sdk-go-v2/service/s3/types`) and is returned when attempting to read objects in `GLACIER`, `ARCHIVE`, or similar storage classes

Closes #3137