### PR TITLE
feat: dynamic sandbox log routing and ClickHouse-backed log reads

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ flowchart TB
     subgraph datastores["State"]
         PG[("PostgreSQL<br/>teams, templates, builds, snapshots")]
         RD[("Redis<br/>running sandboxes, routing catalog, caches")]
-        CH[("ClickHouse<br/>metrics, events")]
+        CH[("ClickHouse<br/>metrics, events, optional logs")]
         OS[("Object storage GCS/S3<br/>template + snapshot artifacts")]
     end
 
@@ -115,8 +115,10 @@ The control-plane entry point (Gin, OpenAPI-generated from `spec/openapi.yml`, p
   (templates, builds, snapshots, teams) live in Postgres.
 - **Extra listeners**: internal gRPC :5009 and edge gRPC :5109 expose `ResumeSandbox` so
   client-proxy can wake paused sandboxes on incoming traffic.
-- Reads ClickHouse for sandbox/team metrics endpoints; queries Loki for logs; LaunchDarkly
-  feature flags gate placement parameters, rate limits, and rollouts.
+- Reads ClickHouse for sandbox/team metrics endpoints. Sandbox and template-build logs default to
+  Loki, with a LaunchDarkly-gated ClickHouse read path for local-cluster logs during the log
+  storage migration. LaunchDarkly feature flags also gate placement parameters, rate limits, and
+  rollouts.
 
 ### Orchestrator (`packages/orchestrator`)
 
@@ -151,7 +153,10 @@ Key mechanisms (all under `pkg/sandbox/`):
   reused; slot allocation is coordinated through Consul KV.
 - **Sandbox proxy** (:5007, `pkg/proxy/`): reverse-proxies incoming traffic from client-proxy to
   the sandbox's slot IP and requested port, enforcing per-sandbox traffic access tokens.
-- Writes sandbox lifecycle **events** and cgroup **host stats** to ClickHouse; exports metrics via OTel.
+- Writes sandbox lifecycle **events** and cgroup **host stats** to ClickHouse; exports metrics via
+  OTel. Sandbox and template-build log writes go through a flag-resolved HTTP route: the legacy
+  collector remains the fallback primary destination, and configured shadow destinations can mirror
+  writes during collector/storage migrations without changing sandbox behavior.
 
 ### Envd (`packages/envd`)
 
@@ -194,7 +199,7 @@ into the cloud artifact registry (`/v2/e2b/custom-envs/<templateID>` → project
 |---|---|---|
 | **PostgreSQL** | `packages/db` (goose migrations, sqlc) | Durable control-plane state: `teams`, `users`, `tiers` (quotas), `envs` (templates), `env_builds` (build rows: vcpu, ram_mb, status, versions), `env_aliases`, `snapshots` (paused sandboxes), `team_api_keys`, `access_tokens`, `volumes`, `clusters` |
 | **Redis** | API, client-proxy, orchestrator | Ephemeral runtime state: running-sandbox store (source of truth), sandbox→node routing catalog, team/template/snapshot caches, rate limiting, P2P chunk peer registry |
-| **ClickHouse** | `packages/clickhouse` | Time-series/analytics: `metrics_gauge`/`metrics_sum` (written by the OTel collector), `sandbox_events`, `sandbox_host_stats` (written by orchestrator), team metrics. Read by API and dashboard-api |
+| **ClickHouse** | `packages/clickhouse` | Time-series/analytics: `metrics_gauge`/`metrics_sum` (written by the OTel collector), `sandbox_events`, `sandbox_host_stats` (written by orchestrator), team metrics, and optionally `sandbox_logs` during the log migration. Read by API and dashboard-api |
 | **Object storage** (GCS/S3/local, `packages/shared/pkg/storage`) | orchestrator, template-manager | Template & snapshot artifacts, keyed by build ID: `{buildID}/memfile`, `{buildID}/rootfs.ext4`, `{buildID}/snapfile`, `{buildID}/metadata.json` + `.header` index files |
 | **Consul KV** | orchestrator | Network slot allocation across restarts |
 
@@ -348,7 +353,9 @@ flowchart TB
 - PostgreSQL is external (connection string via secrets); Redis runs as a Nomad job or as a
   managed service; ClickHouse runs on its own pool.
 - Observability: everything exports OTel; the collector fans out to ClickHouse (product metrics)
-  and Grafana Cloud/stack; logs flow through Vector to Loki.
+  and Grafana Cloud/stack. Logs default to the legacy Vector → Loki path; dynamic log routing can
+  select a primary collector and shadow collectors, and local-cluster log reads can be switched to
+  ClickHouse with `logs-read-config` after `sandbox_logs` is populated.
 
 ## Repository layout
 

--- a/packages/api/internal/clusters/cluster.go
+++ b/packages/api/internal/clusters/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/clusters/discovery"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	infogrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator-info"
 	api "github.com/e2b-dev/infra/packages/shared/pkg/http/edge"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
@@ -75,6 +76,8 @@ func newLocalCluster(
 	storeDiscovery discovery.Discovery,
 	clickhouse clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
+	sandboxLogsReader ClickhouseLogsReader,
+	featureFlags *featureflags.Client,
 	config cfg.Config,
 ) *Cluster {
 	clusterID := consts.LocalClusterID
@@ -93,7 +96,7 @@ func newLocalCluster(
 		"",
 		instances,
 		synchronization.NewSynchronize("cluster-instances", "Cluster instances", store),
-		newLocalClusterResourceProvider(clickhouse, queryLogsProvider, instances, config),
+		newLocalClusterResourceProvider(clickhouse, queryLogsProvider, sandboxLogsReader, featureFlags, instances, config),
 	)
 
 	// Periodically sync cluster instances

--- a/packages/api/internal/clusters/clusters_sync.go
+++ b/packages/api/internal/clusters/clusters_sync.go
@@ -14,6 +14,7 @@ import (
 	"github.com/e2b-dev/infra/packages/db/client"
 	"github.com/e2b-dev/infra/packages/db/queries"
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs/loki"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
@@ -49,6 +50,8 @@ func NewPool(
 	localDiscovery discovery.Discovery,
 	queryMetricsProvider clickhouse.Clickhouse,
 	queryLogsProvider *loki.LokiQueryProvider,
+	sandboxLogsReader ClickhouseLogsReader,
+	featureFlags *featureflags.Client,
 	config cfg.Config,
 ) (*Pool, error) {
 	clusters := smap.New[*Cluster]()
@@ -71,6 +74,8 @@ func NewPool(
 				localDiscovery:       localDiscovery,
 				queryLogsProvider:    queryLogsProvider,
 				queryMetricsProvider: queryMetricsProvider,
+				sandboxLogsReader:    sandboxLogsReader,
+				featureFlags:         featureFlags,
 			},
 		),
 	}
@@ -114,6 +119,8 @@ type clustersSyncStore struct {
 	localDiscovery       discovery.Discovery
 	queryMetricsProvider clickhouse.Clickhouse
 	queryLogsProvider    *loki.LokiQueryProvider
+	sandboxLogsReader    ClickhouseLogsReader
+	featureFlags         *featureflags.Client
 	config               cfg.Config
 }
 
@@ -171,7 +178,7 @@ func (d clustersSyncStore) PoolInsert(ctx context.Context, cluster queries.Clust
 
 	// Local cluster
 	if cluster.ID == consts.LocalClusterID {
-		c = newLocalCluster(context.WithoutCancel(ctx), d.tel, d.localDiscovery, d.queryMetricsProvider, d.queryLogsProvider, d.config)
+		c = newLocalCluster(context.WithoutCancel(ctx), d.tel, d.localDiscovery, d.queryMetricsProvider, d.queryLogsProvider, d.sandboxLogsReader, d.featureFlags, d.config)
 		d.clusters.Insert(clusterID, c)
 		logger.L().Info(ctx, "Local cluster initialized successfully", logger.WithClusterID(cluster.ID))
 

--- a/packages/api/internal/clusters/resources.go
+++ b/packages/api/internal/clusters/resources.go
@@ -222,11 +222,13 @@ func getBuildLogsWithSources(
 		sources = append(sources, persistentLogFetcher)
 	}
 
-	// Iterate through sources and return the first successful fetch
+	// Iterate through sources and return the first successful fetch.
+	var lastErr *api.APIError
 	for _, sourceFetch := range sources {
 		entries, err := sourceFetch()
 		if err != nil {
 			logger.L().Warn(ctx, "Error fetching build logs", logger.WithTemplateID(templateID), logger.WithBuildID(buildID), zap.Error(err))
+			lastErr = err
 
 			continue
 		}
@@ -234,5 +236,5 @@ func getBuildLogsWithSources(
 		return entries, nil
 	}
 
-	return nil, nil
+	return nil, lastErr
 }

--- a/packages/api/internal/clusters/resources_local.go
+++ b/packages/api/internal/clusters/resources_local.go
@@ -6,27 +6,73 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/grafana/loki/v3/pkg/logproto"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/cfg"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/sandboxlogs"
 	clickhouseutils "github.com/e2b-dev/infra/packages/clickhouse/pkg/utils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs/loki"
 	"github.com/e2b-dev/infra/packages/shared/pkg/smap"
 )
 
+// ClickhouseLogsReader is the narrow ClickHouse sandbox_logs reader the local
+// cluster needs.
+type ClickhouseLogsReader interface {
+	QuerySandboxLogs(ctx context.Context, teamID uuid.UUID, sandboxID string, start, end time.Time, limit int, order sandboxlogs.SortOrder, level *logs.LogLevel, search *string) ([]logs.LogEntry, error)
+	QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, order sandboxlogs.SortOrder) ([]logs.LogEntry, error)
+}
+
+var _ ClickhouseLogsReader = (*sandboxlogs.Reader)(nil)
+
+// logReadMeter/logReadErrorCount count ClickHouse log read failures so
+// operators can alert on them, broken down by log kind.
+var (
+	logReadMeter    = otel.Meter("github.com/e2b-dev/infra/packages/api/internal/clusters")
+	logReadErrCount = mustLogReadCounter(
+		"log_read_clickhouse_error_count",
+		"Number of local-cluster ClickHouse log read failures by log kind",
+	)
+)
+
+func mustLogReadCounter(name, description string) metric.Int64Counter {
+	counter, err := logReadMeter.Int64Counter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
+
+func recordClickhouseLogReadError(ctx context.Context, kind string) {
+	if logReadErrCount == nil {
+		return
+	}
+
+	logReadErrCount.Add(ctx, 1, metric.WithAttributes(attribute.String("kind", kind)))
+}
+
 type LocalClusterResourceProvider struct {
 	config                      cfg.Config
 	querySandboxMetricsProvider clickhouse.SandboxQueriesProvider
 	queryLogsProvider           *loki.LokiQueryProvider
+	sandboxLogsReader           ClickhouseLogsReader
+	featureFlags                *featureflags.Client
 	instances                   *smap.Map[*Instance]
 }
 
 func newLocalClusterResourceProvider(
 	querySandboxMetricsProvider clickhouse.SandboxQueriesProvider,
 	queryLogsProvider *loki.LokiQueryProvider,
+	sandboxLogsReader ClickhouseLogsReader,
+	featureFlags *featureflags.Client,
 	instances *smap.Map[*Instance],
 	config cfg.Config,
 ) ClusterResource {
@@ -34,8 +80,31 @@ func newLocalClusterResourceProvider(
 		config:                      config,
 		querySandboxMetricsProvider: querySandboxMetricsProvider,
 		queryLogsProvider:           queryLogsProvider,
+		sandboxLogsReader:           sandboxLogsReader,
+		featureFlags:                featureFlags,
 		instances:                   instances,
 	}
+}
+
+// readFromClickhouse reports whether log reads should hit ClickHouse. It is
+// true only when the logs-read-config flag is enabled AND a ClickHouse reader
+// is configured; otherwise reads stay on Loki (default behavior).
+func (l *LocalClusterResourceProvider) readFromClickhouse(ctx context.Context) bool {
+	if l.sandboxLogsReader == nil || l.featureFlags == nil {
+		return false
+	}
+
+	return l.featureFlags.BoolFlag(ctx, featureflags.LogsReadConfigFlag)
+}
+
+// apiLogDirectionToSandboxLogsSortOrder converts an API log direction into the
+// ClickHouse reader's SortOrder (Forward by default).
+func apiLogDirectionToSandboxLogsSortOrder(direction *api.LogsDirection) sandboxlogs.SortOrder {
+	if direction != nil && *direction == api.LogsDirectionBackward {
+		return sandboxlogs.SortOrderBackward
+	}
+
+	return sandboxlogs.SortOrderForward
 }
 
 func (l *LocalClusterResourceProvider) GetSandboxMetrics(ctx context.Context, teamID string, sandboxID string, qStart *int64, qEnd *int64) ([]api.SandboxMetric, *api.APIError) {
@@ -130,7 +199,27 @@ func (l *LocalClusterResourceProvider) GetSandboxLogs(ctx context.Context, teamI
 		limit = int(*qLimit)
 	}
 
-	raw, err := l.queryLogsProvider.QuerySandboxLogs(ctx, teamID, sandboxID, start, end, limit, apiLogDirectionToLokiProtoDirection(qDirection), level, search)
+	var (
+		raw []logs.LogEntry
+		err error
+	)
+	if l.readFromClickhouse(ctx) {
+		teamUUID, parseErr := uuid.Parse(teamID)
+		if parseErr != nil {
+			return api.SandboxLogs{}, &api.APIError{
+				Err:       fmt.Errorf("invalid team ID %q: %w", teamID, parseErr),
+				ClientMsg: "Invalid team ID",
+				Code:      http.StatusBadRequest,
+			}
+		}
+
+		raw, err = l.sandboxLogsReader.QuerySandboxLogs(ctx, teamUUID, sandboxID, start, end, limit, apiLogDirectionToSandboxLogsSortOrder(qDirection), level, search)
+		if err != nil {
+			recordClickhouseLogReadError(ctx, "sandbox")
+		}
+	} else {
+		raw, err = l.queryLogsProvider.QuerySandboxLogs(ctx, teamID, sandboxID, start, end, limit, apiLogDirectionToLokiProtoDirection(qDirection), level, search)
+	}
 	if err != nil {
 		return api.SandboxLogs{}, &api.APIError{
 			Err:       fmt.Errorf("error when fetching sandbox logs: %w", err),
@@ -169,11 +258,35 @@ func (l *LocalClusterResourceProvider) GetBuildLogs(
 	direction api.LogsDirection,
 	source *api.LogsSource,
 ) ([]logs.LogEntry, *api.APIError) {
-	// Use shared implementation with Loki as the persistent log backend
+	// The persistent log backend is Loki by default, ClickHouse when the
+	// logs-read-config flag is enabled and a ClickHouse reader is configured.
 	start, end := LogQueryWindow(cursor, direction)
-	persistentFetcher := l.logsFromLocalLoki(ctx, templateID, buildID, start, end, int(limit), offset, level, apiLogDirectionToLokiProtoDirection(&direction))
+
+	var persistentFetcher logSourceFunc
+	if l.readFromClickhouse(ctx) {
+		persistentFetcher = l.logsFromClickhouse(ctx, templateID, buildID, start, end, int(limit), offset, level, apiLogDirectionToSandboxLogsSortOrder(&direction))
+	} else {
+		persistentFetcher = l.logsFromLocalLoki(ctx, templateID, buildID, start, end, int(limit), offset, level, apiLogDirectionToLokiProtoDirection(&direction))
+	}
 
 	return getBuildLogsWithSources(ctx, l.instances, nodeID, templateID, buildID, offset, limit, level, cursor, direction, source, persistentFetcher)
+}
+
+func (l *LocalClusterResourceProvider) logsFromClickhouse(ctx context.Context, templateID string, buildID string, start time.Time, end time.Time, limit int, offset int32, level *logs.LogLevel, order sandboxlogs.SortOrder) logSourceFunc {
+	return func() ([]logs.LogEntry, *api.APIError) {
+		entries, err := l.sandboxLogsReader.QueryBuildLogs(ctx, templateID, buildID, start, end, limit, offset, level, order)
+		if err != nil {
+			recordClickhouseLogReadError(ctx, "build")
+
+			return nil, &api.APIError{
+				Err:       fmt.Errorf("error when fetching build logs from ClickHouse: %w", err),
+				ClientMsg: "Failed to fetch build logs",
+				Code:      http.StatusInternalServerError,
+			}
+		}
+
+		return entries, nil
+	}
 }
 
 func (l *LocalClusterResourceProvider) logsFromLocalLoki(ctx context.Context, templateID string, buildID string, start time.Time, end time.Time, limit int, offset int32, level *logs.LogLevel, direction logproto.Direction) logSourceFunc {

--- a/packages/api/internal/clusters/resources_local_test.go
+++ b/packages/api/internal/clusters/resources_local_test.go
@@ -1,0 +1,84 @@
+package clusters
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/sandboxlogs"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
+)
+
+type stubClickhouseLogsReader struct {
+	sandbox func(context.Context, uuid.UUID, string, time.Time, time.Time, int, sandboxlogs.SortOrder, *logs.LogLevel, *string) ([]logs.LogEntry, error)
+	build   func(context.Context, string, string, time.Time, time.Time, int, int32, *logs.LogLevel, sandboxlogs.SortOrder) ([]logs.LogEntry, error)
+}
+
+func (s *stubClickhouseLogsReader) QuerySandboxLogs(ctx context.Context, teamID uuid.UUID, sandboxID string, start, end time.Time, limit int, order sandboxlogs.SortOrder, level *logs.LogLevel, search *string) ([]logs.LogEntry, error) {
+	return s.sandbox(ctx, teamID, sandboxID, start, end, limit, order, level, search)
+}
+
+func (s *stubClickhouseLogsReader) QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, order sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+	return s.build(ctx, templateID, buildID, start, end, limit, offset, level, order)
+}
+
+// TestBuildLogsFromClickhouseFailsFast asserts that a ClickHouse read error
+// during GetBuildLogs is propagated directly (no automatic Loki fallback).
+// The migration relies on the logs-read-config flag plus alerting on
+// log_read_clickhouse_error_count to drive rollback decisions, rather than
+// per-request fallback masking a degraded ClickHouse.
+func TestBuildLogsFromClickhouseFailsFast(t *testing.T) {
+	t.Parallel()
+
+	clickhouseErr := errors.New("clickhouse unavailable")
+	start, end := time.Now().Add(-time.Minute), time.Now()
+	level := logs.LevelInfo
+	want := []logs.LogEntry{{Message: "from ClickHouse"}}
+
+	tests := []struct {
+		name             string
+		clickhouseResult []logs.LogEntry
+		clickhouseErr    error
+		want             []logs.LogEntry
+		wantErr          bool
+	}{
+		{name: "success returns ClickHouse result", clickhouseResult: want, want: want},
+		{name: "ClickHouse error propagates without fallback", clickhouseErr: clickhouseErr, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := &LocalClusterResourceProvider{
+				sandboxLogsReader: &stubClickhouseLogsReader{build: func(_ context.Context, templateID, buildID string, gotStart, gotEnd time.Time, limit int, offset int32, gotLevel *logs.LogLevel, order sandboxlogs.SortOrder) ([]logs.LogEntry, error) {
+					assert.Equal(t, "template-id", templateID)
+					assert.Equal(t, "build-id", buildID)
+					assert.Equal(t, start, gotStart)
+					assert.Equal(t, end, gotEnd)
+					assert.Equal(t, 42, limit)
+					assert.Equal(t, int32(7), offset)
+					assert.Same(t, &level, gotLevel)
+					assert.Equal(t, sandboxlogs.SortOrderBackward, order)
+
+					return tt.clickhouseResult, tt.clickhouseErr
+				}},
+			}
+
+			got, apiErr := provider.logsFromClickhouse(t.Context(), "template-id", "build-id", start, end, 42, 7, &level, sandboxlogs.SortOrderBackward)()
+			if tt.wantErr {
+				require.NotNil(t, apiErr)
+				require.ErrorIs(t, apiErr.Err, clickhouseErr)
+
+				return
+			}
+			require.Nil(t, apiErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -33,6 +33,7 @@ import (
 	sharedauth "github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/auth/pkg/types"
 	clickhouse "github.com/e2b-dev/infra/packages/clickhouse/pkg"
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/sandboxlogs"
 	sqlcdb "github.com/e2b-dev/infra/packages/db/client"
 	authdb "github.com/e2b-dev/infra/packages/db/pkg/auth"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
@@ -80,6 +81,7 @@ type APIStore struct {
 	authService           sharedauth.Service
 	templateSpawnCounter  *utils.TemplateSpawnCounter
 	clickhouseStore       clickhouse.Clickhouse
+	sandboxLogsReader     *sandboxlogs.Reader
 	accessTokenGenerator  *sandbox.AccessTokenGenerator
 	featureFlags          *featureflags.Client
 	clusters              *clusters.Pool
@@ -122,6 +124,24 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 	)
 	if err != nil {
 		logger.L().Fatal(ctx, "initializing ClickHouse switching client", zap.Error(err))
+	}
+
+	// ClickHouse-backed sandbox/build log reader for the local cluster, gated at
+	// read time by the logs-read-config flag. Built from the singular DSN; when
+	// it is unset, the local cluster stays on Loki.
+	var sandboxLogsReader *sandboxlogs.Reader
+	// clusterLogsReader carries the reader into the clusters pool as an
+	// interface. It is left as a nil interface (not a typed-nil pointer boxed in
+	// an interface) when no reader is configured, so the nil check in the local
+	// cluster resource provider fires correctly and reads stay on Loki.
+	var clusterLogsReader clusters.ClickhouseLogsReader
+	if config.ClickhouseConnectionString != "" {
+		conn, readerErr := clickhouse.NewDriver(config.ClickhouseConnectionString)
+		if readerErr != nil {
+			logger.L().Fatal(ctx, "initializing ClickHouse sandbox logs reader", zap.Error(readerErr))
+		}
+		sandboxLogsReader = sandboxlogs.NewReader(conn)
+		clusterLogsReader = sandboxLogsReader
 	}
 
 	posthogClient, posthogErr := analyticscollector.NewPosthogClient(ctx, config.PosthogAPIKey)
@@ -194,7 +214,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		logger.L().Fatal(ctx, "error when getting logs query provider", zap.Error(err))
 	}
 
-	clusters, err := clusters.NewPool(ctx, tel, sqlcDB, templateBuilderDiscovery, clickhouseStore, queryLogsProvider, config)
+	clusters, err := clusters.NewPool(ctx, tel, sqlcDB, templateBuilderDiscovery, clickhouseStore, queryLogsProvider, clusterLogsReader, featureFlags, config)
 	if err != nil {
 		logger.L().Fatal(ctx, "initializing edge clusters pool failed", zap.Error(err))
 	}
@@ -259,6 +279,7 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 		authService:           authService,
 		templateSpawnCounter:  templateSpawnCounter,
 		clickhouseStore:       clickhouseStore,
+		sandboxLogsReader:     sandboxLogsReader,
 		accessTokenGenerator:  accessTokenGenerator,
 		clusters:              clusters,
 		featureFlags:          featureFlags,
@@ -338,6 +359,11 @@ func (a *APIStore) Close(ctx context.Context) error {
 	if a.clickhouseStore != nil {
 		if err := a.clickhouseStore.Close(ctx); err != nil {
 			errs = append(errs, fmt.Errorf("closing ClickHouse store: %w", err))
+		}
+	}
+	if a.sandboxLogsReader != nil {
+		if err := a.sandboxLogsReader.Close(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("closing ClickHouse sandbox logs reader: %w", err))
 		}
 	}
 

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -305,18 +305,6 @@ func run() int {
 	defer l.Sync()
 	logger.ReplaceGlobals(ctx, l)
 
-	sbxLoggerExternal := sbxlogger.NewLogger(
-		ctx,
-		tel.LogsProvider,
-		sbxlogger.SandboxLoggerConfig{
-			ServiceName:      serviceName,
-			IsInternal:       false,
-			CollectorAddress: env.LogsCollectorAddress(),
-		},
-	)
-	defer sbxLoggerExternal.Sync()
-	sbxlogger.SetSandboxLoggerExternal(sbxLoggerExternal)
-
 	sbxLoggerInternal := sbxlogger.NewLogger(
 		ctx,
 		tel.LogsProvider,
@@ -434,6 +422,22 @@ func run() int {
 
 	featureFlags.SetServiceName(serviceName)
 	featureFlags.SetDeploymentName(config.DomainName)
+
+	// External sandbox logger routes through LaunchDarkly (LogsWriteConfigFlag),
+	// falling back to the fixed collector address. Created here so it can use the
+	// feature flags client.
+	sbxLoggerExternal := sbxlogger.NewLogger(
+		ctx,
+		tel.LogsProvider,
+		sbxlogger.SandboxLoggerConfig{
+			ServiceName:      serviceName,
+			IsInternal:       false,
+			CollectorAddress: env.LogsCollectorAddress(),
+			FeatureFlags:     featureFlags,
+		},
+	)
+	defer sbxLoggerExternal.Sync()
+	sbxlogger.SetSandboxLoggerExternal(sbxLoggerExternal)
 
 	// Create an instance of our handler which satisfies the generated interface
 	//  (use the outer context rather than the signal handling

--- a/packages/clickhouse/migrations/20260702181515_add_sandbox_logs.sql
+++ b/packages/clickhouse/migrations/20260702181515_add_sandbox_logs.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE sandbox_logs_local (
+    timestamp DateTime64(9) CODEC (Delta, ZSTD(1)),
+    ingested_at DateTime64(9) DEFAULT now64(9) CODEC (Delta, ZSTD(1)),
+    team_id UUID CODEC (ZSTD(1)),
+    sandbox_id String CODEC (ZSTD(1)),
+    template_id String CODEC (ZSTD(1)),
+    build_id String CODEC (ZSTD(1)),
+    service LowCardinality(String) CODEC (ZSTD(1)),
+    category LowCardinality(String) CODEC (ZSTD(1)),
+    level LowCardinality(String) CODEC (ZSTD(1)),
+    message String CODEC (ZSTD(1)),
+    raw String CODEC (ZSTD(1)),
+    fields String CODEC (ZSTD(1)),
+    INDEX idx_build_id build_id TYPE bloom_filter GRANULARITY 4,
+    -- ngram bloom filter so the `position(message, ?) > 0` substring search used
+    -- by the reader can be index-accelerated. tokenbf_v1 only supports whole-token
+    -- (hasToken) lookups and would not help a substring predicate.
+    INDEX idx_message_ngram message TYPE ngrambf_v1(4, 8192, 3, 0) GRANULARITY 4
+) ENGINE = MergeTree
+    PARTITION BY toDate(ingested_at)
+    ORDER BY (team_id, sandbox_id, timestamp)
+    TTL toDateTime(ingested_at) + INTERVAL 7 DAY
+    SETTINGS ttl_only_drop_parts = 1;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE TABLE sandbox_logs AS sandbox_logs_local
+    ENGINE = Distributed('cluster', currentDatabase(), 'sandbox_logs_local', xxHash64(team_id));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS sandbox_logs;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+DROP TABLE IF EXISTS sandbox_logs_local;
+-- +goose StatementEnd

--- a/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
+++ b/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
@@ -1,0 +1,234 @@
+// Package sandboxlogs is a minimal ClickHouse reader for the sandbox_logs
+// table, used by the API local cluster to serve sandbox/build logs from
+// ClickHouse behind the logs-read-config LaunchDarkly flag.
+package sandboxlogs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
+)
+
+// SortOrder controls the timestamp ordering of returned log rows.
+type SortOrder int
+
+const (
+	SortOrderForward SortOrder = iota
+	SortOrderBackward
+)
+
+// Reader queries the ClickHouse sandbox_logs table.
+type Reader struct {
+	conn driver.Conn
+}
+
+// NewReader builds a Reader over an existing ClickHouse driver connection.
+func NewReader(conn driver.Conn) *Reader {
+	return &Reader{conn: conn}
+}
+
+// Close closes the underlying ClickHouse connection.
+func (r *Reader) Close(_ context.Context) error {
+	return r.conn.Close()
+}
+
+// row maps a single sandbox_logs table row.
+type row struct {
+	Timestamp  time.Time
+	TeamID     uuid.UUID
+	SandboxID  string
+	TemplateID string
+	BuildID    string
+	Service    string
+	Category   string
+	Level      string
+	Message    string
+	Raw        string
+	Fields     string
+}
+
+// toLogEntry converts a row into a logs.LogEntry. The Fields column holds a
+// JSON-encoded map[string]string; on unmarshal failure onParseErr is invoked
+// (when non-nil), an empty map is used, and Raw is preserved.
+func (r row) toLogEntry(onParseErr func(err error)) logs.LogEntry {
+	fields := map[string]string{}
+	if r.Fields != "" {
+		if err := json.Unmarshal([]byte(r.Fields), &fields); err != nil {
+			if onParseErr != nil {
+				onParseErr(err)
+			}
+			fields = map[string]string{}
+		}
+	}
+
+	return logs.LogEntry{
+		Timestamp: r.Timestamp,
+		Raw:       r.Raw,
+		Level:     logs.StringToLevel(r.Level),
+		Message:   r.Message,
+		Fields:    fields,
+	}
+}
+
+// orderSQL renders the ORDER BY direction keyword for a SortOrder.
+func orderSQL(o SortOrder) string {
+	if o == SortOrderBackward {
+		return "DESC"
+	}
+
+	return "ASC"
+}
+
+// atLeastLevels returns the set of stored level strings at or above minLevel,
+// mirroring the Loki minimum-level filter semantics.
+func atLeastLevels(minLevel logs.LogLevel) []string {
+	switch minLevel {
+	case logs.LevelError:
+		return []string{"error"}
+	case logs.LevelWarn:
+		return []string{"warn", "error"}
+	case logs.LevelInfo:
+		return []string{"", "info", "warn", "error"}
+	default:
+		return []string{"", "debug", "info", "warn", "error"}
+	}
+}
+
+func unixNano(t time.Time) int64 {
+	return t.UTC().UnixNano()
+}
+
+const sandboxLogsSelect = `
+SELECT
+    timestamp,
+    team_id,
+    sandbox_id,
+    template_id,
+    build_id,
+    service,
+    category,
+    level,
+    message,
+    raw,
+    fields
+FROM sandbox_logs
+`
+
+func (r *Reader) QuerySandboxLogs(ctx context.Context, teamID uuid.UUID, sandboxID string, start, end time.Time, limit int, order SortOrder, level *logs.LogLevel, search *string) ([]logs.LogEntry, error) {
+	filters := []string{
+		"team_id = {team_id:String}",
+		"sandbox_id = {sandbox_id:String}",
+		"timestamp >= fromUnixTimestamp64Nano({start:Int64})",
+		"timestamp <= fromUnixTimestamp64Nano({end:Int64})",
+		"category != 'metrics'",
+	}
+	args := []any{
+		clickhouse.Named("team_id", teamID.String()),
+		clickhouse.Named("sandbox_id", sandboxID),
+		clickhouse.Named("start", unixNano(start)),
+		clickhouse.Named("end", unixNano(end)),
+	}
+
+	if level != nil {
+		filters = append(filters, "level IN {levels:Array(String)}")
+		args = append(args, clickhouse.Named("levels", atLeastLevels(*level)))
+	}
+	if search != nil && *search != "" {
+		filters = append(filters, "position(message, {search:String}) > 0")
+		args = append(args, clickhouse.Named("search", *search))
+	}
+
+	q := sandboxLogsSelect +
+		"WHERE " + strings.Join(filters, "\n  AND ") + "\n" +
+		"ORDER BY timestamp " + orderSQL(order) + "\n" +
+		fmt.Sprintf("LIMIT %d", limit)
+
+	out, err := r.scanSandboxLogs(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error querying sandbox logs: %w", err)
+	}
+
+	return out, nil
+}
+
+func (r *Reader) QueryBuildLogs(ctx context.Context, templateID, buildID string, start, end time.Time, limit int, offset int32, level *logs.LogLevel, order SortOrder) ([]logs.LogEntry, error) {
+	filters := []string{
+		"build_id = {build_id:String}",
+		"template_id = {template_id:String}",
+		"timestamp >= fromUnixTimestamp64Nano({start:Int64})",
+		"timestamp <= fromUnixTimestamp64Nano({end:Int64})",
+		"service = 'template-manager'",
+	}
+	args := []any{
+		clickhouse.Named("build_id", buildID),
+		clickhouse.Named("template_id", templateID),
+		clickhouse.Named("start", unixNano(start)),
+		clickhouse.Named("end", unixNano(end)),
+	}
+
+	if level != nil {
+		filters = append(filters, "level IN {levels:Array(String)}")
+		args = append(args, clickhouse.Named("levels", atLeastLevels(*level)))
+	}
+
+	q := sandboxLogsSelect +
+		"WHERE " + strings.Join(filters, "\n  AND ") + "\n" +
+		"ORDER BY timestamp " + orderSQL(order) + "\n" +
+		fmt.Sprintf("LIMIT %d, %d", offset, limit)
+
+	out, err := r.scanSandboxLogs(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error querying build logs: %w", err)
+	}
+
+	return out, nil
+}
+
+func (r *Reader) scanSandboxLogs(ctx context.Context, q string, args ...any) ([]logs.LogEntry, error) {
+	rows, err := r.conn.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("error querying sandbox logs: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]logs.LogEntry, 0)
+	for rows.Next() {
+		var rr row
+		if err := rows.Scan(
+			&rr.Timestamp,
+			&rr.TeamID,
+			&rr.SandboxID,
+			&rr.TemplateID,
+			&rr.BuildID,
+			&rr.Service,
+			&rr.Category,
+			&rr.Level,
+			&rr.Message,
+			&rr.Raw,
+			&rr.Fields,
+		); err != nil {
+			return nil, fmt.Errorf("error scanning sandbox log row: %w", err)
+		}
+
+		entry := rr.toLogEntry(func(err error) {
+			logger.L().Warn(ctx, "failed to parse sandbox log fields",
+				zap.String("sandbox_id", rr.SandboxID),
+				logger.Time("timestamp", rr.Timestamp),
+				zap.Error(err),
+			)
+		})
+		out = append(out, entry)
+	}
+
+	return out, rows.Err()
+}

--- a/packages/clickhouse/pkg/sandboxlogs/sandboxlogs_test.go
+++ b/packages/clickhouse/pkg/sandboxlogs/sandboxlogs_test.go
@@ -1,0 +1,104 @@
+package sandboxlogs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
+)
+
+func TestOrderSQL(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ASC", orderSQL(SortOrderForward))
+	assert.Equal(t, "DESC", orderSQL(SortOrderBackward))
+	// Unknown values default to ascending.
+	assert.Equal(t, "ASC", orderSQL(SortOrder(42)))
+}
+
+func TestAtLeastLevels(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []string{"error"}, atLeastLevels(logs.LevelError))
+	assert.Equal(t, []string{"warn", "error"}, atLeastLevels(logs.LevelWarn))
+	assert.Equal(t, []string{"", "info", "warn", "error"}, atLeastLevels(logs.LevelInfo))
+	assert.Equal(t, []string{"", "debug", "info", "warn", "error"}, atLeastLevels(logs.LevelDebug))
+}
+
+func TestUnixNano(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 1, 2, 3, 4, 5, 6, time.UTC)
+	assert.Equal(t, ts.UnixNano(), unixNano(ts))
+
+	// Non-UTC input must be normalized to the same instant.
+	loc := time.FixedZone("test", 3600)
+	local := ts.In(loc)
+	assert.Equal(t, ts.UnixNano(), unixNano(local))
+}
+
+func TestRowToLogEntry(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+	r := row{
+		Timestamp: ts,
+		Level:     "warn",
+		Message:   "hello",
+		Raw:       `{"raw":"line"}`,
+		Fields:    `{"key":"value","n":"2"}`,
+	}
+
+	var parseErr error
+	entry := r.toLogEntry(func(err error) { parseErr = err })
+
+	require.NoError(t, parseErr)
+	assert.Equal(t, ts, entry.Timestamp)
+	assert.JSONEq(t, `{"raw":"line"}`, entry.Raw)
+	assert.Equal(t, logs.LevelWarn, entry.Level)
+	assert.Equal(t, "hello", entry.Message)
+	assert.Equal(t, map[string]string{"key": "value", "n": "2"}, entry.Fields)
+}
+
+func TestRowToLogEntryEmptyFields(t *testing.T) {
+	t.Parallel()
+
+	r := row{Message: "m", Fields: ""}
+
+	called := false
+	entry := r.toLogEntry(func(error) { called = true })
+
+	assert.False(t, called, "empty fields must not trigger a parse error")
+	assert.Equal(t, map[string]string{}, entry.Fields)
+}
+
+func TestRowToLogEntryInvalidFieldsPreservesRaw(t *testing.T) {
+	t.Parallel()
+
+	r := row{
+		Raw:    "original-raw",
+		Fields: `{"broken": `,
+	}
+
+	var gotErr error
+	entry := r.toLogEntry(func(err error) { gotErr = err })
+
+	require.Error(t, gotErr)
+	// Malformed fields fall back to an empty map but raw is preserved.
+	assert.Equal(t, map[string]string{}, entry.Fields)
+	assert.Equal(t, "original-raw", entry.Raw)
+}
+
+func TestRowToLogEntryNilCallbackDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	r := row{Fields: `{"broken": `}
+
+	assert.NotPanics(t, func() {
+		entry := r.toLogEntry(nil)
+		assert.Equal(t, map[string]string{}, entry.Fields)
+	})
+}

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -339,24 +339,6 @@ func run(config cfg.Config, opts Options) (success bool) {
 	}(globalLogger)
 	logger.ReplaceGlobals(ctx, globalLogger)
 
-	sbxLoggerExternal := sbxlogger.NewLogger(
-		ctx,
-		tel.LogsProvider,
-		sbxlogger.SandboxLoggerConfig{
-			ServiceName:      serviceName,
-			IsInternal:       false,
-			CollectorAddress: env.LogsCollectorAddress(),
-		},
-	)
-	defer func(l logger.Logger) {
-		err := l.Sync()
-		if err != nil {
-			log.Printf("error while shutting down sandbox logger: %v", err)
-			success = false
-		}
-	}(sbxLoggerExternal)
-	sbxlogger.SetSandboxLoggerExternal(sbxLoggerExternal)
-
 	sbxLoggerInternal := sbxlogger.NewLogger(
 		ctx,
 		tel.LogsProvider,
@@ -418,6 +400,28 @@ func run(config cfg.Config, opts Options) (success bool) {
 
 	featureFlags.SetDeploymentName(config.DomainName)
 	featureFlags.RegisterContextProvider(orchestratorContextProvider(nodeID, commitSHA))
+
+	// External sandbox logger routes through LaunchDarkly (LogsWriteConfigFlag),
+	// falling back to the fixed collector address. Created here so it can use the
+	// feature flags client.
+	sbxLoggerExternal := sbxlogger.NewLogger(
+		ctx,
+		tel.LogsProvider,
+		sbxlogger.SandboxLoggerConfig{
+			ServiceName:      serviceName,
+			IsInternal:       false,
+			CollectorAddress: env.LogsCollectorAddress(),
+			FeatureFlags:     featureFlags,
+		},
+	)
+	defer func(l logger.Logger) {
+		err := l.Sync()
+		if err != nil {
+			log.Printf("error while shutting down sandbox logger: %v", err)
+			success = false
+		}
+	}(sbxLoggerExternal)
+	sbxlogger.SetSandboxLoggerExternal(sbxLoggerExternal)
 
 	// gcp concurrent upload limiter
 	limiter, err := limit.New(ctx, featureFlags)
@@ -771,6 +775,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 			ServiceName:      constants.ServiceNameTemplate,
 			IsInternal:       false,
 			CollectorAddress: env.LogsCollectorAddress(),
+			FeatureFlags:     featureFlags,
 		},
 	)
 	closers = append(closers, closer{
@@ -794,7 +799,7 @@ func run(config cfg.Config, opts Options) (success bool) {
 	}
 
 	// hyperloop server
-	hyperloopSrv, err := hyperloopserver.NewHyperloopServer(ctx, config.NetworkConfig.HyperloopProxyPort, globalLogger, sandboxes)
+	hyperloopSrv, err := hyperloopserver.NewHyperloopServer(ctx, config.NetworkConfig.HyperloopProxyPort, globalLogger, sandboxes, featureFlags)
 	if err != nil {
 		logger.L().Fatal(ctx, "failed to create hyperloop server", zap.Error(err))
 	}

--- a/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
+++ b/packages/orchestrator/pkg/hyperloopserver/handlers/logs.go
@@ -4,18 +4,53 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
+
+var (
+	logForwardMeter      = otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/hyperloopserver/handlers")
+	logForwardWriteCount = mustLogForwardCounter(
+		"hyperloop_log_forward_write_count",
+		"Number of hyperloop log forward HTTP attempts by route and result",
+	)
+	logForwardShadowInflight = mustLogForwardUpDownCounter(
+		"hyperloop_log_forward_shadow_inflight",
+		"Current number of in-flight best-effort shadow log forwards",
+	)
+)
+
+func mustLogForwardCounter(name, description string) metric.Int64Counter {
+	counter, err := logForwardMeter.Int64Counter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
+
+func mustLogForwardUpDownCounter(name, description string) metric.Int64UpDownCounter {
+	counter, err := logForwardMeter.Int64UpDownCounter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
 
 func (h *APIStore) Logs(c *gin.Context) {
 	ctx := c.Request.Context()
@@ -68,25 +103,127 @@ func (h *APIStore) Logs(c *gin.Context) {
 		return
 	}
 
-	request, err := http.NewRequestWithContext(c, http.MethodPost, h.collectorAddr, bytes.NewBuffer(logs))
-	if err != nil {
-		h.sendAPIStoreError(c, http.StatusInternalServerError, "Error when creating request to forwarding sandbox logs")
-		h.logger.Error(ctx, "error when creating request to forwarding sandbox logs", zap.Error(err), logger.WithSandboxID(sbxID))
+	// Resolve log destinations from LaunchDarkly (cached behind a short TTL),
+	// falling back to the fixed collector address. This lets operators retarget
+	// logs without a redeploy.
+	route := h.logWriteConfig.Resolve(ctx)
 
-		return
+	// Fire-and-forget shadow writes: never affect the response. Concurrency is
+	// bounded by the resolved route limit; excess writes are dropped silently to avoid
+	// unbounded goroutine growth (and a shadow log storm) under high volume.
+	maxInflight := route.MaxInflightShadowWrites
+	if maxInflight <= 0 {
+		maxInflight = defaultMaxInflightShadowWrites
+	}
+	for _, shadowURL := range route.ShadowURLs {
+		if !h.tryAcquireShadow(maxInflight) {
+			// Semaphore full: drop this shadow write.
+			recordLogForwardWrite(ctx, "shadow", "dropped", "saturated")
+
+			continue
+		}
+		recordLogForwardShadowInflight(ctx, 1)
+
+		go func(url string, payload []byte) {
+			defer func() {
+				h.shadowInflight.Add(-1)
+				recordLogForwardShadowInflight(context.WithoutCancel(ctx), -1)
+			}()
+
+			shadowCtx := context.WithoutCancel(ctx)
+			if err := h.forwardLogs(shadowCtx, url, payload, route.Timeout); err != nil {
+				recordLogForwardWrite(shadowCtx, "shadow", "failure", "send_error")
+
+				return
+			}
+			recordLogForwardWrite(shadowCtx, "shadow", "success", "")
+		}(shadowURL, logs)
 	}
 
-	request.Header.Set("Content-Type", "application/json")
-	response, err := h.collectorClient.Do(request)
-	if err != nil {
+	// The primary write controls the response, preserving today's behavior.
+	if err := h.forwardLogs(c.Request.Context(), route.PrimaryURL, logs, route.Timeout); err != nil {
+		recordLogForwardWrite(ctx, "primary", "failure", "send_error")
 		h.sendAPIStoreError(c, http.StatusInternalServerError, "Error when forwarding sandbox logs")
 		h.logger.Error(ctx, "error when forwarding sandbox logs", zap.Error(err), logger.WithSandboxID(sbxID))
 
 		return
 	}
-	defer response.Body.Close()
+	recordLogForwardWrite(ctx, "primary", "success", "")
 
 	c.Status(http.StatusOK)
+}
+
+func (h *APIStore) tryAcquireShadow(maxInflight int64) bool {
+	for {
+		current := h.shadowInflight.Load()
+		if current >= maxInflight {
+			return false
+		}
+		if h.shadowInflight.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func recordLogForwardWrite(ctx context.Context, route, result, reason string) {
+	if logForwardWriteCount == nil {
+		return
+	}
+
+	logForwardWriteCount.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("route", route),
+		attribute.String("result", result),
+		attribute.String("reason", reason),
+	))
+}
+
+func recordLogForwardShadowInflight(ctx context.Context, delta int64) {
+	if logForwardShadowInflight == nil {
+		return
+	}
+
+	logForwardShadowInflight.Add(ctx, delta)
+}
+
+// forwardLogs POSTs the marshaled logs payload to url, bounded by timeout.
+func (h *APIStore) forwardLogs(ctx context.Context, url string, payload []byte, timeout time.Duration) error {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return fmt.Errorf("error creating request to forward sandbox logs: %w", err)
+	}
+
+	request.Header.Set("Content-Type", "application/json")
+	response, err := h.collectorClient.Do(request)
+	if err != nil {
+		return fmt.Errorf("error forwarding sandbox logs: %w", err)
+	}
+	defer response.Body.Close()
+
+	// Always drain so the transport can reuse the connection; the body itself
+	// is never surfaced in the returned error (it may echo request content).
+	drainErr := drainLogForwardResponse(response.Body)
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		statusErr := fmt.Errorf("error forwarding sandbox logs: unexpected HTTP status %d", response.StatusCode)
+
+		return errors.Join(statusErr, drainErr)
+	}
+
+	return drainErr
+}
+
+func drainLogForwardResponse(body io.Reader) error {
+	if _, err := io.Copy(io.Discard, body); err != nil {
+		return fmt.Errorf("error draining log forward response body: %w", err)
+	}
+
+	return nil
 }
 
 // validatePayloadSandboxID checks if the payload contains correct instanceID to prevent slow requests to contaminating the logs of other sandboxes.

--- a/packages/orchestrator/pkg/hyperloopserver/handlers/logs_test.go
+++ b/packages/orchestrator/pkg/hyperloopserver/handlers/logs_test.go
@@ -3,6 +3,9 @@
 package handlers
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,4 +102,112 @@ func TestHasStaleLogTimestamp(t *testing.T) {
 
 		assert.False(t, hasStaleLogTimestamp(payload, lifecycleStart))
 	})
+}
+
+func TestAPIStoreForwardLogsStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "success", status: http.StatusAccepted},
+		{name: "client error", status: http.StatusUnprocessableEntity, wantErr: true},
+		{name: "server error", status: http.StatusBadGateway, wantErr: true},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantErr: true},
+		{name: "internal server error", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte("collector diagnostic"))
+			}))
+			t.Cleanup(server.Close)
+
+			store := &APIStore{collectorClient: *server.Client()}
+			err := store.forwardLogs(t.Context(), server.URL, []byte(`{"secret":"not-in-error"}`), 0)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil && strings.Contains(err.Error(), "not-in-error") {
+				t.Fatalf("error contains request payload: %v", err)
+			}
+		})
+	}
+}
+
+// TestAPIStoreForwardLogsRespectsTimeout verifies a slow/hung Vector doesn't
+// block forwardLogs forever when a non-zero timeout is passed: the request is
+// aborted client-side and an error is returned promptly, regardless of
+// whether the server ever responds.
+func TestAPIStoreForwardLogsRespectsTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	store := &APIStore{collectorClient: *server.Client()}
+
+	start := time.Now()
+	err := store.forwardLogs(t.Context(), server.URL, []byte(`{"msg":"slow"}`), 50*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a slow/hung response once the timeout passes")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("forwardLogs took %v to return; expected it to abort promptly once the 50ms timeout passed", elapsed)
+	}
+}
+
+// TestAPIStoreForwardLogsZeroTimeoutRespectsClientTimeout is the legacy-mode
+// equivalent: with timeout == 0 (route.Timeout unset, matching pre-flag
+// behavior), forwardLogs must still be bounded by collectorClient's own
+// Timeout rather than hanging forever.
+func TestAPIStoreForwardLogsZeroTimeoutRespectsClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	client := server.Client()
+	client.Timeout = 50 * time.Millisecond
+	store := &APIStore{collectorClient: *client}
+
+	start := time.Now()
+	err := store.forwardLogs(t.Context(), server.URL, []byte(`{"msg":"slow"}`), 0)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a slow/hung response once the client timeout passes")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("forwardLogs took %v to return; expected it to abort promptly once the 50ms client timeout passed", elapsed)
+	}
 }

--- a/packages/orchestrator/pkg/hyperloopserver/handlers/store.go
+++ b/packages/orchestrator/pkg/hyperloopserver/handlers/store.go
@@ -4,34 +4,42 @@ package handlers
 
 import (
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/apierrors"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
 const CollectorExporterTimeout = 10 * time.Second
+
+const defaultMaxInflightShadowWrites = 1024
 
 type APIStore struct {
 	logger    logger.Logger
 	sandboxes *sandbox.Map
 
 	collectorClient http.Client
-	collectorAddr   string
+	logWriteConfig  *featureflags.LogWriteConfigResolver
+
+	// shadowInflight bounds concurrent shadow forwards (best-effort, non-blocking
+	// acquire; dropped when the resolved route limit is reached).
+	shadowInflight atomic.Int64
 }
 
-func NewHyperloopStore(logger logger.Logger, sandboxes *sandbox.Map, sandboxCollectorAddr string) *APIStore {
+func NewHyperloopStore(logger logger.Logger, sandboxes *sandbox.Map, sandboxCollectorAddr string, featureFlags *featureflags.Client) *APIStore {
 	return &APIStore{
 		logger:    logger,
 		sandboxes: sandboxes,
 
-		collectorAddr: sandboxCollectorAddr,
 		collectorClient: http.Client{
 			Timeout: CollectorExporterTimeout,
 		},
+		logWriteConfig: featureflags.NewLogWriteConfigResolver(featureFlags, sandboxCollectorAddr),
 	}
 }
 

--- a/packages/orchestrator/pkg/hyperloopserver/server.go
+++ b/packages/orchestrator/pkg/hyperloopserver/server.go
@@ -16,15 +16,16 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/hyperloopserver/handlers"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/httpserver"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
 const maxUploadLimit = 1 << 28 // 256 MiB
 
-func NewHyperloopServer(ctx context.Context, port uint16, logger logger.Logger, sandboxes *sandbox.Map) (*http.Server, error) {
+func NewHyperloopServer(ctx context.Context, port uint16, logger logger.Logger, sandboxes *sandbox.Map, featureFlags *featureflags.Client) (*http.Server, error) {
 	sandboxCollectorAddr := env.LogsCollectorAddress()
-	store := handlers.NewHyperloopStore(logger, sandboxes, sandboxCollectorAddr)
+	store := handlers.NewHyperloopStore(logger, sandboxes, sandboxCollectorAddr, featureFlags)
 	swagger, err := contracts.GetSwagger()
 	if err != nil {
 		return nil, fmt.Errorf("error getting swagger spec: %w", err)

--- a/packages/orchestrator/pkg/template/server/create_template.go
+++ b/packages/orchestrator/pkg/template/server/create_template.go
@@ -116,6 +116,7 @@ func (s *ServerStore) TemplateCreate(ctx context.Context, templateRequest *templ
 	// both destinations.
 	core := zapcore.NewTee(logs, s.buildLogger.Detach(ctx).Core().
 		With([]zap.Field{
+			{Type: zapcore.StringType, Key: "teamID", String: template.TeamID},
 			{Type: zapcore.StringType, Key: "envID", String: cfg.GetTemplateID()},
 			{Type: zapcore.StringType, Key: "buildID", String: metadata.BuildID},
 		}),

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -3,12 +3,17 @@ package featureflags
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
@@ -507,6 +512,282 @@ var (
 	// is unaffected.
 	ClickhouseWriteFanoutFlag = NewBoolFlag("clickhouse-write-fanout", false)
 )
+
+// LogsWriteConfigFlag controls where sandbox/external logs are written, so
+// operators can retarget log destinations from LaunchDarkly without a redeploy.
+//
+// Shape:
+//
+//	{
+//	  "mode": "primary_only" | "primary_and_shadow",
+//	  "primary_url": "http://localhost:30006",
+//	  "shadow_urls": ["http://localhost:4321/logs"],
+//	  "timeout_ms": 2000,
+//	  "max_inflight_shadow_writes": 1024
+//	}
+//
+// Semantics:
+//   - null/missing/invalid  -> fall back to the legacy collector address only.
+//   - "primary_only"        -> write to primary_url only.
+//   - "primary_and_shadow"  -> write to primary_url; fire-and-forget shadow_urls
+//     (shadow failures never affect the primary result).
+//   - Empty primary_url in a non-disabled mode is invalid -> legacy fallback.
+//   - shadow_urls must be an array of <= maxLogWriteShadowURLs safe string URLs.
+//   - timeout_ms <= 0 or too large is clamped to a safe range.
+//   - max_inflight_shadow_writes <= 0 defaults to defaultMaxInflightShadowWrites.
+//   - Only http URLs pointing at local/private hosts or allowed internal DNS
+//     suffixes are allowed; anything else is rejected and the whole config falls
+//     back to legacy.
+//
+// The fallback collector address is a runtime env value the flag cannot know,
+// so the default is Null() and the code substitutes the legacy address.
+var LogsWriteConfigFlag = NewJSONFlag("logs-write-config", ldvalue.Null())
+
+// LogsReadConfigFlag selects the backend used to read sandbox/build logs.
+// false (default) reads from Loki (unchanged behavior); true reads from the
+// ClickHouse sandbox_logs table.
+var LogsReadConfigFlag = NewBoolFlag("logs-read-config", false)
+
+// Log write routing modes for LogsWriteConfigFlag.
+const (
+	LogsWriteModePrimaryOnly      = "primary_only"
+	LogsWriteModePrimaryAndShadow = "primary_and_shadow"
+)
+
+const (
+	// defaultLogWriteTimeout is used when timeout_ms is missing/invalid.
+	defaultLogWriteTimeout = 2000 * time.Millisecond
+	// maxLogWriteTimeout caps operator-provided timeouts.
+	maxLogWriteTimeout = 10000 * time.Millisecond
+	// maxLogWriteShadowURLs caps fanout configured from LaunchDarkly.
+	maxLogWriteShadowURLs = 4
+	// defaultMaxInflightShadowWrites is used when max_inflight_shadow_writes is missing/invalid.
+	defaultMaxInflightShadowWrites = 1024
+)
+
+var (
+	logRoutingMeter                = otel.Meter("github.com/e2b-dev/infra/packages/shared/pkg/featureflags")
+	logWriteConfigResolutionMetric = mustLogRoutingCounter(
+		"log_write_config_resolution_count",
+		"Number of logs-write-config resolutions by outcome and fallback reason",
+	)
+)
+
+func mustLogRoutingCounter(name, description string) metric.Int64Counter {
+	counter, err := logRoutingMeter.Int64Counter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
+
+// LogWriteConfig is the resolved, validated log write routing configuration.
+// The zero value (PrimaryURL set by the resolver) preserves legacy behavior.
+type LogWriteConfig struct {
+	// PrimaryURL is the synchronous, success-controlling destination.
+	PrimaryURL string
+	// ShadowURLs are best-effort, fire-and-forget destinations.
+	ShadowURLs []string
+	// Timeout bounds each individual log write request.
+	Timeout time.Duration
+	// MaxInflightShadowWrites bounds concurrent best-effort shadow writes.
+	MaxInflightShadowWrites int64
+}
+
+// ResolveLogWriteConfig reads LogsWriteConfigFlag and returns a validated
+// LogWriteConfig. On any missing/malformed/unsafe input it falls back to
+// writing only to fallbackURL (today's behavior).
+func ResolveLogWriteConfig(ctx context.Context, ff *Client, fallbackURL string, contexts ...ldcontext.Context) LogWriteConfig {
+	// The legacy fallback (flag null/invalid) preserves pre-flag behavior: it
+	// leaves Timeout at 0 so callers skip the per-request WithTimeout and rely
+	// solely on the HTTP client's own timeout, exactly as before this flag
+	// existed. defaultLogWriteTimeout only applies to explicitly-configured
+	// flags with a missing/invalid timeout_ms.
+	legacy := LogWriteConfig{
+		PrimaryURL:              strings.TrimSpace(fallbackURL),
+		Timeout:                 0,
+		MaxInflightShadowWrites: defaultMaxInflightShadowWrites,
+	}
+
+	if ff == nil {
+		recordLogWriteConfigResolution(ctx, "legacy", "nil_client", "")
+
+		return legacy
+	}
+
+	value := ff.JSONFlag(ctx, LogsWriteConfigFlag, contexts...)
+	if value.IsNull() {
+		recordLogWriteConfigResolution(ctx, "legacy", "null", "")
+
+		return legacy
+	}
+	if value.Type() != ldvalue.ObjectType {
+		recordLogWriteConfigResolution(ctx, "legacy", "non_object", "")
+
+		return legacy
+	}
+
+	modeValue := value.GetByKey("mode")
+	if modeValue.Type() != ldvalue.StringType {
+		recordLogWriteConfigResolution(ctx, "legacy", "mode_not_string", "")
+
+		return legacy
+	}
+	mode := strings.TrimSpace(modeValue.StringValue())
+	switch mode {
+	case LogsWriteModePrimaryOnly, LogsWriteModePrimaryAndShadow:
+		// handled below
+	default:
+		// unknown/missing mode -> legacy fallback
+		recordLogWriteConfigResolution(ctx, "legacy", "unknown_mode", mode)
+
+		return legacy
+	}
+
+	primaryValue := value.GetByKey("primary_url")
+	if primaryValue.Type() != ldvalue.StringType {
+		recordLogWriteConfigResolution(ctx, "legacy", "primary_not_string", mode)
+
+		return legacy
+	}
+	primary := strings.TrimSpace(primaryValue.StringValue())
+	if !isSafeLogURL(primary) {
+		recordLogWriteConfigResolution(ctx, "legacy", "unsafe_primary", mode)
+
+		return legacy
+	}
+
+	var shadows []string
+	if mode == LogsWriteModePrimaryAndShadow {
+		raw := value.GetByKey("shadow_urls")
+		if !raw.IsNull() {
+			if raw.Type() != ldvalue.ArrayType {
+				recordLogWriteConfigResolution(ctx, "legacy", "shadow_not_array", mode)
+
+				return legacy
+			}
+			if raw.Count() > maxLogWriteShadowURLs {
+				recordLogWriteConfigResolution(ctx, "legacy", "too_many_shadows", mode)
+
+				return legacy
+			}
+
+			seen := map[string]struct{}{primary: {}}
+			for i := range raw.Count() {
+				item := raw.GetByIndex(i)
+				if item.Type() != ldvalue.StringType {
+					recordLogWriteConfigResolution(ctx, "legacy", "shadow_not_string", mode)
+
+					return legacy
+				}
+				u := strings.TrimSpace(item.StringValue())
+				// An unsafe shadow URL invalidates the whole config: fail safe to
+				// legacy rather than silently exfiltrating to an external host.
+				if !isSafeLogURL(u) {
+					recordLogWriteConfigResolution(ctx, "legacy", "unsafe_shadow", mode)
+
+					return legacy
+				}
+				if _, ok := seen[u]; ok {
+					continue
+				}
+				seen[u] = struct{}{}
+				shadows = append(shadows, u)
+			}
+		}
+	}
+
+	recordLogWriteConfigResolution(ctx, "configured", "", mode)
+
+	return LogWriteConfig{
+		PrimaryURL:              primary,
+		ShadowURLs:              shadows,
+		Timeout:                 clampLogWriteTimeout(value),
+		MaxInflightShadowWrites: clampMaxInflightShadowWrites(value),
+	}
+}
+
+func recordLogWriteConfigResolution(ctx context.Context, outcome, reason, mode string) {
+	if logWriteConfigResolutionMetric == nil {
+		return
+	}
+
+	logWriteConfigResolutionMetric.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", outcome),
+		attribute.String("reason", reason),
+		attribute.String("mode", mode),
+	))
+}
+
+// clampLogWriteTimeout reads timeout_ms and clamps it to a safe range.
+func clampLogWriteTimeout(value ldvalue.Value) time.Duration {
+	ms := value.GetByKey("timeout_ms").IntValue()
+	if ms <= 0 {
+		return defaultLogWriteTimeout
+	}
+
+	d := time.Duration(ms) * time.Millisecond
+	if d > maxLogWriteTimeout {
+		return maxLogWriteTimeout
+	}
+
+	return d
+}
+
+func clampMaxInflightShadowWrites(value ldvalue.Value) int64 {
+	maxInflight := value.GetByKey("max_inflight_shadow_writes").IntValue()
+	if maxInflight <= 0 {
+		return defaultMaxInflightShadowWrites
+	}
+
+	return int64(maxInflight)
+}
+
+var allowedLogHostSuffixes = []string{
+	".service.consul",
+	".consul",
+	".svc.cluster.local",
+	".svc",
+	".local",
+	".internal",
+}
+
+// isSafeLogURL allows only http URLs pointing at loopback, link-local, private
+// IPs, or internal service-discovery DNS suffixes. This keeps log routing on
+// local/private infrastructure and prevents exfiltration to arbitrary external
+// endpoints via the flag.
+func isSafeLogURL(raw string) bool {
+	if raw == "" {
+		return false
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "http" || u.Host == "" {
+		return false
+	}
+
+	host := u.Hostname()
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+
+	hostLower := strings.ToLower(host)
+	for _, suffix := range allowedLogHostSuffixes {
+		if strings.HasSuffix(hostLower, suffix) {
+			return true
+		}
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Non-IP host without an explicitly allowed internal suffix -> reject.
+		return false
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
+}
 
 // ResolveFirecrackerVersion resolves the firecracker version using the FirecrackerVersions feature flag.
 // The buildVersion format is "v1.12.1_210cbac" — we extract "v1.12" as the lookup key.

--- a/packages/shared/pkg/featureflags/logrouting_resolver.go
+++ b/packages/shared/pkg/featureflags/logrouting_resolver.go
@@ -1,0 +1,80 @@
+package featureflags
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldcontext"
+)
+
+// logWriteConfigCacheTTL bounds how often LogsWriteConfigFlag is resolved.
+// LaunchDarkly already caches flag data locally; this cache is for the parsed
+// and validated LogWriteConfig (type checks, URL validation, dedupe, defaults).
+// Log writes happen on a very hot path (per line / per request), so resolving
+// that JSON config on every write would add avoidable CPU/allocations. 1s keeps
+// the flag responsive while making resolution cost negligible under high volume.
+const logWriteConfigCacheTTL = 1 * time.Second
+
+// LogWriteConfigResolver caches the resolved LogWriteConfig for a short TTL so
+// callers on hot log-write paths avoid evaluating LaunchDarkly on every line.
+// It is safe for concurrent use.
+type LogWriteConfigResolver struct {
+	ff          *Client
+	fallbackURL string
+	ttl         time.Duration
+
+	mu     sync.RWMutex
+	cached LogWriteConfig
+	expiry time.Time
+	loaded bool
+}
+
+// NewLogWriteConfigResolver builds a resolver that caches LogsWriteConfigFlag
+// evaluations for a short TTL. A nil ff is supported: Resolve then always
+// returns the legacy fallback config (current behavior).
+func NewLogWriteConfigResolver(ff *Client, fallbackURL string) *LogWriteConfigResolver {
+	return newLogWriteConfigResolverWithTTL(ff, fallbackURL, logWriteConfigCacheTTL)
+}
+
+// newLogWriteConfigResolverWithTTL is the test-friendly constructor allowing a
+// custom TTL so tests can exercise cache expiry without real-time sleeps.
+func newLogWriteConfigResolverWithTTL(ff *Client, fallbackURL string, ttl time.Duration) *LogWriteConfigResolver {
+	return &LogWriteConfigResolver{
+		ff:          ff,
+		fallbackURL: fallbackURL,
+		ttl:         ttl,
+	}
+}
+
+// Resolve returns the cached LogWriteConfig, refreshing it via
+// ResolveLogWriteConfig when the cache is empty or expired. Behavior for
+// null/malformed/unsafe flag values is identical to ResolveLogWriteConfig.
+func (r *LogWriteConfigResolver) Resolve(ctx context.Context, contexts ...ldcontext.Context) LogWriteConfig {
+	now := time.Now()
+
+	r.mu.RLock()
+	if r.loaded && now.Before(r.expiry) {
+		cfg := r.cached
+		r.mu.RUnlock()
+
+		return cfg
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Another goroutine may have refreshed the cache while we were waiting for
+	// the exclusive lock.
+	if r.loaded && now.Before(r.expiry) {
+		return r.cached
+	}
+
+	cfg := ResolveLogWriteConfig(ctx, r.ff, r.fallbackURL, contexts...)
+	r.cached = cfg
+	r.expiry = now.Add(r.ttl)
+	r.loaded = true
+
+	return cfg
+}

--- a/packages/shared/pkg/featureflags/logrouting_resolver_test.go
+++ b/packages/shared/pkg/featureflags/logrouting_resolver_test.go
@@ -1,0 +1,93 @@
+package featureflags
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogWriteConfigResolverNilClient(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewLogWriteConfigResolver(nil, fallbackCollector)
+	got := resolver.Resolve(t.Context())
+
+	assert.Equal(t, fallbackCollector, got.PrimaryURL)
+	assert.Nil(t, got.ShadowURLs)
+	// Legacy fallback leaves Timeout at 0 to rely on the HTTP client timeout.
+	assert.Equal(t, time.Duration(0), got.Timeout)
+	assert.Equal(t, int64(defaultMaxInflightShadowWrites), got.MaxInflightShadowWrites)
+}
+
+func TestLogWriteConfigResolverCachesUntilTTL(t *testing.T) {
+	t.Parallel()
+
+	source := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(source)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(t.Context()))
+	})
+
+	source.Update(source.Flag(LogsWriteConfigFlag.Key()).ValueForAll(ldvalue.FromJSONMarshal(map[string]any{
+		"mode":        LogsWriteModePrimaryOnly,
+		"primary_url": "http://127.0.0.1:11111",
+	})))
+
+	// Long TTL so the change below is not observed until we force expiry.
+	resolver := newLogWriteConfigResolverWithTTL(client, fallbackCollector, time.Hour)
+
+	first := resolver.Resolve(t.Context())
+	assert.Equal(t, "http://127.0.0.1:11111", first.PrimaryURL)
+
+	// Change the flag: the resolver must keep returning the cached value.
+	source.Update(source.Flag(LogsWriteConfigFlag.Key()).ValueForAll(ldvalue.FromJSONMarshal(map[string]any{
+		"mode":        LogsWriteModePrimaryOnly,
+		"primary_url": "http://127.0.0.1:22222",
+	})))
+
+	cached := resolver.Resolve(t.Context())
+	assert.Equal(t, "http://127.0.0.1:11111", cached.PrimaryURL, "should serve cached config before TTL expiry")
+}
+
+func TestLogWriteConfigResolverRefreshesAfterTTL(t *testing.T) {
+	t.Parallel()
+
+	source := ldtestdata.DataSource()
+	client, err := NewClientWithDatasource(source)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close(t.Context()))
+	})
+
+	source.Update(source.Flag(LogsWriteConfigFlag.Key()).ValueForAll(ldvalue.FromJSONMarshal(map[string]any{
+		"mode":        LogsWriteModePrimaryOnly,
+		"primary_url": "http://127.0.0.1:11111",
+	})))
+
+	// Zero TTL forces a refresh on every Resolve, so a flag change is observed
+	// deterministically without a real-time sleep.
+	resolver := newLogWriteConfigResolverWithTTL(client, fallbackCollector, 0)
+
+	first := resolver.Resolve(t.Context())
+	assert.Equal(t, "http://127.0.0.1:11111", first.PrimaryURL)
+
+	source.Update(source.Flag(LogsWriteConfigFlag.Key()).ValueForAll(ldvalue.FromJSONMarshal(map[string]any{
+		"mode":        LogsWriteModePrimaryOnly,
+		"primary_url": "http://127.0.0.1:22222",
+	})))
+
+	refreshed := resolver.Resolve(t.Context())
+	assert.Equal(t, "http://127.0.0.1:22222", refreshed.PrimaryURL, "should refresh after TTL expiry")
+}
+
+func TestLogWriteConfigResolverDefaultTTL(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewLogWriteConfigResolver(nil, fallbackCollector)
+	assert.Equal(t, logWriteConfigCacheTTL, resolver.ttl)
+}

--- a/packages/shared/pkg/featureflags/logrouting_test.go
+++ b/packages/shared/pkg/featureflags/logrouting_test.go
@@ -1,0 +1,304 @@
+package featureflags
+
+import (
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
+	"github.com/launchdarkly/go-server-sdk/v7/testhelpers/ldtestdata"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fallbackCollector = "http://localhost:30006"
+
+func legacyLogWriteConfig() LogWriteConfig {
+	// The legacy fallback leaves Timeout at 0 (rely on the HTTP client timeout),
+	// preserving pre-flag behavior. defaultLogWriteTimeout applies only to
+	// explicitly-configured flags with a missing/invalid timeout_ms.
+	return LogWriteConfig{
+		PrimaryURL:              fallbackCollector,
+		Timeout:                 0,
+		MaxInflightShadowWrites: defaultMaxInflightShadowWrites,
+	}
+}
+
+func TestResolveLogWriteConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value ldvalue.Value
+		want  LogWriteConfig
+	}{
+		{
+			name:  "null falls back to legacy collector",
+			value: ldvalue.Null(),
+			want:  legacyLogWriteConfig(),
+		},
+		{
+			name:  "non-object falls back to legacy collector",
+			value: ldvalue.String("nonsense"),
+			want:  legacyLogWriteConfig(),
+		},
+		{
+			name: "unknown mode falls back to legacy collector",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        "bogus",
+				"primary_url": "http://localhost:9999",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "non-string mode falls back to legacy collector",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        true,
+				"primary_url": "http://localhost:9999",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "missing mode falls back to legacy collector",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"primary_url": "http://localhost:9999",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_only with valid local url",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "http://127.0.0.1:30006",
+				"timeout_ms":  1500,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://127.0.0.1:30006", Timeout: 1500 * time.Millisecond, MaxInflightShadowWrites: defaultMaxInflightShadowWrites},
+		},
+		{
+			name: "primary_only trims url whitespace",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "  http://127.0.0.1:30006/logs  ",
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://127.0.0.1:30006/logs", Timeout: defaultLogWriteTimeout, MaxInflightShadowWrites: defaultMaxInflightShadowWrites},
+		},
+		{
+			name: "primary_only non-string primary url falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": 123,
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_only empty primary url falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_only external https url falls back (unsafe)",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "https://evil.example.com/logs",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_only external http host falls back (unsafe)",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "http://evil.example.com/logs",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_and_shadow with valid urls",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": []any{"http://127.0.0.1:4321/logs", "http://[::1]:4321/logs"},
+				"timeout_ms":  2500,
+			}),
+			want: LogWriteConfig{
+				PrimaryURL:              "http://localhost:30006",
+				ShadowURLs:              []string{"http://127.0.0.1:4321/logs", "http://[::1]:4321/logs"},
+				Timeout:                 2500 * time.Millisecond,
+				MaxInflightShadowWrites: defaultMaxInflightShadowWrites,
+			},
+		},
+		{
+			name: "primary_and_shadow deduplicates primary and duplicate shadows",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": []any{"http://localhost:30006", "http://127.0.0.1:4321/logs", "http://127.0.0.1:4321/logs"},
+			}),
+			want: LogWriteConfig{
+				PrimaryURL:              "http://localhost:30006",
+				ShadowURLs:              []string{"http://127.0.0.1:4321/logs"},
+				Timeout:                 defaultLogWriteTimeout,
+				MaxInflightShadowWrites: defaultMaxInflightShadowWrites,
+			},
+		},
+		{
+			name: "primary_and_shadow non-array shadow urls falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": "http://127.0.0.1:4321/logs",
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_and_shadow non-string shadow falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": []any{"http://127.0.0.1:4321/logs", 42},
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_and_shadow too many shadows falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": []any{
+					"http://127.0.0.1:4321/a",
+					"http://127.0.0.1:4321/b",
+					"http://127.0.0.1:4321/c",
+					"http://127.0.0.1:4321/d",
+					"http://127.0.0.1:4321/e",
+				},
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "primary_and_shadow with unsafe shadow falls back",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryAndShadow,
+				"primary_url": "http://localhost:30006",
+				"shadow_urls": []any{"http://8.8.8.8/logs"},
+			}),
+			want: legacyLogWriteConfig(),
+		},
+		{
+			name: "timeout defaulted when non-positive",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "http://localhost:30006",
+				"timeout_ms":  0,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://localhost:30006", Timeout: defaultLogWriteTimeout, MaxInflightShadowWrites: defaultMaxInflightShadowWrites},
+		},
+		{
+			name: "timeout capped when too large",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":        LogsWriteModePrimaryOnly,
+				"primary_url": "http://localhost:30006",
+				"timeout_ms":  60000,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://localhost:30006", Timeout: maxLogWriteTimeout, MaxInflightShadowWrites: defaultMaxInflightShadowWrites},
+		},
+		{
+			name: "max inflight shadow writes configured",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":                       LogsWriteModePrimaryOnly,
+				"primary_url":                "http://localhost:30006",
+				"max_inflight_shadow_writes": 64,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://localhost:30006", Timeout: defaultLogWriteTimeout, MaxInflightShadowWrites: 64},
+		},
+		{
+			name: "max inflight shadow writes defaults when non-positive",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":                       LogsWriteModePrimaryOnly,
+				"primary_url":                "http://localhost:30006",
+				"max_inflight_shadow_writes": 0,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://localhost:30006", Timeout: defaultLogWriteTimeout, MaxInflightShadowWrites: defaultMaxInflightShadowWrites},
+		},
+		{
+			name: "max inflight shadow writes uses positive value as configured",
+			value: ldvalue.FromJSONMarshal(map[string]any{
+				"mode":                       LogsWriteModePrimaryOnly,
+				"primary_url":                "http://localhost:30006",
+				"max_inflight_shadow_writes": 999999,
+			}),
+			want: LogWriteConfig{PrimaryURL: "http://localhost:30006", Timeout: defaultLogWriteTimeout, MaxInflightShadowWrites: 999999},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Each subtest gets its own datasource/client so parallel runs don't
+			// race on the shared flag value.
+			source := ldtestdata.DataSource()
+			client, err := NewClientWithDatasource(source)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				assert.NoError(t, client.Close(t.Context()))
+			})
+
+			source.Update(source.Flag(LogsWriteConfigFlag.Key()).ValueForAll(tt.value))
+
+			got := ResolveLogWriteConfig(t.Context(), client, fallbackCollector)
+
+			assert.Equal(t, tt.want.PrimaryURL, got.PrimaryURL)
+			assert.Equal(t, tt.want.ShadowURLs, got.ShadowURLs)
+			assert.Equal(t, tt.want.Timeout, got.Timeout)
+			assert.Equal(t, tt.want.MaxInflightShadowWrites, got.MaxInflightShadowWrites)
+		})
+	}
+}
+
+func TestResolveLogWriteConfigNilClientFallsBack(t *testing.T) {
+	t.Parallel()
+
+	got := ResolveLogWriteConfig(t.Context(), nil, fallbackCollector)
+
+	assert.Equal(t, fallbackCollector, got.PrimaryURL)
+	assert.Nil(t, got.ShadowURLs)
+	// Legacy fallback leaves Timeout at 0 to rely on the HTTP client timeout.
+	assert.Equal(t, time.Duration(0), got.Timeout)
+	assert.Equal(t, int64(defaultMaxInflightShadowWrites), got.MaxInflightShadowWrites)
+}
+
+func TestIsSafeLogURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"", false},
+		{"http://localhost:30006", true},
+		{"http://127.0.0.1:30006", true},
+		{"http://[::1]:4321/logs", true},
+		{"http://10.0.0.5:9000/logs", true},
+		{"http://192.168.1.10/logs", true},
+		{"http://169.254.0.1/logs", true},
+		{"http://otel-router.service.consul:4321/logs", true},
+		{"http://vector.logging.svc.cluster.local:8080/logs", true},
+		{"http://collector.logging.svc:8080/logs", true},
+		{"http://logs.internal:8080/logs", true},
+		{"http://logs.local:8080/logs", true},
+		{"https://localhost:30006", false},
+		{"http://8.8.8.8/logs", false},
+		{"http://example.com/logs", false},
+		{"://bad", false},
+		{"ftp://localhost/logs", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, isSafeLogURL(tt.url))
+		})
+	}
+}

--- a/packages/shared/pkg/logger/exporter.go
+++ b/packages/shared/pkg/logger/exporter.go
@@ -3,19 +3,83 @@ package logger
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap/zapcore"
 )
+
+// LogRoute is the resolved destination for a single log write. It is populated
+// by a LogRouteResolver so that this package stays decoupled from featureflags
+// (which imports this package).
+type LogRoute struct {
+	// PrimaryURL is the synchronous, success-controlling destination.
+	PrimaryURL string
+	// ShadowURLs are best-effort, fire-and-forget destinations.
+	ShadowURLs []string
+	// Timeout bounds each individual request.
+	Timeout time.Duration
+	// MaxInflightShadowWrites bounds concurrent best-effort shadow writes.
+	MaxInflightShadowWrites int64
+}
+
+// LogRouteResolver resolves the current log route for a write. It is called on
+// each log line, so it must be cheap and non-blocking.
+type LogRouteResolver func(ctx context.Context) LogRoute
+
+const defaultMaxInflightShadowWrites = 1024
+
+var (
+	logWriterMeter      = otel.Meter("github.com/e2b-dev/infra/packages/shared/pkg/logger")
+	logWriterWriteCount = mustLogWriterCounter(
+		"log_writer_write_count",
+		"Number of log writer HTTP attempts by route and result",
+	)
+	logWriterShadowInflight = mustLogWriterUpDownCounter(
+		"log_writer_shadow_inflight",
+		"Current number of in-flight best-effort shadow log writes",
+	)
+)
+
+func mustLogWriterCounter(name, description string) metric.Int64Counter {
+	counter, err := logWriterMeter.Int64Counter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
+
+func mustLogWriterUpDownCounter(name, description string) metric.Int64UpDownCounter {
+	counter, err := logWriterMeter.Int64UpDownCounter(name, metric.WithDescription(description))
+	if err != nil {
+		return nil
+	}
+
+	return counter
+}
 
 type HTTPWriter struct {
 	ctx        context.Context //nolint:containedctx // todo: fix the interface so this can be removed
 	url        string
 	httpClient *http.Client
+
+	// resolve, when non-nil, dynamically selects the destination(s) per write.
+	// When nil the writer always sends to url (legacy behavior).
+	resolve LogRouteResolver
+
+	// shadowInflight bounds concurrent shadow writes (best-effort, non-blocking
+	// acquire; dropped when the resolved route limit is reached).
+	shadowInflight atomic.Int64
 
 	wgLock sync.Mutex
 	wg     *sync.WaitGroup
@@ -28,6 +92,23 @@ func NewHTTPWriter(ctx context.Context, endpoint string) zapcore.WriteSyncer {
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		wgLock: sync.Mutex{},
+		wg:     &sync.WaitGroup{},
+	}
+}
+
+// NewDynamicHTTPWriter builds a writer that resolves its destination(s) on each
+// write via resolve. endpoint is the legacy fallback used by the resolver when
+// LaunchDarkly config is missing/invalid. If resolve is nil it behaves exactly
+// like NewHTTPWriter(ctx, endpoint).
+func NewDynamicHTTPWriter(ctx context.Context, endpoint string, resolve LogRouteResolver) zapcore.WriteSyncer {
+	return &HTTPWriter{
+		ctx: ctx,
+		url: endpoint,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		resolve: resolve,
 
 		wgLock: sync.Mutex{},
 		wg:     &sync.WaitGroup{},
@@ -54,8 +135,9 @@ func (h *HTTPWriter) Write(source []byte) (n int, err error) {
 			if b == '\n' {
 				if start < i { // Ignore empty lines
 					line := p[start:i]
-					if err := h.sendLogLine(line); err != nil {
-						log.Printf("%v: %s\n", err, line)
+					if err := h.routeLogLine(line); err != nil {
+						// Never log the line itself: it is customer log content.
+						log.Printf("error routing log line (%d bytes): %v\n", len(line), err)
 
 						return
 					}
@@ -67,8 +149,9 @@ func (h *HTTPWriter) Write(source []byte) (n int, err error) {
 		// Handle the last line if there’s no trailing newline
 		if start < len(p) {
 			line := p[start:]
-			if err := h.sendLogLine(line); err != nil {
-				log.Printf("%v: %s\n", err, line)
+			if err := h.routeLogLine(line); err != nil {
+				// Never log the line itself: it is customer log content.
+				log.Printf("error routing log line (%d bytes): %v\n", len(line), err)
 
 				return
 			}
@@ -91,9 +174,123 @@ func (h *HTTPWriter) Sync() error {
 	return nil
 }
 
-// sendLogLine handles sending ONE log line as an HTTP request
-func (h *HTTPWriter) sendLogLine(line []byte) error {
-	request, err := http.NewRequestWithContext(h.ctx, http.MethodPost, h.url, bytes.NewReader(line))
+// routeLogLine resolves the current destination(s) and sends ONE log line.
+// The primary write controls success; shadow writes are fire-and-forget and
+// never affect the returned error. When no resolver is configured it sends to
+// the legacy url (preserving today's behavior).
+func (h *HTTPWriter) routeLogLine(line []byte) error {
+	if h.resolve == nil {
+		if err := h.sendLogLine(h.ctx, h.url, line); err != nil {
+			recordLogWriterWrite(h.ctx, "primary", "failure", "send_error")
+
+			return err
+		}
+		recordLogWriterWrite(h.ctx, "primary", "success", "")
+
+		return nil
+	}
+
+	route := h.resolve(h.ctx)
+	primary := route.PrimaryURL
+	if primary == "" {
+		// Resolver guarantees a non-empty primary on non-disabled routes, but
+		// guard anyway to avoid a bad request.
+		primary = h.url
+	}
+
+	ctx := h.ctx
+	cancel := context.CancelFunc(func() {})
+	if route.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(h.ctx, route.Timeout)
+	}
+	defer cancel()
+
+	// Fire-and-forget shadow writes: line points into the private copy made in
+	// Write, not the caller's/zap's reusable buffer, so it is safe to share with
+	// shadow goroutines without another per-shadow allocation. Shadow outcomes
+	// never influence the primary result. Concurrency is bounded by the resolved
+	// route limit; excess writes are dropped to avoid unbounded goroutine/
+	// connection growth (and to avoid a shadow log storm).
+	maxInflight := route.MaxInflightShadowWrites
+	if maxInflight <= 0 {
+		maxInflight = defaultMaxInflightShadowWrites
+	}
+	for _, shadowURL := range route.ShadowURLs {
+		if !h.tryAcquireShadow(maxInflight) {
+			// Semaphore full: drop this shadow write.
+			recordLogWriterWrite(h.ctx, "shadow", "dropped", "saturated")
+
+			continue
+		}
+		recordLogWriterShadowInflight(h.ctx, 1)
+
+		go func(url string, payload []byte) {
+			defer func() {
+				h.shadowInflight.Add(-1)
+				recordLogWriterShadowInflight(h.ctx, -1)
+			}()
+
+			shadowCtx := h.ctx
+			shadowCancel := context.CancelFunc(func() {})
+			if route.Timeout > 0 {
+				shadowCtx, shadowCancel = context.WithTimeout(h.ctx, route.Timeout)
+			}
+			defer shadowCancel()
+
+			if err := h.sendLogLine(shadowCtx, url, payload); err != nil {
+				recordLogWriterWrite(shadowCtx, "shadow", "failure", "send_error")
+
+				return
+			}
+			recordLogWriterWrite(shadowCtx, "shadow", "success", "")
+		}(shadowURL, line)
+	}
+
+	if err := h.sendLogLine(ctx, primary, line); err != nil {
+		recordLogWriterWrite(ctx, "primary", "failure", "send_error")
+
+		return err
+	}
+	recordLogWriterWrite(ctx, "primary", "success", "")
+
+	return nil
+}
+
+func (h *HTTPWriter) tryAcquireShadow(maxInflight int64) bool {
+	for {
+		current := h.shadowInflight.Load()
+		if current >= maxInflight {
+			return false
+		}
+		if h.shadowInflight.CompareAndSwap(current, current+1) {
+			return true
+		}
+	}
+}
+
+func recordLogWriterWrite(ctx context.Context, route, result, reason string) {
+	if logWriterWriteCount == nil {
+		return
+	}
+
+	logWriterWriteCount.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("route", route),
+		attribute.String("result", result),
+		attribute.String("reason", reason),
+	))
+}
+
+func recordLogWriterShadowInflight(ctx context.Context, delta int64) {
+	if logWriterShadowInflight == nil {
+		return
+	}
+
+	logWriterShadowInflight.Add(ctx, delta)
+}
+
+// sendLogLine handles sending ONE log line as an HTTP request to url.
+func (h *HTTPWriter) sendLogLine(ctx context.Context, url string, line []byte) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(line))
 	if err != nil {
 		return fmt.Errorf("error sending logs: %w", err)
 	}
@@ -104,10 +301,24 @@ func (h *HTTPWriter) sendLogLine(line []byte) error {
 	if err != nil {
 		return fmt.Errorf("error sending logs: %w", err)
 	}
+	defer response.Body.Close()
 
-	err = response.Body.Close()
-	if err != nil {
-		return fmt.Errorf("error closing response body: %w", err)
+	// Always drain so the transport can reuse the connection; the body itself
+	// is never surfaced in the returned error (it may echo request content).
+	drainErr := drainResponseBody(response.Body)
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		statusErr := fmt.Errorf("error sending logs: unexpected HTTP status %d", response.StatusCode)
+
+		return errors.Join(statusErr, drainErr)
+	}
+
+	return drainErr
+}
+
+func drainResponseBody(body io.Reader) error {
+	if _, err := io.Copy(io.Discard, body); err != nil {
+		return fmt.Errorf("error draining response body: %w", err)
 	}
 
 	return nil

--- a/packages/shared/pkg/logger/exporter_test.go
+++ b/packages/shared/pkg/logger/exporter_test.go
@@ -1,15 +1,128 @@
 package logger
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestHTTPWriterSendLogLineStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{name: "success", status: http.StatusNoContent},
+		{name: "client error", status: http.StatusBadRequest, wantErr: true},
+		{name: "server error", status: http.StatusServiceUnavailable, wantErr: true},
+		{name: "rate limited", status: http.StatusTooManyRequests, wantErr: true},
+		{name: "internal server error", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte("collector diagnostic"))
+			}))
+			t.Cleanup(server.Close)
+
+			writer := &HTTPWriter{httpClient: server.Client()}
+			err := writer.sendLogLine(t.Context(), server.URL, []byte(`{"secret":"not-in-error"}`))
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err != nil && strings.Contains(err.Error(), "not-in-error") {
+				t.Fatalf("error contains request payload: %v", err)
+			}
+		})
+	}
+}
+
+// TestHTTPWriterSendLogLineRespectsContextDeadline verifies a slow/hung
+// destination (e.g. Vector under backpressure) doesn't block sendLogLine
+// forever: once the caller-supplied context deadline passes, the request is
+// aborted client-side and an error is returned promptly, regardless of
+// whether the server ever responds. This is the timeout behavior routeLogLine
+// relies on when a resolved route sets Timeout > 0.
+func TestHTTPWriterSendLogLineRespectsContextDeadline(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	writer := &HTTPWriter{httpClient: server.Client()}
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := writer.sendLogLine(ctx, server.URL, []byte(`{"msg":"slow"}`))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a slow/hung response once the context deadline passes")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("sendLogLine took %v to return; expected it to abort promptly once the 50ms deadline passed", elapsed)
+	}
+}
+
+// TestHTTPWriterSendLogLineRespectsClientTimeout is the legacy-mode
+// equivalent: when there is no per-request context deadline (route.Timeout ==
+// 0, i.e. resolve is nil or the resolved route is unconfigured), the request
+// must still be bounded by the http.Client's own Timeout, exactly as it was
+// before per-request timeouts existed.
+func TestHTTPWriterSendLogLineRespectsClientTimeout(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	writer := &HTTPWriter{httpClient: &http.Client{Timeout: 50 * time.Millisecond}}
+
+	start := time.Now()
+	err := writer.sendLogLine(t.Context(), server.URL, []byte(`{"msg":"slow"}`))
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a slow/hung response once the client timeout passes")
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("sendLogLine took %v to return; expected it to abort promptly once the 50ms client timeout passed", elapsed)
+	}
+}
 
 // TestHTTPWriterWaitGroupReuse tests the race condition where WaitGroup is reused
 // before previous Wait has returned, which should panic with:
@@ -234,5 +347,183 @@ func TestHTTPWriterSequentialWrites(t *testing.T) {
 
 	if requestCount.Load() != int32(len(logLines)) {
 		t.Errorf("Expected %d requests, got %d", len(logLines), requestCount.Load())
+	}
+}
+
+// TestDynamicHTTPWriterPrimaryAndShadow verifies primary + shadow fan-out.
+func TestDynamicHTTPWriterPrimaryAndShadow(t *testing.T) {
+	t.Parallel()
+
+	var primaryCount, shadowCount atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		primaryCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(primary.Close)
+	shadow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shadowCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(shadow.Close)
+
+	resolve := func(context.Context) LogRoute {
+		return LogRoute{
+			PrimaryURL:              primary.URL,
+			ShadowURLs:              []string{shadow.URL},
+			Timeout:                 2 * time.Second,
+			MaxInflightShadowWrites: 1,
+		}
+	}
+
+	writer := NewDynamicHTTPWriter(t.Context(), primary.URL, resolve)
+	_, err := writer.Write([]byte(`{"level":"info","msg":"line"}` + "\n"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if primaryCount.Load() != 1 {
+		t.Errorf("expected 1 primary request, got %d", primaryCount.Load())
+	}
+	if shadowCount.Load() != 1 {
+		t.Errorf("expected 1 shadow request, got %d", shadowCount.Load())
+	}
+}
+
+// TestDynamicHTTPWriterShadowFailureIgnored verifies a broken shadow does not
+// affect the primary write.
+func TestDynamicHTTPWriterShadowFailureIgnored(t *testing.T) {
+	t.Parallel()
+
+	var primaryCount atomic.Int32
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		primaryCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(primary.Close)
+	shadowAttempted := make(chan struct{}, 1)
+	shadow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shadowAttempted <- struct{}{}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(shadow.Close)
+
+	resolve := func(context.Context) LogRoute {
+		return LogRoute{
+			PrimaryURL:              primary.URL,
+			ShadowURLs:              []string{shadow.URL},
+			Timeout:                 500 * time.Millisecond,
+			MaxInflightShadowWrites: 1,
+		}
+	}
+
+	writer := NewDynamicHTTPWriter(t.Context(), primary.URL, resolve).(*HTTPWriter)
+	if err := writer.routeLogLine([]byte(`{"msg":"x"}`)); err != nil {
+		t.Fatalf("primary failed because shadow returned an error: %v", err)
+	}
+
+	select {
+	case <-shadowAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("shadow request was not attempted")
+	}
+
+	if primaryCount.Load() != 1 {
+		t.Errorf("expected 1 primary request despite shadow failure, got %d", primaryCount.Load())
+	}
+}
+
+// TestDynamicHTTPWriterShadowFanoutBounded verifies shadow writes are capped by
+// the resolved limit: when it is saturated by in-flight (blocked) shadow
+// requests, additional shadow writes are dropped while the primary always
+// succeeds.
+func TestDynamicHTTPWriterShadowFanoutBounded(t *testing.T) {
+	t.Parallel()
+
+	var primaryCount, shadowStarted atomic.Int32
+
+	// release gates the shadow handler so we can hold the semaphore slots.
+	release := make(chan struct{})
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		primaryCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(primary.Close)
+	shadow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		shadowStarted.Add(1)
+		<-release // block, holding a semaphore slot
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(shadow.Close)
+	t.Cleanup(func() { close(release) })
+
+	const shadowCap = 2
+	resolve := func(context.Context) LogRoute {
+		return LogRoute{
+			PrimaryURL:              primary.URL,
+			ShadowURLs:              []string{shadow.URL},
+			Timeout:                 5 * time.Second,
+			MaxInflightShadowWrites: shadowCap,
+		}
+	}
+
+	writer := &HTTPWriter{
+		ctx:        t.Context(),
+		url:        primary.URL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+		resolve:    resolve,
+		wg:         &sync.WaitGroup{},
+	}
+
+	const writes = 50
+	for range writes {
+		if _, err := writer.Write([]byte(`{"msg":"x"}` + "\n")); err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	// Wait until the shadow slots are saturated (bounded, no unbounded growth).
+	deadline := time.Now().Add(5 * time.Second)
+	for shadowStarted.Load() < int32(shadowCap) && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if got := shadowStarted.Load(); got > int32(shadowCap) {
+		t.Errorf("expected at most %d concurrent shadow writes, got %d", shadowCap, got)
+	}
+	if got := primaryCount.Load(); got != writes {
+		t.Errorf("expected %d primary writes, got %d", writes, got)
+	}
+}
+
+// TestDynamicHTTPWriterNilResolverIsLegacy verifies a nil resolver behaves like
+// the legacy writer (sends to the fixed endpoint).
+func TestDynamicHTTPWriterNilResolverIsLegacy(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	writer := NewDynamicHTTPWriter(t.Context(), server.URL, nil)
+	if _, err := writer.Write([]byte(`{"msg":"x"}` + "\n")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := writer.Sync(); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	if count.Load() != 1 {
+		t.Errorf("expected 1 request with nil resolver, got %d", count.Load())
 	}
 }

--- a/packages/shared/pkg/logger/sandbox/logger.go
+++ b/packages/shared/pkg/logger/sandbox/logger.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 )
 
@@ -18,6 +19,11 @@ type SandboxLoggerConfig struct {
 	// For external logger, we also disable stacktraces
 	IsInternal       bool
 	CollectorAddress string
+	// FeatureFlags, when set for an external logger with a CollectorAddress,
+	// enables LaunchDarkly-controlled log write routing (see
+	// featureflags.LogsWriteConfigFlag). When nil the logger keeps writing only
+	// to CollectorAddress (legacy behavior).
+	FeatureFlags *featureflags.Client
 }
 
 func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config SandboxLoggerConfig) logger.Logger {
@@ -28,7 +34,7 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 	if !config.IsInternal && config.CollectorAddress != "" {
 		// Add Vector exporter to the core
 		vectorEncoder := zapcore.NewJSONEncoder(GetSandboxEncoderConfig())
-		httpWriter := logger.NewHTTPWriter(ctx, config.CollectorAddress)
+		httpWriter := newExternalLogWriter(ctx, config)
 		core = zapcore.NewCore(
 			vectorEncoder,
 			httpWriter,
@@ -55,6 +61,32 @@ func NewLogger(ctx context.Context, loggerProvider log.LoggerProvider, config Sa
 	}
 
 	return lg
+}
+
+// newExternalLogWriter builds the write syncer for external sandbox logs.
+// With a FeatureFlags client it resolves destinations from
+// featureflags.LogsWriteConfigFlag on each write, falling back to
+// CollectorAddress; without one it uses the legacy fixed-address writer.
+func newExternalLogWriter(ctx context.Context, config SandboxLoggerConfig) zapcore.WriteSyncer {
+	if config.FeatureFlags == nil {
+		return logger.NewHTTPWriter(ctx, config.CollectorAddress)
+	}
+
+	// Cache LaunchDarkly evaluations behind a short TTL so per-line writes on
+	// the hot path don't evaluate the flag every time.
+	resolver := featureflags.NewLogWriteConfigResolver(config.FeatureFlags, config.CollectorAddress)
+	resolve := func(ctx context.Context) logger.LogRoute {
+		cfg := resolver.Resolve(ctx)
+
+		return logger.LogRoute{
+			PrimaryURL:              cfg.PrimaryURL,
+			ShadowURLs:              cfg.ShadowURLs,
+			Timeout:                 cfg.Timeout,
+			MaxInflightShadowWrites: cfg.MaxInflightShadowWrites,
+		}
+	}
+
+	return logger.NewDynamicHTTPWriter(ctx, config.CollectorAddress, resolve)
 }
 
 func GetSandboxEncoderConfig() zapcore.EncoderConfig {


### PR DESCRIPTION
## What

Makes sandbox log write routing dynamic and adds a ClickHouse-backed read path for local-cluster sandbox/build logs. Both are controlled by LaunchDarkly flags and remain no-ops when the flags are unset.

### Write path — `logs-write-config` JSON flag
- `HTTPWriter` and the hyperloop `/logs` forwarder resolve their destination per write through a cached `LogWriteConfigResolver` instead of a fixed collector address.
- The config supports one synchronous primary plus optional fire-and-forget shadow destinations.
- Null or invalid config falls back to the legacy `LOGS_COLLECTOR_ADDRESS` behavior.
- Shadow writes are bounded, never block the primary result, and are covered by route/result metrics.

### Read path — `logs-read-config` bool flag
- Adds `clickhouse/pkg/sandboxlogs`, a reader for the `sandbox_logs` table.
- The API uses ClickHouse for local-cluster sandbox/build log reads only when the flag is enabled and `CLICKHOUSE_CONNECTION_STRING` is configured.
- If the flag is disabled or no ClickHouse DSN is configured, reads stay on Loki.

## Why

Lets the log pipeline migrate collectors and storage backends with flag flips instead of redeploys, while keeping every step reversible and preserving the legacy Loki path as the default.

## Testing

- Unit tests for flag parsing, config resolution caching, URL validation, dynamic writer routing, shadow concurrency limits, and ClickHouse sandbox/build log queries.
- Local validation: `go test ./packages/clickhouse/pkg/sandboxlogs ./packages/api/internal/clusters ./packages/api/internal/handlers` and targeted `golangci-lint`.
- Previously verified end-to-end in a dev cluster: logs written through the routed pipeline into ClickHouse and read back through the API with the read flag enabled.
