### PR TITLE
feat(api): add feature flag to stop accepting E2B access tokens

### DIFF
--- a/packages/api/internal/handlers/accesstoken_test.go
+++ b/packages/api/internal/handlers/accesstoken_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,4 +37,85 @@ func TestPostAccessTokensRejectsWhenIssuanceDisabled(t *testing.T) {
 
 	require.Equal(t, http.StatusGone, recorder.Code)
 	require.Contains(t, recorder.Body.String(), "E2B_API_KEY")
+}
+
+// fakeAccessTokenAuthService stubs sharedauth.Service for access token
+// validation; all other methods are inherited no-ops from fakeAPIKeyAuthService.
+type fakeAccessTokenAuthService struct {
+	fakeAPIKeyAuthService
+
+	userID uuid.UUID
+	apiErr *sharedauth.APIError
+}
+
+func (f fakeAccessTokenAuthService) ValidateAccessToken(context.Context, *gin.Context, string) (uuid.UUID, *sharedauth.APIError) {
+	return f.userID, f.apiErr
+}
+
+func newAccessTokenAuthTestClient(t *testing.T, disabled bool) *featureflags.Client {
+	t.Helper()
+
+	td := ldtestdata.DataSource()
+	td.Update(td.Flag(featureflags.DisableE2BAccessTokenAuthFlag.Key()).VariationForAll(disabled))
+	ff, err := featureflags.NewClientWithDatasource(td)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ff.Close(t.Context()) })
+
+	return ff
+}
+
+func TestGetUserFromAccessTokenAcceptsWhenAuthEnabled(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	store := &APIStore{
+		featureFlags: newAccessTokenAuthTestClient(t, false),
+		authService:  fakeAccessTokenAuthService{userID: userID},
+	}
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	gotUserID, apiErr := store.GetUserFromAccessToken(t.Context(), ginCtx, "sk_e2b_valid")
+
+	require.Nil(t, apiErr)
+	require.Equal(t, userID, gotUserID)
+}
+
+func TestGetUserFromAccessTokenRejectsWhenAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	store := &APIStore{
+		featureFlags: newAccessTokenAuthTestClient(t, true),
+		authService:  fakeAccessTokenAuthService{userID: uuid.New()},
+	}
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	gotUserID, apiErr := store.GetUserFromAccessToken(t.Context(), ginCtx, "sk_e2b_valid")
+
+	require.NotNil(t, apiErr)
+	require.Equal(t, http.StatusUnauthorized, apiErr.Code)
+	require.Contains(t, apiErr.ClientMsg, "E2B_API_KEY")
+	require.Contains(t, apiErr.ClientMsg, "https://e2b.dev/docs/migration/access-token-deprecation")
+	require.Equal(t, uuid.UUID{}, gotUserID)
+}
+
+func TestGetUserFromAccessTokenInvalidTokenStillRejected(t *testing.T) {
+	t.Parallel()
+
+	validationErr := &sharedauth.APIError{
+		Err:       errors.New("failed to verify access token"),
+		ClientMsg: "Invalid access token format",
+		Code:      http.StatusUnauthorized,
+	}
+	store := &APIStore{
+		featureFlags: newAccessTokenAuthTestClient(t, true),
+		authService:  fakeAccessTokenAuthService{apiErr: validationErr},
+	}
+
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	gotUserID, apiErr := store.GetUserFromAccessToken(t.Context(), ginCtx, "not-a-token")
+
+	require.NotNil(t, apiErr)
+	require.Equal(t, http.StatusUnauthorized, apiErr.Code)
+	require.Equal(t, "Invalid access token format", apiErr.ClientMsg)
+	require.Equal(t, uuid.UUID{}, gotUserID)
 }

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -397,7 +397,22 @@ func (a *APIStore) GetUserFromAccessToken(ctx context.Context, ginCtx *gin.Conte
 	ctx, span := tracer.Start(ctx, "get user from access token")
 	defer span.End()
 
-	return a.authService.ValidateAccessToken(ctx, ginCtx, accessToken)
+	userID, apiErr := a.authService.ValidateAccessToken(ctx, ginCtx, accessToken)
+	if apiErr != nil {
+		return uuid.UUID{}, apiErr
+	}
+
+	// Access token acceptance is gated after validation so the flag can be
+	// rolled out per-user via LD targeting during the deprecation cutover.
+	if a.featureFlags.BoolFlag(ctx, featureflags.DisableE2BAccessTokenAuthFlag, featureflags.UserContext(userID.String())) {
+		return uuid.UUID{}, &api.APIError{
+			Err:       errors.New("access token authentication is disabled"),
+			ClientMsg: "E2B_ACCESS_TOKEN is deprecated and no longer accepted. Use an API key (E2B_API_KEY) instead. See https://e2b.dev/docs/migration/access-token-deprecation",
+			Code:      http.StatusUnauthorized,
+		}
+	}
+
+	return userID, nil
 }
 
 func (a *APIStore) GetUserIDFromAuthProviderToken(ctx context.Context, ginCtx *gin.Context, token string) (uuid.UUID, *api.APIError) {

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -224,6 +224,13 @@ var (
 	// in favor of E2B_API_KEY; the CLI now authenticates via Hydra JWTs. Off by
 	// default so issuance keeps working until the deprecation cutover.
 	DisableE2BAccessTokenProvisioningFlag = NewBoolFlag("disable-e2b-access-token-provisioning", false)
+
+	// DisableE2BAccessTokenAuthFlag stops the API from accepting E2B access
+	// tokens (sk_e2b_) for authentication once enabled. E2B_ACCESS_TOKEN is
+	// superseded by E2B_API_KEY; existing tokens stop working on the
+	// deprecation cutover (Aug 1, 2026). Off by default. Evaluated per-user so
+	// rejection can be rolled out gradually via LD targeting.
+	DisableE2BAccessTokenAuthFlag = NewBoolFlag("disable-e2b-access-token-auth", false)
 )
 
 // envdTimeoutFallbackMs reads ENVD_TIMEOUT (Go duration string, e.g. "10s")


### PR DESCRIPTION
Adds disable-e2b-access-token-auth flag that rejects sk_e2b_ access token authentication with 401 and a deprecation message once enabled. Evaluated per-user after token validation so the Aug 1, 2026 cutover can be rolled out gradually via LD targeting.