### PR TITLE
chore(envd): document intentional context-propagation nolints

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -177,7 +177,7 @@ func (a *API) PostInit(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	go func() { //nolint:contextcheck // TODO: fix this later
+	go func() { //nolint:contextcheck // MMDS re-poll must outlive the /init HTTP response, so it can't derive from r.Context
 		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer cancel()
 		host.PollForMMDSOpts(ctx, a.mmdsChan, a.defaults.EnvVars)

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -43,7 +43,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 		procCtx, cancelProc = context.WithTimeout(procCtx, requestTimeout)
 	}
 
-	proc, err := handler.New( //nolint:contextcheck // TODO: fix this later
+	proc, err := handler.New( //nolint:contextcheck // procCtx is intentionally decoupled from the request ctx so the process outlives the RPC (see comment above)
 		procCtx,
 		u,
 		req.Msg,


### PR DESCRIPTION
## Summary

Two `//nolint:contextcheck` directives in envd were tagged with misleading `// TODO: fix this later` comments even though the design is intentional:

- **`process/start.go:46`** — `procCtx` deliberately starts from `context.Background()` so the started process survives cancellation of the RPC context. This is already explained in the comment immediately above the call site; the nolint tag now points at that intent instead of implying a fix is pending.
- **`api/init.go:180`** — The MMDS re-poll goroutine is spawned right before `PostInit` writes `204 No Content`, so `r.Context()` would be cancelled almost immediately. It must run from a background context.

Replace both TODOs with the actual design rationale. No behavior change; comments only, so no envd version bump.

## Test plan

- [x] `go vet ./internal/api/... ./internal/services/process/...` clean
- [x] `git diff` shows only the two nolint comments changed