### PR TITLE
[EN-1695] chore(api): simplify the sandbox routing logic for local

### DIFF
--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -14,7 +14,6 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator/nodemanager"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
-	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
@@ -147,9 +146,8 @@ func (o *Orchestrator) removeSandboxFromNode(
 		return fmt.Errorf("node '%s' not found", sbx.NodeID)
 	}
 
-	// Only remove from routing table if the node is managed by Nomad
 	// For remote cluster nodes we are using gPRC metadata for routing registration instead
-	if node.IsNomadManaged() || env.IsLocal() {
+	if node.IsClusterNode() {
 		// Remove the sandbox resources after the sandbox is deleted
 		err := o.routingCatalog.DeleteSandbox(ctx, sbx.SandboxID, sbx.ExecutionID)
 		if err != nil {

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -147,7 +147,7 @@ func (o *Orchestrator) removeSandboxFromNode(
 	}
 
 	// For remote cluster nodes we are using gPRC metadata for routing registration instead
-	if node.IsClusterNode() {
+	if !node.IsClusterNode() {
 		// Remove the sandbox resources after the sandbox is deleted
 		err := o.routingCatalog.DeleteSandbox(ctx, sbx.SandboxID, sbx.ExecutionID)
 		if err != nil {

--- a/packages/api/internal/orchestrator/lifecycle.go
+++ b/packages/api/internal/orchestrator/lifecycle.go
@@ -20,9 +20,8 @@ func (o *Orchestrator) addSandboxToRoutingTable(ctx context.Context, sandbox san
 		return
 	}
 
-	// Only add to routing table if the node is managed by Nomad
 	// For remote cluster nodes we are using gPRC metadata for routing registration instead
-	if !node.IsNomadManaged() && !env.IsLocal() {
+	if node.IsClusterNode() {
 		return
 	}
 

--- a/packages/api/internal/orchestrator/nodemanager/metadata.go
+++ b/packages/api/internal/orchestrator/nodemanager/metadata.go
@@ -62,7 +62,7 @@ func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.Sandbo
 func (n *Node) GetSandboxDeleteCtx(ctx context.Context, sandboxID string, executionID string) (*clusters.GRPCClient, context.Context) {
 	md := metadata.MD{}
 
-	if !n.IsClusterNode() {
+	if n.IsClusterNode() {
 		md = edge.SerializeSandboxCatalogDeleteEvent(
 			edge.SandboxCatalogDeleteEvent{
 				SandboxID:   sandboxID,

--- a/packages/api/internal/orchestrator/nodemanager/metadata.go
+++ b/packages/api/internal/orchestrator/nodemanager/metadata.go
@@ -38,7 +38,7 @@ func (n *Node) Metadata() NodeMetadata {
 func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.SandboxCreateRequest) (*clusters.GRPCClient, context.Context) {
 	md := metadata.MD{}
 
-	if !n.IsClusterNode() {
+	if n.IsClusterNode() {
 		md = edge.SerializeSandboxCatalogCreateEvent(
 			edge.SandboxCatalogCreateEvent{
 				SandboxID:               req.GetSandbox().GetSandboxId(),

--- a/packages/api/internal/orchestrator/nodemanager/metadata.go
+++ b/packages/api/internal/orchestrator/nodemanager/metadata.go
@@ -38,7 +38,7 @@ func (n *Node) Metadata() NodeMetadata {
 func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.SandboxCreateRequest) (*clusters.GRPCClient, context.Context) {
 	md := metadata.MD{}
 
-	if !n.IsNomadManaged() {
+	if !n.IsClusterNode() {
 		md = edge.SerializeSandboxCatalogCreateEvent(
 			edge.SandboxCatalogCreateEvent{
 				SandboxID:               req.GetSandbox().GetSandboxId(),
@@ -62,7 +62,7 @@ func (n *Node) GetSandboxCreateCtx(ctx context.Context, req *orchestrator.Sandbo
 func (n *Node) GetSandboxDeleteCtx(ctx context.Context, sandboxID string, executionID string) (*clusters.GRPCClient, context.Context) {
 	md := metadata.MD{}
 
-	if !n.IsNomadManaged() {
+	if !n.IsClusterNode() {
 		md = edge.SerializeSandboxCatalogDeleteEvent(
 			edge.SandboxCatalogDeleteEvent{
 				SandboxID:   sandboxID,

--- a/packages/api/internal/orchestrator/nodemanager/node.go
+++ b/packages/api/internal/orchestrator/nodemanager/node.go
@@ -194,6 +194,10 @@ func (n *Node) IsNomadManaged() bool {
 	return n.NomadNodeShortID != UnknownNomadNodeShortID
 }
 
+func (n *Node) IsClusterNode() bool {
+	return n.ClusterID != consts.LocalClusterID
+}
+
 func (n *Node) OptimisticAdd(ctx context.Context, res SandboxResources) {
 	if n.featureflags != nil && !n.featureflags.BoolFlag(ctx, featureflags.OptimisticResourceAccountingFlag) {
 		return


### PR DESCRIPTION
- Improves the logic for checking cluster vs running in local mode
- Fixes metadata for local mode
- Local nodes uses Redis to unify the logic