### PR TITLE
fix: align client-proxy HEALTH_PORT default to 3001

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -157,5 +157,5 @@ runs:
         STARTUP_TIMEOUT=60 ./scripts/start-service.sh "API" packages/api run ~/logs/api.log http://localhost:3000/health
 
         # Start client-proxy (needed for auto-resume tests)
-        ./scripts/start-service.sh "ClientProxy" packages/client-proxy run ~/logs/client-proxy.log http://localhost:3003
+        ./scripts/start-service.sh "ClientProxy" packages/client-proxy run ~/logs/client-proxy.log http://localhost:3001
       shell: bash

--- a/DEV-LOCAL.md
+++ b/DEV-LOCAL.md
@@ -128,7 +128,7 @@ These commands launch each service in the foreground. You need multiple terminal
    ```bash
    make -C packages/client-proxy run-local
    ```
-   Verify: `curl -s http://localhost:3003/health` returns a response.
+   Verify: `curl -s http://localhost:3001/health` returns a response.
 
 ## Build the base template
 

--- a/packages/client-proxy/internal/cfg/model.go
+++ b/packages/client-proxy/internal/cfg/model.go
@@ -3,7 +3,7 @@ package cfg
 import "github.com/caarlos0/env/v11"
 
 type Config struct {
-	HealthPort uint16 `env:"HEALTH_PORT" envDefault:"3003"`
+	HealthPort uint16 `env:"HEALTH_PORT" envDefault:"3001"`
 	ProxyPort  uint16 `env:"PROXY_PORT"  envDefault:"3002"`
 
 	RedisURL         string `env:"REDIS_URL"`

--- a/packages/client-proxy/internal/cfg/model_test.go
+++ b/packages/client-proxy/internal/cfg/model_test.go
@@ -21,7 +21,7 @@ func TestParse_Defaults(t *testing.T) {
 
 	cfg, err := Parse()
 	require.NoError(t, err)
-	require.EqualValues(t, 3003, cfg.HealthPort)
+	require.EqualValues(t, 3001, cfg.HealthPort)
 	require.EqualValues(t, 3002, cfg.ProxyPort)
 	require.Equal(t, 40, cfg.RedisPoolSize)
 	require.Empty(t, cfg.RedisURL)


### PR DESCRIPTION
## Summary

Fixes https://github.com/e2b-dev/infra/issues/3052

The binary default for `HEALTH_PORT` in `packages/client-proxy/internal/cfg/model.go` was `3003`, while the Nomad IaC module (`iac/modules/job-client-proxy/variables.tf`) and GCP provider (`iac/provider-gcp/variables.tf`) both default to `3001`.

In Nomad deployments, `HEALTH_PORT` is set from `NOMAD_PORT_health` so the mismatch is masked. However, self-hosted or standalone deployments using the binary default would listen on the wrong port, causing health checks to fail.

## Changes

- `packages/client-proxy/internal/cfg/model.go`: Changed `envDefault:"3003"` → `envDefault:"3001"`

## Verification

| Source | Before | After |
|--------|--------|-------|
| Go binary default | `3003` | `3001` ✅ |
| `job-client-proxy/variables.tf` | `3001` | `3001` ✅ |
| `provider-gcp/variables.tf` | `3001` | `3001` ✅ |

One-line change, no behavior change for Nomad deployments (env var overrides the default).


/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.