### PR TITLE
[EN-1673] feat(orchestrator): ensure requested free disk before finalize

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -293,17 +293,19 @@ sequenceDiagram
     C->>API: POST /v2/templates/{id}/builds/{buildID} (recipe: steps, start/ready cmd)
     API->>TM: gRPC TemplateCreate(TemplateConfig)
     TM->>TM: pull image → inject envd/provisioning → extract ext4 rootfs
-    TM->>FC: boot VM per phase: provision → user steps → finalize → optimize
+    TM->>FC: boot VM per phase: provision → user steps
+    TM->>TM: resize disk on host
+    TM->>FC: boot VM per phase: finalize → optimize
     TM->>OS: upload layers + final {buildID}/memfile, rootfs.ext4, snapfile, metadata
     API->>TM: poll TemplateBuildStatus
     API->>API: mark build ready in Postgres
 ```
 
 Builds are **layered** (`pkg/template/build/phases/`): base → user → one layer per recipe step →
-finalize → optimize. Each layer is hashed and cached, so rebuilds only re-run changed steps; each
-non-cached phase runs in a real Firecracker VM and its pause-diff becomes the layer. The optimize
-phase records which memory pages a fresh resume touches, producing prefetch hints that speed up
-future sandbox starts.
+resize disk → finalize → optimize. Each layer is hashed and cached, so rebuilds only re-run changed
+steps. Resize disk grows the quiescent rootfs on the host; the other non-cached phases run in a real
+Firecracker VM and their pause-diffs become layers. The optimize phase records which memory pages a
+fresh resume touches, producing prefetch hints that speed up future sandbox starts.
 
 ## Deployment topology
 

--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Merovius/nbd/nbdnl"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/shared/pkg/featureflags"
@@ -238,6 +239,33 @@ func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err 
 	telemetry.ReportEvent(ctx, "connected to NBD")
 
 	return deviceIndex, nil
+}
+
+// Flush writes all pending data through the NBD connection and then clears the
+// kernel's block-device buffers. Call this before reading or exporting the
+// backend directly so it cannot observe writes that are still cached by Linux.
+func (d *DirectPathMount) Flush(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "direct-path-mount-flush")
+	defer span.End()
+
+	path := GetDevicePath(d.deviceIndex)
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open NBD device for flush: %w", err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil {
+			logger.L().Warn(ctx, "failed to close NBD device after flush", zap.Error(err), zap.String("path", path))
+		}
+	}()
+
+	// BLKFLSBUF completes all dirty pages as NBD writes to the in-process
+	// backend and invalidates the cache; fsync would only add the unsupported NBD_CMD_FLUSH.
+	if err := unix.IoctlSetInt(int(file.Fd()), unix.BLKFLSBUF, 0); err != nil {
+		return fmt.Errorf("flush NBD device buffers: %w", err)
+	}
+
+	return nil
 }
 
 func (d *DirectPathMount) Close(ctx context.Context) error {

--- a/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"go.uber.org/zap"
-	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
@@ -163,25 +162,9 @@ func (o *NBDProvider) sync(ctx context.Context) error {
 	ctx, span := tracer.Start(ctx, "sync")
 	defer span.End()
 
-	nbdPath, err := o.Path()
-	if err != nil {
+	if _, err := o.Path(); err != nil {
 		return fmt.Errorf("failed to get cow path: %w", err)
 	}
 
-	file, err := os.Open(nbdPath)
-	if err != nil {
-		return fmt.Errorf("failed to open path: %w", err)
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			logger.L().Error(ctx, "failed to close nbd file", zap.Error(err))
-		}
-	}()
-
-	if err := unix.IoctlSetInt(int(file.Fd()), unix.BLKFLSBUF, 0); err != nil {
-		return fmt.Errorf("ioctl BLKFLSBUF failed: %w", err)
-	}
-
-	return flush(ctx, nbdPath)
+	return o.mnt.Flush(ctx)
 }

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -380,6 +380,11 @@ func (f *Factory) EgressProxy() network.EgressProxy {
 	return f.egressProxy
 }
 
+// NewDirectPathMount opens host-side NBD access without a Firecracker VM.
+func (f *Factory) NewDirectPathMount(backend block.Device) *nbd.DirectPathMount {
+	return nbd.NewDirectPathMount(backend, f.devicePool, f.featureFlags)
+}
+
 // PreBootFn is an optional callback invoked after the rootfs is ready but before
 // Firecracker boots. It receives the rootfs device path (e.g., a file path for
 // DirectProvider or /dev/nbdX for NBDProvider) and may modify the filesystem

--- a/packages/orchestrator/pkg/sandbox/snapshot.go
+++ b/packages/orchestrator/pkg/sandbox/snapshot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/scheduling"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
@@ -51,6 +52,36 @@ type Snapshot struct {
 	RootfsBlockSize uint64
 
 	cleanup *Cleanup
+}
+
+// NewFilesystemOnlySnapshot wraps a host-generated rootfs layer for upload.
+// It owns rootfsDiff and metafile until the template cache accepts them.
+func NewFilesystemOnlySnapshot(
+	ctx context.Context,
+	buildID uuid.UUID,
+	rootfsDiff build.Diff,
+	rootfsHeader *header.Header,
+	metafile template.File,
+) *Snapshot {
+	cleanup := NewCleanup()
+	cleanup.AddNoContext(ctx, rootfsDiff.Close)
+	cleanup.AddNoContext(ctx, metafile.Close)
+
+	return &Snapshot{
+		MemorySnapshot: MemorySnapshot{
+			Diff:       build.Diff(&build.NoDiff{}),
+			DiffHeader: NewResolvedDiffHeader(nil),
+		},
+		RootfsDiff:         rootfsDiff,
+		RootfsDiffHeader:   NewResolvedDiffHeader(rootfsHeader),
+		Snapfile:           &template.NoopFile{},
+		Metafile:           metafile,
+		BuildID:            buildID,
+		SchedulingMetadata: scheduling.FromHeaders(buildID, nil, rootfsHeader, 0),
+		FilesystemSnapshot: true,
+		RootfsBlockSize:    rootfsHeader.Metadata.BlockSize,
+		cleanup:            cleanup,
+	}
 }
 
 func (s *Snapshot) Close(ctx context.Context) error {

--- a/packages/orchestrator/pkg/template/build/builder.go
+++ b/packages/orchestrator/pkg/template/build/builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/metrics"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/base"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/ensurefreedisk"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/finalize"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/optimize"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/steps"
@@ -396,6 +397,16 @@ func runBuild(
 		builders = append(builders, userBuilder)
 	}
 	builders = append(builders, stepBuilders...)
+	// Grow the quiescent rootfs before finalize cold-boots it.
+	if builder.featureFlags.BoolFlag(ctx, featureflags.BuildEnsureFreeDiskSpace) {
+		builders = append(builders, ensurefreedisk.New(
+			bc,
+			builder.sandboxFactory,
+			layerExecutor,
+			builder.templateCache,
+			index,
+		))
+	}
 	builders = append(builders, postProcessingBuilder)
 	builders = append(builders, optimizeBuilder)
 

--- a/packages/orchestrator/pkg/template/build/config/config.go
+++ b/packages/orchestrator/pkg/template/build/config/config.go
@@ -36,7 +36,8 @@ type TemplateConfig struct {
 	// The amount of RAM memory to allocate to the VM, in MiB.
 	MemoryMB int64
 
-	// The amount of free disk to allocate to the VM, in MiB.
+	// The amount of free rootfs target after build steps and before finalize, in MiB.
+	// ext4 metadata and finalize writes may reduce the available space.
 	DiskSizeMB int64
 
 	// HugePages sets whether the VM use huge pages.

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -246,6 +246,23 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (string, e
 	return strings.TrimSpace(string(out)), nil
 }
 
+// ReplayJournal applies committed ext4 journal transactions without a full
+// filesystem check. Guest sync makes journal commits durable but may leave
+// them uncheckpointed, while debugfs reads raw free-block metadata without
+// replaying the journal. Replaying first reflects the latest durable state.
+func ReplayJournal(ctx context.Context, rootfsPath string) (string, error) {
+	cmd := exec.CommandContext(ctx, "e2fsck", "-p", "-E", "journal_only", rootfsPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() < 0 || exitErr.ExitCode()&^(1|2) != 0 {
+			return string(out), fmt.Errorf("error replaying ext4 journal: %w\n%s", err, out)
+		}
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
 func ReadFile(ctx context.Context, rootfsPath string, filePath string) (string, error) {
 	_, statSpan := tracer.Start(ctx, "ext4-read-file")
 	defer statSpan.End()

--- a/packages/orchestrator/pkg/template/build/layer/layer_executor.go
+++ b/packages/orchestrator/pkg/template/build/layer/layer_executor.go
@@ -261,8 +261,6 @@ func (lb *LayerExecutor) PauseAndUpload(
 	ctx, childSpan := tracer.Start(ctx, "pause-and-upload")
 	defer childSpan.End()
 
-	userLogger.Debug(ctx, fmt.Sprintf("Processing layer: %s", meta.Template.BuildID))
-
 	// snapshot is automatically cleared by the templateCache eviction
 	snapshot, err := sbx.Pause(
 		ctx,
@@ -273,8 +271,22 @@ func (lb *LayerExecutor) PauseAndUpload(
 		return fmt.Errorf("error processing vm: %w", err)
 	}
 
+	return lb.UploadSnapshot(ctx, userLogger, snapshot, hash, meta, buildOrigin)
+}
+
+// UploadSnapshot caches and uploads a snapshot produced without a running VM.
+func (lb *LayerExecutor) UploadSnapshot(
+	ctx context.Context,
+	userLogger logger.Logger,
+	snapshot *sandbox.Snapshot,
+	hash string,
+	meta metadata.Template,
+	buildOrigin storage.ObjectOrigin,
+) error {
+	userLogger.Debug(ctx, fmt.Sprintf("Adding layer to cache: %s", meta.Template.BuildID))
+
 	// Add snapshot to template cache so it can be used immediately
-	err = lb.templateCache.AddSnapshot(
+	err := lb.templateCache.AddSnapshot(
 		context.WithoutCancel(ctx),
 		meta.Template.BuildID,
 		snapshot.MemorySnapshot.DiffHeader,
@@ -291,7 +303,7 @@ func (lb *LayerExecutor) PauseAndUpload(
 	}
 
 	// Upload snapshot async, it's added to the template cache immediately
-	userLogger.Debug(ctx, fmt.Sprintf("Saving: %s", meta.Template.BuildID))
+	userLogger.Debug(ctx, fmt.Sprintf("Uploading layer: %s", meta.Template.BuildID))
 
 	objectMetadata := lb.BuildContext.Config.ObjectMetadata(buildOrigin)
 
@@ -333,6 +345,9 @@ func (lb *LayerExecutor) PauseAndUpload(
 			return fmt.Errorf("error uploading snapshot: %w", err)
 		}
 
+		// Publish the recipe hash only after every artifact has been uploaded. A
+		// cache lookup can then resolve the hash to this build ID without observing
+		// a snapshot whose header, metadata, or data is still missing.
 		if err := lb.index.SaveLayerMeta(ctx, hash, cache.LayerMetadata{
 			Template: cache.Template{
 				BuildID: meta.Template.BuildID,

--- a/packages/orchestrator/pkg/template/build/metrics/metrics.go
+++ b/packages/orchestrator/pkg/template/build/metrics/metrics.go
@@ -15,10 +15,11 @@ import (
 type Phase string
 
 const (
-	PhaseBase     Phase = "base"
-	PhaseSteps    Phase = "steps"
-	PhaseFinalize Phase = "finalize"
-	PhaseOptimize Phase = "optimize"
+	PhaseBase       Phase = "base"
+	PhaseSteps      Phase = "steps"
+	PhaseResizeDisk Phase = "resize-disk"
+	PhaseFinalize   Phase = "finalize"
+	PhaseOptimize   Phase = "optimize"
 )
 
 // BuildResultType represents the type of build result

--- a/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/builder.go
@@ -1,0 +1,253 @@
+//go:build linux
+
+// Package ensurefreedisk grows a quiescent rootfs after user steps and before
+// finalize cold-boots it.
+package ensurefreedisk
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox"
+	sbxtemplate "github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/template"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/buildcontext"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/layer"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/metrics"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/storage/cache"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/metadata"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	"github.com/e2b-dev/infra/packages/shared/pkg/units"
+)
+
+const (
+	resizeDiskName    = "resize-disk"
+	resizeDiskTimeout = time.Hour
+)
+
+type EnsureFreeDiskBuilder struct {
+	buildcontext.BuildContext
+
+	sandboxFactory *sandbox.Factory
+	layerExecutor  *layer.LayerExecutor
+	templateCache  *sbxtemplate.Cache
+	index          cache.Index
+}
+
+func New(
+	buildContext buildcontext.BuildContext,
+	sandboxFactory *sandbox.Factory,
+	layerExecutor *layer.LayerExecutor,
+	templateCache *sbxtemplate.Cache,
+	index cache.Index,
+) *EnsureFreeDiskBuilder {
+	return &EnsureFreeDiskBuilder{
+		BuildContext:   buildContext,
+		sandboxFactory: sandboxFactory,
+		layerExecutor:  layerExecutor,
+		templateCache:  templateCache,
+		index:          index,
+	}
+}
+
+func (b *EnsureFreeDiskBuilder) Prefix() string {
+	return resizeDiskName
+}
+
+func (b *EnsureFreeDiskBuilder) String(context.Context) (string, error) {
+	return "Resizing disk", nil
+}
+
+func (b *EnsureFreeDiskBuilder) Metadata() phases.PhaseMeta {
+	return phases.PhaseMeta{
+		Phase:    metrics.PhaseResizeDisk,
+		StepType: resizeDiskName,
+	}
+}
+
+func (b *EnsureFreeDiskBuilder) Hash(_ context.Context, sourceLayer phases.LayerResult) (string, error) {
+	return cache.HashKeys(
+		sourceLayer.Hash,
+		resizeDiskName,
+		strconv.FormatInt(b.Config.DiskSizeMB, 10),
+	), nil
+}
+
+func (b *EnsureFreeDiskBuilder) Layer(
+	ctx context.Context,
+	sourceLayer phases.LayerResult,
+	hash string,
+) (phases.LayerResult, error) {
+	finalMetadata := sourceLayer.Metadata
+	finalMetadata.Template = metadata.TemplateMetadata{
+		BuildID:            uuid.NewString(),
+		KernelVersion:      b.Config.KernelVersion,
+		FirecrackerVersion: b.Config.FirecrackerVersion,
+	}
+
+	notCachedResult := phases.LayerResult{
+		Metadata: finalMetadata,
+		Cached:   false,
+		Hash:     hash,
+	}
+
+	// A forced or freshly-built source must flow through this phase instead of
+	// reconnecting the build to an older ensure artifact with the same recipe hash.
+	if !sourceLayer.Cached || (b.Config.Force != nil && *b.Config.Force) {
+		return notCachedResult, nil
+	}
+
+	layerMeta, err := b.index.LayerMetaFromHash(ctx, hash)
+	if err != nil {
+		logger.L().Info(ctx, "resize-disk layer unavailable in cache, building it",
+			zap.Error(err),
+			zap.String("hash", hash),
+		)
+
+		return notCachedResult, nil //nolint:nilerr // A failed hash lookup is a cache miss; rebuild and refresh it.
+	}
+
+	meta, err := b.index.Cached(ctx, layerMeta.Template.BuildID)
+	if err != nil {
+		logger.L().Info(ctx, "resize-disk artifact unavailable in cache, building it",
+			zap.Error(err),
+			zap.String("hash", hash),
+			zap.String("build_id", layerMeta.Template.BuildID),
+		)
+
+		return notCachedResult, nil //nolint:nilerr // An unavailable cached artifact must be rebuilt.
+	}
+
+	return phases.LayerResult{
+		Metadata: meta,
+		Cached:   true,
+		Hash:     hash,
+	}, nil
+}
+
+func (b *EnsureFreeDiskBuilder) Build(
+	ctx context.Context,
+	userLogger logger.Logger,
+	_ string,
+	sourceLayer phases.LayerResult,
+	currentLayer phases.LayerResult,
+) (phases.LayerResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, resizeDiskTimeout)
+	defer cancel()
+
+	// Load the last user-step rootfs as the immutable parent of the resized layer.
+	sourceTemplate, err := b.templateCache.GetTemplate(ctx, sourceLayer.Metadata.Template.BuildID, false, true)
+	if err != nil {
+		return phases.LayerResult{}, fmt.Errorf("get source template: %w", err)
+	}
+
+	sourceRootfs, err := sourceTemplate.Rootfs()
+	if err != nil {
+		return phases.LayerResult{}, fmt.Errorf("get source rootfs: %w", err)
+	}
+
+	layerBuildID, err := uuid.Parse(currentLayer.Metadata.Template.BuildID)
+	if err != nil {
+		return phases.LayerResult{}, fmt.Errorf("parse resize-disk layer build id: %w", err)
+	}
+
+	// Measure the source and produce either an empty or grown rootfs layer.
+	rootfsDiff, rootfsHeader, res, err := b.growAndExport(ctx, sourceRootfs, layerBuildID, b.Config.DiskSizeMB)
+	if err != nil {
+		return phases.LayerResult{}, fmt.Errorf("resize disk: %w", err)
+	}
+	telemetry.SetAttributes(ctx,
+		attribute.Int64("template.resize_disk.requested_free_bytes", res.target),
+		attribute.Int64("template.resize_disk.free_before_bytes", res.freeBefore),
+		attribute.Int64("template.resize_disk.free_after_bytes", res.freeAfter),
+	)
+
+	// Keep ownership until it is transferred to the snapshot below.
+	defer func() {
+		if rootfsDiff != nil {
+			if err := rootfsDiff.Close(); err != nil {
+				logger.L().Warn(ctx, "failed to close unowned resize-disk diff", zap.Error(err))
+			}
+		}
+	}()
+
+	if res.freeBefore >= res.target {
+		userLogger.Info(ctx, fmt.Sprintf(
+			"resize-disk: %d MiB free already >= target %d MiB, no resize needed",
+			units.BytesToMB(res.freeBefore), units.BytesToMB(res.target),
+		))
+	} else {
+		if res.freeAfter < res.target {
+			// ext4 block-group metadata may consume part of the added capacity. Exact
+			// top-up is intentionally deferred; publish the best-effort result.
+			logger.L().Warn(ctx, "resize-disk target undershot after ext4 resize",
+				zap.Int64("requested_free_bytes", res.target),
+				zap.Int64("free_before_bytes", res.freeBefore),
+				zap.Int64("free_after_bytes", res.freeAfter),
+			)
+		}
+
+		userLogger.Info(ctx, fmt.Sprintf(
+			"resize-disk: free %d -> %d MiB",
+			units.BytesToMB(res.freeBefore), units.BytesToMB(res.freeAfter),
+		))
+	}
+
+	// The VM-less layer has no matching memory snapshot, so finalize must cold-boot it.
+	meta := currentLayer.Metadata.MarkFilesystemOnly(true)
+
+	cachePaths, err := storage.Paths{BuildID: layerBuildID.String()}.Cache(b.BuilderConfig.StorageConfig)
+	if err != nil {
+		return phases.LayerResult{}, fmt.Errorf("create cache paths: %w", err)
+	}
+	metafile := sbxtemplate.NewLocalFileLink(cachePaths.CacheMetadata())
+	defer func() {
+		if metafile != nil {
+			if err := metafile.Close(); err != nil {
+				logger.L().Warn(ctx, "failed to close unowned resize-disk metadata", zap.Error(err))
+			}
+		}
+	}()
+	if err := meta.ToFile(metafile.Path()); err != nil {
+		return phases.LayerResult{}, fmt.Errorf("write resize-disk layer metadata: %w", err)
+	}
+
+	// Bundle the rootfs layer and metadata, transferring their cleanup ownership.
+	snapshot := sandbox.NewFilesystemOnlySnapshot(
+		ctx,
+		layerBuildID,
+		rootfsDiff,
+		rootfsHeader,
+		metafile,
+	)
+	rootfsDiff = nil
+	metafile = nil
+
+	// Publish resized and no-op results through the same normal layer path. For a
+	// no-op, NoDiff skips the rootfs data body while the new header and metadata
+	// still refresh the ensure hash mapping, including after a forced rebuild.
+	if err := b.layerExecutor.UploadSnapshot(
+		ctx,
+		userLogger,
+		snapshot,
+		currentLayer.Hash,
+		meta,
+		storage.ObjectOriginTemplateBuildCache,
+	); err != nil {
+		return phases.LayerResult{}, fmt.Errorf("persist resized rootfs layer: %w", err)
+	}
+
+	return phases.LayerResult{
+		Metadata: meta,
+		Cached:   sourceLayer.Cached,
+		Hash:     currentLayer.Hash,
+	}, nil
+}

--- a/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/grow.go
+++ b/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/grow.go
@@ -1,0 +1,274 @@
+//go:build linux
+
+package ensurefreedisk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/nbd"
+	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/filesystem"
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/units"
+)
+
+const offlineCleanupTimeout = time.Minute
+
+type growResult struct {
+	freeBefore int64
+	freeAfter  int64
+	target     int64
+}
+
+func (b *EnsureFreeDiskBuilder) growAndExport(
+	ctx context.Context,
+	sourceRootfs block.ReadonlyDevice,
+	buildID uuid.UUID,
+	targetFreeMB int64,
+) (build.Diff, *header.Header, growResult, error) {
+	if targetFreeMB < 0 || targetFreeMB > math.MaxInt64>>units.MBShift {
+		return nil, nil, growResult{}, fmt.Errorf("disk target overflows: %d MiB", targetFreeMB)
+	}
+	target := units.MBToBytes(targetFreeMB)
+
+	// Storage.Size and BlockSize read header metadata directly, so validate the
+	// pointers before calling either method.
+	sourceHeader := sourceRootfs.Header()
+	if sourceHeader == nil || sourceHeader.Metadata == nil {
+		return nil, nil, growResult{}, errors.New("source rootfs header metadata is missing")
+	}
+
+	// Validate the source device before exposing it to host filesystem tools.
+	sourceSize, err := sourceRootfs.Size(ctx)
+	if err != nil {
+		return nil, nil, growResult{}, fmt.Errorf("get source rootfs size: %w", err)
+	}
+	blockSize := sourceRootfs.BlockSize()
+	if err := validateSourceGeometry(
+		sourceSize,
+		blockSize,
+		sourceHeader.Metadata.Size,
+		sourceHeader.Metadata.BlockSize,
+	); err != nil {
+		return nil, nil, growResult{}, err
+	}
+
+	// Measure the latest durable ext4 state without modifying the source layer.
+	freeBefore, err := b.measureFree(ctx, sourceRootfs, sourceSize, blockSize, buildID)
+	if err != nil {
+		return nil, nil, growResult{}, err
+	}
+	result := growResult{freeBefore: freeBefore, freeAfter: freeBefore, target: target}
+	if freeBefore >= target {
+		// The filesystem already satisfies the request, but this phase still needs
+		// its own cacheable artifact. Otherwise a forced rebuild would execute the
+		// phase and then have nothing new to publish under the ensure-layer hash.
+		//
+		// This is an empty-diff header, not an empty rootfs. ToDiffHeader carries
+		// forward every mapping from the source header while advancing it to a new
+		// generation and build ID. Paired with NoDiff, the upload stores this header
+		// and the metadata without uploading rootfs data that did not change.
+		noChangeHeader, err := header.NewDiffMetadata(blockSize, nil, nil).ToDiffHeader(ctx, sourceHeader, buildID)
+		if err != nil {
+			return nil, nil, growResult{}, fmt.Errorf("build unchanged rootfs header: %w", err)
+		}
+		if err := noChangeHeader.Mapping.Validate(noChangeHeader.Metadata.Size, header.PageSize); err != nil {
+			return nil, nil, growResult{}, fmt.Errorf("validate unchanged rootfs mapping: %w", err)
+		}
+
+		return &build.NoDiff{}, noChangeHeader, result, nil
+	}
+
+	// Grow once by the measured deficit, rounded up to a whole MiB.
+	newSize, err := computeGrownSize(sourceSize, target, freeBefore)
+	if err != nil {
+		return nil, nil, growResult{}, err
+	}
+	// Resize in a separate COW overlay and export only the changed blocks.
+	diff, grownHeader, freeAfter, err := b.resizeAndExport(
+		ctx, sourceRootfs, sourceHeader, buildID, sourceSize, newSize,
+	)
+	if err != nil {
+		return nil, nil, growResult{}, err
+	}
+	result.freeAfter = freeAfter
+
+	return diff, grownHeader, result, nil
+}
+
+func (b *EnsureFreeDiskBuilder) measureFree(
+	ctx context.Context,
+	source block.ReadonlyDevice,
+	size, blockSize int64,
+	buildID uuid.UUID,
+) (free int64, e error) {
+	cache, err := block.NewCache(size, blockSize, filepath.Join(b.BuilderConfig.DefaultCacheDir, resizeDiskName+"-"+buildID.String()+"-measure.cache"), false)
+	if err != nil {
+		return 0, fmt.Errorf("create measurement cache: %w", err)
+	}
+	defer func() { e = errors.Join(e, cache.Close()) }()
+
+	device, err := b.openOfflineDevice(ctx, block.NewOverlay(source, cache))
+	if err != nil {
+		return 0, err
+	}
+	defer func() { e = errors.Join(e, device.close(ctx)) }()
+
+	if _, err := filesystem.ReplayJournal(ctx, device.path); err != nil {
+		return 0, fmt.Errorf("replay source journal: %w", err)
+	}
+	free, err = filesystem.GetFreeSpace(ctx, device.path, blockSize)
+	if err != nil {
+		return 0, fmt.Errorf("measure source free space: %w", err)
+	}
+
+	return free, nil
+}
+
+func (b *EnsureFreeDiskBuilder) resizeAndExport(
+	ctx context.Context,
+	source block.ReadonlyDevice,
+	sourceHeader *header.Header,
+	buildID uuid.UUID,
+	sourceSize, newSize int64,
+) (d build.Diff, h *header.Header, freeAfter int64, e error) {
+	blockSize := source.BlockSize()
+	// Use a sparse writable overlay at the final size; the source stays immutable.
+	cache, err := block.NewCache(newSize, blockSize, filepath.Join(b.BuilderConfig.DefaultCacheDir, resizeDiskName+"-"+buildID.String()+"-grow.cache"), false)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("create grow cache: %w", err)
+	}
+	cacheOpen := true
+	defer func() {
+		if cacheOpen {
+			e = errors.Join(e, cache.Close())
+		}
+	}()
+
+	// Represent the new device tail as zeroes before ext4 grows into it.
+	if _, err := cache.WriteZeroesAt(sourceSize, newSize-sourceSize); err != nil {
+		return nil, nil, 0, fmt.Errorf("zero-fill grown tail: %w", err)
+	}
+
+	freeAfter, err = b.resizeOffline(ctx, block.NewOverlay(source, cache), newSize)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
+	// Serialize only changed extents and compose them over the source header.
+	diffFile, err := build.NewLocalDiffFile(b.BuilderConfig.DefaultCacheDir, buildID.String(), build.Rootfs)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("create rootfs diff file: %w", err)
+	}
+	diffFileOwned := true
+	defer func() {
+		if diffFileOwned {
+			e = errors.Join(e, cleanupDiffFile(diffFile))
+		}
+	}()
+
+	diffMetadata, err := cache.ExportToDiff(ctx, diffFile.File)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("export grown overlay: %w", err)
+	}
+	grownHeader, err := diffMetadata.ToResizedDiffHeader(ctx, sourceHeader, buildID, uint64(newSize))
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("build grown rootfs header: %w", err)
+	}
+
+	// Remove the temporary overlay before handing the finalized diff to the caller.
+	cacheOpen = false
+	if err := cache.Close(); err != nil {
+		return nil, nil, 0, fmt.Errorf("close grow cache: %w", err)
+	}
+	rootfsDiff, err := diffFile.CloseToDiff(blockSize)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("convert rootfs diff file: %w", err)
+	}
+	diffFileOwned = false
+
+	return rootfsDiff, grownHeader, freeAfter, nil
+}
+
+// resizeOffline owns the NBD connection for the complete filesystem operation.
+// Its deferred close finishes before this function returns, so the caller cannot
+// export the backing cache while the NBD server may still be using it. A close
+// failure is joined into the return error and therefore also prevents export.
+func (b *EnsureFreeDiskBuilder) resizeOffline(
+	ctx context.Context,
+	backend block.Device,
+	newSize int64,
+) (freeAfter int64, e error) {
+	// Expose the detached overlay as a normal host block device for e2fsprogs.
+	device, err := b.openOfflineDevice(ctx, backend)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { e = errors.Join(e, device.close(ctx)) }()
+
+	// Repair before resizing, then verify the enlarged filesystem.
+	if _, err := filesystem.CheckIntegrity(ctx, device.path, true); err != nil {
+		return 0, fmt.Errorf("pre-resize e2fsck: %w", err)
+	}
+	if _, err := filesystem.Resize(ctx, device.path, newSize); err != nil {
+		return 0, fmt.Errorf("resize rootfs: %w", err)
+	}
+	if _, err := filesystem.CheckIntegrity(ctx, device.path, true); err != nil {
+		return 0, fmt.Errorf("post-resize e2fsck: %w", err)
+	}
+
+	// Measure and flush the final state before the deferred close detaches it.
+	freeAfter, err = filesystem.GetFreeSpace(ctx, device.path, backend.BlockSize())
+	if err != nil {
+		return 0, fmt.Errorf("measure grown free space: %w", err)
+	}
+	if err := device.mnt.Flush(ctx); err != nil {
+		return 0, fmt.Errorf("flush grown device: %w", err)
+	}
+
+	return freeAfter, nil
+}
+
+type offlineDevice struct {
+	mnt  *nbd.DirectPathMount
+	path string
+}
+
+func (b *EnsureFreeDiskBuilder) openOfflineDevice(ctx context.Context, backend block.Device) (*offlineDevice, error) {
+	mnt := b.sandboxFactory.NewDirectPathMount(backend)
+	idx, err := mnt.Open(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("open NBD device: %w", err)
+	}
+
+	return &offlineDevice{mnt: mnt, path: nbd.GetDevicePath(idx)}, nil
+}
+
+func (d *offlineDevice) close(ctx context.Context) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), offlineCleanupTimeout)
+	defer cancel()
+
+	return d.mnt.Close(cleanupCtx)
+}
+
+func cleanupDiffFile(f *build.LocalDiffFile) error {
+	closeErr := f.File.Close()
+	if errors.Is(closeErr, os.ErrClosed) {
+		closeErr = nil
+	}
+	removeErr := os.Remove(f.Name())
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+
+	return errors.Join(closeErr, removeErr)
+}

--- a/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/sizing.go
+++ b/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/sizing.go
@@ -1,0 +1,65 @@
+package ensurefreedisk
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/units"
+)
+
+// computeGrownSize assumes the caller has already validated the source
+// geometry (see validateSourceGeometry), including that the block size
+// matches header.RootfsBlockSize.
+func computeGrownSize(currentSize, targetFree, freeBefore int64) (int64, error) {
+	if currentSize <= 0 {
+		return 0, fmt.Errorf("invalid current size: %d", currentSize)
+	}
+	if targetFree < 0 {
+		return 0, fmt.Errorf("invalid target free space: %d", targetFree)
+	}
+	if freeBefore >= targetFree {
+		return 0, fmt.Errorf("free space before (%d) is already at or above target (%d)", freeBefore, targetFree)
+	}
+	if freeBefore < 0 && targetFree > math.MaxInt64+freeBefore {
+		return 0, errors.New("free-space shortage overflows")
+	}
+
+	shortage := targetFree - freeBefore
+	if currentSize > math.MaxInt64-shortage {
+		return 0, errors.New("grown size overflows")
+	}
+
+	size := currentSize + shortage
+	resizeUnit := units.MBToBytes(1)
+	if remainder := size % resizeUnit; remainder != 0 {
+		add := resizeUnit - remainder
+		if size > math.MaxInt64-add {
+			return 0, errors.New("aligned grown size overflows")
+		}
+		size += add
+	}
+
+	return size, nil
+}
+
+func validateSourceGeometry(sourceSize, blockSize int64, headerSize, headerBlockSize uint64) error {
+	if sourceSize <= 0 {
+		return fmt.Errorf("invalid source size: %d", sourceSize)
+	}
+	if blockSize != int64(header.RootfsBlockSize) {
+		return fmt.Errorf("unsupported source block size: %d", blockSize)
+	}
+	if headerSize > math.MaxInt64 || headerBlockSize > math.MaxInt64 {
+		return errors.New("source header geometry overflows")
+	}
+	if sourceSize != int64(headerSize) || blockSize != int64(headerBlockSize) {
+		return fmt.Errorf("source geometry mismatch: device=%d/%d header=%d/%d", sourceSize, blockSize, headerSize, headerBlockSize)
+	}
+	if sourceSize%blockSize != 0 {
+		return fmt.Errorf("source size %d is not block aligned", sourceSize)
+	}
+
+	return nil
+}

--- a/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/sizing_test.go
+++ b/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/sizing_test.go
@@ -1,0 +1,37 @@
+package ensurefreedisk
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
+	"github.com/e2b-dev/infra/packages/shared/pkg/units"
+)
+
+func TestComputeGrownSize(t *testing.T) {
+	t.Parallel()
+
+	const currentSize = int64(1 << 30)
+	oneMiB := units.MBToBytes(1)
+	size, err := computeGrownSize(currentSize, units.MBToBytes(512), units.MBToBytes(512)-1)
+	require.NoError(t, err)
+	require.Equal(t, currentSize+oneMiB, size)
+
+	size, err = computeGrownSize(currentSize, units.MBToBytes(512), -oneMiB)
+	require.NoError(t, err)
+	require.Equal(t, currentSize+units.MBToBytes(513), size)
+
+	_, err = computeGrownSize(math.MaxInt64, 1, 0)
+	require.Error(t, err)
+}
+
+func TestValidateSourceGeometry(t *testing.T) {
+	t.Parallel()
+
+	const size = int64(16 << 20)
+	require.NoError(t, validateSourceGeometry(size, header.RootfsBlockSize, uint64(size), header.RootfsBlockSize))
+	require.Error(t, validateSourceGeometry(size+header.RootfsBlockSize, header.RootfsBlockSize, uint64(size), header.RootfsBlockSize))
+	require.Error(t, validateSourceGeometry(size, 2*header.RootfsBlockSize, uint64(size), 2*header.RootfsBlockSize))
+}

--- a/packages/orchestrator/pkg/template/build/phases/phase.go
+++ b/packages/orchestrator/pkg/template/build/phases/phase.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
@@ -76,56 +77,7 @@ func Run(
 	sourceLayer := LayerResult{}
 
 	for _, builder := range builders {
-		meta := builder.Metadata()
-
-		loggerFields := []zap.Field{
-			zap.String("phase", string(meta.Phase)),
-			zap.String("step_type", meta.StepType),
-			zap.Intp("step_number", meta.StepNumber),
-			zap.String("step", stepString(meta)),
-		}
-
-		logger.Debug(ctx, "running builder phase", loggerFields...)
-		stepUserLogger := userLogger.With(loggerFields...)
-
-		phaseStartTime := time.Now()
-		hash, err := builder.Hash(ctx, sourceLayer)
-		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting hash: %w", err)
-		}
-
-		currentLayer, err := builder.Layer(ctx, sourceLayer, hash)
-		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting layer: %w", err)
-		}
-		metrics.RecordCacheResult(ctx, meta.Phase, meta.StepType, currentLayer.Cached)
-
-		prefix := builder.Prefix()
-		source, err := builder.String(ctx)
-		if err != nil {
-			return LayerResult{}, fmt.Errorf("getting source: %w", err)
-		}
-		stepUserLogger.Info(ctx, layerInfo(currentLayer.Cached, prefix, source, currentLayer.Hash))
-
-		if currentLayer.Cached {
-			phaseDuration := time.Since(phaseStartTime)
-			metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, true)
-
-			sourceLayer = currentLayer
-
-			continue
-		}
-
-		err = validateLayer(currentLayer)
-		if err != nil {
-			return LayerResult{}, fmt.Errorf("validating layer: %w", err)
-		}
-
-		res, err := builder.Build(ctx, stepUserLogger, prefix, sourceLayer, currentLayer)
-		// Record phase duration
-		phaseDuration := time.Since(phaseStartTime)
-		metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, false)
-
+		res, err := runPhase(ctx, logger, userLogger, metrics, builder, sourceLayer)
 		if err != nil {
 			return LayerResult{}, err
 		}
@@ -134,6 +86,88 @@ func Run(
 	}
 
 	return sourceLayer, nil
+}
+
+// runPhase executes a single build phase (hash, cache lookup, and build) within
+// its own span so every phase, including cache hits, produces one span.
+func runPhase(
+	ctx context.Context,
+	logger logger.Logger,
+	userLogger logger.Logger,
+	metrics *metrics.BuildMetrics,
+	builder BuilderPhase,
+	sourceLayer LayerResult,
+) (_ LayerResult, e error) {
+	meta := builder.Metadata()
+
+	ctx, span := tracer.Start(ctx, string(meta.Phase), trace.WithAttributes(
+		attribute.String("phase", string(meta.Phase)),
+		attribute.String("step_type", meta.StepType),
+		attribute.String("step", stepString(meta)),
+	))
+	if meta.StepNumber != nil {
+		span.SetAttributes(attribute.Int("step_number", *meta.StepNumber))
+	}
+	defer span.End()
+	defer func() {
+		if e != nil {
+			span.RecordError(e)
+			span.SetStatus(codes.Error, e.Error())
+		}
+	}()
+
+	loggerFields := []zap.Field{
+		zap.String("phase", string(meta.Phase)),
+		zap.String("step_type", meta.StepType),
+		zap.Intp("step_number", meta.StepNumber),
+		zap.String("step", stepString(meta)),
+	}
+
+	logger.Debug(ctx, "running builder phase", loggerFields...)
+	stepUserLogger := userLogger.With(loggerFields...)
+
+	phaseStartTime := time.Now()
+	hash, err := builder.Hash(ctx, sourceLayer)
+	if err != nil {
+		return LayerResult{}, fmt.Errorf("getting hash: %w", err)
+	}
+
+	currentLayer, err := builder.Layer(ctx, sourceLayer, hash)
+	if err != nil {
+		return LayerResult{}, fmt.Errorf("getting layer: %w", err)
+	}
+	metrics.RecordCacheResult(ctx, meta.Phase, meta.StepType, currentLayer.Cached)
+	span.SetAttributes(attribute.Bool("cached", currentLayer.Cached))
+
+	prefix := builder.Prefix()
+	source, err := builder.String(ctx)
+	if err != nil {
+		return LayerResult{}, fmt.Errorf("getting source: %w", err)
+	}
+	stepUserLogger.Info(ctx, layerInfo(currentLayer.Cached, prefix, source, currentLayer.Hash))
+
+	if currentLayer.Cached {
+		phaseDuration := time.Since(phaseStartTime)
+		metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, true)
+
+		return currentLayer, nil
+	}
+
+	err = validateLayer(currentLayer)
+	if err != nil {
+		return LayerResult{}, fmt.Errorf("validating layer: %w", err)
+	}
+
+	res, err := builder.Build(ctx, stepUserLogger, prefix, sourceLayer, currentLayer)
+	// Record phase duration
+	phaseDuration := time.Since(phaseStartTime)
+	metrics.RecordPhaseDuration(ctx, phaseDuration, meta.Phase, meta.StepType, false)
+
+	if err != nil {
+		return LayerResult{}, err
+	}
+
+	return res, nil
 }
 
 func validateLayer(

--- a/packages/shared/pkg/featureflags/flags.go
+++ b/packages/shared/pkg/featureflags/flags.go
@@ -232,6 +232,9 @@ var (
 	// (Aug 1, 2026). Off by default. Evaluated per-user so rejection can be
 	// rolled out gradually via LD targeting.
 	DisableE2BAccessTokenAuthFlag = NewBoolFlag("disable-e2b-access-token-auth", false)
+
+	// BuildEnsureFreeDiskSpace grows the rootfs after build steps and before finalize.
+	BuildEnsureFreeDiskSpace = NewBoolFlag("build-ensure-free-disk-space", false)
 )
 
 // envdTimeoutFallbackMs reads ENVD_TIMEOUT (Go duration string, e.g. "10s")

--- a/packages/shared/pkg/storage/header/grown_rootfs_test.go
+++ b/packages/shared/pkg/storage/header/grown_rootfs_test.go
@@ -1,0 +1,39 @@
+package header
+
+import (
+	"testing"
+
+	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGrownRootfsHeader(t *testing.T) {
+	t.Parallel()
+
+	const (
+		blockSize  = int64(PageSize)
+		sourceSize = 4 * blockSize
+		grownSize  = 8 * blockSize
+	)
+	sourceID, grownID := uuid.New(), uuid.New()
+	source, err := NewHeader(NewTemplateMetadata(sourceID, uint64(blockSize), uint64(sourceSize)), nil)
+	require.NoError(t, err)
+
+	diff := NewDiffMetadata(blockSize, roaring.BitmapOf(4), roaring.BitmapOf(5, 6, 7))
+	grown, err := diff.ToResizedDiffHeader(t.Context(), source, grownID, uint64(grownSize))
+	require.NoError(t, err)
+	require.Equal(t, uint64(sourceSize), source.Metadata.Size)
+	require.Equal(t, uint64(grownSize), grown.Metadata.Size)
+	require.NoError(t, grown.Mapping.Validate(grown.Metadata.Size, PageSize))
+
+	for offset, buildID := range map[int64]uuid.UUID{
+		2 * blockSize: sourceID,
+		4 * blockSize: grownID,
+		6 * blockSize: uuid.Nil,
+	} {
+		mapping, err := grown.GetShiftedMapping(t.Context(), offset)
+		require.NoError(t, err)
+		require.Equal(t, buildID, mapping.BuildId)
+	}
+}

--- a/packages/shared/pkg/storage/header/metadata.go
+++ b/packages/shared/pkg/storage/header/metadata.go
@@ -185,6 +185,31 @@ func (d *DiffMetadata) ToDiffHeader(
 	return header, nil
 }
 
+// ToResizedDiffHeader composes the diff over the original header while changing
+// the rootfs logical size. It leaves the original header untouched and strictly
+// validates that the resulting mapping covers the entire resized rootfs.
+func (d *DiffMetadata) ToResizedDiffHeader(
+	ctx context.Context,
+	originalHeader *Header,
+	buildID uuid.UUID,
+	newSize uint64,
+) (*Header, error) {
+	resizedHeader := *originalHeader
+	resizedMetadata := *originalHeader.Metadata
+	resizedMetadata.Size = newSize
+	resizedHeader.Metadata = &resizedMetadata
+
+	header, err := d.ToDiffHeader(ctx, &resizedHeader, buildID)
+	if err != nil {
+		return nil, err
+	}
+	if err := header.Mapping.Validate(header.Metadata.Size, PageSize); err != nil {
+		return nil, fmt.Errorf("invalid resized header mappings: %w", err)
+	}
+
+	return header, nil
+}
+
 type DiffMetadataBuilder struct {
 	dirty *roaring.Bitmap
 	empty *roaring.Bitmap


### PR DESCRIPTION
[EN-1673] feat(orchestrator): ensure requested free disk before finalize
    
Template build steps can consume the free space allocated by the base
builder, leaving newly built templates below the DiskSizeMB target.
Resizing after finalize would make the rootfs inconsistent with its
Firecracker memory snapshot, while layered rootfs artifacts cannot use
the existing local-file resize path directly.

Add a feature-gated ensure-free-disk phase after user steps and before
finalize. Hash the layer from the parent hash, the ensure-free-disk key,
and the requested disk size. Reuse cached ensure artifacts for ordinary
cached builds, while fresh and forced builds bypass lookup, execute the
phase, and refresh the cache mapping through the normal upload pipeline.

Measure ext4 through a detached host-side NBD overlay. When the target is
already satisfied, emit a header-and-metadata-only filesystem layer that
preserves the source mappings without uploading a rootfs data body. When
growth is required, create a larger sparse overlay, zero-fill its tail,
run e2fsck, resize2fs, and e2fsck again, then export only the changed
extents. Compose and validate resized headers without mutating the source
header.

Keep the resize NBD device scoped to a single lifecycle: open it for the
filesystem operations, flush it, and close it exactly once before
exporting the backing cache. Move block-device flushing onto
DirectPathMount so template growth and sandbox rootfs cleanup share the
same BLKFLSBUF implementation.

Publish layer metadata only after all snapshot artifacts are uploaded,
ensuring cache lookups cannot observe incomplete artifacts. Finalize then
cold-boots from the filesystem-only ensure layer, keeping the disk and
memory snapshot coherent.
    
DiskSizeMB remains a best-effort free-space target because ext4 metadata
and finalize writes may consume part of the resulting capacity. Also
preserve correct e2fsck bitmask handling and cancellation-safe NBD
partial-open cleanup.
    
Part of: EN-1673
Related: EN-896