### PR TITLE
fix(orchestrator): downgrade expected VM-exit cascade errors from ERROR to Warn

### DIFF
--- a/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
+++ b/packages/orchestrator/pkg/sandbox/fc/fc_metrics.go
@@ -285,6 +285,14 @@ func (p *Process) startMetricsReader(ctx context.Context) {
 			case <-p.Exit.Done():
 				return
 			case <-ticker.C:
+				// Guard against the race where Exit.Done() and ticker.C are
+				// both ready simultaneously: Go selects randomly, so we may
+				// land here even though the process has already exited.
+				select {
+				case <-p.Exit.Done():
+					return
+				default:
+				}
 				if err := p.client.flushMetrics(ctx); err != nil {
 					logger.L().Warn(ctx, "failed to flush fc metrics",
 						zap.Error(err),

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -333,14 +333,22 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 			// Per-request backend failure: signal it to the NBD client via the
 			// response error byte and keep the dispatch loop alive. Only
 			// writeResponse errors (dead NBD socket) escalate through d.fatal.
-			logger.L().Error(ctx, "nbd backend read failed",
+			//
+			// context.Canceled/DeadlineExceeded means the sandbox is shutting
+			// down; that's expected, so log at Warn rather than Error.
+			fields := []zap.Field{
 				zap.Error(readErr),
 				zap.String("nbd_op", "read"),
 				zap.String("nbd_provider", d.provName),
 				zap.Uint64("nbd_handle", handle),
 				zap.Uint64("nbd_offset", from),
 				zap.Uint32("nbd_length", length),
-			)
+			}
+			if errors.Is(readErr, context.Canceled) || errors.Is(readErr, context.DeadlineExceeded) {
+				logger.L().Warn(ctx, "nbd backend read cancelled (sandbox exiting)", fields...)
+			} else {
+				logger.L().Error(ctx, "nbd backend read failed", fields...)
+			}
 
 			return d.writeResponse(1, handle, []byte{})
 		}
@@ -355,7 +363,10 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 			select {
 			case d.fatal <- err:
 			default:
-				logger.L().Error(ctx, "nbd error cmd read",
+				// fatal channel full: shutdown already in progress.
+				// Downgrade to Warn since this is a response-write failure
+				// on a closing socket, not a new independent failure.
+				logger.L().Warn(ctx, "nbd error cmd read",
 					zap.Error(err),
 					zap.String("nbd_op", "read"),
 					zap.String("nbd_provider", d.provName),
@@ -400,14 +411,19 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 		}
 
 		if writeErr != nil {
-			logger.L().Error(ctx, "nbd backend write failed",
+			fields := []zap.Field{
 				zap.Error(writeErr),
 				zap.String("nbd_op", "write"),
 				zap.String("nbd_provider", d.provName),
 				zap.Uint64("nbd_handle", handle),
 				zap.Uint64("nbd_offset", from),
 				zap.Int("nbd_length", len(data)),
-			)
+			}
+			if errors.Is(writeErr, context.Canceled) || errors.Is(writeErr, context.DeadlineExceeded) {
+				logger.L().Warn(ctx, "nbd backend write cancelled (sandbox exiting)", fields...)
+			} else {
+				logger.L().Error(ctx, "nbd backend write failed", fields...)
+			}
 
 			return d.writeResponse(1, handle, []byte{})
 		}
@@ -422,7 +438,7 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 			select {
 			case d.fatal <- err:
 			default:
-				logger.L().Error(ctx, "nbd error cmd write",
+				logger.L().Warn(ctx, "nbd error cmd write",
 					zap.Error(err),
 					zap.String("nbd_op", "write"),
 					zap.String("nbd_provider", d.provName),


### PR DESCRIPTION
## Summary

Closes #3274  
Closes #3275

After a Firecracker VM exits (normally or abnormally), two sources of spurious ERROR-level logs appear:

1. **NBD dispatch** (`dispatch.go`): In-flight reads/writes fail with `context.Canceled` and response writes fail with `use of closed network connection` / `broken pipe`. All were logged at ERROR, generating noise that drowns out real backend failures.

2. **FC metrics flusher** (`fc_metrics.go`): A Go `select` race between `p.Exit.Done()` and `ticker.C` can cause `flushMetrics()` to be called against a dead Firecracker socket, emitting a spurious `"failed to flush fc metrics: connection reset by peer"` Warn log even after the process has exited.

## Changes

**`packages/orchestrator/pkg/sandbox/nbd/dispatch.go`**
- `nbd backend read/write failed`: downgrade to Warn when `errors.Is(err, context.Canceled || context.DeadlineExceeded)`; keep ERROR for real backend failures
- `nbd error cmd read/write` (fatal-channel-full path): downgrade to Warn; by the time this path is reached, shutdown is already in progress

**`packages/orchestrator/pkg/sandbox/fc/fc_metrics.go`**
- After `case <-ticker.C` fires, add a non-blocking `select { case <-p.Exit.Done(): return; default: }` guard to handle the race where both channels are simultaneously ready

## Before / After

**Before** (every sandbox teardown with in-flight I/O):
```
level=error msg="nbd backend read failed"  error="context canceled"
level=error msg="nbd error cmd read"       error="write unix @->@: use of closed network connection"
level=error msg="nbd backend write failed" error="context canceled"
level=error msg="nbd error cmd write"      error="write unix @->@: write: broken pipe"
level=warn  msg="failed to flush fc metrics" error="connection reset by peer"   ← still emitted after process exit
```

**After**:
```
level=warn msg="nbd backend read cancelled (sandbox exiting)"  error="context canceled"
level=warn msg="nbd error cmd read"   error="use of closed network connection"
level=warn msg="nbd backend write cancelled (sandbox exiting)" error="context canceled"
level=warn msg="nbd error cmd write"  error="broken pipe"
                                                               ← fc metrics flush suppressed after process exit
```

Real backend errors (non-canceled) still surface at ERROR level.

## Test plan

- [x] Kill a Firecracker VM with `kill -9` while I/O is in-flight; confirm no ERROR logs for `nbd backend read/write failed` with `context canceled`
- [x] Confirm real NBD backend errors (e.g. backing store returning actual error) still log at ERROR
- [x] Under high sandbox-creation load, confirm `"failed to flush fc metrics"` Warn disappears after VM exit
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.