### PR TITLE
chore(api): clamp sandbox duration

### DIFF
--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -23,12 +23,21 @@ const (
 	reportTimeout = 4 * time.Minute
 )
 
+// sbxStopTime returns the effective stop time, prevents stale record evicted late reporting incorrect data
+func sbxStopTime(sbx sandbox.Sandbox, now time.Time) time.Time {
+	if sbx.EndTime.After(sbx.StartTime) && sbx.EndTime.Before(now) {
+		return sbx.EndTime
+	}
+
+	return now
+}
+
 func (o *Orchestrator) analyticsRemove(ctx context.Context, sandbox sandbox.Sandbox, stateAction sandbox.StateAction) {
 	ctx, cancel := context.WithTimeout(ctx, reportTimeout)
 	defer cancel()
 
-	duration := time.Since(sandbox.StartTime).Seconds()
-	stopTime := time.Now()
+	stopTime := sbxStopTime(sandbox, time.Now())
+	duration := stopTime.Sub(sandbox.StartTime).Seconds()
 
 	o.posthogClient.CreateAnalyticsTeamEvent(
 		ctx,

--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -29,6 +29,10 @@ func sbxStopTime(sbx sandbox.Sandbox, now time.Time) time.Time {
 		return sbx.EndTime
 	}
 
+	if now.Before(sbx.StartTime) {
+		return sbx.StartTime
+	}
+
 	return now
 }
 

--- a/packages/api/internal/orchestrator/analytics_test.go
+++ b/packages/api/internal/orchestrator/analytics_test.go
@@ -55,6 +55,12 @@ func TestSandboxStopTime(t *testing.T) {
 			endTime:   time.Time{},
 			want:      now,
 		},
+		{
+			name:      "now before start time",
+			startTime: now.Add(time.Second),
+			endTime:   now.Add(time.Hour),
+			want:      now.Add(time.Second),
+		},
 	}
 
 	for _, tt := range tests {

--- a/packages/api/internal/orchestrator/analytics_test.go
+++ b/packages/api/internal/orchestrator/analytics_test.go
@@ -1,0 +1,70 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+)
+
+func TestSandboxStopTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		startTime time.Time
+		endTime   time.Time
+		want      time.Time
+	}{
+		{
+			// Normal kill/pause before timeout: StartRemoving already moved
+			// EndTime to now for non-expired sandboxes; stop time is now.
+			name:      "end time in the future",
+			startTime: now.Add(-time.Hour),
+			endTime:   now.Add(time.Hour),
+			want:      now,
+		},
+		{
+			// Late eviction of a stale record
+			name:      "end time long past",
+			startTime: now.Add(-30 * 24 * time.Hour),
+			endTime:   now.Add(-30*24*time.Hour + time.Hour),
+			want:      now.Add(-30*24*time.Hour + time.Hour),
+		},
+		{
+			name:      "end time just passed",
+			startTime: now.Add(-time.Hour),
+			endTime:   now.Add(-time.Minute),
+			want:      now.Add(-time.Minute),
+		},
+		{
+			// Corrupt record: EndTime before StartTime must not produce a
+			// negative duration; fall back to now.
+			name:      "end time before start time",
+			startTime: now.Add(-time.Hour),
+			endTime:   now.Add(-2 * time.Hour),
+			want:      now,
+		},
+		{
+			name:      "zero end time",
+			startTime: now.Add(-time.Hour),
+			endTime:   time.Time{},
+			want:      now,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sbx := sandbox.Sandbox{StartTime: tt.startTime, EndTime: tt.endTime}
+			got := sbxStopTime(sbx, now)
+			require.True(t, tt.want.Equal(got), "want %v, got %v", tt.want, got)
+			require.GreaterOrEqual(t, got.Sub(tt.startTime), time.Duration(0), "sandbox duration must never be negative")
+		})
+	}
+}


### PR DESCRIPTION
Prevents accidentally report duration than actual sandbox duration. Prerequisite for #3199