### PR TITLE
fix(envd): use constant-time comparison for signature validation

### DIFF
--- a/packages/envd/internal/api/auth.go
+++ b/packages/envd/internal/api/auth.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net/http"
@@ -113,7 +114,8 @@ func (a *API) validateSigning(r *http.Request, signature *string, signatureExpir
 	}
 
 	// signature validation
-	if expectedSignature != *signature {
+	// Use constant-time comparison to prevent timing attacks.
+	if subtle.ConstantTimeCompare([]byte(expectedSignature), []byte(*signature)) != 1 {
 		return errors.New("invalid signature")
 	}
 

--- a/packages/envd/internal/api/auth_test.go
+++ b/packages/envd/internal/api/auth_test.go
@@ -21,6 +21,7 @@ func newAuthTestAPI(t *testing.T, token string) *API {
 	err := secureToken.Set([]byte(token))
 	require.NoError(t, err)
 	logger := zerolog.Nop()
+
 	return &API{accessToken: secureToken, logger: &logger}
 }
 
@@ -74,13 +75,13 @@ func TestValidateSigningAcceptsCorrectSignature(t *testing.T) {
 	path := "/files"
 	username := "user1"
 	operation := SigningWriteOperation
-	exp := int64(time.Now().Add(time.Hour).Unix())
+	exp := time.Now().Add(time.Hour).Unix()
 
 	sig, err := api.generateSignature(path, username, operation, &exp)
 	require.NoError(t, err)
 
 	expInt := int(exp)
-	r := httptest.NewRequest(http.MethodPost, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/files", nil)
 	err = api.validateSigning(r, &sig, &expInt, &username, path, operation)
 	assert.NoError(t, err)
 }
@@ -93,7 +94,7 @@ func TestValidateSigningRejectsWrongSignature(t *testing.T) {
 	exp := int(time.Now().Add(time.Hour).Unix())
 	username := "user1"
 
-	r := httptest.NewRequest(http.MethodPost, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/files", nil)
 	err := api.validateSigning(r, &wrong, &exp, &username, "/files", SigningWriteOperation)
 	assert.EqualError(t, err, "invalid signature")
 }
@@ -106,13 +107,13 @@ func TestValidateSigningRejectsExpiredSignature(t *testing.T) {
 	username := "user1"
 	operation := SigningReadOperation
 	// Expired 1 hour ago
-	exp := int64(time.Now().Add(-time.Hour).Unix())
+	exp := time.Now().Add(-time.Hour).Unix()
 
 	sig, err := api.generateSignature(path, username, operation, &exp)
 	require.NoError(t, err)
 
 	expInt := int(exp)
-	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files", nil)
 	err = api.validateSigning(r, &sig, &expInt, &username, path, operation)
 	assert.EqualError(t, err, "signature is already expired")
 }
@@ -121,7 +122,7 @@ func TestValidateSigningRejectsMissingSignature(t *testing.T) {
 	t.Parallel()
 	api := newAuthTestAPI(t, "test-token")
 
-	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files", nil)
 	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
 	assert.EqualError(t, err, "missing signature query parameter")
 }
@@ -130,7 +131,7 @@ func TestValidateSigningAcceptsValidAccessTokenHeader(t *testing.T) {
 	t.Parallel()
 	api := newAuthTestAPI(t, "test-token")
 
-	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files", nil)
 	r.Header.Set(accessTokenHeader, "test-token")
 	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
 	assert.NoError(t, err)
@@ -140,7 +141,7 @@ func TestValidateSigningRejectsInvalidAccessTokenHeader(t *testing.T) {
 	t.Parallel()
 	api := newAuthTestAPI(t, "test-token")
 
-	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/files", nil)
 	r.Header.Set(accessTokenHeader, "wrong-token")
 	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
 	assert.EqualError(t, err, "access token present in header but does not match")

--- a/packages/envd/internal/api/auth_test.go
+++ b/packages/envd/internal/api/auth_test.go
@@ -2,23 +2,32 @@ package api
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/keys"
 )
 
+func newAuthTestAPI(t *testing.T, token string) *API {
+	t.Helper()
+	secureToken := &SecureToken{}
+	err := secureToken.Set([]byte(token))
+	require.NoError(t, err)
+	logger := zerolog.Nop()
+	return &API{accessToken: secureToken, logger: &logger}
+}
+
 func TestKeyGenerationAlgorithmIsStable(t *testing.T) {
 	t.Parallel()
 	apiToken := "secret-access-token"
-	secureToken := &SecureToken{}
-	err := secureToken.Set([]byte(apiToken))
-	require.NoError(t, err)
-	api := &API{accessToken: secureToken}
+	api := newAuthTestAPI(t, apiToken)
 
 	path := "/path/to/demo.txt"
 	username := "root"
@@ -40,10 +49,7 @@ func TestKeyGenerationAlgorithmIsStable(t *testing.T) {
 func TestKeyGenerationAlgorithmWithoutExpirationIsStable(t *testing.T) {
 	t.Parallel()
 	apiToken := "secret-access-token"
-	secureToken := &SecureToken{}
-	err := secureToken.Set([]byte(apiToken))
-	require.NoError(t, err)
-	api := &API{accessToken: secureToken}
+	api := newAuthTestAPI(t, apiToken)
 
 	path := "/path/to/resource.txt"
 	username := "user"
@@ -59,4 +65,83 @@ func TestKeyGenerationAlgorithmWithoutExpirationIsStable(t *testing.T) {
 	localSignature := fmt.Sprintf("v1_%s", hasher.HashWithoutPrefix([]byte(localSignatureTmp)))
 
 	assert.Equal(t, localSignature, signature)
+}
+
+func TestValidateSigningAcceptsCorrectSignature(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	path := "/files"
+	username := "user1"
+	operation := SigningWriteOperation
+	exp := int64(time.Now().Add(time.Hour).Unix())
+
+	sig, err := api.generateSignature(path, username, operation, &exp)
+	require.NoError(t, err)
+
+	expInt := int(exp)
+	r := httptest.NewRequest(http.MethodPost, "/files", nil)
+	err = api.validateSigning(r, &sig, &expInt, &username, path, operation)
+	assert.NoError(t, err)
+}
+
+func TestValidateSigningRejectsWrongSignature(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	wrong := "v1_wrong_signature"
+	exp := int(time.Now().Add(time.Hour).Unix())
+	username := "user1"
+
+	r := httptest.NewRequest(http.MethodPost, "/files", nil)
+	err := api.validateSigning(r, &wrong, &exp, &username, "/files", SigningWriteOperation)
+	assert.EqualError(t, err, "invalid signature")
+}
+
+func TestValidateSigningRejectsExpiredSignature(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	path := "/files"
+	username := "user1"
+	operation := SigningReadOperation
+	// Expired 1 hour ago
+	exp := int64(time.Now().Add(-time.Hour).Unix())
+
+	sig, err := api.generateSignature(path, username, operation, &exp)
+	require.NoError(t, err)
+
+	expInt := int(exp)
+	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	err = api.validateSigning(r, &sig, &expInt, &username, path, operation)
+	assert.EqualError(t, err, "signature is already expired")
+}
+
+func TestValidateSigningRejectsMissingSignature(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
+	assert.EqualError(t, err, "missing signature query parameter")
+}
+
+func TestValidateSigningAcceptsValidAccessTokenHeader(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r.Header.Set(accessTokenHeader, "test-token")
+	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
+	assert.NoError(t, err)
+}
+
+func TestValidateSigningRejectsInvalidAccessTokenHeader(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "test-token")
+
+	r := httptest.NewRequest(http.MethodGet, "/files", nil)
+	r.Header.Set(accessTokenHeader, "wrong-token")
+	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
+	assert.EqualError(t, err, "access token present in header but does not match")
 }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.8"
+const Version = "0.6.9"


### PR DESCRIPTION
Replace string inequality operator (!=) with crypto/subtle.ConstantTimeCompare for signature validation in auth.go. The previous implementation was vulnerable to timing attacks, where an attacker could potentially determine the correct signature byte-by-byte by measuring response times.

This is a standard security best practice for comparing cryptographic values such as HMAC signatures, tokens, and hashes.

/cc @jakubno @dobrac @ValentaTomas Would appreciate your review on this change, thanks!