### PR TITLE
fix(orchestrator): suppress EIO/ENXIO on sandbox cleanup after VM crash

### DIFF
--- a/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"syscall"
 
 	"go.uber.org/zap"
 
@@ -135,13 +134,7 @@ func (o *NBDProvider) Close(ctx context.Context) error {
 
 	err := o.sync(ctx)
 	if err != nil {
-		if errors.Is(err, syscall.EIO) {
-			// EIO means the NBD device is already in error state — the VM likely
-			// crashed before cleanup. Nothing to flush; log and continue.
-			logger.L().Warn(ctx, "error flushing cow device (VM likely crashed, ignoring EIO)", zap.Error(err))
-		} else {
-			errs = append(errs, fmt.Errorf("error flushing cow device: %w", err))
-		}
+		errs = append(errs, fmt.Errorf("error flushing cow device: %w", err))
 	}
 
 	err = o.mnt.Close(ctx)

--- a/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
+++ b/packages/orchestrator/pkg/sandbox/rootfs/nbd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -134,7 +135,13 @@ func (o *NBDProvider) Close(ctx context.Context) error {
 
 	err := o.sync(ctx)
 	if err != nil {
-		errs = append(errs, fmt.Errorf("error flushing cow device: %w", err))
+		if errors.Is(err, syscall.EIO) {
+			// EIO means the NBD device is already in error state — the VM likely
+			// crashed before cleanup. Nothing to flush; log and continue.
+			logger.L().Warn(ctx, "error flushing cow device (VM likely crashed, ignoring EIO)", zap.Error(err))
+		} else {
+			errs = append(errs, fmt.Errorf("error flushing cow device: %w", err))
+		}
 	}
 
 	err = o.mnt.Close(ctx)

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"syscall"
 	"time"
 
 	"github.com/google/uuid"
@@ -1106,7 +1107,15 @@ func (s *Server) setupSandboxLifecycle(ctx context.Context, sbx *sandbox.Sandbox
 
 		cleanupErr := sbx.Close(ctx)
 		if cleanupErr != nil {
-			sbxlogger.I(sbx).Error(ctx, "failed to cleanup sandbox, will remove from cache", zap.Error(cleanupErr))
+			if errors.Is(cleanupErr, syscall.EIO) || errors.Is(cleanupErr, syscall.ENXIO) {
+				// After a VM crash the NBD device is in error state. sync() on
+				// /dev/nbdX returns EIO (device error) or ENXIO (device already
+				// disconnected). Both are expected here — no data is lost because
+				// the VM already exited. Log at Warn and continue cleanup.
+				sbxlogger.I(sbx).Warn(ctx, "failed to flush sandbox device after VM crash (ignoring)", zap.Error(cleanupErr))
+			} else {
+				sbxlogger.I(sbx).Error(ctx, "failed to cleanup sandbox, will remove from cache", zap.Error(cleanupErr))
+			}
 		}
 
 		closeErr := s.proxy.RemoveFromPool(sbx.LifecycleID)


### PR DESCRIPTION
## Summary

Closes #3273

When a VM crashes or is OOM-killed, `NBDProvider.Close()` calls `sync()` which issues `BLKFLSBUF ioctl + fsync` on `/dev/nbdX`. Because the NBD device is already in error state after the VM dies, the kernel returns:

- `EIO` — device is in error state (broken NBD connection)
- `ENXIO` — device is already disconnected/cleared

Both are expected — there is nothing to flush because the VM is gone. This caused every abnormal VM exit to emit a spurious ERROR:

```
level=error msg="failed to cleanup sandbox, will remove from cache"
  error="failed to cleanup sandbox: error flushing cow device: failed to fsync path: input/output error"
```

## Why not suppress in `NBDProvider.Close()` directly?

The initial approach (commit `82a2ec2`) caught `EIO` in `NBDProvider.Close()` itself. This was flagged by code review ([Codex](https://github.com/e2b-dev/infra/pull/3276#pullrequestreview-2991889987)) as too broad: `Sandbox.Shutdown()` also calls `s.Close()` with the explicit comment `"This should properly flush rootfs to the underlying device"` — a genuine `EIO` there (e.g. host disk full) must still propagate as an error or a corrupt template could be silently published.

## Actual fix

Handle `EIO`/`ENXIO` in `setupSandboxLifecycle()` in `sandboxes.go` — the **only** call site that is guaranteed to run after VM exit. The `Sandbox.Shutdown()` path is unaffected and still treats `EIO` as a hard error.

**`packages/orchestrator/pkg/server/sandboxes.go`**:
```go
// Before
cleanupErr := sbx.Close(ctx)
if cleanupErr != nil {
    sbxlogger.I(sbx).Error(ctx, "failed to cleanup sandbox, will remove from cache", zap.Error(cleanupErr))
}

// After
cleanupErr := sbx.Close(ctx)
if cleanupErr != nil {
    if errors.Is(cleanupErr, syscall.EIO) || errors.Is(cleanupErr, syscall.ENXIO) {
        // After a VM crash the NBD device is in error state. sync() on
        // /dev/nbdX returns EIO (device error) or ENXIO (device already
        // disconnected). Both are expected — no data is lost because
        // the VM already exited.
        sbxlogger.I(sbx).Warn(ctx, "failed to flush sandbox device after VM crash (ignoring)", zap.Error(cleanupErr))
    } else {
        sbxlogger.I(sbx).Error(ctx, "failed to cleanup sandbox, will remove from cache", zap.Error(cleanupErr))
    }
}
```

## Before / After

**Before** (every abnormal VM exit):
```
level=error msg="failed to cleanup sandbox, will remove from cache"
  error="failed to cleanup sandbox: error flushing cow device: failed to fsync path: input/output error"
```

**After**:
```
level=warn msg="failed to flush sandbox device after VM crash (ignoring)"
  error="failed to cleanup sandbox: error flushing cow device: failed to fsync path: input/output error"
```

Real non-EIO/ENXIO failures still surface at ERROR.

## Test plan

- [ ] Kill a Firecracker VM with `kill -9`; confirm no ERROR log for `"failed to cleanup sandbox"` and a WARN appears instead
- [ ] Normal `Sandbox.Shutdown()` (pause/snapshot): confirm a genuine disk error still propagates as ERROR

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.