### PR TITLE
fix(envd): use WithoutCancel for CA cleanup goroutine ctx

### DIFF
--- a/packages/envd/internal/host/cacerts.go
+++ b/packages/envd/internal/host/cacerts.go
@@ -115,10 +115,10 @@ func (c *CACertInstaller) install(ctx context.Context, certPEM, bundlePath, extr
 		Dur("append_duration", time.Since(start)).
 		Msg("CA cert appended to bundle")
 
-	go func() { //nolint:contextcheck // background cleanup must outlive the caller's ctx
+	go func() {
 		cleanStart := time.Now()
 
-		_ = c.mu.Acquire(context.Background(), 1)
+		_ = c.mu.Acquire(context.WithoutCancel(ctx), 1)
 		defer c.mu.Release(1)
 
 		// A newer install has taken over; let that goroutine handle cleanup.


### PR DESCRIPTION
The background CA cleanup goroutine acquired the lock with context.Background() (since 83ee89f9b303, "fix(envd): make CA install lock ctx-aware (#2690)"), discarding any values (trace/span, request-scoped data) from the caller's ctx. Use context.WithoutCancel(ctx) instead so the goroutine still outlives the request's cancellation but inherits its values.