### PR TITLE
fix(storage): suppress SDK checksum WARN for S3-compatible backends (MinIO/Ceph)

### DIFF
--- a/packages/shared/pkg/storage/storage_aws.go
+++ b/packages/shared/pkg/storage/storage_aws.go
@@ -73,6 +73,18 @@ func newAWSStorage(ctx context.Context, spec Spec, limiter *limit.Limiter) (*aws
 		// default virtual-host style https://bucket.host/key) is required by
 		// most S3-compatible backends (MinIO, Ceph, …).
 		o.UsePathStyle = spec.UsePathStyle
+
+		// S3-compatible backends (MinIO, Ceph, etc.) do not return x-amz-checksum-*
+		// response headers. Without this setting the SDK logs a WARN for every
+		// GetObject response because it cannot validate the payload checksum.
+		// WhenRequired tells the SDK to only validate when the caller explicitly
+		// requested a checksum — matching the actual contract with these backends.
+		// Standard AWS S3 returns checksums and benefits from WhenSupported (the
+		// SDK default), so this opt-out is gated on UsePathStyle which already
+		// identifies S3-compatible deployments.
+		if spec.UsePathStyle {
+			o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired
+		}
 	})
 	presignClient := s3.NewPresignClient(client)
 


### PR DESCRIPTION
## Problem

When using an S3-compatible backend (MinIO, Ceph, etc.), the orchestrator logs a flood of WARN messages:

```
SDK WARN Response has no supported checksum. Not validating response payload.
```

This fires on **every `GetObject` response** because MinIO does not return `x-amz-checksum-*` response headers, and AWS SDK Go v2 defaults to `ResponseChecksumValidationWhenSupported` — logging a WARN whenever it cannot find a checksum to validate.

## Root Cause

`newAWSStorage` in `packages/shared/pkg/storage/storage_aws.go` creates the S3 client without setting `ResponseChecksumValidation`. The SDK default (`WhenSupported`) attempts checksum validation on every response and emits a WARN when no checksum header is present.

## Fix

Set `o.ResponseChecksumValidation = aws.ResponseChecksumValidationWhenRequired` in the `s3.NewFromConfig` options func. This tells the SDK to only validate checksums when the caller explicitly requests one — which is the correct contract for S3-compatible backends that don't implement the checksum extension.

This does **not** weaken integrity guarantees for callers that do pass `WithChecksum` options; it only stops the SDK from logging warnings for responses where no checksum was requested.

## Testing

- Build: `go build ./packages/shared/pkg/storage/` ✅
- The WARN log no longer appears when running against a MinIO backend.
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.