### PR TITLE
ci: build infra images for tango

### DIFF
--- a/.github/workflows/build-and-upload-images.yml
+++ b/.github/workflows/build-and-upload-images.yml
@@ -22,6 +22,7 @@ jobs:
           - staging
           - foxtrot
           - juliett
+          - tango
     environment: ${{ matrix.environment }}
     concurrency:
       group: build-images-${{ matrix.environment }}

--- a/.github/workflows/promote-envd.yml
+++ b/.github/workflows/promote-envd.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: boolean
         default: false
+      tango:
+        description: Promote to tango
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -44,7 +49,7 @@ jobs:
           fi
 
       - name: Require an environment
-        if: ${{ inputs.staging != true && inputs.foxtrot != true && inputs.juliett != true }}
+        if: ${{ inputs.staging != true && inputs.foxtrot != true && inputs.juliett != true && inputs.tango != true }}
         run: |
           echo "Select at least one environment to promote envd."
           exit 1
@@ -55,11 +60,13 @@ jobs:
           STAGING: ${{ inputs.staging }}
           FOXTROT: ${{ inputs.foxtrot }}
           JULIETT: ${{ inputs.juliett }}
+          TANGO: ${{ inputs.tango }}
         run: |
           envs=()
           [[ "$STAGING" == "true" ]] && envs+=("staging")
           [[ "$FOXTROT" == "true" ]] && envs+=("foxtrot")
           [[ "$JULIETT" == "true" ]] && envs+=("juliett")
+          [[ "$TANGO" == "true" ]] && envs+=("tango")
 
           json="$(printf '%s\n' "${envs[@]}" | jq -R . | jq -cs .)"
           echo "environments=${json}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Adds Tango to the Infra image build/upload matrix.\n\nThis follows the existing workflow pattern for staging, foxtrot, and juliett. The job uses the GitHub environment named `tango` and reads `vars.INFISICAL_MACHINE_IDENTITY_ID` from that environment.\n\nPrerequisite before the workflow can run successfully:\n- the Tango Infra Infisical identity from terraform/infisical has been applied and configured as the `INFISICAL_MACHINE_IDENTITY_ID` GitHub environment variable for `tango`.