### PR TITLE
Paginate S3 prefix deletes

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -85,25 +85,53 @@ func newAWSStorage(ctx context.Context, spec Spec, limiter *limit.Limiter) (*aws
 }
 
 func (s *awsStorage) DeleteObjectsWithPrefix(ctx context.Context, prefix string) error {
+	if prefix == "" {
+		return errors.New("refusing to delete objects with an empty prefix")
+	}
+
+	// A large prefix spans many pages, so scope the timeout per round-trip
+	// below instead of wrapping the whole walk.
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucketName),
+		Prefix: aws.String(prefix),
+	})
+
+	deleted := false
+	for paginator.HasMorePages() {
+		pageCtx, cancel := context.WithTimeout(ctx, awsOperationTimeout)
+		list, err := paginator.NextPage(pageCtx)
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		objects := make([]types.ObjectIdentifier, 0, len(list.Contents))
+		for _, obj := range list.Contents {
+			objects = append(objects, types.ObjectIdentifier{Key: obj.Key})
+		}
+
+		// AWS S3 delete operation requires at least one object to delete.
+		if len(objects) == 0 {
+			continue
+		}
+
+		if err := s.deleteObjects(ctx, objects); err != nil {
+			return err
+		}
+
+		deleted = true
+	}
+
+	if !deleted {
+		logger.L().Warn(ctx, "No objects found to delete with the given prefix", zap.String("prefix", prefix), zap.String("bucket", s.bucketName))
+	}
+
+	return nil
+}
+
+func (s *awsStorage) deleteObjects(ctx context.Context, objects []types.ObjectIdentifier) error {
 	ctx, cancel := context.WithTimeout(ctx, awsOperationTimeout)
 	defer cancel()
-
-	list, err := s.client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: &s.bucketName, Prefix: &prefix})
-	if err != nil {
-		return err
-	}
-
-	objects := make([]types.ObjectIdentifier, 0, len(list.Contents))
-	for _, obj := range list.Contents {
-		objects = append(objects, types.ObjectIdentifier{Key: obj.Key})
-	}
-
-	// AWS S3 delete operation requires at least one object to delete.
-	if len(objects) == 0 {
-		logger.L().Warn(ctx, "No objects found to delete with the given prefix", zap.String("prefix", prefix), zap.String("bucket", s.bucketName))
-
-		return nil
-	}
 
 	output, err := s.client.DeleteObjects(
 		ctx, &s3.DeleteObjectsInput{

--- a/packages/shared/pkg/storage/storage_aws_test.go
+++ b/packages/shared/pkg/storage/storage_aws_test.go
@@ -680,3 +680,13 @@ func TestS3UncompressedStoreFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, sha256.Sum256(data), sha256.Sum256(got.Bytes()))
 }
+
+func TestAWSDeleteObjectsWithPrefixRejectsEmptyPrefix(t *testing.T) {
+	t.Parallel()
+
+	s := &awsStorage{bucketName: "test-bucket"}
+
+	err := s.DeleteObjectsWithPrefix(context.Background(), "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty prefix")
+}


### PR DESCRIPTION
DeleteObjectsWithPrefix only deleted the first ListObjectsV2 page (1000 keys max), so prefixes with more than 1000 objects left the rest behind. Now it pages through all of them. Also refuses an empty prefix so a bad call can't wipe the whole bucket.