### PR TITLE
[EN-1410] feat(clickhouse): per-team TTL on sandbox_events

### DIFF
--- a/packages/clickhouse/migrations/20260702120000_add_sandbox_events_ttl_days.sql
+++ b/packages/clickhouse/migrations/20260702120000_add_sandbox_events_ttl_days.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- Retention of the event in days
+ALTER TABLE sandbox_events_local
+    ADD COLUMN IF NOT EXISTS events_ttl_days Int64 DEFAULT 7 CODEC (ZSTD(1));
+
+ALTER TABLE sandbox_events
+    ADD COLUMN IF NOT EXISTS events_ttl_days Int64 DEFAULT 7;
+
+-- Switch the fixed 7-day table TTL to a per-row TTL driven by the team's
+-- retention. Existing rows use the column DEFAULT (7), so nothing expires
+-- earlier than before.
+ALTER TABLE sandbox_events_local
+    MODIFY TTL toDateTime(timestamp) + toIntervalDay(events_ttl_days);
+
+-- Rows in this table now carry per-team TTLs, so a single daily part mixes
+-- expiry times. ttl_only_drop_parts=1 (set globally in 20260417120000) would
+-- keep the whole part alive until its max TTL passes. Turn it off for this
+-- table only so TTL merges evict expired rows exactly, at the cost of part
+-- rewrites instead of whole-part drops.
+ALTER TABLE sandbox_events_local
+    MODIFY SETTING ttl_only_drop_parts = 0;
+
+-- +goose Down
+ALTER TABLE sandbox_events_local
+    MODIFY SETTING ttl_only_drop_parts = 1;
+
+ALTER TABLE sandbox_events_local
+    MODIFY TTL toDateTime(timestamp) + INTERVAL 7 DAY;
+
+ALTER TABLE sandbox_events
+    DROP COLUMN IF EXISTS events_ttl_days;
+
+ALTER TABLE sandbox_events_local
+    DROP COLUMN IF EXISTS events_ttl_days;

--- a/packages/clickhouse/migrations/20260702120000_add_sandbox_events_ttl_days.sql
+++ b/packages/clickhouse/migrations/20260702120000_add_sandbox_events_ttl_days.sql
@@ -6,9 +6,7 @@ ALTER TABLE sandbox_events_local
 ALTER TABLE sandbox_events
     ADD COLUMN IF NOT EXISTS events_ttl_days Int64 DEFAULT 7;
 
--- Switch the fixed 7-day table TTL to a per-row TTL driven by the team's
--- retention. Existing rows use the column DEFAULT (7), so nothing expires
--- earlier than before.
+-- Switch the fixed 7-day table TTL to a per-row TTL driven by the team's retention
 ALTER TABLE sandbox_events_local
     MODIFY TTL toDateTime(timestamp) + toIntervalDay(events_ttl_days);
 

--- a/packages/clickhouse/pkg/events/delivery.go
+++ b/packages/clickhouse/pkg/events/delivery.go
@@ -115,6 +115,9 @@ func (c *ClickhouseDelivery) Publish(_ context.Context, _ string, event events.S
 	if ttlDays <= 0 {
 		ttlDays = events.DefaultEventsTTLDays
 	}
+	if ttlDays > 365 {
+		ttlDays = 365
+	}
 
 	return c.batcher.Push(SandboxEvent{
 		Version:   event.Version,

--- a/packages/clickhouse/pkg/events/delivery.go
+++ b/packages/clickhouse/pkg/events/delivery.go
@@ -31,9 +31,11 @@ const InsertSandboxEventQuery = `INSERT INTO sandbox_events
     event_data,
     type,
     version,
-    id
+    id,
+    events_ttl_days
 )
 VALUES (
+    ?,
     ?,
     ?,
     ?,
@@ -109,6 +111,11 @@ func (c *ClickhouseDelivery) Publish(_ context.Context, _ string, event events.S
 
 	eventData := string(eventDataJson)
 
+	ttlDays := event.EventsTTLDays
+	if ttlDays <= 0 {
+		ttlDays = events.DefaultEventsTTLDays
+	}
+
 	return c.batcher.Push(SandboxEvent{
 		Version:   event.Version,
 		ID:        event.ID,
@@ -121,6 +128,7 @@ func (c *ClickhouseDelivery) Publish(_ context.Context, _ string, event events.S
 		SandboxBuildID:     event.SandboxBuildID,
 		SandboxTeamID:      event.SandboxTeamID,
 		SandboxExecutionID: event.SandboxExecutionID,
+		EventsTTLDays:      ttlDays,
 	})
 }
 
@@ -163,6 +171,7 @@ func (c *ClickhouseDelivery) batchInserter(ctx context.Context, events []Sandbox
 			event.Type,
 			event.Version,
 			event.ID,
+			event.EventsTTLDays,
 		)
 		if err != nil {
 			span.RecordError(err)

--- a/packages/clickhouse/pkg/events/event.go
+++ b/packages/clickhouse/pkg/events/event.go
@@ -19,4 +19,6 @@ type SandboxEvent struct {
 	SandboxTemplateID  string         `ch:"sandbox_template_id"`
 	SandboxBuildID     string         `ch:"sandbox_build_id"`
 	SandboxTeamID      uuid.UUID      `ch:"sandbox_team_id"`
+
+	EventsTTLDays int64 `ch:"events_ttl_days"`
 }

--- a/packages/shared/pkg/events/sandbox.go
+++ b/packages/shared/pkg/events/sandbox.go
@@ -12,8 +12,7 @@ const (
 )
 
 // DefaultEventsTTLDays is the fallback event retention used when an event
-// doesn't carry a team-specific TTL (legacy publishers). Matches the
-// historical fixed 7-day retention of the events store.
+// doesn't carry a team-specific TTL
 const DefaultEventsTTLDays int64 = 7
 
 const (
@@ -52,7 +51,6 @@ type SandboxEvent struct {
 	SandboxBuildID     string    `json:"sandbox_build_id"`
 	SandboxTeamID      uuid.UUID `json:"sandbox_team_id"`
 
-	// Retention of the event in days, from the team's limits (tier + addons).
-	// Eviction is handled downstream; 0 means "not set" (legacy default applies).
+	// Retention of the event in days
 	EventsTTLDays int64 `json:"events_ttl_days,omitempty"`
 }

--- a/packages/shared/pkg/events/sandbox.go
+++ b/packages/shared/pkg/events/sandbox.go
@@ -11,6 +11,11 @@ const (
 	StructureVersionV2 = "v2"
 )
 
+// DefaultEventsTTLDays is the fallback event retention used when an event
+// doesn't carry a team-specific TTL (legacy publishers). Matches the
+// historical fixed 7-day retention of the events store.
+const DefaultEventsTTLDays int64 = 7
+
 const (
 	SandboxCreatedEvent      = "sandbox.lifecycle.created"
 	SandboxKilledEvent       = "sandbox.lifecycle.killed"
@@ -46,4 +51,8 @@ type SandboxEvent struct {
 	SandboxTemplateID  string    `json:"sandbox_template_id"`
 	SandboxBuildID     string    `json:"sandbox_build_id"`
 	SandboxTeamID      uuid.UUID `json:"sandbox_team_id"`
+
+	// Retention of the event in days, from the team's limits (tier + addons).
+	// Eviction is handled downstream; 0 means "not set" (legacy default applies).
+	EventsTTLDays int64 `json:"events_ttl_days,omitempty"`
 }


### PR DESCRIPTION
Add events_ttl_days column stamped on each event so retention can vary. Table TTL switches from fixed 7 days to per-row toIntervalDay(events_ttl_days); 

ttl_only_drop_parts disabled for this table since parts now mix expiry times. Missing/zero TTL falls back to the historical 7-day default.