### PR TITLE
chore(featureflags): remove dead EdgeProvidedSandboxMetricsFlag

### DIFF
--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -123,7 +123,6 @@ var (
 	UseNFSCacheForBuildingTemplatesFlag = NewBoolFlag("use-nfs-for-building-templates", env.IsDevelopment())
 	BestOfKCanFitFlag                   = NewBoolFlag("best-of-k-can-fit", true)
 	BestOfKTooManyStartingFlag          = NewBoolFlag("best-of-k-too-many-starting", false)
-	EdgeProvidedSandboxMetricsFlag      = NewBoolFlag("edge-provided-sandbox-metrics", false)
 	CreateStorageCacheSpansFlag         = NewBoolFlag("create-storage-cache-spans", env.IsDevelopment())
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)
 


### PR DESCRIPTION
This flag was a temporary migration toggle from #1588 for the sandbox-metrics read path. The consuming code was removed in 9cc15048274 ("Make edge api optional for OSS deployment", #1638), which collapsed onto a single cluster resource provider but left this declaration behind as dead code. No references remain.

Link: https://github.com/e2b-dev/infra/pull/1638