### PR TITLE
feat: make GCS DirectPath opt-in via GCS_ENABLE_DIRECT_PATH

### DIFF
--- a/packages/shared/pkg/storage/storage_google.go
+++ b/packages/shared/pkg/storage/storage_google.go
@@ -42,7 +42,7 @@ const (
 	googleBackoffMultiplier        = 2
 	googleMaxAttempts              = 10
 	defaultGRPCConnectionPoolSize  = 8
-	defaultGCSEnableDirectPath     = false
+	defaultGCSEnableDirectPath     = "false"
 	gcloudDefaultUploadConcurrency = 16
 
 	gcsOperationAttr                    = "operation"
@@ -80,11 +80,14 @@ func NewGCP(ctx context.Context, bucketName string, limiter *limit.Limiter) (Sto
 		return nil, fmt.Errorf("failed to parse GCS_GRPC_CONNECTION_POOL_SIZE: %w", err)
 	}
 
+	// Off by default (#2149); opt-in for bulk readers where Direct Connectivity pays off.
+	enableDirectPath := env.GetEnv("GCS_ENABLE_DIRECT_PATH", defaultGCSEnableDirectPath) == "true"
+
 	opts := []option.ClientOption{
 		option.WithGRPCConnectionPool(grpcPoolSize),
 		option.WithGRPCDialOption(grpc.WithInitialConnWindowSize(32 * megabyte)),
 		option.WithGRPCDialOption(grpc.WithInitialWindowSize(4 * megabyte)),
-		internaloption.EnableDirectPath(defaultGCSEnableDirectPath),
+		internaloption.EnableDirectPath(enableDirectPath),
 	}
 
 	client, err := storage.NewGRPCClient(ctx, opts...)


### PR DESCRIPTION
#2149 hardcoded `EnableDirectPath(false)` when it cleaned up the gRPC env vars, so today the flag can't be enabled at all. This restores the env knob from #2133 but with **default off** — no behavior change for the orchestrator (which is where DirectPath performed badly).

The storage compactor's Cloud Batch workers are pure bulk readers where Direct Connectivity pays off (LB bypass, higher per-connection throughput at PB-scale reads); they'll set `GCS_ENABLE_DIRECT_PATH=true` per submit. The client library already pairs its DirectPath default with `AllowNonDefaultServiceAccount(true)`, which our override doesn't touch, so the flag works for non-default SAs.