### PR TITLE
fix(api): include exhaustion reason in "Node exhausted" placement warning

### DIFF
--- a/packages/api/internal/orchestrator/placement/placement.go
+++ b/packages/api/internal/orchestrator/placement/placement.go
@@ -149,7 +149,7 @@ func PlaceSandbox(
 		switch statusCode {
 		case codes.ResourceExhausted:
 			failedNode.PlacementMetrics.Skip(sbxRequest.GetSandbox().GetSandboxId())
-			logger.L().Warn(ctx, "Node exhausted, trying another node", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID))
+			logger.L().Warn(ctx, "Node exhausted, trying another node", logger.WithSandboxID(sbxRequest.GetSandbox().GetSandboxId()), logger.WithNodeID(failedNode.ID), zap.Error(utils.UnwrapGRPCError(err)))
 		default:
 			nodesExcluded[failedNode.ID] = struct{}{}
 			failedNode.PlacementMetrics.Fail(sbxRequest.GetSandbox().GetSandboxId())


### PR DESCRIPTION
## Summary

Closes #3278

The `"Node exhausted, trying another node"` Warn log in `PlaceSandbox` discarded the gRPC error from the orchestrator, making it impossible to tell from API logs which resource limit was hit.

## Change

One-line fix in `packages/api/internal/orchestrator/placement/placement.go`:

```go
// Before
logger.L().Warn(ctx, "Node exhausted, trying another node",
    logger.WithSandboxID(...), logger.WithNodeID(failedNode.ID))

// After
logger.L().Warn(ctx, "Node exhausted, trying another node",
    logger.WithSandboxID(...), logger.WithNodeID(failedNode.ID),
    zap.Error(utils.UnwrapGRPCError(err)))
```

This matches the pattern already used in the `default` branch two lines below.

## Before / After

**Before:**
```
WARN  Node exhausted, trying another node  {"sandbox.id": "i5ksfunc...", "node.id": "cpu-nat-398"}
```

**After:**
```
WARN  Node exhausted, trying another node  {"sandbox.id": "i5ksfunc...", "node.id": "cpu-nat-398", "error": "too many sandboxes starting on this node, please retry"}
```

or

```
WARN  Node exhausted, trying another node  {"sandbox.id": "i5ksfunc...", "node.id": "cpu-nat-398", "error": "max number of running sandboxes on node reached (350), please retry"}
```

Now you can tell at a glance whether the node hit its concurrent-start limit (`MaxStartingInstancesPerNode`, default 3) or its total-sandbox limit (`MaxSandboxesPerNode`).

## Test plan

- [ ] Trigger sandbox creation against a node at capacity; confirm `"Node exhausted"` Warn log now includes the error field with the specific reason
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.