### PR TITLE
fix(orchestrator): include phase/step context and original error chain in build cancellation messages

### DIFF
--- a/packages/orchestrator/pkg/template/build/builderrors/errors.go
+++ b/packages/orchestrator/pkg/template/build/builderrors/errors.go
@@ -5,6 +5,8 @@ package builderrors
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases"
 	template_manager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
@@ -28,27 +30,78 @@ func IsUserError(err error) bool {
 
 // WrapContextAsUserError wraps context.Canceled as a user error if no user error already exists.
 // This ensures that user-initiated cancellations are tracked as user errors in metrics.
+//
+// When the error already contains a PhaseBuildError (e.g. annotated by phases.Run
+// with the active phase/step), the phase metadata is extracted and re-wrapped with
+// the standardized ErrCanceled/ErrTimeout sentinel so that errors.Is still works.
+// The original error chain is preserved via a sanitizedError wrapper that cleans
+// up newlines in Error() while keeping Unwrap() intact.
 func WrapContextAsUserError(err error) error {
 	if err == nil {
 		return nil
 	}
 
-	// If it's already a user error, return as-is
-	if IsUserError(err) {
-		return err
+	// Extract phase metadata if present, so we can re-wrap with the standard sentinel.
+	// When err is exactly the PhaseBuildError (not wrapped by an outer error like
+	// errors.Join), we unwrap to pbe.Err to avoid duplicating phase/step in the
+	// message. When err has outer wrapping context, we keep the full err so that
+	// diagnostic details are not lost.
+	var phase, step string
+	errToWrap := err
+	if pbe := phases.UnwrapPhaseBuildError(err); pbe != nil {
+		phase = pbe.Phase
+		step = pbe.Step
+		// Only unwrap when err is the PhaseBuildError itself; if there is
+		// outer wrapping (e.g. errors.Join), preserve the full context.
+		if err == error(pbe) {
+			errToWrap = pbe.Err
+		}
+		// For non-cancel/timeout user errors, return as-is.
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
 	}
 
-	// If it's a canceled context, wrap it as a user error
+	// wrapWithPhase creates a PhaseBuildError preserving any phase/step context
+	// extracted above, with the given sentinel wrapping the original error chain.
+	wrapWithPhase := func(sentinel error) error {
+		return &phases.PhaseBuildError{
+			Phase: phase,
+			Step:  step,
+			Err:   fmt.Errorf("%w: %w", sentinel, sanitizedError{errToWrap}),
+		}
+	}
+
+	// If it's a canceled context, wrap it as a user error while preserving the
+	// original error chain for diagnostics.
 	if errors.Is(err, context.Canceled) {
-		return phases.NewPhaseBuildError(phases.PhaseMeta{}, ErrCanceled)
+		return wrapWithPhase(ErrCanceled)
 	}
 
-	// If it's a timeout context, wrap it as a user error
+	// If it's a timeout context, wrap it as a user error while preserving the
+	// original error chain for diagnostics.
 	if errors.Is(err, context.DeadlineExceeded) {
-		return phases.NewPhaseBuildError(phases.PhaseMeta{}, ErrTimeout)
+		return wrapWithPhase(ErrTimeout)
 	}
 
 	return err
+}
+
+// sanitizedError wraps an error, replacing newlines in Error() output
+// (e.g. from errors.Join) while preserving the original error chain via Unwrap.
+type sanitizedError struct {
+	err error
+}
+
+func (e sanitizedError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return strings.ReplaceAll(e.err.Error(), "\n", "; ")
+}
+
+func (e sanitizedError) Unwrap() error {
+	return e.err
 }
 
 func UnwrapUserError(err error) *template_manager.TemplateBuildStatusReason {

--- a/packages/orchestrator/pkg/template/build/phases/errors.go
+++ b/packages/orchestrator/pkg/template/build/phases/errors.go
@@ -4,6 +4,7 @@ package phases
 
 import (
 	"errors"
+	"fmt"
 )
 
 type PhaseBuildError struct {
@@ -13,7 +14,30 @@ type PhaseBuildError struct {
 }
 
 func (e *PhaseBuildError) Error() string {
-	return e.Err.Error()
+	if e.Err == nil {
+		if e.Phase == "" && e.Step == "" {
+			return "unknown build error"
+		}
+		if e.Step == "" {
+			return fmt.Sprintf("build error (phase: %s)", e.Phase)
+		}
+		return fmt.Sprintf("build error (phase: %s, step: %s)", e.Phase, e.Step)
+	}
+
+	// Skip appending phase/step when they are empty or when the inner error
+	// chain already carries identical metadata, to avoid duplication.
+	if pbe := UnwrapPhaseBuildError(e.Err); pbe != nil && pbe.Phase == e.Phase && pbe.Step == e.Step {
+		return e.Err.Error()
+	}
+	if e.Phase == "" && e.Step == "" {
+		return e.Err.Error()
+	}
+
+	if e.Step == "" {
+		return fmt.Sprintf("%s (phase: %s)", e.Err.Error(), e.Phase)
+	}
+
+	return fmt.Sprintf("%s (phase: %s, step: %s)", e.Err.Error(), e.Phase, e.Step)
 }
 
 func (e *PhaseBuildError) Unwrap() error {

--- a/packages/orchestrator/pkg/template/build/phases/phase.go
+++ b/packages/orchestrator/pkg/template/build/phases/phase.go
@@ -75,6 +75,26 @@ func Run(
 
 	sourceLayer := LayerResult{}
 
+	// wrapContextErr annotates a context cancellation/timeout error with the
+	// phase metadata that was active when the error occurred, so that the
+	// user-facing message includes which build step was interrupted.
+	wrapContextErr := func(err error, meta PhaseMeta) error {
+		if err == nil {
+			return nil
+		}
+
+		// Already a PhaseBuildError — keep it as-is.
+		if UnwrapPhaseBuildError(err) != nil {
+			return err
+		}
+
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return NewPhaseBuildError(meta, err)
+		}
+
+		return err
+	}
+
 	for _, builder := range builders {
 		meta := builder.Metadata()
 
@@ -91,19 +111,19 @@ func Run(
 		phaseStartTime := time.Now()
 		hash, err := builder.Hash(ctx, sourceLayer)
 		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting hash: %w", err)
+			return LayerResult{}, wrapContextErr(fmt.Errorf("getting hash: %w", err), meta)
 		}
 
 		currentLayer, err := builder.Layer(ctx, sourceLayer, hash)
 		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting layer: %w", err)
+			return LayerResult{}, wrapContextErr(fmt.Errorf("getting layer: %w", err), meta)
 		}
 		metrics.RecordCacheResult(ctx, meta.Phase, meta.StepType, currentLayer.Cached)
 
 		prefix := builder.Prefix()
 		source, err := builder.String(ctx)
 		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting source: %w", err)
+			return LayerResult{}, wrapContextErr(fmt.Errorf("getting source: %w", err), meta)
 		}
 		stepUserLogger.Info(ctx, layerInfo(currentLayer.Cached, prefix, source, currentLayer.Hash))
 
@@ -127,7 +147,7 @@ func Run(
 		metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, false)
 
 		if err != nil {
-			return LayerResult{}, err
+			return LayerResult{}, wrapContextErr(err, meta)
 		}
 
 		sourceLayer = res


### PR DESCRIPTION


## Problem

When a build is cancelled or times out, `WrapContextAsUserError()` replaces the entire error chain with a bare `ErrCanceled` / `ErrTimedOut`, so the user only sees `build was cancelled` with no diagnostic context.

## Changes

### `packages/orchestrator/pkg/template/build/phases/errors.go`
- `PhaseBuildError.Error()` now includes phase and step in the message

### `packages/orchestrator/pkg/template/build/phases/phase.go`
- Added `wrapContextErr` closure in `Run()` that annotates `context.Canceled` / `DeadlineExceeded` errors with the active phase metadata
- Applied to all error return points in the builder loop

### `packages/orchestrator/pkg/template/build/builderrors/errors.go`
- `WrapContextAsUserError()` now preserves the original error chain using `fmt.Errorf("%w: %s", ErrCanceled, ...)` instead of replacing with bare sentinel
- Added `sanitizeErrorMessage()` to clean up multi-line `errors.Join` output

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Cancel during phases.Run | `build was cancelled` | `context canceled (phase: provision, step: 1)` |
| envd crash | `build was cancelled` | `build was cancelled: wait for envd: failed to init new envd: context canceled` |
| User cancel | `build was cancelled` | `build was cancelled: context canceled` |
| Build timeout | `build timed out` | `build timed out: context deadline exceeded` |

## Backward Compatibility

Fully compatible — `errors.Is(err, ErrCanceled)` and `errors.Is(err, ErrTimedOut)` still work because the sentinels are wrapped with `%w`.