### PR TITLE
Parse multiple SDK user agents in builder check

### DIFF
--- a/packages/api/internal/handlers/template_start_build_v2.go
+++ b/packages/api/internal/handlers/template_start_build_v2.go
@@ -208,32 +208,38 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 func userAgentToTemplateVersion(ctx context.Context, logger logger.Logger, userAgent string) (string, error) {
 	version := templates.TemplateV2LatestVersion
 
-	switch {
-	case strings.HasPrefix(userAgent, jsSDKPrefix):
-		sdk := strings.TrimPrefix(userAgent, jsSDKPrefix)
+	for _, agent := range strings.Fields(userAgent) {
+		switch {
+		case strings.HasPrefix(agent, jsSDKPrefix):
+			sdk := strings.TrimPrefix(agent, jsSDKPrefix)
 
-		// Check if the SDK version supports the latest template version
-		ok, err := utils.IsGTEVersion(sdk, templates.SDKTemplateReleaseVersion)
-		if err != nil {
-			return "", fmt.Errorf("parsing JS SDK version: %w", err)
-		}
-		if !ok {
-			version = templates.TemplateV2BetaVersion
-		}
-	case strings.HasPrefix(userAgent, pythonSDKPrefix):
-		sdk := strings.TrimPrefix(userAgent, pythonSDKPrefix)
+			// Check if the SDK version supports the latest template version
+			ok, err := utils.IsGTEVersion(sdk, templates.SDKTemplateReleaseVersion)
+			if err != nil {
+				return "", fmt.Errorf("parsing JS SDK version: %w", err)
+			}
+			if !ok {
+				version = templates.TemplateV2BetaVersion
+			}
 
-		// Check if the SDK version supports the latest template version
-		ok, err := utils.IsGTEVersion(sdk, templates.SDKTemplateReleaseVersion)
-		if err != nil {
-			return "", fmt.Errorf("parsing Python SDK version: %w", err)
+			return version, nil
+		case strings.HasPrefix(agent, pythonSDKPrefix):
+			sdk := strings.TrimPrefix(agent, pythonSDKPrefix)
+
+			// Check if the SDK version supports the latest template version
+			ok, err := utils.IsGTEVersion(sdk, templates.SDKTemplateReleaseVersion)
+			if err != nil {
+				return "", fmt.Errorf("parsing Python SDK version: %w", err)
+			}
+			if !ok {
+				version = templates.TemplateV2BetaVersion
+			}
+
+			return version, nil
 		}
-		if !ok {
-			version = templates.TemplateV2BetaVersion
-		}
-	default:
-		logger.Debug(ctx, "Unrecognized user agent, defaulting to the latest template version", zap.String("user_agent", userAgent), zap.String("version", version))
 	}
+
+	logger.Debug(ctx, "Unrecognized user agent, defaulting to the latest template version", zap.String("user_agent", userAgent), zap.String("version", version))
 
 	return version, nil
 }

--- a/packages/api/internal/handlers/template_start_build_v2.go
+++ b/packages/api/internal/handlers/template_start_build_v2.go
@@ -208,7 +208,7 @@ func (a *APIStore) PostV2TemplatesTemplateIDBuildsBuildID(c *gin.Context, templa
 func userAgentToTemplateVersion(ctx context.Context, logger logger.Logger, userAgent string) (string, error) {
 	version := templates.TemplateV2LatestVersion
 
-	for _, agent := range strings.Fields(userAgent) {
+	for agent := range strings.FieldsSeq(userAgent) {
 		switch {
 		case strings.HasPrefix(agent, jsSDKPrefix):
 			sdk := strings.TrimPrefix(agent, jsSDKPrefix)

--- a/packages/api/internal/handlers/template_start_build_v2_test.go
+++ b/packages/api/internal/handlers/template_start_build_v2_test.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/templates"
+)
+
+func TestUserAgentToTemplateVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		userAgent string
+		want      string
+	}{
+		{
+			name:      "current JS SDK",
+			userAgent: "e2b-js-sdk/2.31.0",
+			want:      templates.TemplateV2LatestVersion,
+		},
+		{
+			name:      "current JS SDK with CLI integration",
+			userAgent: "e2b-js-sdk/v2.31.0 e2b-cli/2.13.0",
+			want:      templates.TemplateV2LatestVersion,
+		},
+		{
+			name:      "old JS SDK with CLI integration",
+			userAgent: "e2b-js-sdk/2.2.0 e2b-cli/2.13.0",
+			want:      templates.TemplateV2BetaVersion,
+		},
+		{
+			name:      "current Python SDK with integration",
+			userAgent: "e2b-python-sdk/2.31.0 custom-client/1.0.0",
+			want:      templates.TemplateV2LatestVersion,
+		},
+		{
+			name:      "unrecognized user agent",
+			userAgent: "custom-client/1.0.0",
+			want:      templates.TemplateV2LatestVersion,
+		},
+		{
+			name:      "empty user agent",
+			userAgent: "",
+			want:      templates.TemplateV2LatestVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := userAgentToTemplateVersion(context.Background(), logger.L(), tt.userAgent)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
template builder checks the sdk version to decide whtehr to use the beta builder or ga builder. crashes on multiple user agents so this splits it up.

makes a loop to check each of the user agents for compatibility with template v2; the first agent _should_ be the right one, but if it isn't ordered right for some reason will still check the rest