### PR TITLE
chore(featureflags): remove sandbox-metrics read/write kill-switch flags

### DIFF
--- a/packages/api/internal/handlers/sandbox_metrics.go
+++ b/packages/api/internal/handlers/sandbox_metrics.go
@@ -4,13 +4,11 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -28,28 +26,6 @@ func (a *APIStore) GetSandboxesSandboxIDMetrics(c *gin.Context, sandboxID string
 	}
 
 	team := auth.MustGetTeamInfo(c)
-
-	// Build the context for feature flags
-	ctx = featureflags.AddToContext(
-		ctx,
-		ldcontext.NewBuilder(sandboxID).
-			Kind(featureflags.SandboxKind).
-			Build(),
-		ldcontext.NewBuilder(team.ID.String()).
-			Kind(featureflags.TeamKind).
-			Build(),
-	)
-
-	metricsReadFlag := a.featureFlags.BoolFlag(ctx, featureflags.MetricsReadFlag)
-	if !metricsReadFlag {
-		logger.L().Debug(ctx, "sandbox metrics read feature flag is disabled")
-		// If we are not reading from ClickHouse, we can return an empty map
-		// This is here just to have the possibility to turn off ClickHouse metrics reading
-
-		c.JSON(http.StatusOK, []api.SandboxMetric{})
-
-		return
-	}
 
 	clusterID := clusters.WithClusterFallback(team.ClusterID)
 	cluster, found := a.clusters.GetClusterById(clusterID)

--- a/packages/api/internal/handlers/sandboxes_list_metrics.go
+++ b/packages/api/internal/handlers/sandboxes_list_metrics.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
-	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
@@ -50,14 +48,6 @@ func (a *APIStore) getSandboxesMetrics(
 	)
 
 	// Get metrics for all sandboxes
-	metricsReadFlag := a.featureFlags.BoolFlag(ctx, featureflags.MetricsReadFlag)
-	if !metricsReadFlag {
-		logger.L().Debug(ctx, "sandbox metrics read feature flag is disabled")
-		// If we are not reading from ClickHouse, we can return an empty map
-		// This is here just to have the possibility to turn off ClickHouse metrics reading
-		return make(map[string]api.SandboxMetric), nil
-	}
-
 	cluster, found := a.clusters.GetClusterById(clusterID)
 	if !found {
 		return nil, &api.APIError{
@@ -92,14 +82,6 @@ func (a *APIStore) GetSandboxesMetrics(c *gin.Context, params api.GetSandboxesMe
 	a.posthog.IdentifyAnalyticsTeam(ctx, team.ID.String(), team.Name)
 	properties := a.posthog.GetPackageToPosthogProperties(&c.Request.Header)
 	a.posthog.CreateAnalyticsTeamEvent(ctx, team.ID.String(), "listed running instances with metrics", properties)
-
-	// Build the context for feature flags
-	ctx = featureflags.AddToContext(
-		ctx,
-		ldcontext.NewBuilder(team.ID.String()).
-			Kind(featureflags.TeamKind).
-			Build(),
-	)
 
 	sandboxesWithMetrics, apiErr := a.getSandboxesMetrics(ctx, team.ID, clusters.WithClusterFallback(team.ClusterID), params.SandboxIds)
 	if apiErr != nil {

--- a/packages/api/internal/handlers/team_metrics.go
+++ b/packages/api/internal/handlers/team_metrics.go
@@ -10,8 +10,6 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	clickhouseUtils "github.com/e2b-dev/infra/packages/clickhouse/pkg/utils"
-	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -27,18 +25,6 @@ func (a *APIStore) GetTeamsTeamIDMetrics(c *gin.Context, teamID string, params a
 	if teamID != authTeamID.String() {
 		telemetry.ReportError(ctx, "team ids mismatch", fmt.Errorf("you (%s) are not authorized to access this team's (%s) metrics", authTeamID, teamID), telemetry.WithTeamID(authTeamID.String()))
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You (%s) are not authorized to access this team's (%s) metrics", authTeamID, teamID))
-
-		return
-	}
-
-	metricsReadFlag := a.featureFlags.BoolFlag(ctx, featureflags.MetricsReadFlag)
-
-	if !metricsReadFlag {
-		logger.L().Debug(ctx, "sandbox metrics read feature flag is disabled")
-		// If we are not reading from ClickHouse, we can return an empty map
-		// This is here just to have the possibility to turn off ClickHouse metrics reading
-
-		c.JSON(http.StatusOK, []api.TeamMetric{})
 
 		return
 	}

--- a/packages/api/internal/handlers/team_metrics_max.go
+++ b/packages/api/internal/handlers/team_metrics_max.go
@@ -12,8 +12,6 @@ import (
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	clickhouseUtils "github.com/e2b-dev/infra/packages/clickhouse/pkg/utils"
-	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
-	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -27,18 +25,6 @@ func (a *APIStore) GetTeamsTeamIDMetricsMax(c *gin.Context, teamID string, param
 	if teamID != authTeamID.String() {
 		telemetry.ReportError(ctx, "team ids mismatch", fmt.Errorf("you (%s) are not authorized to access this team's (%s) metrics", authTeamID, teamID), telemetry.WithTeamID(authTeamID.String()))
 		a.sendAPIStoreError(c, http.StatusForbidden, fmt.Sprintf("You (%s) are not authorized to access this team's (%s) metrics", authTeamID, teamID))
-
-		return
-	}
-
-	metricsReadFlag := a.featureFlags.BoolFlag(ctx, featureflags.MetricsReadFlag)
-
-	if !metricsReadFlag {
-		logger.L().Debug(ctx, "sandbox metrics read feature flag is disabled")
-		// If we are not reading from ClickHouse, we can return an empty map
-		// This is here just to have the possibility to turn off ClickHouse metrics reading
-
-		c.JSON(http.StatusOK, api.MaxTeamMetric{})
 
 		return
 	}

--- a/packages/orchestrator/pkg/metrics/sandboxes.go
+++ b/packages/orchestrator/pkg/metrics/sandboxes.go
@@ -172,10 +172,6 @@ func (so *SandboxObserver) startObserving() (metric.Registration, error) {
 					continue
 				}
 
-				if !sbx.Checks.UseClickhouseMetrics {
-					continue
-				}
-
 				wg.Go(func() error {
 					// Make sure the sandbox doesn't change while we are getting metrics (the slot could be assigned to another sandbox)
 					sbxMetrics, err := sbx.Checks.GetMetrics(ctx, timeoutGetMetrics)

--- a/packages/orchestrator/pkg/sandbox/checks.go
+++ b/packages/orchestrator/pkg/sandbox/checks.go
@@ -35,18 +35,15 @@ type Checks struct {
 	stopped bool
 
 	healthy atomic.Bool
-
-	UseClickhouseMetrics bool
 }
 
 var ErrChecksStopped = errors.New("checks stopped")
 
-func NewChecks(sandbox *Sandbox, useClickhouseMetrics bool) *Checks {
+func NewChecks(sandbox *Sandbox) *Checks {
 	// Create background context, passed ctx is from create/resume request and will be canceled after the request is processed.
 	h := &Checks{
-		sandbox:              sandbox,
-		healthy:              atomic.Bool{}, // defaults to `false`
-		UseClickhouseMetrics: useClickhouseMetrics,
+		sandbox: sandbox,
+		healthy: atomic.Bool{}, // defaults to `false`
 	}
 
 	// By default, the sandbox should be healthy, if the status change we report it.

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -612,8 +612,7 @@ func (f *Factory) CreateSandbox(
 	}
 	telemetry.ReportEvent(ctx, "created fc process")
 
-	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
-	sbx.Checks = NewChecks(sbx, useClickhouseMetrics)
+	sbx.Checks = NewChecks(sbx)
 
 	// Stop the sandbox first if it is still running, otherwise do nothing
 	cleanup.AddPriority(ctx, sbx.Stop)
@@ -974,13 +973,12 @@ func (f *Factory) ResumeSandbox(
 		skipStartupMetrics: ropts.skipLiveRegistration,
 	}
 
-	useClickhouseMetrics := f.featureFlags.BoolFlag(ctx, featureflags.MetricsWriteFlag)
 	useMemfd := fc.FCSupportsMemfd(config.FirecrackerConfig.FirecrackerVersion) &&
 		f.featureFlags.BoolFlag(ctx, featureflags.UseMemFdFlag, sandboxLDContext(runtime, config))
 
 	// Part of the sandbox as we need to stop Checks before pausing the sandbox
 	// This is to prevent race condition of reporting unhealthy sandbox
-	sbx.Checks = NewChecks(sbx, useClickhouseMetrics)
+	sbx.Checks = NewChecks(sbx)
 
 	cleanup.AddPriority(ctx, func(ctx context.Context) error {
 		// Stop the sandbox first if it is still running, otherwise do nothing

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -115,8 +115,6 @@ func OverrideJSONFlag(flag JSONFlag, value ldvalue.Value) {
 }
 
 var (
-	MetricsWriteFlag                    = NewBoolFlag("sandbox-metrics-write", true)
-	MetricsReadFlag                     = NewBoolFlag("sandbox-metrics-read", true)
 	SnapshotFeatureFlag                 = NewBoolFlag("use-nfs-for-snapshots", env.IsDevelopment())
 	TemplateFeatureFlag                 = NewBoolFlag("use-nfs-for-templates", env.IsDevelopment())
 	EnableWriteThroughCacheFlag         = NewBoolFlag("write-to-cache-on-writes", false)


### PR DESCRIPTION
These flags were kill-switches for the ClickHouse metrics pipeline, both defaulting to true (set in 63a151aff39a, "chore(metrics): turn feature flags on by default", #2202). This hardwires the always-on path: the orchestrator always collects sandbox metrics and the API always queries them, removing the flag declarations, the UseClickhouseMetrics field on Checks, the collection skip, the four handler short-circuits, and now-unused featureflag context and imports. No references remain.

Link: https://github.com/e2b-dev/infra/pull/2202