### PR TITLE
Expose orchestrator roles

### DIFF
--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -303,6 +303,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 		version,
 		serviceInstanceID,
 		attribute.Key("host.labels").StringSlice(config.NodeLabels),
+		attribute.Key("service.roles").StringSlice(config.Services),
 	)
 	if err != nil {
 		logger.L().Fatal(ctx, "failed to init telemetry", zap.Error(err))


### PR DESCRIPTION
Initiative: For some environments, we deploy a template build as part of the orchestrator, which then creates an issue with querying the OTEL data, as they can be under three service names: `orchestrator`, `template-manager,` and `orchestrator_template-manager`. 

This patch adds `service.roles` so we can easily filter, update all services that depend on it, and later switch to a unified service name. 