### PR TITLE
fix(api): handle corrupted data in sandbox stop time

### DIFF
--- a/packages/api/internal/orchestrator/analytics.go
+++ b/packages/api/internal/orchestrator/analytics.go
@@ -25,7 +25,11 @@ const (
 
 // sbxStopTime returns the effective stop time, prevents stale record evicted late reporting incorrect data
 func sbxStopTime(sbx sandbox.Sandbox, now time.Time) time.Time {
-	if sbx.EndTime.After(sbx.StartTime) && sbx.EndTime.Before(now) {
+	if !sbx.EndTime.After(sbx.StartTime) {
+		return sbx.StartTime
+	}
+
+	if sbx.EndTime.Before(now) {
 		return sbx.EndTime
 	}
 

--- a/packages/api/internal/orchestrator/analytics_test.go
+++ b/packages/api/internal/orchestrator/analytics_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 )
 
-func TestSandboxStopTime(t *testing.T) {
+func TestSbxStopTime(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
@@ -42,24 +42,11 @@ func TestSandboxStopTime(t *testing.T) {
 			want:      now.Add(-time.Minute),
 		},
 		{
-			// Corrupt record: EndTime before StartTime must not produce a
-			// negative duration; fall back to now.
-			name:      "end time before start time",
-			startTime: now.Add(-time.Hour),
-			endTime:   now.Add(-2 * time.Hour),
-			want:      now,
-		},
-		{
-			name:      "zero end time",
-			startTime: now.Add(-time.Hour),
-			endTime:   time.Time{},
-			want:      now,
-		},
-		{
-			name:      "now before start time",
-			startTime: now.Add(time.Second),
-			endTime:   now.Add(time.Hour),
-			want:      now.Add(time.Second),
+			// Clock skew: record starts in the future.
+			name:      "start time in the future",
+			startTime: now.Add(time.Hour),
+			endTime:   now.Add(2 * time.Hour),
+			want:      now.Add(time.Hour),
 		},
 	}
 
@@ -70,7 +57,45 @@ func TestSandboxStopTime(t *testing.T) {
 			sbx := sandbox.Sandbox{StartTime: tt.startTime, EndTime: tt.endTime}
 			got := sbxStopTime(sbx, now)
 			require.True(t, tt.want.Equal(got), "want %v, got %v", tt.want, got)
-			require.GreaterOrEqual(t, got.Sub(tt.startTime), time.Duration(0), "sandbox duration must never be negative")
+			require.GreaterOrEqual(t, got.Sub(tt.startTime), time.Duration(0), "duration must never be negative")
+		})
+	}
+}
+
+func TestSbxStopTime_CorruptEndTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	start := now.Add(-30 * 24 * time.Hour)
+
+	tests := []struct {
+		name    string
+		endTime time.Time
+	}{
+		{
+			name:    "end time before start time",
+			endTime: start.Add(-55 * time.Second),
+		},
+		{
+			name:    "end time equal to start time",
+			endTime: start,
+		},
+		{
+			name:    "zero end time",
+			endTime: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sbx := sandbox.Sandbox{StartTime: start, EndTime: tt.endTime}
+			got := sbxStopTime(sbx, now)
+
+			// Corrupt record must bZ zero: stop time collapses to StartTime.
+			require.True(t, start.Equal(got), "want StartTime %v, got %v", start, got)
+			require.Zero(t, got.Sub(sbx.StartTime), "duration must be zero for corrupt records")
 		})
 	}
 }

--- a/packages/api/internal/orchestrator/analytics_test.go
+++ b/packages/api/internal/orchestrator/analytics_test.go
@@ -93,7 +93,7 @@ func TestSbxStopTime_CorruptEndTime(t *testing.T) {
 			sbx := sandbox.Sandbox{StartTime: start, EndTime: tt.endTime}
 			got := sbxStopTime(sbx, now)
 
-			// Corrupt record must bZ zero: stop time collapses to StartTime.
+			// Corrupt record must be zero: stop time collapses to StartTime.
 			require.True(t, start.Equal(got), "want StartTime %v, got %v", start, got)
 			require.Zero(t, got.Sub(sbx.StartTime), "duration must be zero for corrupt records")
 		})


### PR DESCRIPTION
Handle a case where EndTime < StartTime  < now