### PR TITLE
chore(featureflags): remove best-of-k-can-fit and best-of-k-too-many-starting flags

### DIFF
--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -315,19 +315,13 @@ func getBestOfKConfig(ctx context.Context, featureFlagsClient *featureflags.Clie
 
 	alphaPercent := featureFlagsClient.IntFlag(ctx, featureflags.BestOfKAlpha)
 
-	canFit := featureFlagsClient.BoolFlag(ctx, featureflags.BestOfKCanFitFlag)
-
-	tooManyStarting := featureFlagsClient.BoolFlag(ctx, featureflags.BestOfKTooManyStartingFlag)
-
 	// Convert percentage to decimal
 	alpha := float64(alphaPercent) / 100.0
 	maxOvercommit := float64(maxOvercommitPercent) / 100.0
 
 	return placement.BestOfKConfig{
-		R:               maxOvercommit,
-		K:               k,
-		Alpha:           alpha,
-		CanFit:          canFit,
-		TooManyStarting: tooManyStarting,
+		R:     maxOvercommit,
+		K:     k,
+		Alpha: alpha,
 	}
 }

--- a/packages/api/internal/orchestrator/placement/config.go
+++ b/packages/api/internal/orchestrator/placement/config.go
@@ -1,6 +1,5 @@
 package placement
 
 const (
-	maxRetries                  = 3
-	maxStartingInstancesPerNode = 3
+	maxRetries = 3
 )

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K.go
@@ -20,10 +20,6 @@ type BestOfKConfig struct {
 	Alpha float64
 	// K is the number of candidate nodes sampled per placement ("power of K choices")
 	K int
-	// TooManyStarting determines whether to skip nodes that are starting more than maxStartingInstancesPerNode instances
-	TooManyStarting bool
-	// CanFit determines whether to skip the node CanFit check
-	CanFit bool
 }
 
 // DefaultBestOfKConfig returns the default placement configuration
@@ -64,23 +60,6 @@ func (b *BestOfK) Score(node *nodemanager.Node, resources nodemanager.SandboxRes
 	return (cpuRequested + float64(reserved) + config.Alpha*usageAvg) / totalCapacity
 }
 
-// CanFit checks if the node can fit a new VM with the given quota
-func (b *BestOfK) CanFit(node *nodemanager.Node, sandboxResources nodemanager.SandboxResources, config BestOfKConfig) bool {
-	metrics := node.Metrics()
-
-	reserved := metrics.CpuAllocated
-
-	// If the node has no CPUs, there's probably a problem
-	cpuCount := float64(metrics.CpuCount)
-	if cpuCount == 0 {
-		return false
-	}
-
-	totalCapacity := config.R * cpuCount
-
-	return float64(reserved+uint32(sandboxResources.CPUs)) <= totalCapacity
-}
-
 // BestOfK implements the fit-score-place algorithm
 type BestOfK struct {
 	config BestOfKConfig
@@ -116,7 +95,7 @@ func (b *BestOfK) chooseNode(_ context.Context, nodes []*nodemanager.Node, exclu
 	config := b.getConfig()
 
 	// Filter eligible nodes
-	candidates := b.sample(nodes, config, excludedNodes, resources, buildMachineInfo, filterByLabels, requiredLabels)
+	candidates := b.sample(nodes, config, excludedNodes, buildMachineInfo, filterByLabels, requiredLabels)
 
 	// Find the best node among candidates
 	bestScore := math.MaxFloat64
@@ -161,7 +140,7 @@ func (e FailedToPlaceSandboxError) Error() string {
 }
 
 // sample returns up to k items chosen uniformly from those passing ok.
-func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, excludedNodes map[string]struct{}, resources nodemanager.SandboxResources, buildMachineInfo machineinfo.MachineInfo, filterByLabels bool, requiredLabels []string) []*nodemanager.Node {
+func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, excludedNodes map[string]struct{}, buildMachineInfo machineinfo.MachineInfo, filterByLabels bool, requiredLabels []string) []*nodemanager.Node {
 	if config.K <= 0 || len(items) == 0 {
 		return nil
 	}
@@ -203,19 +182,6 @@ func (b *BestOfK) sample(items []*nodemanager.Node, config BestOfKConfig, exclud
 		// Skip if node doesn't have the required labels
 		if filterByLabels && !isNodeLabelsCompatible(n, requiredLabels) {
 			continue
-		}
-
-		if config.CanFit {
-			if !b.CanFit(n, resources, config) {
-				continue
-			}
-		}
-
-		if config.TooManyStarting {
-			// To prevent overloading the node
-			if n.PlacementMetrics.InProgressCount() > maxStartingInstancesPerNode {
-				continue
-			}
 		}
 
 		candidates = append(candidates, n)

--- a/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
+++ b/packages/api/internal/orchestrator/placement/placement_best_of_K_test.go
@@ -96,33 +96,6 @@ func TestBestOfK_Score_WithPendingResources(t *testing.T) {
 	assert.Greater(t, scorePending, scoreNormal, "Node with pending resources should receive a higher (worse) score")
 }
 
-func TestBestOfK_CanFit(t *testing.T) {
-	t.Parallel()
-	config := DefaultBestOfKConfig()
-	algo := NewBestOfK(config).(*BestOfK)
-
-	// Create a test node with moderate CPU usage
-	node := nodemanager.NewTestNode("test-node", api.NodeStatusReady, 5, 4)
-
-	// Test can fit small resource request
-	resources := nodemanager.SandboxResources{
-		CPUs:      2,
-		MiBMemory: 1024,
-	}
-	// Note: CanFit depends on the node's actual metrics which we can't directly control
-	// But we can test the logic works
-	canFit := algo.CanFit(node, resources, config)
-	assert.IsType(t, true, canFit) // Should return a boolean
-
-	// Test with very large resource request - likely won't fit
-	largeResources := nodemanager.SandboxResources{
-		CPUs:      1000,
-		MiBMemory: 8192,
-	}
-	canFitLarge := algo.CanFit(node, largeResources, config)
-	assert.False(t, canFitLarge) // Very large request should not fit
-}
-
 func TestBestOfK_ChooseNode(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -346,13 +319,9 @@ func TestBestOfK_Sample(t *testing.T) {
 	}
 
 	excludedNodes := make(map[string]struct{})
-	resources := nodemanager.SandboxResources{
-		CPUs:      2,
-		MiBMemory: 1024,
-	}
 
 	// Test sampling fewer nodes than available
-	sampled := algo.sample(nodes, config, excludedNodes, resources, machineinfo.MachineInfo{}, false, nil)
+	sampled := algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
 	assert.LessOrEqual(t, len(sampled), 3)
 
 	// Check all sampled nodes are unique
@@ -365,7 +334,7 @@ func TestBestOfK_Sample(t *testing.T) {
 	// Test sampling with exclusions
 	excludedNodes["a"] = struct{}{}
 	excludedNodes["b"] = struct{}{}
-	sampled = algo.sample(nodes, config, excludedNodes, resources, machineinfo.MachineInfo{}, false, nil)
+	sampled = algo.sample(nodes, config, excludedNodes, machineinfo.MachineInfo{}, false, nil)
 
 	for _, n := range sampled {
 		assert.NotEqual(t, "a", n.ID)

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -119,8 +119,6 @@ var (
 	TemplateFeatureFlag                 = NewBoolFlag("use-nfs-for-templates", env.IsDevelopment())
 	EnableWriteThroughCacheFlag         = NewBoolFlag("write-to-cache-on-writes", false)
 	UseNFSCacheForBuildingTemplatesFlag = NewBoolFlag("use-nfs-for-building-templates", env.IsDevelopment())
-	BestOfKCanFitFlag                   = NewBoolFlag("best-of-k-can-fit", true)
-	BestOfKTooManyStartingFlag          = NewBoolFlag("best-of-k-too-many-starting", false)
 	CreateStorageCacheSpansFlag         = NewBoolFlag("create-storage-cache-spans", env.IsDevelopment())
 	OrchAcceptsCombinedHostFlag         = NewBoolFlag("orch-accepts-combined-host", false)
 


### PR DESCRIPTION
Both flags exist in LaunchDarkly with targeting off, so LD serves the off variation (false) for both: prod runs with neither the CanFit over-commit check nor the TooManyStarting check active. The flags were introduced as experiment knobs for the placement algorithm last September, only briefly exercised on staging shortly after, and never used since. Bake the actual behavior in: drop both flags, the CanFit and TooManyStarting checks, and maxStartingInstancesPerNode.

Note the code fallback for best-of-k-can-fit was true, contradicting what LD actually served - removing the flag also removes that footgun (behavior silently flipping when LD is unreachable or the flag is archived).