### PR TITLE
feat(storage): per-role storage URLs, env-free storage library

### DIFF
--- a/packages/orchestrator/benchmarks/benchmark_test.go
+++ b/packages/orchestrator/benchmarks/benchmark_test.go
@@ -170,7 +170,9 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 	limiter, err := limit.New(b.Context(), featureFlags)
 	require.NoError(b, err)
 
-	persistence, err := storage.GetStorageProvider(b.Context(), storage.TemplateStorageConfig.WithLimiter(limiter))
+	templateSpec, err := cfg.TemplateStorage()
+	require.NoError(b, err)
+	persistence, err := storage.NewProvider(b.Context(), templateSpec, storage.WithLimiter(limiter))
 	require.NoError(b, err)
 
 	blockMetrics, err := blockmetrics.NewMetrics(&noop.MeterProvider{})
@@ -224,10 +226,14 @@ func BenchmarkBaseImageLaunch(b *testing.B) {
 	artifactRegistry, err := artifactsregistry.GetArtifactsRegistryProvider(b.Context())
 	require.NoError(b, err)
 
-	persistenceTemplate, err := storage.GetStorageProvider(b.Context(), storage.TemplateStorageConfig)
+	templateSpec2, err := cfg.TemplateStorage()
+	require.NoError(b, err)
+	persistenceTemplate, err := storage.NewProvider(b.Context(), templateSpec2)
 	require.NoError(b, err)
 
-	persistenceBuild, err := storage.GetStorageProvider(b.Context(), storage.BuildCacheStorageConfig)
+	buildCacheSpec, err := cfg.BuildCacheStorage()
+	require.NoError(b, err)
+	persistenceBuild, err := storage.NewProvider(b.Context(), buildCacheSpec)
 	require.NoError(b, err)
 
 	var proxyPort uint16 = 5007

--- a/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
+++ b/packages/orchestrator/benchmarks/concurrent_benchmark_test.go
@@ -247,7 +247,9 @@ func BenchmarkConcurrentResume(b *testing.B) {
 	limiter, err := limit.New(b.Context(), featureFlags)
 	require.NoError(b, err)
 
-	persistence, err := storage.GetStorageProvider(b.Context(), storage.TemplateStorageConfig.WithLimiter(limiter))
+	templateSpec, err := cfg.TemplateStorage()
+	require.NoError(b, err)
+	persistence, err := storage.NewProvider(b.Context(), templateSpec, storage.WithLimiter(limiter))
 	require.NoError(b, err)
 
 	blockMetrics, err := blockmetrics.NewMetrics(&noop.MeterProvider{})
@@ -293,10 +295,14 @@ func BenchmarkConcurrentResume(b *testing.B) {
 	artifactRegistry, err := artifactsregistry.GetArtifactsRegistryProvider(b.Context())
 	require.NoError(b, err)
 
-	persistenceTemplate, err := storage.GetStorageProvider(b.Context(), storage.TemplateStorageConfig)
+	templateSpec2, err := cfg.TemplateStorage()
+	require.NoError(b, err)
+	persistenceTemplate, err := storage.NewProvider(b.Context(), templateSpec2)
 	require.NoError(b, err)
 
-	persistenceBuild, err := storage.GetStorageProvider(b.Context(), storage.BuildCacheStorageConfig)
+	buildCacheSpec, err := cfg.BuildCacheStorage()
+	require.NoError(b, err)
+	persistenceBuild, err := storage.NewProvider(b.Context(), buildCacheSpec)
 	require.NoError(b, err)
 
 	var proxyPort uint16 = 5007

--- a/packages/orchestrator/cmd/create-build/main.go
+++ b/packages/orchestrator/cmd/create-build/main.go
@@ -153,7 +153,7 @@ func setupEnv(ctx context.Context, storagePath, sandboxDir, kernel, fc string, l
 		}
 
 		dataDir := storagePath
-		dirs := []string{"kernels", "templates", "sandbox", "orchestrator", "snapshot-cache", "fc-versions"}
+		dirs := []string{"kernels", "templates", "build-cache", "sandbox", "orchestrator", "snapshot-cache", "fc-versions"}
 		for _, d := range dirs {
 			if err := os.MkdirAll(filepath.Join(dataDir, d), 0o755); err != nil {
 				return fmt.Errorf("mkdir %s: %w", d, err)
@@ -166,20 +166,23 @@ func setupEnv(ctx context.Context, storagePath, sandboxDir, kernel, fc string, l
 		}
 
 		env := map[string]string{
-			"ARTIFACTS_REGISTRY_PROVIDER":      "Local",
-			"FIRECRACKER_VERSIONS_DIR":         abs(filepath.Join(dataDir, "fc-versions")),
-			"HOST_KERNELS_DIR":                 abs(filepath.Join(dataDir, "kernels")),
-			"LOCAL_TEMPLATE_STORAGE_BASE_PATH": abs(filepath.Join(dataDir, "templates")),
-			"ORCHESTRATOR_BASE_PATH":           abs(filepath.Join(dataDir, "orchestrator")),
-			"SNAPSHOT_CACHE_DIR":               abs(filepath.Join(dataDir, "snapshot-cache")),
-			"STORAGE_PROVIDER":                 "Local",
-			"USE_LOCAL_NAMESPACE_STORAGE":      "true",
+			"ARTIFACTS_REGISTRY_PROVIDER": "Local",
+			"FIRECRACKER_VERSIONS_DIR":    abs(filepath.Join(dataDir, "fc-versions")),
+			"HOST_KERNELS_DIR":            abs(filepath.Join(dataDir, "kernels")),
+			"ORCHESTRATOR_BASE_PATH":      abs(filepath.Join(dataDir, "orchestrator")),
+			"SNAPSHOT_CACHE_DIR":          abs(filepath.Join(dataDir, "snapshot-cache")),
+			"USE_LOCAL_NAMESPACE_STORAGE": "true",
 		}
 		for k, v := range env {
 			if os.Getenv(k) == "" {
 				os.Setenv(k, v)
 			}
 		}
+
+		// The explicit -storage flag is authoritative: set unconditionally,
+		// unlike the fill-the-gap defaults above.
+		os.Setenv("TEMPLATE_STORAGE_URL", "file://"+abs(filepath.Join(dataDir, "templates")))
+		os.Setenv("BUILD_CACHE_STORAGE_URL", "file://"+abs(filepath.Join(dataDir, "build-cache")))
 
 		if err := setupKernel(ctx, filepath.Join(dataDir, "kernels"), kernel); err != nil {
 			return err
@@ -219,12 +222,7 @@ func setupEnv(ctx context.Context, storagePath, sandboxDir, kernel, fc string, l
 		fmt.Printf("✓ Storage: %s (local)\n", dataDir)
 	} else {
 		bucket := strings.TrimPrefix(storagePath, "gs://")
-		if os.Getenv("STORAGE_PROVIDER") == "" {
-			os.Setenv("STORAGE_PROVIDER", "GCPBucket")
-		}
-		if os.Getenv("TEMPLATE_BUCKET_NAME") == "" {
-			os.Setenv("TEMPLATE_BUCKET_NAME", bucket)
-		}
+		os.Setenv("TEMPLATE_STORAGE_URL", "gs://"+bucket)
 		fmt.Printf("✓ Storage: gs://%s\n", bucket)
 	}
 
@@ -298,11 +296,19 @@ func doBuild(
 	go tcpFirewall.Start(ctx)
 	defer tcpFirewall.Close(parentCtx)
 
-	persistenceTemplate, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	templateSpec, err := cfg.TemplateStorage()
 	if err != nil {
 		return fmt.Errorf("template storage: %w", err)
 	}
-	persistenceBuild, err := storage.GetStorageProvider(ctx, storage.BuildCacheStorageConfig)
+	persistenceTemplate, err := storage.NewProvider(ctx, templateSpec)
+	if err != nil {
+		return fmt.Errorf("template storage: %w", err)
+	}
+	buildCacheSpec, err := cfg.BuildCacheStorage()
+	if err != nil {
+		return fmt.Errorf("build storage: %w", err)
+	}
+	persistenceBuild, err := storage.NewProvider(ctx, buildCacheSpec)
 	if err != nil {
 		return fmt.Errorf("build storage: %w", err)
 	}
@@ -436,7 +442,10 @@ func doBuild(
 
 func printArtifactSizes(ctx context.Context, persistence storage.StorageProvider, buildID string, _ *build.Result) {
 	paths := storage.Paths{BuildID: buildID}
-	basePath := os.Getenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH")
+	var basePath string
+	if spec, err := cfg.TemplateStorage(); err == nil && spec.Provider == storage.LocalStorageProvider {
+		basePath = spec.BasePath
+	}
 
 	fmt.Printf("\n📦 Artifacts:\n")
 

--- a/packages/orchestrator/cmd/inspect-build/validate.go
+++ b/packages/orchestrator/cmd/inspect-build/validate.go
@@ -148,10 +148,11 @@ func validateBuild(ctx context.Context, storagePath, buildID, artifact string, e
 // openChunker wires a production block.Chunker over the build's data file,
 // returning the chunker, the image's uncompressed size, and a cleanup function.
 func openChunker(ctx context.Context, storagePath, buildID, artifact string, h *header.Header, ft *storage.FrameTable) (*block.Chunker, storage.RangeOpener, int64, func(), error) {
-	if err := cmdutil.SetupStorage(storagePath); err != nil {
+	spec, err := cmdutil.TemplateSpec(storagePath)
+	if err != nil {
 		return nil, nil, 0, nil, err
 	}
-	provider, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	provider, err := storage.NewProvider(ctx, spec)
 	if err != nil {
 		return nil, nil, 0, nil, fmt.Errorf("storage provider: %w", err)
 	}

--- a/packages/orchestrator/cmd/internal/cmdutil/storage.go
+++ b/packages/orchestrator/cmd/internal/cmdutil/storage.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	gcsstorage "cloud.google.com/go/storage"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 // IsGCSPath checks if the path is a GCS path (gs:// or gs:).
@@ -35,28 +37,21 @@ func ExtractBucketName(path string) string {
 	return strings.TrimPrefix(normalized, "gs://")
 }
 
-// SetupStorage configures storage environment variables based on the storage path.
-// If path starts with "gs://" or "gs:", configures GCS storage.
-// Otherwise, configures local storage.
-func SetupStorage(storagePath string) error {
-	absPath := func(p string) string {
-		abs, err := filepath.Abs(p)
-		if err != nil {
-			return p
-		}
-
-		return abs
-	}
-
+// TemplateSpec resolves the template storage destination from the -storage
+// flag value: "gs://bucket" (or "gs:bucket") addresses GCS, anything else is
+// a local directory. The flag is authoritative — no environment variables are
+// consulted.
+func TemplateSpec(storagePath string) (storage.Spec, error) {
 	if IsGCSPath(storagePath) {
-		os.Setenv("STORAGE_PROVIDER", "GCPBucket")
-		os.Setenv("TEMPLATE_BUCKET_NAME", ExtractBucketName(storagePath))
-	} else {
-		os.Setenv("STORAGE_PROVIDER", "Local")
-		os.Setenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH", absPath(filepath.Join(storagePath, "templates")))
+		return storage.ParseStorageURL(NormalizeGCSPath(storagePath))
 	}
 
-	return nil
+	basePath := filepath.Join(storagePath, "templates")
+	if abs, err := filepath.Abs(basePath); err == nil {
+		basePath = abs
+	}
+
+	return storage.Spec{Provider: storage.LocalStorageProvider, BasePath: basePath}, nil
 }
 
 // ReadFile reads a file from local storage or GCS.

--- a/packages/orchestrator/cmd/mount-build-rootfs/main.go
+++ b/packages/orchestrator/cmd/mount-build-rootfs/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd/testutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 )
 
 func main() {
@@ -42,8 +43,9 @@ func main() {
 		log.Fatal("-verify requires -mount")
 	}
 
-	// Set up storage env vars based on -storage flag
-	if err := cmdutil.SetupStorage(*storagePath); err != nil {
+	// Resolve template storage from the -storage flag.
+	templateSpec, err := cmdutil.TemplateSpec(*storagePath)
+	if err != nil {
 		log.Fatal(err)
 	}
 
@@ -87,7 +89,7 @@ func main() {
 			panic(fmt.Errorf("failed to create empty rootfs: %w", err))
 		}
 	} else {
-		err := run(ctx, nbdContext, featureFlags, *build, *mountPath, *verify)
+		err := run(ctx, nbdContext, featureFlags, templateSpec, *build, *mountPath, *verify)
 		if err != nil {
 			panic(fmt.Errorf("failed to mount rootfs: %w", err))
 		}
@@ -134,8 +136,8 @@ func runEmpty(ctx, nbdContext context.Context, featureFlags *featureflags.Client
 	return nil
 }
 
-func run(ctx, nbdContext context.Context, featureFlags *featureflags.Client, buildID, mountPath string, verify bool) error {
-	rootfs, rootfsCleanup, err := testutils.TemplateRootfs(ctx, buildID)
+func run(ctx, nbdContext context.Context, featureFlags *featureflags.Client, templateSpec storage.Spec, buildID, mountPath string, verify bool) error {
+	rootfs, rootfsCleanup, err := testutils.TemplateRootfs(ctx, templateSpec, buildID)
 	defer rootfsCleanup.Run(ctx, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("failed to get template rootfs: %w", err)

--- a/packages/orchestrator/cmd/resume-build/fph_bench.go
+++ b/packages/orchestrator/cmd/resume-build/fph_bench.go
@@ -14,6 +14,7 @@ import (
 	"github.com/launchdarkly/go-sdk-common/v3/ldvalue"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/cmd/internal/cmdutil"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/cfg"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -178,17 +179,31 @@ func (r *runner) fphBenchOnce(ctx context.Context, opts fphBenchOptions, withFph
 	}
 }
 
+// localTemplateBasePath resolves the template storage and returns its local
+// base path; errors when template storage is not on the local filesystem.
+func localTemplateBasePath() (string, error) {
+	spec, err := cfg.TemplateStorage()
+	if err != nil {
+		return "", err
+	}
+	if spec.Provider != storage.LocalStorageProvider {
+		return "", fmt.Errorf("template storage provider is %s, not local", spec.Provider)
+	}
+
+	return spec.BasePath, nil
+}
+
 func readLocalMemfileSize(buildID string) (int64, error) {
-	basePath := os.Getenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH")
-	if basePath == "" {
-		return 0, errors.New("LOCAL_TEMPLATE_STORAGE_BASE_PATH not set; -fph-bench requires local storage")
+	basePath, err := localTemplateBasePath()
+	if err != nil {
+		return 0, fmt.Errorf("-fph-bench requires local storage: %w", err)
 	}
 
 	return cmdutil.GetActualFileSize(filepath.Join(basePath, buildID, storage.MemfileName))
 }
 
 func cleanupLocalBuild(buildID string) {
-	if base := os.Getenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH"); base != "" {
+	if base, err := localTemplateBasePath(); err == nil {
 		_ = os.RemoveAll(filepath.Join(base, buildID))
 	}
 }

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -193,7 +193,14 @@ func main() {
 		outputBuildID = uuid.New().String()
 	}
 
-	if err := setupEnv(*storagePath, *sandboxDir); err != nil {
+	storageExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "storage" {
+			storageExplicit = true
+		}
+	})
+
+	if err := setupEnv(*storagePath, *sandboxDir, storageExplicit); err != nil {
 		log.Fatal(err)
 	}
 
@@ -291,7 +298,7 @@ type cmdTimings struct {
 	err     error
 }
 
-func setupEnv(from string, sandboxDir string) error {
+func setupEnv(from string, sandboxDir string, storageExplicit bool) error {
 	abs := func(s string) string { return utils.Must(filepath.Abs(s)) }
 
 	if sandboxDir != "" {
@@ -328,18 +335,21 @@ func setupEnv(from string, sandboxDir string) error {
 		"USE_LOCAL_NAMESPACE_STORAGE": "true",
 	}
 
-	if strings.HasPrefix(from, "gs://") {
-		env["STORAGE_PROVIDER"] = "GCPBucket"
-		env["TEMPLATE_BUCKET_NAME"] = strings.TrimPrefix(from, "gs://")
-	} else {
-		env["STORAGE_PROVIDER"] = "Local"
-		env["LOCAL_TEMPLATE_STORAGE_BASE_PATH"] = abs(filepath.Join(dataDir, "templates"))
-	}
-
 	for k, v := range env {
 		if os.Getenv(k) == "" {
 			os.Setenv(k, v)
 		}
+	}
+
+	templateURL := from
+	if !strings.HasPrefix(from, "gs://") {
+		templateURL = "file://" + abs(filepath.Join(dataDir, "templates"))
+	}
+
+	// An explicit -storage flag overrides ambient storage config; the flag's
+	// default value only applies when nothing is configured.
+	if storageExplicit || (os.Getenv("TEMPLATE_STORAGE_URL") == "" && os.Getenv("STORAGE_PROVIDER") == "") {
+		os.Setenv("TEMPLATE_STORAGE_URL", templateURL)
 	}
 
 	return nil
@@ -1175,7 +1185,11 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	if verbose {
 		fmt.Println("🔧 Creating storage provider...")
 	}
-	persistence, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	templateSpec, err := cfg.TemplateStorage()
+	if err != nil {
+		return fmt.Errorf("resolve template storage: %w", err)
+	}
+	persistence, err := storage.NewProvider(ctx, templateSpec)
 	if verbose {
 		fmt.Println("🔧 Storage provider created, err:", err)
 	}
@@ -1442,12 +1456,12 @@ func parseSignal(name string) os.Signal {
 
 // printArtifactSizes prints artifact sizes
 func printArtifactSizes(_, buildID string) {
-	basePath := os.Getenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH")
-	if basePath == "" {
+	spec, err := cfg.TemplateStorage()
+	if err != nil || spec.Provider != storage.LocalStorageProvider {
 		return
 	}
 
-	dir := filepath.Join(basePath, buildID)
+	dir := filepath.Join(spec.BasePath, buildID)
 
 	fmt.Println("\n📦 Artifacts:")
 

--- a/packages/orchestrator/cmd/smoketest/smoke_test.go
+++ b/packages/orchestrator/cmd/smoketest/smoke_test.go
@@ -184,10 +184,14 @@ func newTestInfra(t *testing.T, ctx context.Context) *testInfra {
 	ti := &testInfra{}
 
 	// Storage
-	persistenceTemplate, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	templateSpec, err := cfg.TemplateStorage()
+	require.NoError(t, err)
+	persistenceTemplate, err := storage.NewProvider(ctx, templateSpec)
 	require.NoError(t, err)
 
-	persistenceBuild, err := storage.GetStorageProvider(ctx, storage.BuildCacheStorageConfig)
+	buildCacheSpec, err := cfg.BuildCacheStorage()
+	require.NoError(t, err)
+	persistenceBuild, err := storage.NewProvider(ctx, buildCacheSpec)
 	require.NoError(t, err)
 
 	// NBD

--- a/packages/orchestrator/pkg/cfg/storage.go
+++ b/packages/orchestrator/pkg/cfg/storage.go
@@ -1,0 +1,109 @@
+// Storage role resolution: which destination (provider, bucket/path,
+// connection options) the template and build-cache storage use. A role's
+// storage URL env is authoritative; when unset, the legacy envs are converted
+// to the equivalent URL so both styles share one parsing path:
+//
+//	TEMPLATE_STORAGE_URL | legacy envs → storage.ParseStorageURL → storage.Spec
+//
+// Deliberately not build-tagged linux like the rest of this package so the
+// resolution logic and its tests run everywhere.
+
+package cfg
+
+import (
+	"cmp"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/caarlos0/env/v11"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+// storageEnv is the environment surface for storage role resolution, parsed
+// lazily on each resolution because the CLI tools set these from flags after
+// startup. Empty values behave as unset.
+type storageEnv struct {
+	TemplateURL   string `env:"TEMPLATE_STORAGE_URL"`
+	BuildCacheURL string `env:"BUILD_CACHE_STORAGE_URL"`
+
+	// Legacy environment style, converted to storage URLs by legacyStorageURL.
+	Provider           storage.Provider `env:"STORAGE_PROVIDER"`
+	TemplateBucket     string           `env:"TEMPLATE_BUCKET_NAME"`
+	TemplateBasePath   string           `env:"LOCAL_TEMPLATE_STORAGE_BASE_PATH"`
+	BuildCacheBucket   string           `env:"BUILD_CACHE_BUCKET_NAME"`
+	BuildCacheBasePath string           `env:"LOCAL_BUILD_CACHE_STORAGE_BASE_PATH"`
+	// Parsed strictly: a malformed value fails resolution loudly (even for
+	// URL-configured roles) instead of being silently treated as false.
+	S3PathStyle bool `env:"S3_USE_PATH_STYLE"`
+}
+
+// TemplateStorage resolves the template storage destination.
+func TemplateStorage() (storage.Spec, error) {
+	e, err := env.ParseAs[storageEnv]()
+	if err != nil {
+		return storage.Spec{}, fmt.Errorf("parse storage environment: %w", err)
+	}
+
+	return resolveStorage(e, e.TemplateURL, e.TemplateBucket, e.TemplateBasePath,
+		"template", "TEMPLATE_BUCKET_NAME", "/tmp/templates")
+}
+
+// BuildCacheStorage resolves the build-cache storage destination.
+func BuildCacheStorage() (storage.Spec, error) {
+	e, err := env.ParseAs[storageEnv]()
+	if err != nil {
+		return storage.Spec{}, fmt.Errorf("parse storage environment: %w", err)
+	}
+
+	return resolveStorage(e, e.BuildCacheURL, e.BuildCacheBucket, e.BuildCacheBasePath,
+		"build cache", "BUILD_CACHE_BUCKET_NAME", "/tmp/build-cache")
+}
+
+func resolveStorage(e storageEnv, rawURL, bucket, basePath, name, bucketEnv, defaultBasePath string) (storage.Spec, error) {
+	if raw := strings.TrimSpace(rawURL); raw != "" {
+		return storage.ParseStorageURL(raw)
+	}
+
+	legacy, err := legacyStorageURL(e, bucket, basePath, name, bucketEnv, defaultBasePath)
+	if err != nil {
+		return storage.Spec{}, err
+	}
+
+	return storage.ParseStorageURL(legacy)
+}
+
+// legacyStorageURL converts the legacy env style into a storage URL. Delete
+// together with the legacy fields of storageEnv once the legacy envs are
+// retired.
+func legacyStorageURL(e storageEnv, bucket, basePath, name, bucketEnv, defaultBasePath string) (string, error) {
+	provider := cmp.Or(e.Provider, storage.DefaultStorageProvider)
+	switch provider {
+	case storage.LocalStorageProvider:
+		basePath = cmp.Or(basePath, defaultBasePath)
+		if strings.HasPrefix(basePath, "/") {
+			return (&url.URL{Scheme: "file", Path: basePath}).String(), nil
+		}
+
+		// The hierarchical file:// form cannot express a relative base
+		// path; use the opaque form.
+		return (&url.URL{Scheme: "file", Opaque: basePath}).String(), nil
+	case storage.GCPStorageProvider, storage.AWSStorageProvider:
+		if bucket == "" {
+			return "", fmt.Errorf("%s storage bucket not configured: set %s", name, bucketEnv)
+		}
+
+		u := url.URL{Scheme: "gs", Host: bucket}
+		if provider == storage.AWSStorageProvider {
+			u.Scheme = "s3"
+			if e.S3PathStyle {
+				u.RawQuery = url.Values{"s3ForcePathStyle": []string{"true"}}.Encode()
+			}
+		}
+
+		return u.String(), nil
+	default:
+		return "", fmt.Errorf("unknown storage provider: %s", e.Provider)
+	}
+}

--- a/packages/orchestrator/pkg/cfg/storage_test.go
+++ b/packages/orchestrator/pkg/cfg/storage_test.go
@@ -1,0 +1,190 @@
+//nolint:paralleltest // env-driven tests use t.Setenv
+package cfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+)
+
+func TestTemplateStorage_URLOverridesLegacyEnv(t *testing.T) {
+	t.Setenv("STORAGE_PROVIDER", "GCPBucket")
+	t.Setenv("TEMPLATE_BUCKET_NAME", "legacy-bucket")
+	t.Setenv("TEMPLATE_STORAGE_URL", "s3://url-bucket?endpoint=http://minio:9000&s3ForcePathStyle=true")
+
+	spec, err := TemplateStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.Spec{
+		Provider:     storage.AWSStorageProvider,
+		Bucket:       "url-bucket",
+		Endpoint:     "http://minio:9000",
+		UsePathStyle: true,
+	}, spec)
+}
+
+// TestTemplateStorage_Legacy drives the legacy env style through the template
+// role: STORAGE_PROVIDER + TEMPLATE_BUCKET_NAME / LOCAL_TEMPLATE_STORAGE_BASE_PATH
+// (+ S3_USE_PATH_STYLE) are converted into a storage URL and resolved through
+// the same pipeline as explicit URLs.
+func TestTemplateStorage_Legacy(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    string // STORAGE_PROVIDER ("" behaves as unset → GCPBucket)
+		bucket      string // TEMPLATE_BUCKET_NAME
+		basePath    string // LOCAL_TEMPLATE_STORAGE_BASE_PATH ("" → default)
+		s3PathStyle string // S3_USE_PATH_STYLE
+		want        storage.Spec
+		wantErr     string
+	}{
+		{
+			name:     "gcp bucket",
+			provider: "GCPBucket",
+			bucket:   "fc-templates",
+			want:     storage.Spec{Provider: storage.GCPStorageProvider, Bucket: "fc-templates"},
+		},
+		{
+			name:     "unset provider defaults to gcp",
+			provider: "",
+			bucket:   "fc-templates",
+			want:     storage.Spec{Provider: storage.GCPStorageProvider, Bucket: "fc-templates"},
+		},
+		{
+			// Endpoint/region stay empty in the legacy path: the AWS SDK
+			// resolves AWS_ENDPOINT_URL / AWS_REGION itself.
+			name:     "aws bucket",
+			provider: "AWSBucket",
+			bucket:   "legacy-bucket",
+			want:     storage.Spec{Provider: storage.AWSStorageProvider, Bucket: "legacy-bucket"},
+		},
+		{
+			// Our own legacy env (S3_USE_PATH_STYLE) is folded into the
+			// synthesized URL, so the resolved spec is fully transparent.
+			name:        "aws bucket with path style env",
+			provider:    "AWSBucket",
+			bucket:      "legacy-bucket",
+			s3PathStyle: "True",
+			want:        storage.Spec{Provider: storage.AWSStorageProvider, Bucket: "legacy-bucket", UsePathStyle: true},
+		},
+		{
+			name:     "local absolute path",
+			provider: "Local",
+			basePath: "/tmp/some-cache",
+			want:     storage.Spec{Provider: storage.LocalStorageProvider, BasePath: "/tmp/some-cache"},
+		},
+		{
+			name:     "local path with spaces",
+			provider: "Local",
+			basePath: "/var/lib/e2b storage",
+			want:     storage.Spec{Provider: storage.LocalStorageProvider, BasePath: "/var/lib/e2b storage"},
+		},
+		{
+			// The CLI tools (create-build, resume-build) configure relative
+			// base paths like ".local-build"; the legacy→URL conversion keeps
+			// them intact via the opaque file: form.
+			name:     "local relative path",
+			provider: "Local",
+			basePath: ".local-build",
+			want:     storage.Spec{Provider: storage.LocalStorageProvider, BasePath: ".local-build"},
+		},
+		{
+			name:     "local default base path",
+			provider: "Local",
+			want:     storage.Spec{Provider: storage.LocalStorageProvider, BasePath: "/tmp/templates"},
+		},
+		{
+			name:     "unknown provider",
+			provider: "FloppyDisk",
+			wantErr:  "unknown storage provider: FloppyDisk",
+		},
+		{
+			name:     "cloud provider without bucket",
+			provider: "GCPBucket",
+			bucket:   "",
+			wantErr:  "template storage bucket not configured: set TEMPLATE_BUCKET_NAME",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TEMPLATE_STORAGE_URL", "")
+			t.Setenv("STORAGE_PROVIDER", tt.provider)
+			t.Setenv("TEMPLATE_BUCKET_NAME", tt.bucket)
+			t.Setenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH", tt.basePath)
+			t.Setenv("S3_USE_PATH_STYLE", tt.s3PathStyle)
+
+			spec, err := TemplateStorage()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, spec)
+		})
+	}
+}
+
+func TestTemplateStorage_URLIgnoresLegacyPathStyleEnv(t *testing.T) {
+	// A defined storage URL is fully self-describing: the legacy
+	// S3_USE_PATH_STYLE env must not leak into URL-configured roles.
+	t.Setenv("TEMPLATE_STORAGE_URL", "s3://url-bucket")
+	t.Setenv("S3_USE_PATH_STYLE", "true")
+
+	spec, err := TemplateStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.Spec{Provider: storage.AWSStorageProvider, Bucket: "url-bucket"}, spec)
+}
+
+func TestStorage_MalformedPathStyleEnvFailsFast(t *testing.T) {
+	// Deliberate: a malformed S3_USE_PATH_STYLE fails resolution loudly
+	// (even for URL-configured roles) instead of silently meaning false.
+	t.Setenv("TEMPLATE_STORAGE_URL", "s3://url-bucket")
+	t.Setenv("S3_USE_PATH_STYLE", "yes-please")
+
+	_, err := TemplateStorage()
+	require.ErrorContains(t, err, "parse storage environment")
+}
+
+func TestStorageRolesDiverge(t *testing.T) {
+	// The template role reads through an S3-compatible cache while the build
+	// cache stays on GCS — the scenario per-role URLs exist for.
+	t.Setenv("STORAGE_PROVIDER", "GCPBucket")
+	t.Setenv("TEMPLATE_STORAGE_URL", "s3://fc-templates?endpoint=http://minio:9000&s3ForcePathStyle=true")
+	t.Setenv("BUILD_CACHE_STORAGE_URL", "")
+	t.Setenv("BUILD_CACHE_BUCKET_NAME", "fc-build-cache")
+
+	templateSpec, err := TemplateStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.AWSStorageProvider, templateSpec.Provider)
+
+	buildCacheSpec, err := BuildCacheStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.Spec{Provider: storage.GCPStorageProvider, Bucket: "fc-build-cache"}, buildCacheSpec)
+}
+
+func TestBuildCacheStorage_Legacy(t *testing.T) {
+	t.Setenv("BUILD_CACHE_STORAGE_URL", "")
+	t.Setenv("STORAGE_PROVIDER", "Local")
+	t.Setenv("LOCAL_BUILD_CACHE_STORAGE_BASE_PATH", "/tmp/some-cache")
+
+	spec, err := BuildCacheStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.Spec{Provider: storage.LocalStorageProvider, BasePath: "/tmp/some-cache"}, spec)
+
+	t.Setenv("LOCAL_BUILD_CACHE_STORAGE_BASE_PATH", "")
+
+	spec, err = BuildCacheStorage()
+	require.NoError(t, err)
+	assert.Equal(t, storage.Spec{Provider: storage.LocalStorageProvider, BasePath: "/tmp/build-cache"}, spec)
+}
+
+func TestTemplateStorage_InvalidURL(t *testing.T) {
+	t.Setenv("TEMPLATE_STORAGE_URL", "s3://bucket?bogus=1")
+
+	_, err := TemplateStorage()
+	require.ErrorContains(t, err, "unsupported query parameter")
+}

--- a/packages/orchestrator/pkg/factories/run.go
+++ b/packages/orchestrator/pkg/factories/run.go
@@ -423,7 +423,12 @@ func run(config cfg.Config, opts Options) (success bool) {
 	}
 	closers = append(closers, closer{"limiter", limiter.Close})
 
-	persistence, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig.WithLimiter(limiter))
+	templateSpec, err := cfg.TemplateStorage()
+	if err != nil {
+		logger.L().Fatal(ctx, "failed to resolve template storage", zap.Error(err))
+	}
+
+	persistence, err := storage.NewProvider(ctx, templateSpec, storage.WithLimiter(limiter))
 	if err != nil {
 		logger.L().Fatal(ctx, "failed to create template storage provider", zap.Error(err))
 	}
@@ -1040,11 +1045,16 @@ func startNFSProxy(
 }
 
 func setupBuildStorage(ctx context.Context, limiter *limit.Limiter, orchConfig cfg.Config) (storage.StorageProvider, *localupload.Handler, error) {
-	cfg := storage.BuildCacheStorageConfig.WithLimiter(limiter)
+	spec, err := cfg.BuildCacheStorage()
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve build cache storage: %w", err)
+	}
+
+	opts := []storage.Option{storage.WithLimiter(limiter)}
 
 	var uploadHandler *localupload.Handler
 
-	if storage.IsLocal() {
+	if spec.Provider == storage.LocalStorageProvider {
 		hmacKey := make([]byte, 32)
 		if _, err := rand.Read(hmacKey); err != nil {
 			return nil, nil, fmt.Errorf("generate HMAC key: %w", err)
@@ -1055,17 +1065,15 @@ func setupBuildStorage(ctx context.Context, limiter *limit.Limiter, orchConfig c
 			uploadBaseURL = fmt.Sprintf("http://localhost:%d", orchConfig.GRPCPort)
 		}
 
-		cfg = cfg.WithLocalUpload(uploadBaseURL, hmacKey)
-
-		basePath := cfg.GetLocalBasePath()
-		uploadHandler = localupload.NewHandler(basePath, hmacKey)
+		opts = append(opts, storage.WithLocalUpload(uploadBaseURL, hmacKey))
+		uploadHandler = localupload.NewHandler(spec.BasePath, hmacKey)
 
 		logger.L().Info(ctx, "Local upload endpoint enabled for filesystem storage",
 			zap.String("upload_base_url", uploadBaseURL),
-			zap.String("base_path", basePath))
+			zap.String("base_path", spec.BasePath))
 	}
 
-	provider, err := storage.GetStorageProvider(ctx, cfg)
+	provider, err := storage.NewProvider(ctx, spec, opts...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create build cache storage provider: %w", err)
 	}

--- a/packages/orchestrator/pkg/sandbox/nbd/testutils/template_rootfs.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/testutils/template_rootfs.go
@@ -20,14 +20,14 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
 
-func TemplateRootfs(ctx context.Context, buildID string) (*BuildDevice, *Cleaner, error) {
+func TemplateRootfs(ctx context.Context, spec storage.Spec, buildID string) (*BuildDevice, *Cleaner, error) {
 	var cleaner Cleaner
 
 	paths := storage.Paths{
 		BuildID: buildID,
 	}
 
-	s, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	s, err := storage.NewProvider(ctx, spec)
 	if err != nil {
 		return nil, &cleaner, fmt.Errorf("failed to get storage provider: %w", err)
 	}

--- a/packages/shared/pkg/storage/storage.go
+++ b/packages/shared/pkg/storage/storage.go
@@ -14,10 +14,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/e2b-dev/infra/packages/shared/pkg/env"
-	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/storageopts"
-	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
 
 var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/shared/pkg/storage")
@@ -41,32 +38,8 @@ var ErrMetadataUnsupported = errors.New("blob does not support reading custom me
 // ObjectMetadataSoftDeleted is the storage-index soft-delete tombstone key.
 const ObjectMetadataSoftDeleted = storageopts.ObjectMetadataSoftDeleted
 
-type Provider string
-
-const (
-	GCPStorageProvider   Provider = "GCPBucket"
-	AWSStorageProvider   Provider = "AWSBucket"
-	LocalStorageProvider Provider = "Local"
-
-	DefaultStorageProvider Provider = GCPStorageProvider
-
-	storageProviderEnv = "STORAGE_PROVIDER"
-
-	// MemoryChunkSize must always be bigger or equal to the block size.
-	MemoryChunkSize = 4 * 1024 * 1024 // 4 MB
-)
-
-// GetProviderType returns the configured storage provider type from the
-// STORAGE_PROVIDER environment variable, defaulting to GCPBucket.
-func GetProviderType() Provider {
-	return Provider(env.GetEnv(storageProviderEnv, string(DefaultStorageProvider)))
-}
-
-// IsLocal reports whether the configured storage provider is the local
-// filesystem backend.
-func IsLocal() bool {
-	return GetProviderType() == LocalStorageProvider
-}
+// MemoryChunkSize must always be bigger or equal to the block size.
+const MemoryChunkSize = 4 * 1024 * 1024 // 4 MB
 
 type SeekableObjectType int
 
@@ -253,73 +226,6 @@ type PeerTransitionedError struct {
 
 func (e *PeerTransitionedError) Error() string {
 	return "peer upload completed, reload header from storage"
-}
-
-// StorageConfig holds the configuration for creating a storage provider.
-// Both GetLocalBasePath and GetBucketName are evaluated lazily so that
-// callers who set environment variables at runtime (e.g. via os.Setenv
-// or t.Setenv in tests) see their overrides respected.
-type StorageConfig struct {
-	GetLocalBasePath func() string
-	GetBucketName    func() string
-	limiter          *limit.Limiter
-	uploadBaseURL    string
-	hmacKey          []byte
-}
-
-// WithLimiter returns a copy of the config with the given limiter set.
-func (c StorageConfig) WithLimiter(limiter *limit.Limiter) StorageConfig {
-	c.limiter = limiter
-
-	return c
-}
-
-// WithLocalUpload returns a copy of the config with the given local upload
-// parameters set. These are only used when STORAGE_PROVIDER=Local to let the
-// filesystem storage provider generate signed URLs for file uploads.
-func (c StorageConfig) WithLocalUpload(uploadBaseURL string, hmacKey []byte) StorageConfig {
-	c.uploadBaseURL = uploadBaseURL
-	c.hmacKey = hmacKey
-
-	return c
-}
-
-var TemplateStorageConfig = StorageConfig{
-	GetLocalBasePath: func() string {
-		return env.GetEnv("LOCAL_TEMPLATE_STORAGE_BASE_PATH", "/tmp/templates")
-	},
-	GetBucketName: func() string {
-		return utils.RequiredEnv("TEMPLATE_BUCKET_NAME", "Bucket for storing template files")
-	},
-}
-
-var BuildCacheStorageConfig = StorageConfig{
-	GetLocalBasePath: func() string {
-		return env.GetEnv("LOCAL_BUILD_CACHE_STORAGE_BASE_PATH", "/tmp/build-cache")
-	},
-	GetBucketName: func() string {
-		return utils.RequiredEnv("BUILD_CACHE_BUCKET_NAME", "Bucket for storing build cache files")
-	},
-}
-
-func GetStorageProvider(ctx context.Context, cfg StorageConfig) (StorageProvider, error) {
-	provider := GetProviderType()
-
-	if provider == LocalStorageProvider {
-		return newFileSystemStorage(cfg), nil
-	}
-
-	bucketName := cfg.GetBucketName()
-
-	// cloud bucket-based storage
-	switch provider {
-	case AWSStorageProvider:
-		return newAWSStorage(ctx, bucketName, cfg.limiter)
-	case GCPStorageProvider:
-		return NewGCP(ctx, bucketName, cfg.limiter)
-	}
-
-	return nil, fmt.Errorf("unknown storage provider: %s", provider)
 }
 
 func recordError(span trace.Span, err error) {

--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -52,7 +52,7 @@ var (
 	_ Blob     = (*awsObject)(nil)
 )
 
-func newAWSStorage(ctx context.Context, bucketName string, limiter *limit.Limiter) (*awsStorage, error) {
+func newAWSStorage(ctx context.Context, spec Spec, limiter *limit.Limiter) (*awsStorage, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -60,23 +60,26 @@ func newAWSStorage(ctx context.Context, bucketName string, limiter *limit.Limite
 	otelaws.AppendMiddlewares(&cfg.APIOptions)
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-		// S3_USE_PATH_STYLE controls the addressing style:
-		//   "true"  → path-style:         https://host/bucket/key
-		//   "false" → virtual-host-style: https://bucket.host/key  (SDK default)
-		//
-		// Path-style is required for S3-compatible backends (MinIO, Ceph, etc.)
-		// that don't support virtual-host addressing. Set this explicitly when
-		// using a custom endpoint via AWS_ENDPOINT_URL.
-		if strings.EqualFold(os.Getenv("S3_USE_PATH_STYLE"), "true") {
-			o.UsePathStyle = true
+		// Options the spec leaves unset fall back to the AWS SDK's own
+		// resolution (AWS_ENDPOINT_URL, AWS_REGION, credentials, …).
+		if spec.Endpoint != "" {
+			o.BaseEndpoint = aws.String(spec.Endpoint)
 		}
+		if spec.Region != "" {
+			o.Region = spec.Region
+		}
+
+		// Path-style addressing (https://host/bucket/key instead of the SDK's
+		// default virtual-host style https://bucket.host/key) is required by
+		// most S3-compatible backends (MinIO, Ceph, …).
+		o.UsePathStyle = spec.UsePathStyle
 	})
 	presignClient := s3.NewPresignClient(client)
 
 	return &awsStorage{
 		client:        client,
 		presignClient: presignClient,
-		bucketName:    bucketName,
+		bucketName:    spec.Bucket,
 		limiter:       limiter,
 	}, nil
 }

--- a/packages/shared/pkg/storage/storage_factory.go
+++ b/packages/shared/pkg/storage/storage_factory.go
@@ -1,0 +1,49 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/limit"
+)
+
+// Option configures provider construction (see NewProvider).
+type Option func(*providerOptions)
+
+type providerOptions struct {
+	limiter       *limit.Limiter
+	uploadBaseURL string
+	hmacKey       []byte
+}
+
+// WithLimiter sets the concurrent-upload limiter used by the cloud providers.
+func WithLimiter(limiter *limit.Limiter) Option {
+	return func(o *providerOptions) { o.limiter = limiter }
+}
+
+// WithLocalUpload configures the filesystem provider to sign upload URLs.
+func WithLocalUpload(uploadBaseURL string, hmacKey []byte) Option {
+	return func(o *providerOptions) {
+		o.uploadBaseURL = uploadBaseURL
+		o.hmacKey = hmacKey
+	}
+}
+
+// NewProvider constructs the storage provider for a resolved destination.
+func NewProvider(ctx context.Context, spec Spec, opts ...Option) (StorageProvider, error) {
+	var o providerOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	switch spec.Provider {
+	case LocalStorageProvider:
+		return newFileSystemStorage(spec.BasePath, o.uploadBaseURL, o.hmacKey), nil
+	case AWSStorageProvider:
+		return newAWSStorage(ctx, spec, o.limiter)
+	case GCPStorageProvider:
+		return NewGCP(ctx, spec.Bucket, o.limiter)
+	}
+
+	return nil, fmt.Errorf("unknown storage provider: %s", spec.Provider)
+}

--- a/packages/shared/pkg/storage/storage_factory_test.go
+++ b/packages/shared/pkg/storage/storage_factory_test.go
@@ -1,0 +1,74 @@
+package storage
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateAWSEnv makes AWS SDK config loading hermetic: no host profiles or
+// shared config files leak into the test.
+func isolateAWSEnv(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(dir, "config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(dir, "credentials"))
+}
+
+func TestNewProvider_Local(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+
+	provider, err := NewProvider(t.Context(), Spec{Provider: LocalStorageProvider, BasePath: base})
+	require.NoError(t, err)
+
+	fs, ok := provider.(*fsStorage)
+	require.True(t, ok, "expected *fsStorage, got %T", provider)
+	assert.Equal(t, base, fs.basePath)
+}
+
+func TestNewProvider_LocalWithUpload(t *testing.T) {
+	t.Parallel()
+
+	base := t.TempDir()
+	hmacKey := []byte("0123456789abcdef0123456789abcdef")
+
+	provider, err := NewProvider(t.Context(),
+		Spec{Provider: LocalStorageProvider, BasePath: base},
+		WithLocalUpload("http://localhost:5008", hmacKey))
+	require.NoError(t, err)
+
+	fs, ok := provider.(*fsStorage)
+	require.True(t, ok, "expected *fsStorage, got %T", provider)
+	assert.Equal(t, "http://localhost:5008", fs.uploadURL)
+	assert.Equal(t, hmacKey, fs.hmacKey)
+}
+
+//nolint:paralleltest // isolateAWSEnv uses t.Setenv
+func TestNewProvider_AWS(t *testing.T) {
+	isolateAWSEnv(t)
+
+	provider, err := NewProvider(t.Context(), Spec{
+		Provider:     AWSStorageProvider,
+		Bucket:       "some-bucket",
+		Endpoint:     "http://minio:9000",
+		UsePathStyle: true,
+	})
+	require.NoError(t, err)
+
+	s3p, ok := provider.(*awsStorage)
+	require.True(t, ok, "expected *awsStorage, got %T", provider)
+	assert.Equal(t, "some-bucket", s3p.bucketName)
+}
+
+func TestNewProvider_UnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewProvider(t.Context(), Spec{Provider: "FloppyDisk"})
+	require.ErrorContains(t, err, "unknown storage provider: FloppyDisk")
+}

--- a/packages/shared/pkg/storage/storage_fs.go
+++ b/packages/shared/pkg/storage/storage_fs.go
@@ -40,11 +40,11 @@ var (
 	_ RangeOpener = (*fsObject)(nil)
 )
 
-func newFileSystemStorage(cfg StorageConfig) *fsStorage {
+func newFileSystemStorage(basePath, uploadBaseURL string, hmacKey []byte) *fsStorage {
 	return &fsStorage{
-		basePath:  cfg.GetLocalBasePath(),
-		uploadURL: cfg.uploadBaseURL,
-		hmacKey:   cfg.hmacKey,
+		basePath:  basePath,
+		uploadURL: uploadBaseURL,
+		hmacKey:   hmacKey,
 	}
 }
 

--- a/packages/shared/pkg/storage/storage_fs_test.go
+++ b/packages/shared/pkg/storage/storage_fs_test.go
@@ -14,9 +14,7 @@ func newTempProvider(t *testing.T) *fsStorage {
 	t.Helper()
 
 	base := t.TempDir()
-	p := newFileSystemStorage(StorageConfig{
-		GetLocalBasePath: func() string { return base },
-	})
+	p := newFileSystemStorage(base, "", nil)
 
 	return p
 }

--- a/packages/shared/pkg/storage/storage_url.go
+++ b/packages/shared/pkg/storage/storage_url.go
@@ -1,0 +1,185 @@
+// Storage URL parsing: the gocloud.dev blob URL dialect declaring a storage
+// destination (provider, bucket/path, connection options) in one string.
+// Which destination each storage role uses is resolved by the binaries'
+// config layer (e.g. orchestrator/pkg/cfg); this package only parses URLs
+// (ParseStorageURL) and constructs providers (NewProvider).
+
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+type Provider string
+
+const (
+	GCPStorageProvider   Provider = "GCPBucket"
+	AWSStorageProvider   Provider = "AWSBucket"
+	LocalStorageProvider Provider = "Local"
+
+	DefaultStorageProvider Provider = GCPStorageProvider
+)
+
+// Spec is a fully resolved storage destination, produced from a
+// storage URL (see ParseStorageURL).
+type Spec struct {
+	Provider Provider
+
+	// Bucket for cloud providers (gs://, s3://).
+	Bucket string
+	// BasePath for the local filesystem provider (file://).
+	BasePath string
+
+	// Endpoint overrides the S3 endpoint; empty defers to the AWS SDK (incl. AWS_ENDPOINT_URL).
+	Endpoint string
+	// UsePathStyle forces S3 path-style addressing (needed by most S3-compatible backends).
+	UsePathStyle bool
+	// Region overrides the S3 region; empty defers to the AWS SDK (AWS_REGION et al.).
+	Region string
+}
+
+// ParseStorageURL parses a storage URL into a Spec, following the
+// gocloud.dev blob URL dialect:
+//
+//	gs://bucket                                                    Google Cloud Storage
+//	s3://bucket?endpoint=http://host:port/s3&s3ForcePathStyle=true S3 / S3-compatible
+//	s3://bucket?region=us-east-1                                   plain AWS S3
+//	file:///var/lib/storage                                        local filesystem
+//	file:relative/path                                             local filesystem (relative)
+//
+// Unknown query parameters are rejected so typos fail fast. Credentials are
+// not accepted in URLs; they come from the provider's usual environment
+// (ADC / Workload Identity for gs://, AWS_ACCESS_KEY_ID etc. for s3://).
+func ParseStorageURL(raw string) (Spec, error) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		// Do not echo the raw URL: it may carry credentials. url.Error also
+		// embeds the URL, so unwrap it and keep only the underlying cause.
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) {
+			err = urlErr.Err
+		}
+
+		return Spec{}, fmt.Errorf("invalid storage URL: %w", err)
+	}
+
+	switch strings.ToLower(u.Scheme) {
+	case "gs":
+		return parseBucketURL(u, GCPStorageProvider)
+	case "s3":
+		return parseBucketURL(u, AWSStorageProvider)
+	case "file":
+		return parseFileURL(u)
+	default:
+		return Spec{}, fmt.Errorf("storage URL %q: unsupported scheme %q (want gs, s3, or file)", redactedURL(u), u.Scheme)
+	}
+}
+
+// redactedURL renders a URL for error messages with any userinfo stripped, so
+// credentials mistakenly pasted into a storage URL never round-trip into
+// errors and from there into logs and observability sinks. Query parameter
+// values may themselves be URLs (endpoint=…) carrying mistyped credentials,
+// so userinfo is stripped from those too.
+func redactedURL(u *url.URL) string {
+	c := *u
+	c.User = nil
+
+	if c.RawQuery != "" {
+		query := c.Query()
+		for key, values := range query {
+			for i, value := range values {
+				if v, err := url.Parse(value); err == nil && v.User != nil {
+					v.User = nil
+					values[i] = v.String()
+				}
+			}
+			query[key] = values
+		}
+		c.RawQuery = query.Encode()
+	}
+
+	return c.String()
+}
+
+// parseBucketURL handles the bucket-addressed schemes (gs://, s3://). Only
+// s3:// accepts connection query parameters.
+func parseBucketURL(u *url.URL, provider Provider) (Spec, error) {
+	if err := validateBucketURL(u); err != nil {
+		return Spec{}, err
+	}
+
+	spec := Spec{Provider: provider, Bucket: u.Host}
+
+	query := u.Query()
+	if provider != AWSStorageProvider && len(query) > 0 {
+		return Spec{}, fmt.Errorf("storage URL %q: %s:// does not accept query parameters", redactedURL(u), u.Scheme)
+	}
+
+	for key, values := range query {
+		value := values[len(values)-1]
+
+		switch key {
+		case "endpoint":
+			endpoint, err := url.Parse(value)
+			if err != nil || endpoint.Scheme != "http" && endpoint.Scheme != "https" || endpoint.Host == "" {
+				return Spec{}, fmt.Errorf("storage URL %q: endpoint must be an absolute http(s) URL", redactedURL(u))
+			}
+			if endpoint.User != nil {
+				return Spec{}, fmt.Errorf("storage URL %q: credentials in URLs are not supported", redactedURL(u))
+			}
+			spec.Endpoint = value
+		case "s3ForcePathStyle":
+			pathStyle, err := strconv.ParseBool(value)
+			if err != nil {
+				return Spec{}, fmt.Errorf("storage URL %q: invalid s3ForcePathStyle %q: %w", redactedURL(u), value, err)
+			}
+			spec.UsePathStyle = pathStyle
+		case "region":
+			spec.Region = value
+		default:
+			return Spec{}, fmt.Errorf("storage URL %q: unsupported query parameter %q (want endpoint, s3ForcePathStyle, or region)", redactedURL(u), key)
+		}
+	}
+
+	return spec, nil
+}
+
+func parseFileURL(u *url.URL) (Spec, error) {
+	if len(u.Query()) > 0 {
+		return Spec{}, fmt.Errorf("storage URL %q: file: does not accept query parameters", redactedURL(u))
+	}
+
+	// Non-hierarchical form (file:relative/path) carries a relative base path.
+	if u.Opaque != "" {
+		return Spec{Provider: LocalStorageProvider, BasePath: u.Opaque}, nil
+	}
+
+	// RFC 8089: the authority must be empty or "localhost"; the path carries
+	// the absolute directory, e.g. file:///var/lib/storage.
+	if u.Host != "" && u.Host != "localhost" {
+		return Spec{}, fmt.Errorf("storage URL %q: file:// must not have a host (use file:///abs/path)", redactedURL(u))
+	}
+	if u.Path == "" {
+		return Spec{}, fmt.Errorf("storage URL %q: file:// requires a path", redactedURL(u))
+	}
+
+	return Spec{Provider: LocalStorageProvider, BasePath: u.Path}, nil
+}
+
+func validateBucketURL(u *url.URL) error {
+	if u.Host == "" {
+		return fmt.Errorf("storage URL %q: missing bucket name", redactedURL(u))
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("storage URL %q: key prefixes are not supported (bucket only)", redactedURL(u))
+	}
+	if u.User != nil {
+		return fmt.Errorf("storage URL %q: credentials in URLs are not supported", redactedURL(u))
+	}
+
+	return nil
+}

--- a/packages/shared/pkg/storage/storage_url_test.go
+++ b/packages/shared/pkg/storage/storage_url_test.go
@@ -1,0 +1,194 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseStorageURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		url     string
+		want    Spec
+		wantErr string
+	}{
+		{
+			name: "gcs bucket",
+			url:  "gs://my-bucket",
+			want: Spec{Provider: GCPStorageProvider, Bucket: "my-bucket"},
+		},
+		{
+			name: "gcs bucket trailing slash",
+			url:  "gs://my-bucket/",
+			want: Spec{Provider: GCPStorageProvider, Bucket: "my-bucket"},
+		},
+		{
+			name: "plain s3 bucket",
+			url:  "s3://my-bucket",
+			want: Spec{Provider: AWSStorageProvider, Bucket: "my-bucket"},
+		},
+		{
+			name: "s3 with region",
+			url:  "s3://my-bucket?region=eu-west-1",
+			want: Spec{Provider: AWSStorageProvider, Bucket: "my-bucket", Region: "eu-west-1"},
+		},
+		{
+			name: "s3-compatible endpoint with path style",
+			url:  "s3://templates?endpoint=http://minio:9000&s3ForcePathStyle=true",
+			want: Spec{
+				Provider:     AWSStorageProvider,
+				Bucket:       "templates",
+				Endpoint:     "http://minio:9000",
+				UsePathStyle: true,
+			},
+		},
+		{
+			name: "s3 path style false",
+			url:  "s3://my-bucket?s3ForcePathStyle=false",
+			want: Spec{Provider: AWSStorageProvider, Bucket: "my-bucket"},
+		},
+		{
+			name: "local filesystem",
+			url:  "file:///var/lib/storage",
+			want: Spec{Provider: LocalStorageProvider, BasePath: "/var/lib/storage"},
+		},
+		{
+			name: "local filesystem localhost authority",
+			url:  "file://localhost/var/lib/storage",
+			want: Spec{Provider: LocalStorageProvider, BasePath: "/var/lib/storage"},
+		},
+		{
+			name: "local filesystem relative path",
+			url:  "file:.local-build",
+			want: Spec{Provider: LocalStorageProvider, BasePath: ".local-build"},
+		},
+		{
+			name: "local filesystem nested relative path",
+			url:  "file:build/cache",
+			want: Spec{Provider: LocalStorageProvider, BasePath: "build/cache"},
+		},
+		{
+			name: "surrounding whitespace",
+			url:  "  gs://my-bucket\n",
+			want: Spec{Provider: GCPStorageProvider, Bucket: "my-bucket"},
+		},
+		{
+			name:    "unknown scheme",
+			url:     "azblob://my-bucket",
+			wantErr: "unsupported scheme",
+		},
+		{
+			name:    "missing bucket",
+			url:     "s3://",
+			wantErr: "missing bucket name",
+		},
+		{
+			name:    "key prefix rejected",
+			url:     "gs://my-bucket/some/prefix",
+			wantErr: "key prefixes are not supported",
+		},
+		{
+			name:    "gcs query params rejected",
+			url:     "gs://my-bucket?endpoint=http://x",
+			wantErr: "does not accept query parameters",
+		},
+		{
+			name:    "unknown s3 param",
+			url:     "s3://my-bucket?s3ForcePathStyle=true&pathStyle=true",
+			wantErr: `unsupported query parameter "pathStyle"`,
+		},
+		{
+			name:    "invalid path style value",
+			url:     "s3://my-bucket?s3ForcePathStyle=yep",
+			wantErr: "invalid s3ForcePathStyle",
+		},
+		{
+			name:    "endpoint without scheme",
+			url:     "s3://my-bucket?endpoint=minio:9000",
+			wantErr: "endpoint must be an absolute http(s) URL",
+		},
+		{
+			name:    "endpoint with credentials rejected",
+			url:     "s3://my-bucket?endpoint=http://key:secret@minio:9000",
+			wantErr: "credentials in URLs are not supported",
+		},
+		{
+			name:    "credentials rejected",
+			url:     "s3://key:secret@my-bucket",
+			wantErr: "credentials in URLs are not supported",
+		},
+		{
+			name:    "file with remote host",
+			url:     "file://nfs-server/export",
+			wantErr: "must not have a host",
+		},
+		{
+			name:    "file without path",
+			url:     "file://",
+			wantErr: "requires a path",
+		},
+		{
+			name:    "file query params rejected",
+			url:     "file:///var/lib/storage?mode=fast",
+			wantErr: "does not accept query parameters",
+		},
+		{
+			name:    "file relative with query params rejected",
+			url:     "file:.local-build?mode=fast",
+			wantErr: "does not accept query parameters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseStorageURL(tt.url)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestParseStorageURLDoesNotLeakCredentials asserts that credentials pasted
+// into a storage URL never round-trip into error messages (which propagate to
+// logs and observability sinks).
+func TestParseStorageURLDoesNotLeakCredentials(t *testing.T) {
+	t.Parallel()
+
+	urls := []string{
+		"s3://AKIAKEY:supersecret@bucket",                    // credentials rejection
+		"azblob://AKIAKEY:supersecret@bucket",                // unsupported scheme
+		"s3://AKIAKEY:supersecret@bucket/prefix",             // key prefix rejection
+		"s3://AKIAKEY:supersecret@bucket?bogus=1",            // unknown query parameter
+		"gs://AKIAKEY:supersecret@bucket?x=1",                // gs query parameter rejection
+		"s3://AKIAKEY:supersecret@bucket?endpoint=x",         // invalid endpoint
+		"s3://AKIAKEY:supersecret@bucket?s3ForcePathStyle=y", // invalid bool
+		"s3://AKIAKEY:supersecret@bucket\x00",                // unparseable (control char)
+
+		// Credentials hidden inside the endpoint query parameter must not
+		// leak either — via the endpoint errors or any other query-echoing
+		// error (redactedURL strips userinfo from URL-valued params).
+		"s3://bucket?endpoint=http://AKIAKEY:supersecret@minio:9000&bogus=1",
+		"s3://bucket?endpoint=ftp://AKIAKEY:supersecret@minio:9000",
+		"s3://bucket?endpoint=http://AKIAKEY:supersecret@minio:9000",
+		"s3://bucket?endpoint=http://AKIAKEY:supersecret@minio:9000&s3ForcePathStyle=maybe",
+	}
+
+	for _, raw := range urls {
+		_, err := ParseStorageURL(raw)
+		require.Error(t, err, raw)
+		assert.NotContains(t, err.Error(), "supersecret", "error must not leak the password: %s", err)
+		assert.NotContains(t, err.Error(), "AKIAKEY", "error must not leak the username: %s", err)
+	}
+}

--- a/tests/integration/internal/tests/api/sandboxes/sandbox_rapid_pause_resume_test.go
+++ b/tests/integration/internal/tests/api/sandboxes/sandbox_rapid_pause_resume_test.go
@@ -1,11 +1,13 @@
 package sandboxes
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,13 +91,35 @@ type chainNode struct {
 func verifyChainOnStorage(t *testing.T, ctx context.Context, chain []chainNode) {
 	t.Helper()
 
-	if os.Getenv("TEMPLATE_BUCKET_NAME") == "" && !storage.IsLocal() {
-		t.Log("storage env not configured (TEMPLATE_BUCKET_NAME / STORAGE_PROVIDER); skipping direct storage verification")
+	// Storage role resolution lives in the orchestrator's config layer; the
+	// test builds its spec from its own env contract instead of importing the
+	// orchestrator module.
+	var (
+		spec storage.Spec
+		err  error
+	)
+	switch {
+	case os.Getenv("TEMPLATE_STORAGE_URL") != "":
+		spec, err = storage.ParseStorageURL(os.Getenv("TEMPLATE_STORAGE_URL"))
+	case os.Getenv("TEMPLATE_BUCKET_NAME") != "":
+		spec = storage.Spec{
+			Provider: storage.Provider(cmp.Or(os.Getenv("STORAGE_PROVIDER"), string(storage.GCPStorageProvider))),
+			Bucket:   os.Getenv("TEMPLATE_BUCKET_NAME"),
+		}
+		spec.UsePathStyle = strings.EqualFold(os.Getenv("S3_USE_PATH_STYLE"), "true")
+	case strings.EqualFold(os.Getenv("STORAGE_PROVIDER"), "Local"):
+		spec = storage.Spec{
+			Provider: storage.LocalStorageProvider,
+			BasePath: cmp.Or(os.Getenv("LOCAL_TEMPLATE_STORAGE_BASE_PATH"), "/tmp/templates"),
+		}
+	default:
+		t.Log("template storage not configured (TEMPLATE_STORAGE_URL / TEMPLATE_BUCKET_NAME / STORAGE_PROVIDER); skipping direct storage verification")
 
 		return
 	}
+	require.NoError(t, err, "resolve template storage")
 
-	persistence, err := storage.GetStorageProvider(ctx, storage.TemplateStorageConfig)
+	persistence, err := storage.NewProvider(ctx, spec)
 	require.NoError(t, err, "build storage provider")
 
 	ancestors := make(map[string][]string, len(chain))


### PR DESCRIPTION
## Why

Storage roles (templates, build cache) are coupled through the process-global `STORAGE_PROVIDER`: both are forced onto the same provider, and the S3 connection options (`AWS_ENDPOINT_URL`, `S3_USE_PATH_STYLE`) are process-global SDK envs, so two roles can never target different S3 endpoints — e.g. reading templates through an S3-compatible cache or store while the build cache stays on GCS.

## What

**1. Storage URLs** — each role declares its full destination in one self-describing string, using the [gocloud.dev blob URL dialect](https://gocloud.dev/howto/blob/):

```bash
# templates via an S3-compatible store, build cache on GCS
TEMPLATE_STORAGE_URL="s3://templates?endpoint=http://minio:9000&s3ForcePathStyle=true"
BUILD_CACHE_STORAGE_URL="gs://build-cache"

# local dev
TEMPLATE_STORAGE_URL="file:///tmp/templates"
```

**2. Clean layering** — `shared/pkg/storage` is a pure mechanism library with **zero env reads**; role/env policy lives in the orchestrator's config layer:

```
orchestrator/pkg/cfg              shared/pkg/storage
──────────────────────            ─────────────────────────────
cfg.TemplateStorage()      ─┐
cfg.BuildCacheStorage()    ─┼───► storage.Spec ───► storage.NewProvider(ctx, spec,
  URL env (authoritative)   │                          WithLimiter(…),
  legacy envs → URL shim   ─┘                          WithLocalUpload(…))
```

- `storage_url.go`: `Spec`, `ParseStorageURL` (gs/s3/file, strict param validation). Credentials are rejected everywhere — including inside the `endpoint` query parameter — and all error messages redact userinfo so mistyped secrets never reach logs.
- `storage_factory.go`: `NewProvider(ctx, spec, opts…)` with functional options for construction deps. The AWS client binds endpoint/path-style/region per instance (`o.BaseEndpoint`), so different roles can use different S3 endpoints in one process.
- `cfg/storage.go` (untagged, builds everywhere): env-tagged `storageEnv`, `TemplateStorage()`/`BuildCacheStorage()`, and the **legacy shim** (`STORAGE_PROVIDER` + `*_BUCKET_NAME` / `LOCAL_*_BASE_PATH` + `S3_USE_PATH_STYLE` → equivalent URL) — deleted wholesale when the legacy envs retire.
- CLI tools: `cmdutil.TemplateSpec(-storage flag)` builds the spec directly instead of `os.Setenv`-ing at itself.

## Compatibility

- No URL set → legacy envs resolve to identical specs and error messages as before.
- A defined URL is authoritative: legacy envs never leak into URL-configured roles. A malformed `S3_USE_PATH_STYLE` deliberately fails resolution loudly instead of being silently treated as false.
- Options a URL leaves unset keep the AWS SDK's standard resolution (`AWS_ENDPOINT_URL`, `AWS_REGION`, credentials).
- Unknown `STORAGE_PROVIDER` / missing bucket now fail with clean errors instead of panics.
- One deliberate fix: an exported `TEMPLATE_STORAGE_URL` no longer silently overrides the explicit `-storage` flag in `inspect-build`/`mount-build-rootfs`.
- Existing providers untouched (GCS gRPC/DirectPath transport, parallel XML MPU, compression frame tables) — only gocloud's URL *syntax* is adopted, not its implementation.

## Testing

- `TestParseStorageURL` + credential-leak regression across every rejection path, incl. credentials hidden in the `endpoint` parameter (`storage_url_test.go`).
- `TestNewProvider_*` — env-free construction (`storage_factory_test.go`).
- `cfg/storage_test.go` — URL-over-legacy precedence (incl. malformed legacy values), full legacy matrix (gcp/aws/local/defaults/errors), diverging roles, path-style folding.
- `go test` green on shared + cfg; `golangci-lint` clean; linux cross-build of all touched binaries verified.
