### PR TITLE
chore(orchestrator): serialize sandbox updates

### DIFF
--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -261,6 +261,8 @@ type Sandbox struct {
 	*Resources
 	*Metadata
 
+	updateMu sync.Mutex
+
 	// LifecycleID is a unique identifier for each Firecracker process.
 	// It is used internally by the orchestrator for map eviction guards
 	// and proxy connection pooling. Unlike ExecutionID (which is stable
@@ -308,6 +310,13 @@ type Sandbox struct {
 	// so the warm harvest never pollutes the customer resume distributions. Set
 	// from the WithoutLiveRegistration resume option.
 	skipStartupMetrics bool
+}
+
+func (s *Sandbox) RunUpdate(update func() error) error {
+	s.updateMu.Lock()
+	defer s.updateMu.Unlock()
+
+	return update()
 }
 
 func (s *Sandbox) LoggerMetadata() sbxlogger.SandboxMetadata {

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -414,44 +414,51 @@ func (s *Server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequ
 		})
 	}
 
-	if err := utils.ApplyAllOrNone(ctx, updates); err != nil {
-		telemetry.ReportCriticalError(ctx, "failed to update sandbox", err)
+	err := sbx.RunUpdate(func() error {
+		if err := utils.ApplyAllOrNone(ctx, updates); err != nil {
+			telemetry.ReportCriticalError(ctx, "failed to update sandbox", err)
 
-		return nil, status.Errorf(codes.Internal, "failed to update sandbox: %s", err)
-	}
-
-	// Publish event if any updates were applied.
-	if len(updates) > 0 {
-		teamID, buildId, eventsTTLDays, eventData := s.prepareSandboxEventData(ctx, sbx)
-		if req.GetEndTime() != nil {
-			eventData["set_timeout"] = req.GetEndTime().AsTime().Format(time.RFC3339)
+			return status.Errorf(codes.Internal, "failed to update sandbox: %s", err)
 		}
-		if egress := req.GetEgress(); egress != nil {
-			eventData["network_egress"] = map[string]any{
-				"allowed_cidrs":   egress.GetAllowedCidrs(),
-				"denied_cidrs":    egress.GetDeniedCidrs(),
-				"allowed_domains": egress.GetAllowedDomains(),
+
+		// Publish event if any updates were applied.
+		if len(updates) > 0 {
+			teamID, buildId, eventsTTLDays, eventData := s.prepareSandboxEventData(ctx, sbx)
+			if req.GetEndTime() != nil {
+				eventData["set_timeout"] = req.GetEndTime().AsTime().Format(time.RFC3339)
 			}
+			if egress := req.GetEgress(); egress != nil {
+				eventData["network_egress"] = map[string]any{
+					"allowed_cidrs":   egress.GetAllowedCidrs(),
+					"denied_cidrs":    egress.GetDeniedCidrs(),
+					"allowed_domains": egress.GetAllowedDomains(),
+				}
+			}
+
+			go s.sbxEventsService.Publish(
+				context.WithoutCancel(ctx),
+				teamID,
+				events.SandboxEvent{
+					Version:   events.StructureVersionV2,
+					ID:        uuid.New(),
+					Type:      events.SandboxUpdatedEventPair.Type,
+					Timestamp: time.Now().UTC(),
+
+					EventData:          eventData,
+					SandboxID:          sbx.Runtime.SandboxID,
+					SandboxExecutionID: sbx.Runtime.ExecutionID,
+					SandboxTemplateID:  sbx.Config.BaseTemplateID,
+					SandboxBuildID:     buildId,
+					SandboxTeamID:      teamID,
+					EventsTTLDays:      eventsTTLDays,
+				},
+			)
 		}
 
-		go s.sbxEventsService.Publish(
-			context.WithoutCancel(ctx),
-			teamID,
-			events.SandboxEvent{
-				Version:   events.StructureVersionV2,
-				ID:        uuid.New(),
-				Type:      events.SandboxUpdatedEventPair.Type,
-				Timestamp: time.Now().UTC(),
-
-				EventData:          eventData,
-				SandboxID:          sbx.Runtime.SandboxID,
-				SandboxExecutionID: sbx.Runtime.ExecutionID,
-				SandboxTemplateID:  sbx.Config.BaseTemplateID,
-				SandboxBuildID:     buildId,
-				SandboxTeamID:      teamID,
-				EventsTTLDays:      eventsTTLDays,
-			},
-		)
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return &emptypb.Empty{}, nil

--- a/packages/orchestrator/pkg/server/sandboxes_update_test.go
+++ b/packages/orchestrator/pkg/server/sandboxes_update_test.go
@@ -108,3 +108,72 @@ func TestUpdate_EndTimeAndEgress_EgressFails_RevertsEndTime(t *testing.T) {
 	assert.Empty(t, egress.GetDeniedCidrs())
 	assert.Empty(t, egress.GetAllowedDomains())
 }
+
+func TestUpdate_SerializesUpdatesPerSandbox(t *testing.T) {
+	t.Parallel()
+
+	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{})
+	require.NoError(t, err)
+
+	sbx := &sandbox.Sandbox{
+		Metadata: &sandbox.Metadata{
+			Config:  sandbox.NewConfig(sandbox.Config{}),
+			Runtime: sandbox.RuntimeMetadata{SandboxID: id.Generate()},
+		},
+		Resources: &sandbox.Resources{Slot: slot},
+	}
+	sbx.SetStartedAt(time.Now())
+	sbx.SetEndAt(time.Now().Add(time.Hour))
+	originalEnd := sbx.GetEndAt()
+
+	sandboxMap := sandbox.NewSandboxesMap()
+	sandboxMap.AssignNetwork(t.Context(), sbx)
+	sandboxMap.MarkRunning(t.Context(), sbx)
+
+	s := &Server{
+		sandboxFactory:   &sandbox.Factory{Sandboxes: sandboxMap},
+		info:             &service.ServiceInfo{},
+		sbxEventsService: internalevents.NewEventsService(nil),
+	}
+
+	updateStarted := make(chan struct{})
+	releaseUpdate := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- sbx.RunUpdate(func() error {
+			close(updateStarted)
+			<-releaseUpdate
+
+			return nil
+		})
+	}()
+	<-updateStarted
+
+	newEnd := time.Now().Add(5 * time.Hour)
+	updateDone := make(chan error, 1)
+	go func() {
+		_, updateErr := s.Update(t.Context(), &orchestrator.SandboxUpdateRequest{
+			SandboxId: sbx.Runtime.SandboxID,
+			EndTime:   timestamppb.New(newEnd),
+		})
+		updateDone <- updateErr
+	}()
+
+	var earlyErr error
+	completedEarly := false
+	select {
+	case earlyErr = <-updateDone:
+		completedEarly = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, originalEnd, sbx.GetEndAt())
+	close(releaseUpdate)
+	require.NoError(t, <-holderDone)
+	if completedEarly {
+		require.Failf(t, "update completed before lock release", "error: %v", earlyErr)
+	}
+
+	require.NoError(t, <-updateDone)
+	assert.True(t, newEnd.Equal(sbx.GetEndAt()))
+}


### PR DESCRIPTION
API should make sure this never happens, this is just defense in depth