### PR TITLE
feat(nomad-nodepool-apm): add deployment-aware target plugin

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,7 +363,7 @@ packages/
   db/                   Postgres migrations (goose) + queries (sqlc)
   clickhouse/           ClickHouse schema, batching writers, query clients
   otel-collector/       Collector config
-  nomad-nodepool-apm/   Nomad autoscaler plugin (scale job = node count)
+  nomad-nodepool-apm/   Nomad autoscaler metric and deployment-aware target plugins
   local-dev/            docker-compose local stack + DB seeding
 spec/                   OpenAPI specs (public, edge, dashboard) — codegen sources
 iac/                    Terraform + Nomad jobs (provider-gcp, provider-aws, shared modules)

--- a/packages/nomad-nodepool-apm/Makefile
+++ b/packages/nomad-nodepool-apm/Makefile
@@ -5,13 +5,16 @@ AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
 
 PLUGIN_NAME := nomad-nodepool-apm
+TARGET_PLUGIN_NAME := nomad-deployment-aware-target
 BIN_DIR := bin
 BINARY := $(BIN_DIR)/$(PLUGIN_NAME)
+TARGET_BINARY := $(BIN_DIR)/$(TARGET_PLUGIN_NAME)
 
 .PHONY: build
 build:
 	@mkdir -p $(BIN_DIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BINARY) .
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(TARGET_BINARY) ./cmd/nomad-deployment-aware-target
 
 .PHONY: clean
 clean:
@@ -25,12 +28,17 @@ test:
 upload:
 	$(eval COMMIT_SHA := $(shell git rev-parse --short HEAD))
 	chmod +x $(BINARY)
+	chmod +x $(TARGET_BINARY)
 ifeq ($(PROVIDER),aws)
 	aws s3 cp $(BINARY) "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 	aws s3 cp $(BINARY) "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm.$(COMMIT_SHA)" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+	aws s3 cp $(TARGET_BINARY) "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/nomad-deployment-aware-target" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
+	aws s3 cp $(TARGET_BINARY) "s3://${AWS_BUCKET_PREFIX}fc-env-pipeline/nomad-deployment-aware-target.$(COMMIT_SHA)" --profile ${AWS_PROFILE} --cache-control "no-cache, max-age=0"
 else
 	gcloud storage cp --cache-control="no-cache, max-age=0" $(BINARY) "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm"
 	gcloud storage cp --cache-control="no-cache, max-age=0" $(BINARY) "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/nomad-nodepool-apm.$(COMMIT_SHA)"
+	gcloud storage cp --cache-control="no-cache, max-age=0" $(TARGET_BINARY) "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/nomad-deployment-aware-target"
+	gcloud storage cp --cache-control="no-cache, max-age=0" $(TARGET_BINARY) "gs://${GCP_BUCKET_PREFIX}fc-env-pipeline/nomad-deployment-aware-target.$(COMMIT_SHA)"
 endif
 
 .PHONY: build-and-upload

--- a/packages/nomad-nodepool-apm/README.md
+++ b/packages/nomad-nodepool-apm/README.md
@@ -1,10 +1,15 @@
-# Nomad NodePool APM Plugin
+# Nomad Node Pool Autoscaler Plugins
 
-A custom APM (Application Performance Monitoring) plugin for the [Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler) that provides the count of nodes in a Nomad node pool.
+Custom plugins for the [Nomad Autoscaler](https://github.com/hashicorp/nomad-autoscaler) that keep a service-job allocation count aligned with the number of nodes in a Nomad node pool.
 
 ## Purpose
 
-This plugin enables service jobs to scale their count based on the number of nodes in a specific node pool, effectively replicating the behavior of system jobs while benefiting from proper rolling update support.
+The package builds two plugins because Nomad Autoscaler supports only one plugin type per external binary:
+
+- `nomad-nodepool-apm` reports the number of ready, eligible nodes in a pool.
+- `nomad-deployment-aware-target` fails an active deployment before applying the requested task-group count.
+
+Together they let service jobs replicate system-job placement while retaining rolling updates. The deployment-aware target is used by the `orchestrator-ee` service job. When the task-group count must change, scaling intentionally abandons a conflicting in-progress rollout (Nomad rejects scaling while a deployment is active); Nomad records that deployment as `failed`, rather than `cancelled`. The rollout spawned by the scale itself is left to run, and no deployment is touched when the count already matches. The job sets `auto_revert = false`, so failure does not restore an older version.
 
 ## Usage
 
@@ -25,12 +30,21 @@ GCP_PROJECT_ID=your-project-id make build-and-upload
 In your Nomad Autoscaler configuration:
 
 ```hcl
-apm "nomad-nodepool" {
-  driver = "nomad-nodepool"
+apm "nomad-nodepool-apm" {
+  driver = "nomad-nodepool-apm"
   config = {
     nomad_address = "http://localhost:4646"  # Optional, uses NOMAD_ADDR env var
     nomad_token   = "your-token"             # Optional, uses NOMAD_TOKEN env var
     nomad_region  = "global"                 # Optional
+  }
+}
+
+target "nomad-deployment-aware-target" {
+  driver = "nomad-deployment-aware-target"
+  config = {
+    nomad_address = "http://localhost:4646"
+    nomad_token   = "your-token"
+    nomad_region  = "global"
   }
 }
 ```
@@ -47,9 +61,11 @@ scaling {
     evaluation_interval = "30s"
     cooldown            = "2m"
 
+    target "nomad-deployment-aware-target" {}
+
     check "match_node_count" {
-      source = "nomad-nodepool"
-      query  = "build"  # Node pool name
+      source = "nomad-nodepool-apm"
+      query  = "orchestrator"  # Node pool name
 
       strategy "pass-through" {}  # Use node count directly as desired count
     }
@@ -65,12 +81,18 @@ scaling {
    - Scheduling eligibility: `eligible`
 3. Returns the count as a metric for the autoscaler to use
 4. With the `pass-through` strategy, this count becomes the desired number of allocations
+5. The target serializes scaling per namespaced job and is a no-op when the durable count already matches
+6. When the count must change it fails a conflicting active deployment, rereads the job, and scales with the current job modify index
+7. It verifies the final durable count; the rollout spawned by the scale proceeds normally
+8. Concurrent job or deployment changes are retried from fresh state with a bounded attempt count
+
+Dry-run actions do not fail deployments or write task-group counts.
 
 ## Query Format
 
 The `query` parameter should be the name of the node pool you want to count nodes from.
 
-Example: `query = "build"` will count all ready, eligible nodes in the "build" node pool.
+Example: `query = "orchestrator"` counts all ready, eligible nodes in the `orchestrator` node pool.
 
 ## Configuration Options
 
@@ -80,4 +102,3 @@ Example: `query = "build"` will count all ready, eligible nodes in the "build" n
 | `nomad_token` | Nomad ACL token | `NOMAD_TOKEN` env var |
 | `nomad_region` | Nomad region | Default region |
 | `nomad_namespace` | Nomad namespace | Default namespace |
-

--- a/packages/nomad-nodepool-apm/README.md
+++ b/packages/nomad-nodepool-apm/README.md
@@ -9,7 +9,7 @@ The package builds two plugins because Nomad Autoscaler supports only one plugin
 - `nomad-nodepool-apm` reports the number of ready, eligible nodes in a pool.
 - `nomad-deployment-aware-target` fails an active deployment before applying the requested task-group count.
 
-Together they let service jobs replicate system-job placement while retaining rolling updates. The deployment-aware target is used by the `orchestrator-ee` service job. When the task-group count must change, scaling intentionally abandons a conflicting in-progress rollout (Nomad rejects scaling while a deployment is active); Nomad records that deployment as `failed`, rather than `cancelled`. The rollout spawned by the scale itself is left to run, and no deployment is touched when the count already matches. The job sets `auto_revert = false`, so failure does not restore an older version.
+Together they let service jobs replicate system-job placement while retaining rolling updates. The deployment-aware target is used by the `orchestrator-ee` service job. When the task-group count must change, scaling intentionally abandons a conflicting in-progress rollout (Nomad rejects scaling while a deployment is active); Nomad records that deployment as `failed`, rather than `cancelled`. The rollout spawned by the scale itself is left to run, and no deployment is touched when the count already matches. The target requires `auto_revert = false` on the scaled group (otherwise failing a deployment would restore an older job version and ping-pong); it refuses to scale groups with `auto_revert = true` and returns an error on every attempt.
 
 ## Usage
 

--- a/packages/nomad-nodepool-apm/cmd/nomad-deployment-aware-target/main.go
+++ b/packages/nomad-nodepool-apm/cmd/nomad-deployment-aware-target/main.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins"
+
+	targetplugin "github.com/e2b-dev/infra/packages/nomad-nodepool-apm/target"
+)
+
+func main() {
+	plugins.Serve(factory)
+}
+
+func factory(log hclog.Logger) any {
+	return targetplugin.New(log)
+}

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -1,0 +1,284 @@
+package target
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/plugins/base"
+	targetsdk "github.com/hashicorp/nomad-autoscaler/plugins/target"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+)
+
+const (
+	pluginName  = "nomad-deployment-aware-target"
+	maxAttempts = 5
+	retryDelay  = 10 * time.Millisecond
+
+	// deploymentStatusInitializing is reported by Nomad for a deployment that
+	// has been created but not yet processed; the api package has no constant
+	// for it.
+	deploymentStatusInitializing = "initializing"
+)
+
+var pluginInfo = &base.PluginInfo{Name: pluginName, PluginType: sdk.PluginTypeTarget}
+
+var _ targetsdk.Target = (*Plugin)(nil)
+
+type jobKey struct {
+	namespace string
+	job       string
+}
+
+type Plugin struct {
+	client           *api.Client
+	logger           hclog.Logger
+	defaultNamespace string
+	locksMu          sync.Mutex
+	locks            map[jobKey]*sync.Mutex
+	retryDelay       time.Duration
+}
+
+func New(log hclog.Logger) *Plugin {
+	return &Plugin{logger: log, locks: make(map[jobKey]*sync.Mutex), retryDelay: retryDelay}
+}
+
+func (p *Plugin) SetConfig(config map[string]string) error {
+	cfg := api.DefaultConfig()
+	if value := config["nomad_address"]; value != "" {
+		cfg.Address = value
+	}
+	if value := config["nomad_token"]; value != "" {
+		cfg.SecretID = value
+	}
+	if value := config["nomad_region"]; value != "" {
+		cfg.Region = value
+	}
+	if value := config["nomad_namespace"]; value != "" {
+		cfg.Namespace = value
+	}
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create Nomad client: %w", err)
+	}
+	p.client = client
+	p.defaultNamespace = cfg.Namespace
+
+	return nil
+}
+
+func (p *Plugin) PluginInfo() (*base.PluginInfo, error) {
+	return pluginInfo, nil
+}
+
+func (p *Plugin) Scale(action sdk.ScalingAction, config map[string]string) error {
+	if action.Count == sdk.StrategyActionMetaValueDryRunCount {
+		return nil
+	}
+	if p.client == nil {
+		return errors.New("target plugin is not configured")
+	}
+
+	jobID, group, namespace, err := p.target(config)
+	if err != nil {
+		return err
+	}
+	lock := p.jobLock(jobKey{namespace: namespace, job: jobID})
+	lock.Lock()
+	defer lock.Unlock()
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = p.attemptScale(action, jobID, group, namespace)
+		if lastErr == nil {
+			return nil
+		}
+		p.logger.Warn("scale reconciliation attempt failed",
+			"namespace", namespace, "job", jobID, "group", group, "attempt", attempt, "error", lastErr)
+		if attempt < maxAttempts && p.retryDelay > 0 {
+			time.Sleep(p.retryDelay)
+		}
+	}
+
+	return fmt.Errorf("scale reconciliation exhausted for %s/%s group %q after %d attempts: %w",
+		namespace, jobID, group, maxAttempts, lastErr)
+}
+
+// attemptScale performs one reconciliation pass from fresh state. It is a
+// no-op when the durable count already matches; otherwise it fails a
+// conflicting active deployment (Nomad rejects scaling while one is in
+// progress) or applies and verifies the new count. A nil return means the
+// durable count matches the action; any error is retryable from fresh state.
+func (p *Plugin) attemptScale(action sdk.ScalingAction, jobID, group, namespace string) error {
+	query := &api.QueryOptions{Namespace: namespace}
+	write := &api.WriteOptions{Namespace: namespace}
+
+	job, err := p.readJob(jobID, query)
+	if err != nil {
+		return err
+	}
+	count, err := taskGroupCount(job, group)
+	if err != nil {
+		return err
+	}
+	if count == action.Count {
+		// The durable count already matches. Any active deployment is a
+		// rollout converging to the desired count; leave it alone.
+		return nil
+	}
+
+	deployment, err := p.readDeployment(jobID, query)
+	if err != nil {
+		return err
+	}
+
+	// The count must change, and Nomad rejects scaling while a deployment is
+	// active, so fail the conflicting deployment and restart from fresh state.
+	if activeForJob(job, deployment) {
+		p.logger.Info("failing active deployment before scaling",
+			"namespace", namespace, "job", jobID, "deployment", deployment.ID)
+		if _, _, err := p.client.Deployments().Fail(deployment.ID, write); err != nil {
+			return fmt.Errorf("failed to fail deployment %s: %w", deployment.ID, err)
+		}
+
+		return fmt.Errorf("marked deployment %s failed; rechecking from fresh state", deployment.ID)
+	}
+
+	if job.JobModifyIndex == nil {
+		return fmt.Errorf("job %s/%s has no JobModifyIndex", namespace, jobID)
+	}
+	desired := action.Count
+	req := &api.ScalingRequest{
+		Count:          &desired,
+		Target:         map[string]string{"Job": jobID, "Group": group},
+		Message:        action.Reason,
+		Error:          action.Error,
+		Meta:           action.Meta,
+		JobModifyIndex: *job.JobModifyIndex,
+	}
+	if _, _, err := p.client.Jobs().ScaleWithRequest(jobID, req, write); err != nil {
+		return fmt.Errorf("scale write raced: %w", err)
+	}
+
+	// Verify only the durable count. The scale itself spawns a deployment for
+	// its own rollout; that is expected and left to run.
+	job, err = p.readJob(jobID, query)
+	if err != nil {
+		return err
+	}
+	count, err = taskGroupCount(job, group)
+	if err != nil {
+		return err
+	}
+	if count != action.Count {
+		return fmt.Errorf("count after scale is %d, want %d", count, action.Count)
+	}
+
+	return nil
+}
+
+func (p *Plugin) Status(config map[string]string) (*sdk.TargetStatus, error) {
+	if p.client == nil {
+		return nil, errors.New("target plugin is not configured")
+	}
+	jobID, group, namespace, err := p.target(config)
+	if err != nil {
+		return nil, err
+	}
+	status, _, err := p.client.Jobs().ScaleStatus(jobID, &api.QueryOptions{Namespace: namespace})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read scale status for %s/%s: %w", namespace, jobID, err)
+	}
+	groupStatus, ok := status.TaskGroups[group]
+	if !ok {
+		return nil, fmt.Errorf("task group %q not found", group)
+	}
+	meta := map[string]string{
+		"nomad_autoscaler.target.nomad." + jobID + ".stopped": strconv.FormatBool(status.JobStopped),
+	}
+	if len(groupStatus.Events) > 0 {
+		meta[sdk.TargetStatusMetaKeyLastEvent] = strconv.FormatUint(groupStatus.Events[0].Time, 10)
+	}
+
+	return &sdk.TargetStatus{Ready: !status.JobStopped, Count: int64(groupStatus.Running), Meta: meta}, nil
+}
+
+func (p *Plugin) target(config map[string]string) (string, string, string, error) {
+	jobID := config[sdk.TargetConfigKeyJob]
+	if jobID == "" {
+		return "", "", "", fmt.Errorf("required config key %q not found", sdk.TargetConfigKeyJob)
+	}
+	group := config[sdk.TargetConfigKeyTaskGroup]
+	if group == "" {
+		return "", "", "", fmt.Errorf("required config key %q not found", sdk.TargetConfigKeyTaskGroup)
+	}
+	namespace := config[sdk.TargetConfigKeyNamespace]
+	if namespace == "" {
+		namespace = p.defaultNamespace
+	}
+	if namespace == "" {
+		namespace = api.DefaultNamespace
+	}
+
+	return jobID, group, namespace, nil
+}
+
+func (p *Plugin) jobLock(key jobKey) *sync.Mutex {
+	p.locksMu.Lock()
+	defer p.locksMu.Unlock()
+	if p.locks[key] == nil {
+		p.locks[key] = &sync.Mutex{}
+	}
+
+	return p.locks[key]
+}
+
+func (p *Plugin) readJob(jobID string, query *api.QueryOptions) (*api.Job, error) {
+	job, _, err := p.client.Jobs().Info(jobID, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read job %s/%s: %w", query.Namespace, jobID, err)
+	}
+
+	return job, nil
+}
+
+func (p *Plugin) readDeployment(jobID string, query *api.QueryOptions) (*api.Deployment, error) {
+	deployment, _, err := p.client.Jobs().LatestDeployment(jobID, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read latest deployment for %s/%s: %w", query.Namespace, jobID, err)
+	}
+
+	return deployment, nil
+}
+
+func taskGroupCount(job *api.Job, group string) (int64, error) {
+	for _, taskGroup := range job.TaskGroups {
+		if taskGroup != nil && taskGroup.Name != nil && *taskGroup.Name == group {
+			if taskGroup.Count == nil {
+				return 0, fmt.Errorf("task group %q has no durable count", group)
+			}
+
+			return int64(*taskGroup.Count), nil
+		}
+	}
+
+	return 0, fmt.Errorf("task group %q not found", group)
+}
+
+func activeForJob(job *api.Job, deployment *api.Deployment) bool {
+	if job == nil || job.CreateIndex == nil || deployment == nil || deployment.JobCreateIndex != *job.CreateIndex {
+		return false
+	}
+	switch deployment.Status {
+	case api.DeploymentStatusRunning, api.DeploymentStatusPaused, api.DeploymentStatusBlocked,
+		api.DeploymentStatusUnblocking, api.DeploymentStatusPending, deploymentStatusInitializing:
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -206,6 +206,10 @@ func (p *Plugin) Status(config map[string]string) (*sdk.TargetStatus, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read scale status for %s/%s: %w", namespace, jobID, err)
 	}
+	if status == nil {
+		return nil, fmt.Errorf("nil scale status for %s/%s", namespace, jobID)
+	}
+	// A nil TaskGroups map is safe: indexing it yields ok=false below.
 	groupStatus, ok := status.TaskGroups[group]
 	if !ok {
 		return nil, fmt.Errorf("task group %q not found", group)
@@ -254,6 +258,9 @@ func (p *Plugin) readJob(jobID string, query *api.QueryOptions) (*api.Job, error
 	job, _, err := p.client.Jobs().Info(jobID, query)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read job %s/%s: %w", query.Namespace, jobID, err)
+	}
+	if job == nil {
+		return nil, fmt.Errorf("nil job returned for %s/%s", query.Namespace, jobID)
 	}
 
 	return job, nil

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -27,6 +27,11 @@ const (
 
 var pluginInfo = &base.PluginInfo{Name: pluginName, PluginType: sdk.PluginTypeTarget}
 
+// errAutoRevertEnabled is a configuration error retrying cannot fix: the
+// plugin fails deployments to unblock scaling, and with auto_revert=true
+// Nomad would restore the previous job version on every such failure.
+var errAutoRevertEnabled = errors.New("auto_revert is enabled; " + pluginName + " requires auto_revert=false")
+
 var _ targetsdk.Target = (*Plugin)(nil)
 
 type jobKey struct {
@@ -98,6 +103,9 @@ func (p *Plugin) Scale(action sdk.ScalingAction, config map[string]string) error
 		if lastErr == nil {
 			return nil
 		}
+		if errors.Is(lastErr, errAutoRevertEnabled) {
+			return lastErr
+		}
 		p.logger.Warn("scale reconciliation attempt failed",
 			"namespace", namespace, "job", jobID, "group", group, "attempt", attempt, "error", lastErr)
 		if attempt < maxAttempts && p.retryDelay > 0 {
@@ -130,6 +138,10 @@ func (p *Plugin) attemptScale(action sdk.ScalingAction, jobID, group, namespace 
 		// The durable count already matches. Any active deployment is a
 		// rollout converging to the desired count; leave it alone.
 		return nil
+	}
+
+	if autoRevertEnabled(job, group) {
+		return fmt.Errorf("%w: job %s/%s group %q", errAutoRevertEnabled, namespace, jobID, group)
 	}
 
 	deployment, err := p.readDeployment(jobID, query)
@@ -268,6 +280,26 @@ func taskGroupCount(job *api.Job, group string) (int64, error) {
 	}
 
 	return 0, fmt.Errorf("task group %q not found", group)
+}
+
+// autoRevertEnabled reports whether the target task group has
+// auto_revert=true in its update strategy. Nomad canonicalizes the job-level
+// update block into each group, but the job-level strategy is still consulted
+// as a fallback.
+func autoRevertEnabled(job *api.Job, group string) bool {
+	var update *api.UpdateStrategy
+	for _, taskGroup := range job.TaskGroups {
+		if taskGroup != nil && taskGroup.Name != nil && *taskGroup.Name == group {
+			update = taskGroup.Update
+
+			break
+		}
+	}
+	if update == nil {
+		update = job.Update
+	}
+
+	return update != nil && update.AutoRevert != nil && *update.AutoRevert
 }
 
 func activeForJob(job *api.Job, deployment *api.Deployment) bool {

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -3,6 +3,7 @@ package target
 import (
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"strconv"
 	"sync"
 	"time"
@@ -109,7 +110,9 @@ func (p *Plugin) Scale(action sdk.ScalingAction, config map[string]string) error
 		p.logger.Warn("scale reconciliation attempt failed",
 			"namespace", namespace, "job", jobID, "group", group, "attempt", attempt, "error", lastErr)
 		if attempt < maxAttempts && p.retryDelay > 0 {
-			time.Sleep(p.retryDelay)
+			// Jitter in [retryDelay, 2*retryDelay) so concurrent scalers
+			// hitting CAS conflicts do not retry in lockstep.
+			time.Sleep(p.retryDelay + rand.N(p.retryDelay))
 		}
 	}
 

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -279,6 +279,9 @@ func (p *Plugin) readDeployment(jobID string, query *api.QueryOptions) (*api.Dep
 }
 
 func taskGroupCount(job *api.Job, group string) (int64, error) {
+	if job == nil {
+		return 0, errors.New("nil job")
+	}
 	for _, taskGroup := range job.TaskGroups {
 		if taskGroup != nil && taskGroup.Name != nil && *taskGroup.Name == group {
 			if taskGroup.Count == nil {
@@ -297,6 +300,9 @@ func taskGroupCount(job *api.Job, group string) (int64, error) {
 // update block into each group, but the job-level strategy is still consulted
 // as a fallback.
 func autoRevertEnabled(job *api.Job, group string) bool {
+	if job == nil {
+		return false
+	}
 	var update *api.UpdateStrategy
 	for _, taskGroup := range job.TaskGroups {
 		if taskGroup != nil && taskGroup.Name != nil && *taskGroup.Name == group {

--- a/packages/nomad-nodepool-apm/target/plugin_test.go
+++ b/packages/nomad-nodepool-apm/target/plugin_test.go
@@ -22,6 +22,7 @@ type nomadStub struct {
 	mu                      sync.Mutex
 	count                   int
 	jobModifyIndex          uint64
+	autoRevert              *bool
 	deployment              *api.Deployment
 	scaleConflicts          int
 	injectDeploymentOnScale bool
@@ -137,12 +138,17 @@ func (s *nomadStub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *nomadStub) job() *api.Job {
+	taskGroup := api.NewTaskGroup("web", s.count)
+	if s.autoRevert != nil {
+		taskGroup.Update = &api.UpdateStrategy{AutoRevert: s.autoRevert}
+	}
+
 	return &api.Job{
 		ID:             new("example"),
 		Namespace:      new(testNamespace),
 		CreateIndex:    new(uint64(10)),
 		JobModifyIndex: new(s.jobModifyIndex),
-		TaskGroups:     []*api.TaskGroup{api.NewTaskGroup("web", s.count)},
+		TaskGroups:     []*api.TaskGroup{taskGroup},
 	}
 }
 
@@ -357,6 +363,68 @@ func TestScaleRetriesWhenDeploymentAppearsBeforeWrite(t *testing.T) {
 	rollout := stub.deploymentSnapshot()
 	if rollout == nil || rollout.ID == "deployment-injected" || rollout.Status != api.DeploymentStatusRunning {
 		t.Fatalf("rollout deployment spawned by the retried scale was not left running: %#v", rollout)
+	}
+}
+
+func TestScaleRefusesAutoRevertJob(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.autoRevert = new(true)
+	stub.deployment = &api.Deployment{
+		ID:             "deployment-1",
+		JobID:          "example",
+		Namespace:      testNamespace,
+		JobCreateIndex: 10,
+		Status:         api.DeploymentStatusRunning,
+		CreateIndex:    30,
+		ModifyIndex:    31,
+	}
+	p := newTestPlugin(t, stub)
+
+	err := p.Scale(sdk.ScalingAction{Count: 4}, targetConfig())
+	if err == nil || !strings.Contains(err.Error(), "auto_revert") {
+		t.Fatalf("Scale error = %v, want auto_revert configuration error", err)
+	}
+
+	calls, requests := stub.snapshot()
+	// The guard trips before any deployment read or mutation, and the error
+	// is terminal so there is no retry.
+	wantCalls := []string{"GET /v1/job/example"}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("scale requests = %d, want 0", len(requests))
+	}
+	rollout := stub.deploymentSnapshot()
+	if rollout.Status != api.DeploymentStatusRunning {
+		t.Fatalf("deployment of auto_revert job was disturbed: %#v", rollout)
+	}
+}
+
+func TestScaleAutoRevertJobNoOpWhenCountMatches(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.autoRevert = new(true)
+	stub.count = 4
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 4}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+}
+
+func TestScaleAllowsExplicitAutoRevertFalse(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.autoRevert = new(false)
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 5}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
 	}
 }
 

--- a/packages/nomad-nodepool-apm/target/plugin_test.go
+++ b/packages/nomad-nodepool-apm/target/plugin_test.go
@@ -1,0 +1,451 @@
+package target
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/hashicorp/nomad/api"
+)
+
+const testNamespace = "workloads"
+
+type nomadStub struct {
+	t                       *testing.T
+	mu                      sync.Mutex
+	count                   int
+	jobModifyIndex          uint64
+	deployment              *api.Deployment
+	scaleConflicts          int
+	injectDeploymentOnScale bool
+	scaleDeployments        int
+	calls                   []string
+	scaleRequests           []api.ScalingRequest
+	status                  api.JobScaleStatusResponse
+}
+
+func newNomadStub(t *testing.T) *nomadStub {
+	t.Helper()
+
+	return &nomadStub{
+		t:              t,
+		count:          2,
+		jobModifyIndex: 20,
+		status: api.JobScaleStatusResponse{
+			JobID:      "example",
+			Namespace:  testNamespace,
+			JobStopped: true,
+			TaskGroups: map[string]api.TaskGroupScaleStatus{
+				"web": {Running: 2, Events: []api.ScalingEvent{{Time: 12345}}},
+			},
+		},
+	}
+}
+
+func (s *nomadStub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if got := r.URL.Query().Get("namespace"); got != testNamespace {
+		http.Error(w, "wrong namespace "+got, http.StatusBadRequest)
+
+		return
+	}
+	s.calls = append(s.calls, r.Method+" "+r.URL.Path)
+	w.Header().Set("Content-Type", "application/json")
+
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/job/example":
+		writeJSON(s.t, w, s.job())
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/job/example/deployment":
+		writeJSON(s.t, w, s.deployment)
+	case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/deployment/fail/"):
+		id := strings.TrimPrefix(r.URL.Path, "/v1/deployment/fail/")
+		if s.deployment != nil && s.deployment.ID == id {
+			s.deployment.Status = api.DeploymentStatusFailed
+			s.deployment.ModifyIndex++
+		}
+		writeJSON(s.t, w, map[string]any{})
+	case r.Method == http.MethodPut && r.URL.Path == "/v1/job/example/scale":
+		var req api.ScalingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			s.t.Errorf("decode scale request: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+		s.scaleRequests = append(s.scaleRequests, req)
+		if s.injectDeploymentOnScale {
+			// Simulate a deployment appearing between the plugin's read and
+			// its scale write.
+			s.injectDeploymentOnScale = false
+			s.deployment = &api.Deployment{
+				ID:             "deployment-injected",
+				JobID:          "example",
+				Namespace:      testNamespace,
+				JobCreateIndex: 10,
+				Status:         api.DeploymentStatusRunning,
+				CreateIndex:    40,
+				ModifyIndex:    41,
+			}
+			http.Error(w, "job scaling blocked due to active deployment", http.StatusBadRequest)
+
+			return
+		}
+		if deploymentActive(s.deployment) {
+			// Real Nomad rejects scaling while a deployment is in progress.
+			http.Error(w, "job scaling blocked due to active deployment", http.StatusBadRequest)
+
+			return
+		}
+		if s.scaleConflicts > 0 {
+			s.scaleConflicts--
+			s.jobModifyIndex++
+			http.Error(w, "job modify index conflict", http.StatusConflict)
+
+			return
+		}
+		if req.Count != nil {
+			s.count = int(*req.Count)
+		}
+		s.jobModifyIndex++
+		// Real Nomad registers a new job version and spawns a deployment to
+		// roll out the new count (for jobs with an update stanza).
+		s.scaleDeployments++
+		s.deployment = &api.Deployment{
+			ID:             fmt.Sprintf("deployment-scale-%d", s.scaleDeployments),
+			JobID:          "example",
+			Namespace:      testNamespace,
+			JobCreateIndex: 10,
+			Status:         api.DeploymentStatusRunning,
+			CreateIndex:    50 + uint64(s.scaleDeployments),
+			ModifyIndex:    50 + uint64(s.scaleDeployments),
+		}
+		writeJSON(s.t, w, map[string]any{})
+	case r.Method == http.MethodGet && r.URL.Path == "/v1/job/example/scale":
+		writeJSON(s.t, w, s.status)
+	default:
+		http.Error(w, "unexpected request", http.StatusNotFound)
+	}
+}
+
+func (s *nomadStub) job() *api.Job {
+	return &api.Job{
+		ID:             new("example"),
+		Namespace:      new(testNamespace),
+		CreateIndex:    new(uint64(10)),
+		JobModifyIndex: new(s.jobModifyIndex),
+		TaskGroups:     []*api.TaskGroup{api.NewTaskGroup("web", s.count)},
+	}
+}
+
+func (s *nomadStub) snapshot() ([]string, []api.ScalingRequest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return append([]string(nil), s.calls...), append([]api.ScalingRequest(nil), s.scaleRequests...)
+}
+
+func (s *nomadStub) deploymentSnapshot() *api.Deployment {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.deployment == nil {
+		return nil
+	}
+	copied := *s.deployment
+
+	return &copied
+}
+
+func deploymentActive(deployment *api.Deployment) bool {
+	if deployment == nil {
+		return false
+	}
+	switch deployment.Status {
+	case api.DeploymentStatusRunning, api.DeploymentStatusPaused, api.DeploymentStatusBlocked,
+		api.DeploymentStatusUnblocking, api.DeploymentStatusPending, deploymentStatusInitializing:
+		return true
+	default:
+		return false
+	}
+}
+
+func newTestPlugin(t *testing.T, stub *nomadStub) *Plugin {
+	t.Helper()
+	server := httptest.NewServer(stub)
+	t.Cleanup(server.Close)
+
+	p := New(hclog.NewNullLogger())
+	p.retryDelay = 0
+	if err := p.SetConfig(map[string]string{
+		"nomad_address":   server.URL,
+		"nomad_namespace": "configured-default",
+	}); err != nil {
+		t.Fatalf("SetConfig: %v", err)
+	}
+
+	return p
+}
+
+func targetConfig() map[string]string {
+	return map[string]string{
+		sdk.TargetConfigKeyJob:       "example",
+		sdk.TargetConfigKeyTaskGroup: "web",
+		sdk.TargetConfigKeyNamespace: testNamespace,
+	}
+}
+
+func TestScaleNormal(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	p := newTestPlugin(t, stub)
+	action := sdk.ScalingAction{
+		Count:  5,
+		Reason: "load increased",
+		Error:  true,
+		Meta:   map[string]any{"policy": "web"},
+	}
+
+	if err := p.Scale(action, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+
+	calls, requests := stub.snapshot()
+	wantCalls := []string{
+		"GET /v1/job/example",
+		"GET /v1/job/example/deployment",
+		"PUT /v1/job/example/scale",
+		"GET /v1/job/example",
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("scale request count = %d, want 1", len(requests))
+	}
+	req := requests[0]
+	if req.Count == nil || *req.Count != 5 || req.JobModifyIndex != 20 {
+		t.Fatalf("scale request count/index = %v/%d", req.Count, req.JobModifyIndex)
+	}
+	if req.Message != action.Reason || req.Error != action.Error || !reflect.DeepEqual(req.Meta, action.Meta) {
+		t.Fatalf("scale action fields not preserved: %#v", req)
+	}
+	rollout := stub.deploymentSnapshot()
+	if rollout == nil || rollout.Status != api.DeploymentStatusRunning {
+		t.Fatalf("rollout deployment spawned by the scale was not left running: %#v", rollout)
+	}
+}
+
+func TestScaleFailsActiveDeploymentBeforeScaling(t *testing.T) {
+	t.Parallel()
+
+	statuses := []string{
+		api.DeploymentStatusRunning,
+		api.DeploymentStatusPaused,
+		api.DeploymentStatusBlocked,
+		api.DeploymentStatusUnblocking,
+		api.DeploymentStatusPending,
+		deploymentStatusInitializing,
+	}
+	for _, status := range statuses {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			stub := newNomadStub(t)
+			stub.deployment = &api.Deployment{
+				ID:             "deployment-1",
+				JobID:          "example",
+				Namespace:      testNamespace,
+				JobCreateIndex: 10,
+				Status:         status,
+				CreateIndex:    30,
+				ModifyIndex:    31,
+			}
+			p := newTestPlugin(t, stub)
+
+			if err := p.Scale(sdk.ScalingAction{Count: 4}, targetConfig()); err != nil {
+				t.Fatalf("Scale: %v", err)
+			}
+
+			calls, _ := stub.snapshot()
+			wantCalls := []string{
+				"GET /v1/job/example",
+				"GET /v1/job/example/deployment",
+				"PUT /v1/deployment/fail/deployment-1",
+				"GET /v1/job/example",
+				"GET /v1/job/example/deployment",
+				"PUT /v1/job/example/scale",
+				"GET /v1/job/example",
+			}
+			if !reflect.DeepEqual(calls, wantCalls) {
+				t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+			}
+			rollout := stub.deploymentSnapshot()
+			if rollout == nil || rollout.ID == "deployment-1" || rollout.Status != api.DeploymentStatusRunning {
+				t.Fatalf("rollout deployment spawned by the scale was not left running: %#v", rollout)
+			}
+		})
+	}
+}
+
+func TestScaleLeavesOwnRolloutAloneWhenCountMatches(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.count = 4
+	stub.deployment = &api.Deployment{
+		ID:             "deployment-1",
+		JobID:          "example",
+		Namespace:      testNamespace,
+		JobCreateIndex: 10,
+		Status:         api.DeploymentStatusRunning,
+		CreateIndex:    30,
+		ModifyIndex:    31,
+	}
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 4}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+
+	calls, requests := stub.snapshot()
+	wantCalls := []string{"GET /v1/job/example"}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("scale requests = %d, want 0", len(requests))
+	}
+	rollout := stub.deploymentSnapshot()
+	if rollout.Status != api.DeploymentStatusRunning {
+		t.Fatalf("in-flight rollout was disturbed: %#v", rollout)
+	}
+}
+
+func TestScaleRetriesWhenDeploymentAppearsBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.injectDeploymentOnScale = true
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 6}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+
+	calls, requests := stub.snapshot()
+	if len(requests) != 2 {
+		t.Fatalf("scale request count = %d, want 2", len(requests))
+	}
+	failedInjected := false
+	for _, call := range calls {
+		if call == "PUT /v1/deployment/fail/deployment-injected" {
+			failedInjected = true
+		}
+	}
+	if !failedInjected {
+		t.Fatalf("conflicting deployment was not failed before retrying: %#v", calls)
+	}
+	rollout := stub.deploymentSnapshot()
+	if rollout == nil || rollout.ID == "deployment-injected" || rollout.Status != api.DeploymentStatusRunning {
+		t.Fatalf("rollout deployment spawned by the retried scale was not left running: %#v", rollout)
+	}
+}
+
+func TestScaleLeavesTerminalDeploymentAlone(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.deployment = &api.Deployment{
+		ID:             "deployment-1",
+		JobCreateIndex: 10,
+		Status:         api.DeploymentStatusSuccessful,
+	}
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 3}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+
+	calls, _ := stub.snapshot()
+	for _, call := range calls {
+		if strings.HasPrefix(call, "PUT /v1/deployment/fail/") {
+			t.Fatal("terminal deployment was failed")
+		}
+	}
+}
+
+func TestScaleDryRunDoesNotReadOrWrite(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.deployment = &api.Deployment{
+		ID:             "deployment-1",
+		JobCreateIndex: 10,
+		Status:         api.DeploymentStatusRunning,
+	}
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: sdk.StrategyActionMetaValueDryRunCount}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+	if calls, _ := stub.snapshot(); len(calls) != 0 {
+		t.Fatalf("dry run made requests: %#v", calls)
+	}
+}
+
+func TestScaleRetriesCASRaceFromFreshJob(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	stub.scaleConflicts = 1
+	p := newTestPlugin(t, stub)
+
+	if err := p.Scale(sdk.ScalingAction{Count: 6}, targetConfig()); err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+
+	_, requests := stub.snapshot()
+	if len(requests) != 2 {
+		t.Fatalf("scale request count = %d, want 2", len(requests))
+	}
+	if requests[0].JobModifyIndex != 20 || requests[1].JobModifyIndex != 21 {
+		t.Fatalf("CAS indexes = %d, %d; want 20, 21", requests[0].JobModifyIndex, requests[1].JobModifyIndex)
+	}
+}
+
+func TestStatusPreservesNomadTargetSemantics(t *testing.T) {
+	t.Parallel()
+
+	stub := newNomadStub(t)
+	p := newTestPlugin(t, stub)
+
+	status, err := p.Status(targetConfig())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if status.Ready || status.Count != 2 {
+		t.Fatalf("status ready/count = %v/%d", status.Ready, status.Count)
+	}
+	if status.Meta["nomad_autoscaler.target.nomad.example.stopped"] != "true" {
+		t.Fatalf("stopped meta = %#v", status.Meta)
+	}
+	if status.Meta[sdk.TargetStatusMetaKeyLastEvent] != "12345" {
+		t.Fatalf("last event meta = %#v", status.Meta)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Errorf("encode response: %v", err)
+	}
+}


### PR DESCRIPTION
Adds a Nomad Autoscaler target plugin that fails a conflicting active deployment before changing a task group count (Nomad rejects scaling while a deployment is in progress). Scaling is serialized per namespaced job and retried from fresh state on races.

The plugin is a no-op when the durable count already matches, and the convergence check ignores the rollout deployment spawned by its own scale, so in-flight rollouts converging to the right count are never failed.