### PR TITLE
fix(orchestrator): prevent nil panic when finding default gateway

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/host.go
+++ b/packages/orchestrator/pkg/sandbox/network/host.go
@@ -39,8 +39,8 @@ func getDefaultGateway(ctx context.Context) (string, error) {
 	}
 
 	for _, route := range routes {
-		// 0.0.0.0/0
-		if route.Dst.String() == "0.0.0.0/0" && route.Gw != nil {
+		// Default route has a nil Dst (representing 0.0.0.0/0).
+		if route.Dst == nil && route.Gw != nil {
 			logger.L().Info(ctx, "default gateway", zap.String("gateway", route.Gw.String()))
 
 			link, linkErr := netlink.LinkByIndex(route.LinkIndex)


### PR DESCRIPTION
In Linux, the default route (0.0.0.0/0) has a nil Dst field in the netlink.Route struct. The previous code called route.Dst.String() without a nil check, which would panic on systems where the default route's Dst is nil.

Fix by checking route.Dst == nil directly, which is the canonical way to identify the default route.

/cc @jakubno @dobrac @ValentaTomas Would appreciate your review on this change, thanks!