### PR TITLE
fix: clarify EndEvent.error semantics for normal non-zero exits in envd process handler

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -455,8 +455,17 @@ func (p *Handler) Wait() {
 	var errMsg *string
 
 	if err != nil {
-		msg := err.Error()
-		errMsg = &msg
+		// Distinguish normal non-zero exits from runtime/infrastructure errors.
+		// exec.Cmd.Wait() returns *exec.ExitError for processes that started
+		// successfully but exited with a non-zero status. These are normal
+		// process results represented by exit_code/exited/status fields.
+		// Only populate the error field for actual runtime failures
+		// (e.g., failure to wait for the process).
+		var exitErr *exec.ExitError
+		if !(errors.As(err, &exitErr) && p.cmd.ProcessState != nil && p.cmd.ProcessState.Exited()) {
+			msg := err.Error()
+			errMsg = &msg
+		}
 	}
 
 	endEvent := &rpc.ProcessEvent_EndEvent{

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -455,14 +455,15 @@ func (p *Handler) Wait() {
 	var errMsg *string
 
 	if err != nil {
-		// Distinguish normal non-zero exits from runtime/infrastructure errors.
+		// Distinguish process-level exits from runtime/infrastructure errors.
 		// exec.Cmd.Wait() returns *exec.ExitError for processes that started
-		// successfully but exited with a non-zero status. These are normal
-		// process results represented by exit_code/exited/status fields.
+		// successfully but exited with a non-zero status or were killed by a
+		// signal. These are normal process results represented by exit_code,
+		// exited, and status fields.
 		// Only populate the error field for actual runtime failures
 		// (e.g., failure to wait for the process).
 		var exitErr *exec.ExitError
-		if !(errors.As(err, &exitErr) && p.cmd.ProcessState != nil && p.cmd.ProcessState.Exited()) {
+		if !(errors.As(err, &exitErr) && p.cmd.ProcessState != nil) {
 			msg := err.Error()
 			errMsg = &msg
 		}

--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -469,10 +469,13 @@ func (p *Handler) Wait() {
 	}
 
 	endEvent := &rpc.ProcessEvent_EndEvent{
-		Error:    errMsg,
-		ExitCode: int32(p.cmd.ProcessState.ExitCode()),
-		Exited:   p.cmd.ProcessState.Exited(),
-		Status:   p.cmd.ProcessState.String(),
+		Error: errMsg,
+	}
+
+	if p.cmd.ProcessState != nil {
+		endEvent.ExitCode = int32(p.cmd.ProcessState.ExitCode())
+		endEvent.Exited = p.cmd.ProcessState.Exited()
+		endEvent.Status = p.cmd.ProcessState.String()
 	}
 
 	event := rpc.ProcessEvent_End{

--- a/packages/envd/internal/services/spec/process/process.pb.go
+++ b/packages/envd/internal/services/spec/process/process.pb.go
@@ -7,10 +7,11 @@
 package process
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1514,9 +1515,15 @@ type ProcessEvent_EndEvent struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The exit code of the process. Meaningful only when exited is true.
 	ExitCode int32   `protobuf:"zigzag32,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	// Whether the process exited normally (as opposed to being signaled).
 	Exited   bool    `protobuf:"varint,2,opt,name=exited,proto3" json:"exited,omitempty"`
+	// Human-readable description of the process exit status (e.g. "exit status 1", "signal: killed").
 	Status   string  `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// Runtime/infrastructure-level error encountered while starting, waiting for,
+	// or observing the process. This is NOT set for normal non-zero exits;
+	// use exit_code and status to inspect the process result.
 	Error    *string `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
 }
 

--- a/packages/envd/spec/process/process.proto
+++ b/packages/envd/spec/process/process.proto
@@ -87,9 +87,15 @@ message ProcessEvent {
     }
     
     message EndEvent {
+        // The exit code of the process. Meaningful only when exited is true.
         sint32 exit_code = 1;
+        // Whether the process exited normally (as opposed to being signaled).
         bool exited = 2;
+        // Human-readable description of the process exit status (e.g. "exit status 1", "signal: killed").
         string status = 3;
+        // Runtime/infrastructure-level error encountered while starting, waiting for,
+        // or observing the process. This is NOT set for normal non-zero exits;
+        // use exit_code and status to inspect the process result.
         optional string error = 4;
     }
 

--- a/packages/shared/pkg/grpc/envd/process/process.pb.go
+++ b/packages/shared/pkg/grpc/envd/process/process.pb.go
@@ -7,10 +7,11 @@
 package process
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1514,9 +1515,15 @@ type ProcessEvent_EndEvent struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// The exit code of the process. Meaningful only when exited is true.
 	ExitCode int32   `protobuf:"zigzag32,1,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
+	// Whether the process exited normally (as opposed to being signaled).
 	Exited   bool    `protobuf:"varint,2,opt,name=exited,proto3" json:"exited,omitempty"`
+	// Human-readable description of the process exit status (e.g. "exit status 1", "signal: killed").
 	Status   string  `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
+	// Runtime/infrastructure-level error encountered while starting, waiting for,
+	// or observing the process. This is NOT set for normal non-zero exits;
+	// use exit_code and status to inspect the process result.
 	Error    *string `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Fixes e2b-dev/infra#2657

This PR distinguishes normal process exits (including non-zero exits and signal kills) from runtime/infrastructure errors in `EndEvent.error`.

## Problem

`exec.Cmd.Wait()` in Go returns `*exec.ExitError` for processes that start successfully but exit with a non-zero status **or** are killed by a signal. The previous implementation passed this error directly into `EndEvent.error`, making it impossible for clients to distinguish between:

1. A process that ran and returned a non-zero exit code (normal behavior)
2. A process killed by a signal via `SendSignal` RPC (normal behavior)
3. An actual runtime/infrastructure failure (e.g., failure to start or wait for the process)

## Changes

### `packages/envd/internal/services/process/handler/handler.go`

* Added `*exec.ExitError` check: when `cmd.Wait()` returns an `*exec.ExitError` and the process has a valid `ProcessState`, the error is **not** propagated to `EndEvent.error`
* Normal non-zero exits and signal kills are now represented solely by `exit_code`, `exited`, and `status` fields
* True runtime errors (e.g., wait failures) still populate `EndEvent.error`
* Added nil guard for `ProcessState` to prevent potential nil pointer dereference

### `packages/envd/spec/process/process.proto`

* Added documentation comments to all `EndEvent` fields clarifying their intended semantics
* Explicitly documents that `error` is for runtime/infrastructure-level failures, not normal process exits

### Generated files

* Updated `packages/envd/internal/services/spec/process/process.pb.go` and `packages/shared/pkg/grpc/envd/process/process.pb.go` with the new field comments

## Behavior Change

<!-- linear:table-colwidths:266,266,266 -->
| Scenario | Before | After |
| -- | -- | -- |
| `exit 0` | `exit_code=0, error=nil` | `exit_code=0, error=nil` (unchanged) |
| `exit 1` | `exit_code=1, error="exit status 1"` | `exit_code=1, error=nil` |
| `SIGKILL` | `exit_code=-1, error="signal: killed"` | `exit_code=-1, error=nil` |
| `SIGTERM` | `exit_code=-1, error="signal: terminated"` | `exit_code=-1, error=nil` |
| Runtime failure | `error="..."` | `error="..."` (unchanged) |

## Compatibility Note

This is a behavior change for clients that currently rely on `EndEvent.error` being set for non-zero exits or signal kills. Clients should use `exit_code`, `exited`, and `status` to inspect process results instead.

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.