### PR TITLE
feat: add volume quota per team

### DIFF
--- a/packages/api/internal/handlers/volume_create.go
+++ b/packages/api/internal/handlers/volume_create.go
@@ -84,6 +84,28 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 
 	clusterID := clustershared.WithClusterFallback(team.ClusterID)
 
+	// Check volume quota before creating.
+	if team.Limits.MaxVolumes > 0 {
+		volumeCount, err := a.sqlcDB.CountVolumesByTeamID(ctx, team.ID)
+		if err != nil {
+			a.sendAPIStoreError(c, http.StatusInternalServerError, "Error when checking volume quota")
+			telemetry.ReportCriticalError(ctx, "error when counting volumes", err)
+
+			return
+		}
+
+		if volumeCount >= team.Limits.MaxVolumes {
+			a.sendAPIStoreError(c, http.StatusTooManyRequests,
+				fmt.Sprintf("you have reached the maximum number of volumes (%d). Please delete unused volumes or contact support if you need more.",
+					team.Limits.MaxVolumes))
+			telemetry.ReportError(ctx, "team has reached max volumes", nil,
+				telemetry.WithTeamID(team.ID.String()),
+			)
+
+			return
+		}
+	}
+
 	client, tx, err := a.sqlcDB.WithTx(ctx)
 	if err != nil {
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Failed to create transaction")

--- a/packages/api/internal/handlers/volume_create_test.go
+++ b/packages/api/internal/handlers/volume_create_test.go
@@ -1,0 +1,221 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	ldvalue "github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/api/internal/api"
+	"github.com/e2b-dev/infra/packages/api/internal/cfg"
+	sharedauth "github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	authtypes "github.com/e2b-dev/infra/packages/auth/pkg/types"
+	authqueries "github.com/e2b-dev/infra/packages/db/pkg/auth/queries"
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
+)
+
+// newTestFeatureFlags creates a featureflags.Client with volumes enabled and
+// a non-empty default volume type so PostVolumes passes the early checks.
+func newTestFeatureFlags(t *testing.T) *featureflags.Client {
+	t.Helper()
+
+	td := ldtestdata.DataSource()
+	td.Update(td.Flag(featureflags.PersistentVolumesFlag.Key()).VariationForAll(true))
+	td.Update(td.Flag(featureflags.DefaultPersistentVolumeType.Key()).ValueForAll(ldvalue.String("local")))
+
+	ff, err := featureflags.NewClientWithDatasource(td)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ff.Close(t.Context()) })
+
+	return ff
+}
+
+// newVolumeCreateRequest builds a gin context with a valid POST /volumes JSON body
+// and the given team set via auth helper.
+func newVolumeCreateRequest(t *testing.T, team *authtypes.Team, volumeName string) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	ginCtx.Request = httptest.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		"/volumes",
+		strings.NewReader(`{"name":"`+volumeName+`"}`),
+	)
+	ginCtx.Request.Header.Set("Content-Type", "application/json")
+	sharedauth.SetTeamInfoForTest(t, ginCtx, team)
+
+	return recorder, ginCtx
+}
+
+func TestPostVolumes_QuotaExceeded_Returns429(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	teamID := testutils.CreateTestTeam(t, db)
+
+	// Create 2 volumes to reach the limit.
+	for i := range 2 {
+		_, err := db.SqlcClient.CreateVolume(t.Context(), queries.CreateVolumeParams{
+			TeamID:     teamID,
+			Name:       fmt.Sprintf("vol-%d", i),
+			VolumeType: "local",
+		})
+		require.NoError(t, err)
+	}
+
+	team := &authtypes.Team{
+		Team:   &authqueries.Team{ID: teamID},
+		Limits: &authtypes.TeamLimits{MaxVolumes: 2},
+	}
+
+	recorder, ginCtx := newVolumeCreateRequest(t, team, "vol-c")
+
+	store := &APIStore{
+		sqlcDB:       db.SqlcClient,
+		featureFlags: newTestFeatureFlags(t),
+		config:       cfg.Config{VolumesToken: cfg.VolumesTokenConfig{Enabled: true}},
+	}
+	store.PostVolumes(ginCtx)
+
+	assert.Equal(t, http.StatusTooManyRequests, recorder.Code)
+
+	var apiErr api.Error
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &apiErr))
+	assert.Contains(t, apiErr.Message, "maximum number of volumes")
+}
+
+func TestPostVolumes_QuotaNotReached_PassesQuotaCheck(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	teamID := testutils.CreateTestTeam(t, db)
+
+	// Create 1 volume — well under the limit.
+	_, err := db.SqlcClient.CreateVolume(t.Context(), queries.CreateVolumeParams{
+		TeamID:     teamID,
+		Name:       "vol-existing",
+		VolumeType: "local",
+	})
+	require.NoError(t, err)
+
+	clusterID := uuid.New()
+	team := &authtypes.Team{
+		Team:   &authqueries.Team{ID: teamID, ClusterID: &clusterID},
+		Limits: &authtypes.TeamLimits{MaxVolumes: 5},
+	}
+
+	recorder, ginCtx := newVolumeCreateRequest(t, team, "vol-new")
+
+	store := &APIStore{
+		sqlcDB:       db.SqlcClient,
+		featureFlags: newTestFeatureFlags(t),
+		config:       cfg.Config{VolumesToken: cfg.VolumesTokenConfig{Enabled: true}},
+	}
+
+	// The handler will panic after passing the quota check because there is
+	// no orchestrator backend in the test. We recover the panic and only
+	// assert that the response was NOT a 429 quota error.
+	func() {
+		defer func() { recover() }() //nolint:errcheck // intentional panic recovery
+		store.PostVolumes(ginCtx)
+	}()
+
+	assert.NotEqual(t, http.StatusTooManyRequests, recorder.Code,
+		"quota check should pass when under the limit")
+}
+
+func TestPostVolumes_UnlimitedQuota_SkipsCheck(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	teamID := testutils.CreateTestTeam(t, db)
+
+	// max_volumes defaults to 0 (unlimited) — no update needed.
+
+	// Create several volumes.
+	for i := range 5 {
+		_, err := db.SqlcClient.CreateVolume(t.Context(), queries.CreateVolumeParams{
+			TeamID:     teamID,
+			Name:       fmt.Sprintf("vol-%d", i),
+			VolumeType: "local",
+		})
+		require.NoError(t, err)
+	}
+
+	clusterID := uuid.New()
+	team := &authtypes.Team{
+		Team:   &authqueries.Team{ID: teamID, ClusterID: &clusterID},
+		Limits: &authtypes.TeamLimits{MaxVolumes: 0},
+	}
+
+	recorder, ginCtx := newVolumeCreateRequest(t, team, "vol-new")
+
+	store := &APIStore{
+		sqlcDB:       db.SqlcClient,
+		featureFlags: newTestFeatureFlags(t),
+		config:       cfg.Config{VolumesToken: cfg.VolumesTokenConfig{Enabled: true}},
+	}
+
+	// Same as above — recover the downstream panic and only check quota.
+	func() {
+		defer func() { recover() }() //nolint:errcheck // intentional panic recovery
+		store.PostVolumes(ginCtx)
+	}()
+
+	// With max_volumes=0 the quota check is skipped entirely.
+	// The handler will fail downstream (no orchestrator), but NOT with 429.
+	assert.NotEqual(t, http.StatusTooManyRequests, recorder.Code,
+		"unlimited quota (0) should never return 429")
+}
+
+func TestCountVolumesByTeamID(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	teamID := testutils.CreateTestTeam(t, db)
+
+	// Initially zero.
+	count, err := db.SqlcClient.CountVolumesByTeamID(t.Context(), teamID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	// Create 3 volumes.
+	for i := range 3 {
+		_, err := db.SqlcClient.CreateVolume(t.Context(), queries.CreateVolumeParams{
+			TeamID:     teamID,
+			Name:       fmt.Sprintf("vol-%d", i),
+			VolumeType: "local",
+		})
+		require.NoError(t, err)
+	}
+
+	count, err = db.SqlcClient.CountVolumesByTeamID(t.Context(), teamID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+
+	// Volumes from another team should not be counted.
+	otherTeamID := testutils.CreateTestTeam(t, db)
+	_, err = db.SqlcClient.CreateVolume(t.Context(), queries.CreateVolumeParams{
+		TeamID:     otherTeamID,
+		Name:       "other-vol",
+		VolumeType: "local",
+	})
+	require.NoError(t, err)
+
+	count, err = db.SqlcClient.CountVolumesByTeamID(t.Context(), teamID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), count, "should not count volumes from other teams")
+}

--- a/packages/auth/pkg/types/limits.go
+++ b/packages/auth/pkg/types/limits.go
@@ -5,7 +5,8 @@ type TeamLimits struct {
 	BuildConcurrency   int64
 	MaxLengthHours     int64
 
-	MaxVcpu  int64
-	MaxRamMb int64
-	DiskMb   int64
+	MaxVcpu    int64
+	MaxRamMb   int64
+	DiskMb     int64
+	MaxVolumes int64
 }

--- a/packages/auth/pkg/types/teams.go
+++ b/packages/auth/pkg/types/teams.go
@@ -24,6 +24,7 @@ func newTeamLimits(
 		MaxVcpu:            int64(teamLimits.MaxVcpu),
 		MaxRamMb:           int64(teamLimits.MaxRamMb),
 		DiskMb:             int64(teamLimits.DiskMb),
+		MaxVolumes:         int64(teamLimits.MaxVolumes),
 	}
 }
 

--- a/packages/db/migrations/20260701120000_add_max_volumes_to_tier.sql
+++ b/packages/db/migrations/20260701120000_add_max_volumes_to_tier.sql
@@ -21,7 +21,7 @@ SELECT
     (tier.max_vcpu + a.extra_max_vcpu) as max_vcpu,
     (tier.max_ram_mb + a.extra_max_ram_mb) as max_ram_mb,
     (tier.disk_mb + a.extra_disk_mb) as disk_mb,
-    (tier.max_volumes + a.extra_max_volumes) as max_volumes
+    (CASE WHEN tier.max_volumes = 0 THEN 0 ELSE tier.max_volumes + a.extra_max_volumes END)::bigint as max_volumes
 FROM "public".teams t
 JOIN "public"."tiers" tier on t.tier = tier.id
 LEFT JOIN LATERAL (

--- a/packages/db/migrations/20260701120000_add_max_volumes_to_tier.sql
+++ b/packages/db/migrations/20260701120000_add_max_volumes_to_tier.sql
@@ -1,0 +1,73 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add max_volumes column to tiers table.
+-- 0 means unlimited (no quota enforced).
+ALTER TABLE "public"."tiers"
+    ADD COLUMN "max_volumes" bigint NOT NULL DEFAULT 0;
+
+-- Add extra_max_volumes column to addons table.
+ALTER TABLE "public"."addons"
+    ADD COLUMN "extra_max_volumes" bigint NOT NULL DEFAULT 0;
+
+-- Recreate team_limits view to include max_volumes.
+CREATE OR REPLACE VIEW "team_limits"
+WITH (security_invoker=on) AS
+SELECT
+    t.id,
+    tier.max_length_hours,
+    (tier.concurrent_instances + a.extra_concurrent_sandboxes) as concurrent_sandboxes,
+    (tier.concurrent_template_builds + a.extra_concurrent_template_builds) as concurrent_template_builds,
+    (tier.max_vcpu + a.extra_max_vcpu) as max_vcpu,
+    (tier.max_ram_mb + a.extra_max_ram_mb) as max_ram_mb,
+    (tier.disk_mb + a.extra_disk_mb) as disk_mb,
+    (tier.max_volumes + a.extra_max_volumes) as max_volumes
+FROM "public".teams t
+JOIN "public"."tiers" tier on t.tier = tier.id
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(extra_concurrent_sandboxes),0)::bigint           as extra_concurrent_sandboxes,
+           COALESCE(SUM(extra_concurrent_template_builds),0)::bigint     as extra_concurrent_template_builds,
+           COALESCE(SUM(extra_max_vcpu),0)::bigint                       as extra_max_vcpu,
+           COALESCE(SUM(extra_max_ram_mb),0)::bigint                     as extra_max_ram_mb,
+           COALESCE(SUM(extra_disk_mb),0)::bigint                        as extra_disk_mb,
+           COALESCE(SUM(extra_max_volumes),0)::bigint                    as extra_max_volumes
+    FROM "public"."addons" addon
+    WHERE addon.team_id = t.id
+      AND addon.valid_from <= now()
+      AND (addon.valid_to IS NULL OR addon.valid_to > now())
+    ) a ON true;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Restore original team_limits view without max_volumes.
+CREATE OR REPLACE VIEW "team_limits"
+WITH (security_invoker=on) AS
+SELECT
+    t.id,
+    tier.max_length_hours,
+    (tier.concurrent_instances + a.extra_concurrent_sandboxes) as concurrent_sandboxes,
+    (tier.concurrent_template_builds + a.extra_concurrent_template_builds) as concurrent_template_builds,
+    (tier.max_vcpu + a.extra_max_vcpu) as max_vcpu,
+    (tier.max_ram_mb + a.extra_max_ram_mb) as max_ram_mb,
+    (tier.disk_mb + a.extra_disk_mb) as disk_mb
+FROM "public".teams t
+JOIN "public"."tiers" tier on t.tier = tier.id
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(extra_concurrent_sandboxes),0)::bigint           as extra_concurrent_sandboxes,
+           COALESCE(SUM(extra_concurrent_template_builds),0)::bigint     as extra_concurrent_template_builds,
+           COALESCE(SUM(extra_max_vcpu),0)::bigint                       as extra_max_vcpu,
+           COALESCE(SUM(extra_max_ram_mb),0)::bigint                     as extra_max_ram_mb,
+           COALESCE(SUM(extra_disk_mb),0)::bigint                        as extra_disk_mb
+    FROM "public"."addons" addon
+    WHERE addon.team_id = t.id
+      AND addon.valid_from <= now()
+      AND (addon.valid_to IS NULL OR addon.valid_to > now())
+    ) a ON true;
+
+ALTER TABLE "public"."addons" DROP COLUMN IF EXISTS "extra_max_volumes";
+ALTER TABLE "public"."tiers" DROP COLUMN IF EXISTS "max_volumes";
+
+-- +goose StatementEnd

--- a/packages/db/pkg/auth/queries/get_team.sql.go
+++ b/packages/db/pkg/auth/queries/get_team.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getTeamWithTierByAPIKey = `-- name: GetTeamWithTierByAPIKey :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb FROM "public"."team_api_keys" tak
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.max_volumes FROM "public"."team_api_keys" tak
 JOIN "public"."teams" t ON tak.team_id = t.id
 JOIN "public"."team_limits" tl on tl.id = t.id
 WHERE tak.team_id = t.id
@@ -46,12 +46,13 @@ func (q *Queries) GetTeamWithTierByAPIKey(ctx context.Context, apiKeyHash string
 		&i.TeamLimit.MaxVcpu,
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
+		&i.TeamLimit.MaxVolumes,
 	)
 	return i, err
 }
 
 const getTeamWithTierByTeamAndUser = `-- name: GetTeamWithTierByTeamAndUser :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.max_volumes
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id
@@ -90,12 +91,13 @@ func (q *Queries) GetTeamWithTierByTeamAndUser(ctx context.Context, arg GetTeamW
 		&i.TeamLimit.MaxVcpu,
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
+		&i.TeamLimit.MaxVolumes,
 	)
 	return i, err
 }
 
 const getTeamWithTierByTeamID = `-- name: GetTeamWithTierByTeamID :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.max_volumes
 FROM "public"."teams" t
          JOIN "public"."team_limits" tl on tl.id = t.id
 WHERE t.id = $1
@@ -128,12 +130,13 @@ func (q *Queries) GetTeamWithTierByTeamID(ctx context.Context, id uuid.UUID) (Ge
 		&i.TeamLimit.MaxVcpu,
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
+		&i.TeamLimit.MaxVolumes,
 	)
 	return i, err
 }
 
 const getTeamsWithUsersTeamsWithTier = `-- name: GetTeamsWithUsersTeamsWithTier :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.max_volumes
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id
@@ -175,6 +178,7 @@ func (q *Queries) GetTeamsWithUsersTeamsWithTier(ctx context.Context, userID uui
 			&i.TeamLimit.MaxVcpu,
 			&i.TeamLimit.MaxRamMb,
 			&i.TeamLimit.DiskMb,
+			&i.TeamLimit.MaxVolumes,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/auth/queries/models.go
+++ b/packages/db/pkg/auth/queries/models.go
@@ -48,5 +48,5 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
-	MaxVolumes               int32
+	MaxVolumes               int64
 }

--- a/packages/db/pkg/auth/queries/models.go
+++ b/packages/db/pkg/auth/queries/models.go
@@ -48,4 +48,5 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
+	MaxVolumes               int32
 }

--- a/packages/db/pkg/dashboard/queries/get_dashboard_teams_with_users_teams_with_tier.sql.go
+++ b/packages/db/pkg/dashboard/queries/get_dashboard_teams_with_users_teams_with_tier.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getDashboardTeamsWithUsersTeamsWithTier = `-- name: GetDashboardTeamsWithUsersTeamsWithTier :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, t.profile_picture_url, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.slug, t.profile_picture_url, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.max_volumes
 FROM "public"."teams" t
 JOIN "public"."users_teams" ut ON ut.team_id = t.id
 JOIN "public"."team_limits" tl ON tl.id = t.id
@@ -55,6 +55,7 @@ func (q *Queries) GetDashboardTeamsWithUsersTeamsWithTier(ctx context.Context, u
 			&i.TeamLimit.MaxVcpu,
 			&i.TeamLimit.MaxRamMb,
 			&i.TeamLimit.DiskMb,
+			&i.TeamLimit.MaxVolumes,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/dashboard/queries/models.go
+++ b/packages/db/pkg/dashboard/queries/models.go
@@ -33,5 +33,5 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
-	MaxVolumes               int32
+	MaxVolumes               int64
 }

--- a/packages/db/pkg/dashboard/queries/models.go
+++ b/packages/db/pkg/dashboard/queries/models.go
@@ -33,4 +33,5 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
+	MaxVolumes               int32
 }

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -60,6 +60,7 @@ type Addon struct {
 	ValidTo                       *time.Time
 	AddedBy                       uuid.UUID
 	IdempotencyKey                pgtype.Text
+	ExtraMaxVolumes               int64
 }
 
 type AuthUser struct {
@@ -217,6 +218,7 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
+	MaxVolumes               int32
 }
 
 type Tier struct {
@@ -230,6 +232,7 @@ type Tier struct {
 	MaxRamMb            int64
 	// The number of concurrent template builds the team can run
 	ConcurrentTemplateBuilds int64
+	MaxVolumes               int64
 }
 
 type User struct {

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -218,7 +218,7 @@ type TeamLimit struct {
 	MaxVcpu                  int32
 	MaxRamMb                 int32
 	DiskMb                   int32
-	MaxVolumes               int32
+	MaxVolumes               int64
 }
 
 type Tier struct {

--- a/packages/db/queries/volumes.sql.go
+++ b/packages/db/queries/volumes.sql.go
@@ -11,6 +11,17 @@ import (
 	"github.com/google/uuid"
 )
 
+const countVolumesByTeamID = `-- name: CountVolumesByTeamID :one
+SELECT COUNT(*) FROM volumes WHERE team_id = $1
+`
+
+func (q *Queries) CountVolumesByTeamID(ctx context.Context, teamID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countVolumesByTeamID, teamID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createVolume = `-- name: CreateVolume :one
 INSERT INTO volumes (team_id, volume_type, name)
 VALUES ($1, $2, $3)

--- a/packages/db/queries/volumes/volumes.sql
+++ b/packages/db/queries/volumes/volumes.sql
@@ -14,5 +14,8 @@ SELECT * FROM volumes WHERE team_id = @team_id AND name IN (
 -- name: FindVolumesByTeamID :many
 SELECT * FROM volumes WHERE team_id = @team_id;
 
+-- name: CountVolumesByTeamID :one
+SELECT COUNT(*) FROM volumes WHERE team_id = @team_id;
+
 -- name: DeleteVolume :exec
 DELETE FROM volumes WHERE team_id = @team_id AND id = @volume_id;


### PR DESCRIPTION
## Summary

Implements volume quota per team to fix #2291.

## Changes

### Database
- **Migration** (`20260701120000_add_max_volumes_to_tier.sql`): Adds `max_volumes` column (default 0 = unlimited) to `tiers` and `addons` tables, and includes it in the `team_limits` VIEW.
- **Query**: Adds `CountVolumesByTeamID` query to count existing volumes for a team.

### Auth
- Adds `MaxVolumes int64` field to `TeamLimits` struct and maps it from the DB view.

### API
- Adds quota check in `PostVolumes` handler: if `MaxVolumes > 0` and the team has reached the limit, returns HTTP 429 with a descriptive error message.

### Tests
- `TestPostVolumes_QuotaExceeded_Returns429`: Verifies 429 is returned when quota is reached.
- `TestPostVolumes_QuotaNotReached_PassesQuotaCheck`: Verifies request passes quota check when under limit.
- `TestPostVolumes_UnlimitedQuota_SkipsCheck`: Verifies `MaxVolumes=0` (unlimited) skips the check.
- `TestCountVolumesByTeamID`: Verifies the count query with cross-team isolation.