### PR TITLE
refactor(envd): make MultiplexedChannel.Fork return a receive-only channel

### DIFF
--- a/packages/envd/internal/services/process/handler/multiplex.go
+++ b/packages/envd/internal/services/process/handler/multiplex.go
@@ -100,9 +100,7 @@ func (m *MultiplexedChannel[T]) HasSubscribers() bool {
 
 // Fork registers a new subscriber and returns its channel plus a cancel func.
 // If Source is already closed it returns a pre-closed channel and a no-op cancel.
-// The channel is bidirectional for backwards compat with start.go which writes
-// a bootstrap event into it; new callers should treat it as receive-only.
-func (m *MultiplexedChannel[T]) Fork() (chan T, func()) {
+func (m *MultiplexedChannel[T]) Fork() (<-chan T, func()) {
 	if m.exited.Load() {
 		ch := make(chan T)
 		close(ch)


### PR DESCRIPTION
The bidirectional return type existed only so start.go could write a bootstrap event directly into its fork channel; that hack was removed in 04317f8a2270 ("fix(envd): avoid Start deadlock after request cancellation (#3256)"), so let the compiler enforce that subscribers never send.