### PR TITLE
fix: propagate Docker image ENV vars to runtime sandbox processes

### DIFF
--- a/packages/orchestrator/pkg/sandbox/reboot.go
+++ b/packages/orchestrator/pkg/sandbox/reboot.go
@@ -80,6 +80,19 @@ func (f *Factory) RebootSandbox(
 		config.Envd.DefaultWorkdir = meta.Context.WorkDir
 	}
 
+	// A cold boot also needs Docker image ENV vars from the template metadata.
+	// User-provided env vars take precedence over template defaults.
+	if len(meta.Context.EnvVars) > 0 {
+		merged := make(map[string]string, len(meta.Context.EnvVars)+len(config.Envd.Vars))
+		for k, v := range meta.Context.EnvVars {
+			merged[k] = v
+		}
+		for k, v := range config.Envd.Vars {
+			merged[k] = v
+		}
+		config.Envd.Vars = merged
+	}
+
 	// The masked empty memfile is used only for sizing NoopMemory — guest RAM
 	// is FC's own fresh anonymous memory.
 	pageSize := int64(header.PageSize)

--- a/packages/orchestrator/pkg/server/env_vars_test.go
+++ b/packages/orchestrator/pkg/server/env_vars_test.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package server
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mergeTemplateEnvVars mirrors the inline merge logic in Create() and
+// RebootSandbox(): template (Docker image) env vars form the base layer,
+// user-provided env vars override on top.
+func mergeTemplateEnvVars(templateEnvVars, userEnvVars map[string]string) map[string]string {
+	if len(templateEnvVars) == 0 {
+		return userEnvVars
+	}
+
+	merged := maps.Clone(templateEnvVars)
+	maps.Copy(merged, userEnvVars)
+
+	return merged
+}
+
+func TestMergeTemplateEnvVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		templateEnv map[string]string
+		userEnv     map[string]string
+		want        map[string]string
+	}{
+		{
+			name:        "no template env, no user env",
+			templateEnv: nil,
+			userEnv:     nil,
+			want:        nil,
+		},
+		{
+			name:        "no template env, user env only",
+			templateEnv: nil,
+			userEnv:     map[string]string{"USER_KEY": "user_val"},
+			want:        map[string]string{"USER_KEY": "user_val"},
+		},
+		{
+			name:        "template env only, no user env",
+			templateEnv: map[string]string{"PYTHONPATH": "/app/lib", "MY_CONFIG": "/etc/config"},
+			userEnv:     nil,
+			want:        map[string]string{"PYTHONPATH": "/app/lib", "MY_CONFIG": "/etc/config"},
+		},
+		{
+			name:        "disjoint keys are merged",
+			templateEnv: map[string]string{"PYTHONPATH": "/app/lib"},
+			userEnv:     map[string]string{"API_KEY": "secret"},
+			want:        map[string]string{"PYTHONPATH": "/app/lib", "API_KEY": "secret"},
+		},
+		{
+			name:        "user env overrides template env on conflict",
+			templateEnv: map[string]string{"PYTHONPATH": "/app/lib", "LOG_LEVEL": "info"},
+			userEnv:     map[string]string{"LOG_LEVEL": "debug", "NEW_VAR": "value"},
+			want:        map[string]string{"PYTHONPATH": "/app/lib", "LOG_LEVEL": "debug", "NEW_VAR": "value"},
+		},
+		{
+			name:        "user env completely overrides all template keys",
+			templateEnv: map[string]string{"A": "1", "B": "2"},
+			userEnv:     map[string]string{"A": "x", "B": "y"},
+			want:        map[string]string{"A": "x", "B": "y"},
+		},
+		{
+			name:        "empty template env map treated as no template env",
+			templateEnv: map[string]string{},
+			userEnv:     map[string]string{"KEY": "val"},
+			want:        map[string]string{"KEY": "val"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mergeTemplateEnvVars(tt.templateEnv, tt.userEnv)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestMergeTemplateEnvVars_DoesNotMutateInputs(t *testing.T) {
+	t.Parallel()
+
+	templateEnv := map[string]string{"A": "1", "B": "2"}
+	userEnv := map[string]string{"B": "override", "C": "3"}
+
+	templateCopy := maps.Clone(templateEnv)
+	userCopy := maps.Clone(userEnv)
+
+	_ = mergeTemplateEnvVars(templateEnv, userEnv)
+
+	assert.Equal(t, templateCopy, templateEnv, "template env should not be mutated")
+	assert.Equal(t, userCopy, userEnv, "user env should not be mutated")
+}

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -226,6 +226,14 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 		return nil, fmt.Errorf("failed to read template metadata: %w", err)
 	}
 
+	// Merge Docker image ENV vars from the template metadata into the sandbox
+	// config. User-provided env vars (from the SDK create call) take precedence.
+	if len(meta.Context.EnvVars) > 0 {
+		merged := maps.Clone(meta.Context.EnvVars)
+		maps.Copy(merged, config.Envd.Vars)
+		config.Envd.Vars = merged
+	}
+
 	var sbx *sandbox.Sandbox
 	if meta.IsFilesystemOnly() {
 		sbx, err = s.sandboxFactory.RebootSandbox(


### PR DESCRIPTION
When creating a sandbox, merge the template metadata's Context.EnvVars (which contains Docker image ENV directives) into the sandbox config's Envd.Vars before sending them to envd via POST /init.

User-provided env vars from the SDK create() call take precedence over template defaults. Per-command env vars from process.start() still override both.

This fixes both the standard resume path and the filesystem-only cold boot (reboot) path, where DefaultUser and DefaultWorkdir were already restored from template metadata but EnvVars was not.

Closes #2268

/cc @jakubno @dobrac @ValentaTomas Would appreciate your review on this change, thanks!