### PR TITLE
chore(featureflags): remove host-stats-sampling-interval flag

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -28,7 +28,6 @@ const (
 	metricsReaderBufSize = 1 * 1024 * 1024 // 1 MB
 
 	// metricsFlushInterval controls how often we trigger a Firecracker metrics flush.
-	// Matches the host stats sampling interval (HostStatsSamplingInterval, default 5 s).
 	metricsFlushInterval = 5 * time.Second
 )
 

--- a/packages/orchestrator/pkg/sandbox/hoststats.go
+++ b/packages/orchestrator/pkg/sandbox/hoststats.go
@@ -4,7 +4,6 @@ package sandbox
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
@@ -21,7 +20,6 @@ func initializeHostStatsCollector(
 	runtime RuntimeMetadata,
 	config *Config,
 	hostStatsDelivery hoststats.Delivery,
-	samplingInterval time.Duration,
 ) {
 	teamID, err := uuid.Parse(runtime.TeamID)
 	if err != nil {
@@ -41,7 +39,6 @@ func initializeHostStatsCollector(
 			SandboxType: runtime.SandboxType,
 		},
 		hostStatsDelivery,
-		samplingInterval,
 		sbx.cgroupHandle.GetStats,
 	)
 

--- a/packages/orchestrator/pkg/sandbox/hoststats_collector.go
+++ b/packages/orchestrator/pkg/sandbox/hoststats_collector.go
@@ -19,11 +19,12 @@ import (
 // CgroupStatsFunc is a function that returns current cgroup resource usage statistics.
 type CgroupStatsFunc func(ctx context.Context) (*cgroup.Stats, error)
 
+const hostStatsSamplingInterval = 1 * time.Second
+
 type HostStatsCollector struct {
-	metadata         HostStatsMetadata
-	delivery         hoststats.Delivery
-	samplingInterval time.Duration
-	cgroupStats      CgroupStatsFunc
+	metadata    HostStatsMetadata
+	delivery    hoststats.Delivery
+	cgroupStats CgroupStatsFunc
 
 	prev hoststats.SandboxHostStat // previous sample; seeded with zero counters at construction
 
@@ -46,19 +47,12 @@ type HostStatsMetadata struct {
 func NewHostStatsCollector(
 	metadata HostStatsMetadata,
 	delivery hoststats.Delivery,
-	samplingInterval time.Duration,
 	cgroupStats CgroupStatsFunc,
 ) *HostStatsCollector {
-	// Validate and enforce minimum interval
-	if samplingInterval < 100*time.Millisecond {
-		samplingInterval = 100 * time.Millisecond
-	}
-
 	return &HostStatsCollector{
-		metadata:         metadata,
-		delivery:         delivery,
-		samplingInterval: samplingInterval,
-		cgroupStats:      cgroupStats,
+		metadata:    metadata,
+		delivery:    delivery,
+		cgroupStats: cgroupStats,
 		// Zero baseline so the first sample produces real deltas and interval.
 		prev: hoststats.SandboxHostStat{
 			Timestamp: time.Now(),
@@ -147,7 +141,7 @@ func (h *HostStatsCollector) Start(ctx context.Context) {
 			zap.Error(err))
 	}
 
-	ticker := time.NewTicker(h.samplingInterval)
+	ticker := time.NewTicker(hostStatsSamplingInterval)
 	defer ticker.Stop()
 
 	for {

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -570,8 +570,7 @@ func (f *Factory) CreateSandbox(
 		return nil
 	})
 
-	samplingInterval := time.Duration(f.featureFlags.IntFlag(execCtx, featureflags.HostStatsSamplingInterval)) * time.Millisecond
-	initializeHostStatsCollector(execCtx, sbx, runtime, config, f.hostStatsDelivery, samplingInterval)
+	initializeHostStatsCollector(execCtx, sbx, runtime, config, f.hostStatsDelivery)
 
 	// Collect a final stats sample on cleanup while the cgroup is still alive.
 	cleanup.Add(ctx, func(ctx context.Context) error {
@@ -1001,8 +1000,7 @@ func (f *Factory) ResumeSandbox(
 	// host stats under its (unregistered) identity — consistent with not being in
 	// the live registry. The cleanup below is nil-safe when the collector is unset.
 	if !ropts.skipLiveRegistration {
-		samplingInterval := time.Duration(f.featureFlags.IntFlag(execCtx, featureflags.HostStatsSamplingInterval)) * time.Millisecond
-		initializeHostStatsCollector(execCtx, sbx, runtime, config, f.hostStatsDelivery, samplingInterval)
+		initializeHostStatsCollector(execCtx, sbx, runtime, config, f.hostStatsDelivery)
 	}
 
 	// Collect a final stats sample on cleanup while the cgroup is still alive.

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -276,7 +276,6 @@ var (
 	BestOfKAlpha                  = NewIntFlag("best-of-k-alpha", 50)                                // Default Alpha=0.5 (stored as percentage for int flag, current usage weight)
 	EnvdInitTimeoutMilliseconds   = NewIntFlag("envd-init-request-timeout-milliseconds", 50)         // Timeout for envd init request in milliseconds
 	EnvdTimeoutMilliseconds       = NewIntFlag("envd-timeout-milliseconds", envdTimeoutFallbackMs()) // Timeout for waiting for envd on resume; falls back to ENVD_TIMEOUT env var (default 10s)
-	HostStatsSamplingInterval     = NewIntFlag("host-stats-sampling-interval", 5000)                 // Host stats sampling interval in milliseconds (default 5s)
 	// GuestSyncTimeoutMs overrides the mandatory pre-pause guest-sync deadline
 	// for filesystem-only snapshots, in milliseconds. 0 (default) derives the
 	// timeout from guest RAM; a positive value pins it.


### PR DESCRIPTION
Reverts a56b629b5 ("feat: make host stats sampling interval configurable", #1895), which had replaced the hostStatsSamplingInterval package constant with a flag threaded through the collector. The restored constant is pinned to 1s (rather than the pre-#1895 default of 5s) so that removing the flag does not change the effective sampling interval currently in use. This drops the flag declaration, the samplingInterval parameter on initializeHostStatsCollector and NewHostStatsCollector, the collector field and its minimum-interval guard, and updates the now-stale metricsFlushInterval comment that referenced the flag. No references remain.

Link: https://github.com/e2b-dev/infra/pull/1895