### PR TITLE
fix(orchestrator): pin tap device host-side MAC address

### DIFF
--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -208,10 +208,21 @@ func (s *Slot) CreateNetwork(ctx context.Context) (retErr error) {
 		Mode:      netlink.TUNTAP_MODE_TAP,
 		LinkAttrs: tapAttrs,
 	}
+	tapHostHardwareAddr, err := net.ParseMAC(tapHostMAC)
+	if err != nil {
+		return fmt.Errorf("error parsing tap host MAC address: %w", err)
+	}
 
 	err = netlink.LinkAdd(tap)
 	if err != nil {
 		return fmt.Errorf("error creating tap device: %w", err)
+	}
+
+	// Keep resumed guests' cached gateway ARP entries valid. Tap devices are
+	// isolated in per-sandbox network namespaces, so sharing this MAC is safe.
+	err = netlink.LinkSetHardwareAddr(tap, tapHostHardwareAddr)
+	if err != nil {
+		return fmt.Errorf("error setting tap device hardware address: %w", err)
 	}
 
 	err = netlink.LinkSetUp(tap)

--- a/packages/orchestrator/pkg/sandbox/network/network.go
+++ b/packages/orchestrator/pkg/sandbox/network/network.go
@@ -208,10 +208,6 @@ func (s *Slot) CreateNetwork(ctx context.Context) (retErr error) {
 		Mode:      netlink.TUNTAP_MODE_TAP,
 		LinkAttrs: tapAttrs,
 	}
-	tapHostHardwareAddr, err := net.ParseMAC(tapHostMAC)
-	if err != nil {
-		return fmt.Errorf("error parsing tap host MAC address: %w", err)
-	}
 
 	err = netlink.LinkAdd(tap)
 	if err != nil {

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -39,9 +39,10 @@ const (
 )
 
 var (
-	hostNetworkCIDR = getHostNetworkCIDR()
-	vrtNetworkCIDR  = getVrtNetworkCIDR()
-	vrtSlotsSize    = GetVrtSlotsSize()
+	hostNetworkCIDR     = getHostNetworkCIDR()
+	vrtNetworkCIDR      = getVrtNetworkCIDR()
+	vrtSlotsSize        = GetVrtSlotsSize()
+	tapHostHardwareAddr = getTapHostHardwareAddr()
 )
 
 // Slot network allocation
@@ -389,6 +390,18 @@ func getHostNetworkCIDR() *net.IPNet {
 	log.Println("Using host network cidr", "cidr", cidr)
 
 	return subnet
+}
+
+// getTapHostHardwareAddr parses the fixed tapHostMAC constant once at package
+// init, so CreateNetwork doesn't reparse a value that can never change or
+// fail at runtime.
+func getTapHostHardwareAddr() net.HardwareAddr {
+	addr, err := net.ParseMAC(tapHostMAC)
+	if err != nil {
+		log.Fatalf("Failed to parse tap host MAC address %s: %v", tapHostMAC, err)
+	}
+
+	return addr
 }
 
 func getVrtNetworkCIDR() *net.IPNet {

--- a/packages/orchestrator/pkg/sandbox/network/slot.go
+++ b/packages/orchestrator/pkg/sandbox/network/slot.go
@@ -35,6 +35,7 @@ const (
 	tapInterfaceName = "tap0"
 	tapIp            = "169.254.0.22"
 	tapMAC           = "02:FC:00:00:00:05"
+	tapHostMAC       = "02:FC:00:00:00:06"
 )
 
 var (


### PR DESCRIPTION
Every sandbox resume creates a fresh tap device, and its host-side MAC was left to the kernel's random default. A resumed guest's frozen ARP cache still points at the old MAC for its gateway, so retransmits get silently dropped at the tap's own frame filter until the stale entry times out and re-resolves (Firecracker's own docs call this out as a known resume hazard). Pin it to a fixed constant, same pattern already used for the guest-facing MAC — taps are isolated per sandbox netns and never bridged, so a shared value is safe.