### PR TITLE
fix(shared): never report a failed envd command stream as success

### DIFF
--- a/packages/orchestrator/pkg/template/build/sandboxtools/command.go
+++ b/packages/orchestrator/pkg/template/build/sandboxtools/command.go
@@ -190,7 +190,14 @@ func runCommandWithAllOptions(
 			return fmt.Errorf("command failed: %w", err)
 		case msg, ok := <-msgCh:
 			if !ok {
-				return nil
+				// The terminal status, if any, is in msgErrCh before msgCh
+				// closes - drain it so a failure is not reported as success.
+				select {
+				case err := <-msgErrCh:
+					return fmt.Errorf("command failed: %w", err)
+				default:
+					return nil
+				}
 			}
 			e := msg.GetEvent()
 			if e == nil {

--- a/packages/shared/pkg/grpc/envd_command.go
+++ b/packages/shared/pkg/grpc/envd_command.go
@@ -12,8 +12,14 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/consts"
 )
 
+// StreamToChannel pumps messages from stream into the returned message
+// channel. The error channel holds the terminal status of the stream (stream
+// error or ctx cancellation), if any, before the message channel is closed:
+// after observing the closed message channel, callers must drain the error
+// channel to learn how the stream ended.
 func StreamToChannel[Res any](ctx context.Context, stream *connect.ServerStreamForClient[Res]) (<-chan *Res, <-chan error) {
 	out := make(chan *Res)
+	// Buffered so the terminal send never blocks.
 	errCh := make(chan error, 1)
 
 	go func() {
@@ -22,7 +28,8 @@ func StreamToChannel[Res any](ctx context.Context, stream *connect.ServerStreamF
 		for stream.Receive() {
 			select {
 			case <-ctx.Done():
-				// Context canceled, exit the goroutine
+				errCh <- ctx.Err()
+
 				return
 			case out <- stream.Msg():
 				// Send the message to the channel

--- a/packages/shared/pkg/grpc/envd_command_test.go
+++ b/packages/shared/pkg/grpc/envd_command_test.go
@@ -1,0 +1,130 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/envd/process"
+	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/envd/process/processconnect"
+)
+
+// failingProcessHandler streams msgCount messages from Start and then fails
+// the stream with streamErr. If msgCount is negative it streams until the
+// request context is cancelled.
+type failingProcessHandler struct {
+	processconnect.UnimplementedProcessHandler
+
+	msgCount  int
+	streamErr *connect.Error
+}
+
+func (h *failingProcessHandler) Start(ctx context.Context, _ *connect.Request[process.StartRequest], stream *connect.ServerStream[process.StartResponse]) error {
+	for i := 0; h.msgCount < 0 || i < h.msgCount; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		if err := stream.Send(&process.StartResponse{}); err != nil {
+			return err
+		}
+	}
+
+	return h.streamErr
+}
+
+func newProcessTestServer(t *testing.T, handler *failingProcessHandler) processconnect.ProcessClient {
+	t.Helper()
+
+	path, httpHandler := processconnect.NewProcessHandler(handler)
+	mux := http.NewServeMux()
+	mux.Handle(path, httpHandler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return processconnect.NewProcessClient(server.Client(), server.URL)
+}
+
+// TestStreamToChannel_StreamErrorAvailableOnClose pins the terminal status
+// contract: the stream error is in the error channel before the message
+// channel closes, so a consumer that drains the error channel after
+// observing the close never reports a failed stream as a clean end.
+func TestStreamToChannel_StreamErrorAvailableOnClose(t *testing.T) {
+	t.Parallel()
+
+	client := newProcessTestServer(t, &failingProcessHandler{
+		msgCount:  3,
+		streamErr: connect.NewError(connect.CodeInternal, errors.New("command failed on purpose")),
+	})
+
+	stream, err := client.Start(t.Context(), connect.NewRequest(&process.StartRequest{}))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	msgCh, errCh := StreamToChannel(t.Context(), stream)
+
+	received := 0
+	for range msgCh {
+		received++
+	}
+	require.Equal(t, 3, received)
+
+	select {
+	case err := <-errCh:
+		require.ErrorContains(t, err, "command failed on purpose")
+	default:
+		t.Fatal("terminal status not available after the message channel closed")
+	}
+}
+
+// TestStreamToChannel_CancellationIsTerminalStatus verifies that a context
+// cancellation while the producer is forwarding messages is reported through
+// the error channel instead of being indistinguishable from a clean end of
+// stream.
+func TestStreamToChannel_CancellationIsTerminalStatus(t *testing.T) {
+	t.Parallel()
+
+	client := newProcessTestServer(t, &failingProcessHandler{
+		// Stream until the request context is cancelled.
+		msgCount: -1,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	stream, err := client.Start(ctx, connect.NewRequest(&process.StartRequest{}))
+	require.NoError(t, err)
+	defer stream.Close()
+
+	msgCh, errCh := StreamToChannel(ctx, stream)
+
+	// Receive one message to make sure the stream is live, then cancel.
+	select {
+	case _, ok := <-msgCh:
+		require.True(t, ok, "stream ended before cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first message")
+	}
+
+	cancel()
+
+	// Drain the message channel until the producer exits.
+	for range msgCh { //nolint:revive // draining until closed
+	}
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+	default:
+		t.Fatal("cancellation was indistinguishable from a clean end of stream")
+	}
+}


### PR DESCRIPTION
StreamToChannel delivers the stream error on a separate channel from the messages. Once the producer sent the error and closed the message channel, both select cases in runCommandWithAllOptions were ready and Go's select picks randomly - a failed template-build command was reported as succeeded about half the time. A cancelled producer exited without signaling the error channel at all, indistinguishable from a clean end of stream.

The silent cancellation is residue of the original design, where the consumer treated ctx.Done as success; ff53adee509f ("Add option for a template ready check (#719)") flipped it to an error without updating the producer, and 551939260449 ("Add build finalize traces (#1247)") dropped close(errCh) to avoid wrapping nil errors, leaving the terminal status undelivered.

Make the producer deliver exactly one terminal status (including ctx.Err() on cancellation) before closing the message channel, document that contract, and have the consumer drain the error channel after observing the closed message channel. Tests pin the contract for both the stream-error and cancellation paths.