### PR TITLE
Support local Firecracker template builds

### DIFF
--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -71,6 +71,10 @@ type Config struct {
 	// ServiceDiscoveryProvider=local. Used for local dev against the darwin
 	// dummy orchestrator.
 	LocalOrchestratorAddress string `env:"LOCAL_ORCHESTRATOR_ADDRESS" envDefault:"127.0.0.1:5008"`
+	// LocalTemplateBuilderAddress optionally registers a template-manager at a
+	// fixed address in local discovery. Leave empty for the macOS dummy
+	// orchestrator, which cannot build templates.
+	LocalTemplateBuilderAddress string `env:"LOCAL_TEMPLATE_BUILDER_ADDRESS"`
 
 	// Used when ServiceDiscoveryProvider=kubernetes.
 	K8sNamespace                       string `env:"K8S_NAMESPACE"                           envDefault:"default"`

--- a/packages/api/internal/clusters/discovery/static.go
+++ b/packages/api/internal/clusters/discovery/static.go
@@ -1,6 +1,11 @@
 package discovery
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+)
 
 // StaticServiceDiscovery returns a fixed (possibly empty) list of items on
 // every Query. It is used for local development against the darwin dummy
@@ -13,6 +18,32 @@ type StaticServiceDiscovery struct {
 // items. Passing nil yields an empty-but-non-error discovery.
 func NewStaticDiscovery(items []Item) Discovery {
 	return &StaticServiceDiscovery{items: items}
+}
+
+func NewStaticAddressDiscovery(addr string) (Discovery, error) {
+	host, portString, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid local template builder address %q: %w", addr, err)
+	}
+	if host == "" {
+		return nil, fmt.Errorf("invalid local template builder address %q: empty host", addr)
+	}
+
+	port, err := strconv.ParseUint(portString, 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid local template builder port %q: %w", portString, err)
+	}
+	if port == 0 {
+		return nil, fmt.Errorf("invalid local template builder port %q: port must be non-zero", portString)
+	}
+
+	return NewStaticDiscovery([]Item{{
+		UniqueIdentifier:     "local",
+		NodeID:               "local",
+		InstanceID:           "unknown",
+		LocalIPAddress:       host,
+		LocalInstanceApiPort: uint16(port),
+	}}), nil
 }
 
 func (sd *StaticServiceDiscovery) Query(_ context.Context) ([]Item, error) {

--- a/packages/api/internal/clusters/discovery/static_test.go
+++ b/packages/api/internal/clusters/discovery/static_test.go
@@ -1,0 +1,34 @@
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStaticAddressDiscovery(t *testing.T) {
+	t.Parallel()
+
+	discovery, err := NewStaticAddressDiscovery("127.0.0.1:5008")
+	require.NoError(t, err)
+
+	items, err := discovery.Query(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []Item{{
+		UniqueIdentifier:     "local",
+		NodeID:               "local",
+		InstanceID:           "unknown",
+		LocalIPAddress:       "127.0.0.1",
+		LocalInstanceApiPort: 5008,
+	}}, items)
+}
+
+func TestNewStaticAddressDiscoveryRejectsInvalidAddress(t *testing.T) {
+	t.Parallel()
+
+	for _, address := range []string{"not-an-address", ":5008", "127.0.0.1:0"} {
+		_, err := NewStaticAddressDiscovery(address)
+		require.Error(t, err, address)
+	}
+}

--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -160,9 +160,13 @@ func NewAPIStore(ctx context.Context, tel *telemetry.Client, redisClient redis.U
 			logger.L().Fatal(ctx, "Initializing local orchestrator discovery", zap.Error(localErr))
 		}
 		nodeDiscovery = localND
-		// No template builders in local dev — return an empty list so the
-		// clusters pool initializes cleanly.
 		templateBuilderDiscovery = clustersdiscovery.NewStaticDiscovery(nil)
+		if config.LocalTemplateBuilderAddress != "" {
+			templateBuilderDiscovery, localErr = clustersdiscovery.NewStaticAddressDiscovery(config.LocalTemplateBuilderAddress)
+			if localErr != nil {
+				logger.L().Fatal(ctx, "Initializing local template builder discovery", zap.Error(localErr))
+			}
+		}
 	default: // ServiceDiscoveryProviderNomad
 		nomadClient, nomadErr := nomadapi.NewClient(&nomadapi.Config{
 			Address:  config.NomadAddress,

--- a/packages/orchestrator/pkg/cfg/model.go
+++ b/packages/orchestrator/pkg/cfg/model.go
@@ -23,6 +23,7 @@ const DefaultBusyboxVersion = "1.36.1"
 type BuilderConfig struct {
 	DomainName             string `env:"DOMAIN_NAME"              envDefault:""`
 	FirecrackerVersionsDir string `env:"FIRECRACKER_VERSIONS_DIR" envDefault:"/fc-versions"`
+	FirecrackerNoSeccomp   bool   `env:"FIRECRACKER_NO_SECCOMP"`
 	BusyboxVersion         string `env:"BUSYBOX_VERSION"          envDefault:"1.36.1"`
 	HostBusyboxDir         string `env:"HOST_BUSYBOX_DIR"         envDefault:"/fc-busybox"`
 	HostEnvdPath           string `env:"HOST_ENVD_PATH"           envDefault:"/fc-envd/envd"`

--- a/packages/orchestrator/pkg/cfg/model_test.go
+++ b/packages/orchestrator/pkg/cfg/model_test.go
@@ -20,11 +20,13 @@ func TestParse(t *testing.T) {
 
 	t.Run("embedded structs get overrides", func(t *testing.T) {
 		t.Setenv("SANDBOX_DIR", "/fc-vm2")
+		t.Setenv("FIRECRACKER_NO_SECCOMP", "true")
 
 		config, err := Parse()
 		require.NoError(t, err)
 
 		assert.Equal(t, "/fc-vm2", config.SandboxDir)
+		assert.True(t, config.FirecrackerNoSeccomp)
 	})
 
 	t.Run("network config local flag defaults to false", func(t *testing.T) {

--- a/packages/orchestrator/pkg/sandbox/fc/script_builder.go
+++ b/packages/orchestrator/pkg/sandbox/fc/script_builder.go
@@ -25,9 +25,10 @@ type startScriptArgs struct {
 	DeprecatedSandboxRootfsDir string
 	SandboxRootfsFile          string
 
-	NamespaceID       string
-	FirecrackerPath   string
-	FirecrackerSocket string
+	NamespaceID          string
+	FirecrackerPath      string
+	FirecrackerSocket    string
+	FirecrackerNoSeccomp bool
 }
 
 // StartScriptResult contains the generated script and computed paths
@@ -50,7 +51,7 @@ ln -s {{ .HostRootfsPath }} {{ .DeprecatedSandboxRootfsDir }}/{{ .SandboxRootfsF
 mount -t tmpfs tmpfs {{ .SandboxDir }}/{{ .SandboxKernelDir }} -o X-mount.mkdir &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }}{{ if .FirecrackerNoSeccomp }} --no-seccomp{{ end }} --api-sock {{ .FirecrackerSocket }}`
 
 const startScriptV2 = `mount --make-rprivate / &&
 mount -t tmpfs tmpfs {{ .SandboxDir }} -o X-mount.mkdir &&
@@ -60,7 +61,7 @@ ln -s {{ .HostRootfsPath }} {{ .SandboxDir }}/{{ .SandboxRootfsFile }} &&
 mkdir -p {{ .SandboxDir }}/{{ .SandboxKernelDir }} &&
 ln -s {{ .HostKernelPath }} {{ .SandboxDir }}/{{ .SandboxKernelDir }}/{{ .SandboxKernelFile }} &&
 
-ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }} --api-sock {{ .FirecrackerSocket }}`
+ip netns exec {{ .NamespaceID }} {{ .FirecrackerPath }}{{ if .FirecrackerNoSeccomp }} --no-seccomp{{ end }} --api-sock {{ .FirecrackerSocket }}`
 
 // StartScriptBuilder handles the creation and execution of firecracker start scripts
 type StartScriptBuilder struct {
@@ -103,9 +104,10 @@ func (sb *StartScriptBuilder) buildArgs(
 		SandboxRootfsFile:          artifact.RootfsFileName,
 
 		// FC
-		NamespaceID:       namespaceID,
-		FirecrackerPath:   versions.FirecrackerPath(sb.builderConfig),
-		FirecrackerSocket: files.SandboxFirecrackerSocketPath(),
+		NamespaceID:          namespaceID,
+		FirecrackerPath:      versions.FirecrackerPath(sb.builderConfig),
+		FirecrackerSocket:    files.SandboxFirecrackerSocketPath(),
+		FirecrackerNoSeccomp: sb.builderConfig.FirecrackerNoSeccomp,
 	}
 }
 

--- a/packages/orchestrator/pkg/sandbox/fc/script_builder_test.go
+++ b/packages/orchestrator/pkg/sandbox/fc/script_builder_test.go
@@ -143,6 +143,23 @@ func TestStartScriptBuilder_Build(t *testing.T) {
 	}
 }
 
+func TestStartScriptBuilder_NoSeccomp(t *testing.T) {
+	t.Parallel()
+
+	config, err := cfg.ParseBuilder()
+	require.NoError(t, err)
+	config.FirecrackerNoSeccomp = true
+
+	result, err := NewStartScriptBuilder(config).Build(
+		Config{KernelVersion: "6.1.0", FirecrackerVersion: "1.14.4"},
+		createTestSandboxFiles("test-sandbox", "static-id"),
+		RootfsPaths{TemplateVersion: 2, TemplateID: "template-123", BuildID: "build-456"},
+		"ns-789",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, result.Value, "firecracker --no-seccomp --api-sock")
+}
+
 // createTestSandboxFiles creates a SandboxFiles instance for testing
 func createTestSandboxFiles(sandboxID, staticID string) *storage.SandboxFiles {
 	paths := storage.Paths{


### PR DESCRIPTION
## Problem

A local nested-virtualization development environment runs a real combined orchestrator + template-manager on a fixed loopback endpoint. Two infra behaviors prevented it from completing real template builds.

### Local API discovery never registered a template builder

With `SERVICE_DISCOVERY_PROVIDER=local`, the API registered the local orchestrator node but always returned an empty template-builder discovery list. That remains correct for local development modes without a real builder. When a real local template-manager was present and healthy, however, the API still saw zero builders, so template builds failed with 503/no available template builder.

### Firecracker was killed during the initial snapshot

Under nested arm64 KVM, the current Firecracker build exited with `bad syscall (67)` while serving `/memory/dirty`. That prevented the initial template snapshot and subsequent sandbox launch.

The workaround must be narrowly scoped: globally disabling Firecracker seccomp would weaken normal production and development launches.

## Fix

- Add optional `LOCAL_TEMPLATE_BUILDER_ADDRESS`. When set in local discovery mode, the API registers exactly one fixed template-manager endpoint.
- Validate the address eagerly, including empty hosts, invalid ports, and port zero, so bad configuration fails at startup rather than surfacing later as “no builder available.”
- Add optional `FIRECRACKER_NO_SECCOMP`. When true, generated Firecracker start scripts include `--no-seccomp`.
- Leave both options unset by default. Existing local behavior and production service-discovery paths remain unchanged.

## Validation

- Static discovery tests cover the valid endpoint plus malformed, empty-host, and zero-port inputs.
- Config parsing verifies the no-seccomp flag.
- Script-builder coverage verifies `--no-seccomp` is emitted only when enabled.
- Focused API discovery/config/handler tests pass.
- Orchestrator config and Firecracker script-builder tests pass on Linux arm64.
- Focused golangci-lint reports zero issues.
- Full repo lint reaches only pre-existing failures in `envd/internal/api/auth_test.go` and `orchestrator/cmd/create-build/proxyport_test.go`.
- End-to-end local validation built multiple real templates and launched Firecracker microVM sandboxes.