### PR TITLE
 fix(orchestrator): enforce body-before-header upload ordering in runV3

### DIFF
--- a/packages/orchestrator/pkg/sandbox/build_upload_v3.go
+++ b/packages/orchestrator/pkg/sandbox/build_upload_v3.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	headers "github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
 )
@@ -27,77 +29,77 @@ func (u *Upload) runV3(ctx context.Context) error {
 
 	eg, egCtx := errgroup.WithContext(ctx)
 
+	// Memfile: resolve header, upload body, then write header to storage.
+	// Body must land before the header is visible to peers: PollRemoteStorageForHeader
+	// treats the header's appearance as the durability signal for the entire layer,
+	// so writing it first would let child builds proceed against a body that has not
+	// yet landed. Filesystem-only snapshots skip this goroutine via memfilePath == "".
 	eg.Go(func() error {
 		h, err := u.snap.MemorySnapshot.DiffHeader.WaitWithContext(egCtx)
+		logger.L().Info(egCtx, "memfile diff header resolved",
+			zap.Bool("h_nil", h == nil),
+			zap.Error(err),
+			zap.Stringer("build_id", u.buildID),
+			zap.Bool("filesystem_snapshot", u.snap.FilesystemSnapshot))
 		if err != nil {
 			return fmt.Errorf("wait memfile diff header: %w", err)
 		}
 		if h == nil {
+			// Filesystem-only snapshots intentionally carry no memfile header.
+			// A nil header for a full memory snapshot indicates a bug in the
+			// header-resolution pipeline (e.g. pauseProcessMemory goroutine
+			// never resolved metaOut, or ToDiffHeader returned nil unexpectedly).
+			if !u.snap.FilesystemSnapshot {
+				return fmt.Errorf("memfile diff header resolved to nil for non-filesystem snapshot (build_id=%s)", u.buildID)
+			}
 			return nil
 		}
-
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), uploadFileMemfileHeader, finalizeV3(h), storage.WithMetadata(u.objectMetadata))
-	})
-
-	eg.Go(func() error {
-		h, err := u.snap.RootfsDiffHeader.WaitWithContext(egCtx)
-		if err != nil {
-			return fmt.Errorf("wait rootfs diff header: %w", err)
-		}
-		if h == nil {
-			return nil
-		}
-
-		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), uploadFileRootfsHeader, finalizeV3(h), storage.WithMetadata(u.objectMetadata))
-	})
-
-	meta := storage.WithMetadata(u.objectMetadata)
-
-	eg.Go(func() error {
 		if memfilePath == "" {
 			return nil
-		}
-
-		h, err := u.snap.MemorySnapshot.DiffHeader.WaitWithContext(egCtx)
-		if err != nil {
-			return fmt.Errorf("wait memfile diff header: %w", err)
 		}
 
 		info, err := os.Stat(memfilePath)
 		if err != nil {
 			return fmt.Errorf("memfile stat: %w", err)
 		}
-		_, _, err = storage.UploadFramed(egCtx, u.store, u.paths.Memfile(), memfilePath, storage.WithMetadata(u.layerSizeMetadata(h)))
-		if err != nil {
+		if _, _, err = storage.UploadFramed(egCtx, u.store, u.paths.Memfile(), memfilePath, storage.WithMetadata(u.layerSizeMetadata(h))); err != nil {
 			return err
 		}
 		recordUploadCompression(egCtx, uploadFileMemfile, storage.CompressConfig{}, info.Size(), info.Size())
 
-		return nil
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.MemfileHeader(), uploadFileMemfileHeader, finalizeV3(h), storage.WithMetadata(u.objectMetadata))
 	})
 
+	// Rootfs: same body-before-header ordering as memfile.
 	eg.Go(func() error {
-		if rootfsPath == "" {
-			return nil
-		}
-
 		h, err := u.snap.RootfsDiffHeader.WaitWithContext(egCtx)
+		logger.L().Info(egCtx, "rootfs diff header resolved",
+			zap.Bool("h_nil", h == nil),
+			zap.Error(err),
+			zap.Stringer("build_id", u.buildID))
 		if err != nil {
 			return fmt.Errorf("wait rootfs diff header: %w", err)
+		}
+		if h == nil {
+			return nil
+		}
+		if rootfsPath == "" {
+			return nil
 		}
 
 		info, err := os.Stat(rootfsPath)
 		if err != nil {
 			return fmt.Errorf("rootfs stat: %w", err)
 		}
-		_, _, err = storage.UploadFramed(egCtx, u.store, u.paths.Rootfs(), rootfsPath, storage.WithMetadata(u.layerSizeMetadata(h)))
-		if err != nil {
+		if _, _, err = storage.UploadFramed(egCtx, u.store, u.paths.Rootfs(), rootfsPath, storage.WithMetadata(u.layerSizeMetadata(h))); err != nil {
 			return err
 		}
 		recordUploadCompression(egCtx, uploadFileRootfs, storage.CompressConfig{}, info.Size(), info.Size())
 
-		return nil
+		return storeHeaderWithMetrics(egCtx, u.store, u.paths.RootfsHeader(), uploadFileRootfsHeader, finalizeV3(h), storage.WithMetadata(u.objectMetadata))
 	})
+
+	meta := storage.WithMetadata(u.objectMetadata)
 
 	eg.Go(func() error {
 		// Filesystem-only snapshots resume by reboot, not snapfile restore, so
@@ -117,8 +119,8 @@ func (u *Upload) runV3(ctx context.Context) error {
 		return err
 	}
 
-	// Body uploads done; headers must be ready by now (the per-file Goroutines
-	// above already Wait-ed). Wait() is a fast lookup here.
+	// Body uploads done; headers must be ready by now (the per-file goroutines
+	// above already Wait-ed). WaitWithContext is a fast lookup here.
 	memfileDiffHeader, err := u.snap.MemorySnapshot.DiffHeader.WaitWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("wait memfile diff header: %w", err)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -1677,11 +1677,19 @@ func pauseProcessMemory(
 	headerOut := utils.NewSetOnce[*header.Header]()
 	go func() {
 		setHeader := func(h *header.Header, err error) {
+			logger.L().Info(ctx, "memfile diff header ready",
+				zap.Bool("h_nil", h == nil),
+				zap.Error(err),
+				zap.Stringer("build_id", buildID))
 			if setErr := headerOut.SetResult(h, err); setErr != nil {
 				logger.L().Warn(ctx, "set memfile diff header", zap.Error(setErr))
 			}
 		}
 		meta, err := metaOut.Wait()
+		logger.L().Info(ctx, "memfile dedup metadata ready",
+			zap.Bool("meta_nil", meta == nil),
+			zap.Error(err),
+			zap.Stringer("build_id", buildID))
 		if err != nil {
 			setHeader(nil, err)
 


### PR DESCRIPTION
  ## Problem

  In `runV3`, the memfile body and header were uploaded by **separate racing goroutines**:
  - Goroutine 1 wrote `memfile.header` as soon as `DiffHeader` resolved
  - Goroutine 3 uploaded the memfile body independently

  `PollRemoteStorageForHeader` treats a header appearing in storage as the **durability
  signal** for the entire layer. When goroutine 1 won the race, child builds could start
  deduplicating against a body that had not yet landed — causing data corruption or
  "object does not exist" errors. The same race existed for rootfs body/header.

  ## Root cause analysis

  The original approach (`if h == nil { return error }`) was dead code: as reviewer
  @jakubno correctly pointed out, `pauseProcessMemory` cannot produce `(nil, nil)` for
  a full memory snapshot — `ToDiffHeader` always returns a non-nil header or an error.

  The **actual connected issue** is the body-before-header race described above. A secondary
  contributing factor was a `SetOnce.WaitWithContext` non-determinism bug (fixed in #3241,
  now included via rebase): when both the result channel and the cancelled context fired
  simultaneously, `select` could randomly pick `ctx.Err()` instead of the already-set
  result, causing intermittent upload failures that left `memfile.header` unwritten on disk.

  ## Fix

  1. **Body-before-header ordering** (`build_upload_v3.go`): Merge the memfile body and
     header goroutines into one sequence: resolve header → upload body → write header.
     Same ordering applied to rootfs.

  2. **Explicit error for nil header** (`build_upload_v3.go`): A nil `DiffHeader` for a
     non-filesystem snapshot is now an explicit error instead of a silent no-op.

  3. **Diagnostic logging** (`build_upload_v3.go`, `sandbox.go`): Info-level logs at
     header resolution and upload boundaries for production observability.

  4. **Rebased on main**: Includes the `SetOnce.WaitWithContext` fix (#3241) and the
     provisional header system (#3166).

  ## Test plan

  - [ ] Build a template in local storage mode; verify `memfile.header` exists after build
  - [ ] Filesystem-only snapshots still work (`FilesystemSnapshot == true` skips memfile)
  - [ ] P2P/cloud mode: child builds no longer start before parent body is fully uploaded
  
Closes #3226
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.