### PR TITLE
chore(api): remove legacy expiration member migration code [EN-1602]

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/expiration_index_test.go
+++ b/packages/api/internal/sandbox/storage/redis/expiration_index_test.go
@@ -59,8 +59,7 @@ func TestParseExpirationMember(t *testing.T) {
 		wantParsed bool
 	}{
 		{"execution scoped", teamID + ":sbx-1:" + execID, teamID, "sbx-1", execID, true},
-		{"legacy", teamID + ":sbx-1", teamID, "sbx-1", "", true},
-		{"legacy with uuid sandbox id", teamID + ":" + execID, teamID, execID, "", true},
+		{"legacy two-part member", teamID + ":sbx-1", "", "", "", false},
 		{"no separator", "garbage", "", "", "", false},
 		{"empty rest", teamID + ":", "", "", "", false},
 		{"non-uuid execution tag", teamID + ":sbx-1:not-a-uuid", "", "", "", false},
@@ -179,33 +178,6 @@ func TestExpiredItems_RemovesOrphanMember(t *testing.T) {
 	requireMemberAbsent(t, client, member)
 }
 
-func TestExpiredItems_UpgradesLegacyMember(t *testing.T) {
-	t.Parallel()
-
-	storage, client := setupTestStorage(t)
-
-	teamID := uuid.New()
-	sbx := makeIndexedSandbox(teamID, "sbx-legacy", uuid.NewString(), time.Now(), time.Now().Add(time.Hour))
-	require.NoError(t, storage.Add(t.Context(), sbx))
-
-	// Rewrite the index entry into the legacy format with a drifted (past)
-	// score, simulating pre-deploy data.
-	execMember := expirationMember(teamID.String(), sbx.SandboxID, sbx.ExecutionID)
-	legacyMember := legacyExpirationMember(teamID.String(), sbx.SandboxID)
-	require.NoError(t, client.ZRem(t.Context(), globalExpirationSet, execMember).Err())
-	require.NoError(t, client.ZAdd(t.Context(), globalExpirationSet, redis.Z{
-		Score:  float64(time.Now().Add(-time.Minute).UnixMilli()),
-		Member: legacyMember,
-	}).Err())
-
-	items, err := storage.ExpiredItems(t.Context())
-	require.NoError(t, err)
-	require.Empty(t, items) // sandbox is not expired
-
-	requireMemberAbsent(t, client, legacyMember)
-	requireMemberScore(t, client, execMember, float64(sbx.EndTime.UnixMilli()))
-}
-
 func TestExpiredItems_RescoresDriftedMember(t *testing.T) {
 	t.Parallel()
 
@@ -275,27 +247,6 @@ func TestHeal_RestoresMissingMember(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, items, 1)
 	require.Equal(t, sbx.SandboxID, items[0].SandboxID)
-}
-
-func TestHeal_SkipsLegacyIndexedSandbox(t *testing.T) {
-	t.Parallel()
-
-	storage, client := setupTestStorage(t)
-
-	teamID := uuid.New()
-	sbx := makeIndexedSandbox(teamID, "sbx-legacy-indexed", uuid.NewString(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
-	require.NoError(t, storage.Add(t.Context(), sbx))
-
-	// Sandbox indexed only via the legacy member (written by an old pod).
-	require.NoError(t, client.ZRem(t.Context(), globalExpirationSet, expirationMember(teamID.String(), sbx.SandboxID, sbx.ExecutionID)).Err())
-	require.NoError(t, client.ZAdd(t.Context(), globalExpirationSet, redis.Z{
-		Score:  float64(sbx.EndTime.UnixMilli()),
-		Member: legacyExpirationMember(teamID.String(), sbx.SandboxID),
-	}).Err())
-
-	healed, err := storage.healExpirationIndex(t.Context())
-	require.NoError(t, err)
-	require.Zero(t, healed)
 }
 
 func TestHeal_SkipsYoungSandbox(t *testing.T) {
@@ -386,7 +337,7 @@ func TestHeal_DoesNotClobberExistingScore(t *testing.T) {
 	requireMemberScore(t, client, member, freshScore)
 }
 
-func TestUpdate_RescoresExecutionMemberAndRetiresLegacy(t *testing.T) {
+func TestUpdate_RescoresExecutionMember(t *testing.T) {
 	t.Parallel()
 
 	storage, client := setupTestStorage(t)
@@ -394,13 +345,6 @@ func TestUpdate_RescoresExecutionMemberAndRetiresLegacy(t *testing.T) {
 	teamID := uuid.New()
 	sbx := makeIndexedSandbox(teamID, "sbx-update", uuid.NewString(), time.Now(), time.Now().Add(time.Hour))
 	require.NoError(t, storage.Add(t.Context(), sbx))
-
-	// Seed a leftover legacy member (pre-deploy data).
-	legacyMember := legacyExpirationMember(teamID.String(), sbx.SandboxID)
-	require.NoError(t, client.ZAdd(t.Context(), globalExpirationSet, redis.Z{
-		Score:  float64(sbx.EndTime.UnixMilli()),
-		Member: legacyMember,
-	}).Err())
 
 	newEndTime := time.Now().Add(2 * time.Hour)
 	updated, err := storage.Update(t.Context(), teamID, sbx.SandboxID, func(cur sandboxtypes.Sandbox) (sandboxtypes.Sandbox, error) {
@@ -411,5 +355,4 @@ func TestUpdate_RescoresExecutionMemberAndRetiresLegacy(t *testing.T) {
 	require.NoError(t, err)
 
 	requireMemberScore(t, client, expirationMember(teamID.String(), sbx.SandboxID, updated.ExecutionID), float64(newEndTime.UnixMilli()))
-	requireMemberAbsent(t, client, legacyMember)
 }

--- a/packages/api/internal/sandbox/storage/redis/expiration_index_test.go
+++ b/packages/api/internal/sandbox/storage/redis/expiration_index_test.go
@@ -178,6 +178,42 @@ func TestExpiredItems_RemovesOrphanMember(t *testing.T) {
 	requireMemberAbsent(t, client, member)
 }
 
+// TestExpiredItems_SweepsInvalidMember: unparseable members must be removed, not skipped,
+// otherwise they permanently occupy the batch-limited expired scan window and starve
+// eviction of valid sandboxes. A live sandbox indexed only by such a member
+// is re-indexed in the current format by the healer.
+func TestExpiredItems_SweepsInvalidMember(t *testing.T) {
+	t.Parallel()
+
+	storage, client := setupTestStorage(t)
+
+	teamID := uuid.New()
+	sbx := makeIndexedSandbox(teamID, "sbx-legacy-leftover", uuid.NewString(), time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	require.NoError(t, storage.Add(t.Context(), sbx))
+
+	// Sandbox indexed only via an expired legacy two-part member.
+	execMember := expirationMember(teamID.String(), sbx.SandboxID, sbx.ExecutionID)
+	legacyMember := teamID.String() + ":" + sbx.SandboxID
+	require.NoError(t, client.ZRem(t.Context(), globalExpirationSet, execMember).Err())
+	require.NoError(t, client.ZAdd(t.Context(), globalExpirationSet, redis.Z{
+		Score:  float64(time.Now().Add(-time.Minute).UnixMilli()),
+		Member: legacyMember,
+	}).Err())
+
+	items, err := storage.ExpiredItems(t.Context())
+	require.NoError(t, err)
+	require.Empty(t, items)
+
+	// Invalid member swept: it no longer occupies the scan window.
+	requireMemberAbsent(t, client, legacyMember)
+
+	// Healer restores eviction coverage in the current member format.
+	healed, err := storage.healExpirationIndex(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, healed)
+	requireMemberScore(t, client, execMember, float64(sbx.EndTime.UnixMilli()))
+}
+
 func TestExpiredItems_RescoresDriftedMember(t *testing.T) {
 	t.Parallel()
 

--- a/packages/api/internal/sandbox/storage/redis/heal.go
+++ b/packages/api/internal/sandbox/storage/redis/heal.go
@@ -55,7 +55,6 @@ func (s *Storage) startHealer(ctx context.Context) {
 	}
 }
 
-// TODO: remove after migration
 // healerEnabled reports whether the heal pass should run. A nil feature flag
 // client (tests) falls back to the flag's default.
 func (s *Storage) healerEnabled(ctx context.Context) bool {

--- a/packages/api/internal/sandbox/storage/redis/heal.go
+++ b/packages/api/internal/sandbox/storage/redis/heal.go
@@ -141,9 +141,8 @@ func (s *Storage) healSandboxBatch(ctx context.Context, teamID string, sandboxID
 
 	now := time.Now()
 	type candidate struct {
-		member       string
-		legacyMember string
-		score        float64
+		member string
+		score  float64
 	}
 	var candidates []candidate
 	for _, raw := range vals {
@@ -162,22 +161,19 @@ func (s *Storage) healSandboxBatch(ctx context.Context, teamID string, sandboxID
 		}
 
 		candidates = append(candidates, candidate{
-			member:       sandboxExpirationMember(sbx),
-			legacyMember: legacyExpirationMember(teamID, sbx.SandboxID),
-			score:        float64(sbx.EndTime.UnixMilli()),
+			member: sandboxExpirationMember(sbx),
+			score:  float64(sbx.EndTime.UnixMilli()),
 		})
 	}
 	if len(candidates) == 0 {
 		return 0, nil
 	}
 
-	// A sandbox is indexed if either its execution-scoped member or the
-	// legacy member (written by old pods during rolling deploys) exists.
 	// ZMSCORE returns 0 for absent members; legitimate scores are unix
 	// milliseconds and can never be 0.
-	members := make([]string, 0, len(candidates)*2)
+	members := make([]string, 0, len(candidates))
 	for _, c := range candidates {
-		members = append(members, c.member, c.legacyMember)
+		members = append(members, c.member)
 	}
 
 	scores, err := s.redisClient.ZMScore(ctx, globalExpirationSet, members...).Result()
@@ -187,7 +183,7 @@ func (s *Storage) healSandboxBatch(ctx context.Context, teamID string, sandboxID
 
 	var missing []redis.Z
 	for i, c := range candidates {
-		if scores[2*i] != 0 || scores[2*i+1] != 0 {
+		if scores[i] != 0 {
 			continue
 		}
 

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -45,11 +45,18 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 		teamID string
 		refs   []memberRef
 	}
+	// staleMembers collects ZSET entries to remove: unparseable members, orphans, and dead executions
+	var staleMembers []any
+	var invalidCount int64
+
 	teamSandboxes := make(map[string]*teamEntry)
 	for _, member := range expiredMembers {
 		teamID, sandboxID, executionID, ok := parseExpirationMember(member)
 		if !ok {
-			logger.L().Warn(ctx, "Invalid expiration index member", zap.String("member", member))
+			// Unparseable: sweep it so it stops consuming the scan window on every tick
+			logger.L().Warn(ctx, "Removing invalid expiration index member", zap.String("member", member))
+			staleMembers = append(staleMembers, member)
+			invalidCount++
 
 			continue
 		}
@@ -85,9 +92,8 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 		return nil, fmt.Errorf("MGET pipeline failed: %w", err)
 	}
 
-	// Deserialize and filter; collect stale ZSET members for cleanup.
+	// Deserialize and filter.
 	var result []sandboxtypes.Sandbox
-	var staleMembers []any
 	var rescores []redis.Z // live members whose score drifted from EndTime
 	var orphanCount, deadExecutionCount int64
 
@@ -166,6 +172,9 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 			}
 			if deadExecutionCount > 0 {
 				s.metrics.indexSwept.Add(ctx, deadExecutionCount, s.metrics.sweptDeadExecution)
+			}
+			if invalidCount > 0 {
+				s.metrics.indexSwept.Add(ctx, invalidCount, s.metrics.sweptInvalid)
 			}
 		}
 	}

--- a/packages/api/internal/sandbox/storage/redis/items.go
+++ b/packages/api/internal/sandbox/storage/redis/items.go
@@ -39,7 +39,7 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 	type memberRef struct {
 		member      string
 		sandboxID   string
-		executionID string // "" for legacy (execution-less) members
+		executionID string
 	}
 	type teamEntry struct {
 		teamID string
@@ -88,10 +88,8 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 	// Deserialize and filter; collect stale ZSET members for cleanup.
 	var result []sandboxtypes.Sandbox
 	var staleMembers []any
-	var upgrades []redis.Z   // legacy members re-added in execution-scoped format
-	var upgradedLegacy []any // legacy members to retire once upgrades land
-	var rescores []redis.Z   // live members whose score drifted from EndTime
-	var orphanCount, deadExecutionCount, upgradedCount int64
+	var rescores []redis.Z // live members whose score drifted from EndTime
+	var orphanCount, deadExecutionCount int64
 
 	for _, batch := range batches {
 		for i, raw := range batch.cmd.Val() {
@@ -120,22 +118,11 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 			}
 
 			// Member names a dead execution; the live execution has its own member.
-			if ref.executionID != "" && ref.executionID != sbx.ExecutionID {
+			if ref.executionID != sbx.ExecutionID {
 				staleMembers = append(staleMembers, ref.member)
 				deadExecutionCount++
 
 				continue
-			}
-
-			// Legacy (execution-less) member: upgrade in place so future
-			// removals are execution-exact. ZADD NX first (never a window
-			// with no member for a live key), then retire the legacy member.
-			if ref.executionID == "" && sbx.ExecutionID != "" {
-				upgrades = append(upgrades, redis.Z{
-					Score:  float64(sbx.EndTime.UnixMilli()),
-					Member: expirationMember(batch.teamID, sbx.SandboxID, sbx.ExecutionID),
-				})
-				upgradedLegacy = append(upgradedLegacy, ref.member)
 			}
 
 			// In case that index have failed to be updated
@@ -145,12 +132,10 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 				// Re-score the drifted member to the stored EndTime so it
 				// stops occupying the expired scan window on every tick.
 				// XX: never resurrect a member a concurrent Remove deleted.
-				if ref.executionID != "" {
-					rescores = append(rescores, redis.Z{
-						Score:  float64(sbx.EndTime.UnixMilli()),
-						Member: ref.member,
-					})
-				}
+				rescores = append(rescores, redis.Z{
+					Score:  float64(sbx.EndTime.UnixMilli()),
+					Member: ref.member,
+				})
 
 				continue
 			}
@@ -171,18 +156,6 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 		}
 	}
 
-	// Upgrades before legacy removal: a live key must have a member in the
-	// index at every step. NX keeps a fresher score if one already exists.
-	// Legacy members are retired only after the upgrade landed.
-	if len(upgrades) > 0 {
-		if err := s.redisClient.ZAddNX(ctx, globalExpirationSet, upgrades...).Err(); err != nil {
-			logger.L().Warn(ctx, "Failed to upgrade legacy expiration index entries", zap.Error(err), zap.Int("count", len(upgrades)))
-		} else {
-			staleMembers = append(staleMembers, upgradedLegacy...)
-			upgradedCount = int64(len(upgradedLegacy))
-		}
-	}
-
 	// Remove orphaned ZSET entries so the set doesn't grow unboundedly.
 	if len(staleMembers) > 0 {
 		if err := s.redisClient.ZRem(ctx, globalExpirationSet, staleMembers...).Err(); err != nil {
@@ -193,9 +166,6 @@ func (s *Storage) ExpiredItems(ctx context.Context) ([]sandboxtypes.Sandbox, err
 			}
 			if deadExecutionCount > 0 {
 				s.metrics.indexSwept.Add(ctx, deadExecutionCount, s.metrics.sweptDeadExecution)
-			}
-			if upgradedCount > 0 {
-				s.metrics.indexSwept.Add(ctx, upgradedCount, s.metrics.sweptLegacyUpgraded)
 			}
 		}
 	}

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -52,6 +52,7 @@ type expirationIndexMetrics struct {
 	indexSwept         metric.Int64Counter
 	sweptOrphan        metric.MeasurementOption
 	sweptDeadExecution metric.MeasurementOption
+	sweptInvalid       metric.MeasurementOption
 }
 
 const sweptReasonAttr = "reason"
@@ -78,6 +79,7 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 		indexSwept:         swept,
 		sweptOrphan:        metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "orphan"))),
 		sweptDeadExecution: metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "dead_execution"))),
+		sweptInvalid:       metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "invalid"))),
 	}, nil
 }
 

--- a/packages/api/internal/sandbox/storage/redis/main.go
+++ b/packages/api/internal/sandbox/storage/redis/main.go
@@ -49,10 +49,9 @@ type expirationIndexMetrics struct {
 	indexHealed   metric.Int64Counter
 	indexRescored metric.Int64Counter
 
-	indexSwept          metric.Int64Counter
-	sweptOrphan         metric.MeasurementOption
-	sweptDeadExecution  metric.MeasurementOption
-	sweptLegacyUpgraded metric.MeasurementOption
+	indexSwept         metric.Int64Counter
+	sweptOrphan        metric.MeasurementOption
+	sweptDeadExecution metric.MeasurementOption
 }
 
 const sweptReasonAttr = "reason"
@@ -74,12 +73,11 @@ func newExpirationIndexMetrics(meter metric.Meter) (expirationIndexMetrics, erro
 	}
 
 	return expirationIndexMetrics{
-		indexHealed:         healed,
-		indexRescored:       rescored,
-		indexSwept:          swept,
-		sweptOrphan:         metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "orphan"))),
-		sweptDeadExecution:  metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "dead_execution"))),
-		sweptLegacyUpgraded: metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "legacy_upgraded"))),
+		indexHealed:        healed,
+		indexRescored:      rescored,
+		indexSwept:         swept,
+		sweptOrphan:        metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "orphan"))),
+		sweptDeadExecution: metric.WithAttributeSet(attribute.NewSet(attribute.String(sweptReasonAttr, "dead_execution"))),
 	}, nil
 }
 

--- a/packages/api/internal/sandbox/storage/redis/operations.go
+++ b/packages/api/internal/sandbox/storage/redis/operations.go
@@ -104,21 +104,18 @@ func (s *Storage) Remove(ctx context.Context, teamID uuid.UUID, sandboxID string
 
 	// Clean up from the global expiration index.
 	// Do it after the removal to prevent leaking expired sandboxes.
-	// Always drop the legacy (execution-less) member; drop the execution
-	// member only for the execution we deleted. A concurrent lockless Add for
-	// a newer execution wrote a different member, so it can never be
+	// Drop only the member of the execution we deleted. A concurrent lockless
+	// Add for a newer execution wrote a different member, so it can never be
 	// unindexed here. If the key was already gone, any leftover execution
 	// member is swept by ExpiredItems once its score passes.
-	members := []any{legacyExpirationMember(teamID.String(), sandboxID)}
 	if raw != "" {
 		var sbx sandboxtypes.Sandbox
 		if unmarshalErr := json.Unmarshal([]byte(raw), &sbx); unmarshalErr == nil && sbx.ExecutionID != "" {
-			members = append(members, expirationMember(teamID.String(), sandboxID, sbx.ExecutionID))
+			member := expirationMember(teamID.String(), sandboxID, sbx.ExecutionID)
+			if err := s.redisClient.ZRem(ctx, globalExpirationSet, member).Err(); err != nil {
+				logger.L().Warn(ctx, "Failed to remove sandbox from global expiration index", zap.Error(err), logger.WithSandboxID(sandboxID))
+			}
 		}
-	}
-
-	if err := s.redisClient.ZRem(ctx, globalExpirationSet, members...).Err(); err != nil {
-		logger.L().Warn(ctx, "Failed to remove sandbox from global expiration index", zap.Error(err), logger.WithSandboxID(sandboxID))
 	}
 
 	return nil
@@ -237,15 +234,6 @@ func (s *Storage) Update(ctx context.Context, teamID uuid.UUID, sandboxID string
 			Member: sandboxExpirationMember(updatedSbx),
 		}).Err(); err != nil {
 			return sandboxtypes.Sandbox{}, fmt.Errorf("failed to update sandbox in global expiration index: %w", err)
-		}
-
-		// Migrate-on-write: retire the legacy (execution-less) member so a
-		// stale-scored duplicate can't shadow the fresh score. Warn-only —
-		// the lazy upgrade in ExpiredItems covers failures.
-		if updatedSbx.ExecutionID != "" {
-			if err := s.redisClient.ZRem(ctx, globalExpirationSet, legacyExpirationMember(teamID.String(), sandboxID)).Err(); err != nil {
-				logger.L().Warn(ctx, "Failed to remove legacy expiration index member", zap.Error(err), logger.WithSandboxID(sandboxID))
-			}
 		}
 	}
 

--- a/packages/api/internal/sandbox/storage/redis/utils.go
+++ b/packages/api/internal/sandbox/storage/redis/utils.go
@@ -37,58 +37,25 @@ func expirationMember(teamID, sandboxID, executionID string) string {
 	return redis_utils.CreateKey(teamID, sandboxID, executionID)
 }
 
-// legacyExpirationMember is the pre-executionID member format still present
-// in live data (and written by old pods during a rolling deploy). It drains
-// via Remove's dual ZREM and the lazy upgrade in ExpiredItems.
-//
-// TODO [EN-1602]: remove the legacy member format once the migration is complete
-// Then delete:
-//   - legacyExpirationMember and the ExecutionID == "" fallback in
-//     sandboxExpirationMember (utils.go)
-//   - the executionID == "" legacy branch in parseExpirationMember (utils.go)
-//   - the legacy member in Remove's dual ZREM (operations.go)
-//   - the migrate-on-write ZRem in Update (operations.go)
-//   - the legacy upgrade path in ExpiredItems: upgrades/upgradedLegacy and
-//     the sweptLegacyUpgraded metric attribute (items.go, main.go)
-//   - the legacyMember half of the ZMSCORE existence check in
-//     healTeamExpirationIndex (heal.go)
-//   - the legacy cases in expiration_index_test.go
-func legacyExpirationMember(teamID, sandboxID string) string {
-	return redis_utils.CreateKey(teamID, sandboxID)
-}
-
 // sandboxExpirationMember returns the expiration index member for a stored
-// sandbox, falling back to the legacy format when ExecutionID is absent.
+// sandbox.
 func sandboxExpirationMember(sbx sandboxtypes.Sandbox) string {
-	if sbx.ExecutionID == "" {
-		return legacyExpirationMember(sbx.TeamID.String(), sbx.SandboxID)
-	}
-
 	return expirationMember(sbx.TeamID.String(), sbx.SandboxID, sbx.ExecutionID)
 }
 
-// parseExpirationMember parses both member formats:
-// "teamID:sandboxID:executionID" (current) and "teamID:sandboxID" (legacy).
-// executionID == "" marks a legacy member. Sandbox IDs never contain ':'
-// and execution IDs are always UUIDs.
+// parseExpirationMember parses "teamID:sandboxID:executionID" members.
+// Sandbox IDs never contain ':' and execution IDs are always UUIDs.
 func parseExpirationMember(member string) (teamID, sandboxID, executionID string, ok bool) {
 	parts := strings.Split(member, ":")
-	switch len(parts) {
-	case 2: // legacy
-		if parts[1] == "" {
-			return "", "", "", false
-		}
-
-		return parts[0], parts[1], "", true
-	case 3:
-		if _, err := uuid.Parse(parts[2]); err != nil {
-			return "", "", "", false
-		}
-
-		return parts[0], parts[1], parts[2], true
-	default:
+	if len(parts) != 3 {
 		return "", "", "", false
 	}
+
+	if _, err := uuid.Parse(parts[2]); err != nil {
+		return "", "", "", false
+	}
+
+	return parts[0], parts[1], parts[2], true
 }
 
 // GetTeamPrefix returns the storage team prefix for external packages (e.g. reservations).

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -60,7 +60,7 @@ const (
 	ApiRedisStorageExpirationIndexHealed CounterType = "api.redis_storage.expiration_index.healed"
 	// ApiRedisStorageExpirationIndexSwept counts members removed from the
 	// global expiration index by the evictor scan
-	// (reason=orphan|dead_execution).
+	// (reason=orphan|dead_execution|invalid).
 	ApiRedisStorageExpirationIndexSwept CounterType = "api.redis_storage.expiration_index.swept"
 	// ApiRedisStorageExpirationIndexRescored counts live members whose index
 	// score drifted from the stored EndTime and were re-scored by the evictor
@@ -253,7 +253,7 @@ var counterDesc = map[CounterType]string{
 	ApiRedisStoragePublisherDropped:   "Total storage notifications dropped before reaching Redis (reason=queue_full|closed)",
 
 	ApiRedisStorageExpirationIndexHealed:   "Sandboxes re-added to the global expiration index by the healer; sustained non-zero rate means index writes are being lost",
-	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution)",
+	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution|invalid)",
 	ApiRedisStorageExpirationIndexRescored: "Live expiration index members re-scored after drifting from the stored EndTime",
 }
 

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -60,7 +60,7 @@ const (
 	ApiRedisStorageExpirationIndexHealed CounterType = "api.redis_storage.expiration_index.healed"
 	// ApiRedisStorageExpirationIndexSwept counts members removed from the
 	// global expiration index by the evictor scan
-	// (reason=orphan|dead_execution|legacy_upgraded).
+	// (reason=orphan|dead_execution).
 	ApiRedisStorageExpirationIndexSwept CounterType = "api.redis_storage.expiration_index.swept"
 	// ApiRedisStorageExpirationIndexRescored counts live members whose index
 	// score drifted from the stored EndTime and were re-scored by the evictor
@@ -253,7 +253,7 @@ var counterDesc = map[CounterType]string{
 	ApiRedisStoragePublisherDropped:   "Total storage notifications dropped before reaching Redis (reason=queue_full|closed)",
 
 	ApiRedisStorageExpirationIndexHealed:   "Sandboxes re-added to the global expiration index by the healer; sustained non-zero rate means index writes are being lost",
-	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution|legacy_upgraded)",
+	ApiRedisStorageExpirationIndexSwept:    "Members removed from the global expiration index by the evictor scan (reason=orphan|dead_execution)",
 	ApiRedisStorageExpirationIndexRescored: "Live expiration index members re-scored after drifting from the stored EndTime",
 }
 


### PR DESCRIPTION
Drops the legacy two-part member format: dual ZREM in Remove, migrate-on-write in Update, lazy upgrade in ExpiredItems, legacy half of healer ZMSCORE check, and the legacy_upgraded sweep metric.