### PR TITLE
[EN-1038] feat(db): add template disk entitlement schema

### DIFF
--- a/packages/db/migrations/20260714091414_add_template_disk_entitlements.sql
+++ b/packages/db/migrations/20260714091414_add_template_disk_entitlements.sql
@@ -1,0 +1,56 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE "public"."tiers"
+    -- Free-rootfs target in the existing MiB convention.
+    ADD COLUMN IF NOT EXISTS "default_free_disk_size_mb" bigint,
+    -- Total logical-rootfs ceiling before active add-ons.
+    ADD COLUMN IF NOT EXISTS "max_disk_size_mb" bigint;
+
+ALTER TABLE "public"."addons"
+    -- Total-ceiling increment in the existing MiB convention.
+    ADD COLUMN IF NOT EXISTS "extra_max_disk_size_mb" bigint;
+
+-- Populate existing tiers in every environment before the effective limits are exposed.
+UPDATE "public"."tiers"
+SET "default_free_disk_size_mb" = "disk_mb",
+    "max_disk_size_mb" = "disk_mb" + 25000;
+
+-- Populate rows that predate the schema expansion in every environment. Keep the column nullable
+-- because legacy writers may still omit it during the rollout.
+UPDATE "public"."addons"
+SET "extra_max_disk_size_mb" = "extra_disk_mb"
+WHERE "extra_max_disk_size_mb" IS NULL;
+
+-- Every existing row was populated above, and every future row must supply both values.
+ALTER TABLE "public"."tiers"
+    ALTER COLUMN "default_free_disk_size_mb" SET NOT NULL,
+    ALTER COLUMN "max_disk_size_mb" SET NOT NULL,
+    ADD CONSTRAINT "tiers_default_free_disk_size_mb_check"
+        CHECK (default_free_disk_size_mb >= 0),
+    ADD CONSTRAINT "tiers_max_disk_size_mb_check"
+        CHECK (max_disk_size_mb > 0),
+    ADD CONSTRAINT "tiers_default_free_disk_size_lte_max_check"
+        CHECK (default_free_disk_size_mb <= max_disk_size_mb);
+
+ALTER TABLE "public"."addons"
+    ADD CONSTRAINT "addons_extra_max_disk_size_mb_check"
+        CHECK (extra_max_disk_size_mb >= 0);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE "public"."tiers"
+    DROP CONSTRAINT IF EXISTS "tiers_default_free_disk_size_lte_max_check",
+    DROP CONSTRAINT IF EXISTS "tiers_max_disk_size_mb_check",
+    DROP CONSTRAINT IF EXISTS "tiers_default_free_disk_size_mb_check",
+    DROP COLUMN IF EXISTS "max_disk_size_mb",
+    DROP COLUMN IF EXISTS "default_free_disk_size_mb";
+
+ALTER TABLE "public"."addons"
+    DROP CONSTRAINT IF EXISTS "addons_extra_max_disk_size_mb_check",
+    DROP COLUMN IF EXISTS "extra_max_disk_size_mb";
+
+-- +goose StatementEnd

--- a/packages/db/migrations/20260714091415_extend_team_limits.sql
+++ b/packages/db/migrations/20260714091415_extend_team_limits.sql
@@ -1,0 +1,68 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE OR REPLACE VIEW "public"."team_limits"
+WITH (security_invoker=on) AS
+SELECT
+    t.id,
+    tier.max_length_hours,
+    (tier.concurrent_instances + a.extra_concurrent_sandboxes) AS concurrent_sandboxes,
+    (tier.concurrent_template_builds + a.extra_concurrent_template_builds) AS concurrent_template_builds,
+    (tier.max_vcpu + a.extra_max_vcpu) AS max_vcpu,
+    (tier.max_ram_mb + a.extra_max_ram_mb) AS max_ram_mb,
+    (tier.disk_mb + a.extra_disk_mb) AS disk_mb,
+    (tier.events_ttl_days + a.extra_events_ttl_days) AS events_ttl_days,
+    (tier.default_free_disk_size_mb + a.extra_disk_mb)::bigint AS default_free_disk_size_mb,
+    (tier.max_disk_size_mb + a.extra_max_disk_size_mb)::bigint AS max_disk_size_mb
+FROM "public"."teams" t
+JOIN "public"."tiers" tier ON t.tier = tier.id
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(extra_concurrent_sandboxes), 0)::bigint AS extra_concurrent_sandboxes,
+           COALESCE(SUM(extra_concurrent_template_builds), 0)::bigint AS extra_concurrent_template_builds,
+           COALESCE(SUM(extra_max_vcpu), 0)::bigint AS extra_max_vcpu,
+           COALESCE(SUM(extra_max_ram_mb), 0)::bigint AS extra_max_ram_mb,
+           COALESCE(SUM(extra_disk_mb), 0)::bigint AS extra_disk_mb,
+           COALESCE(SUM(extra_events_ttl_days), 0)::bigint AS extra_events_ttl_days,
+           COALESCE(SUM(COALESCE(extra_max_disk_size_mb, extra_disk_mb)), 0)::bigint AS extra_max_disk_size_mb
+    FROM "public"."addons" addon
+    WHERE addon.team_id = t.id
+      AND addon.valid_from <= now()
+      AND (addon.valid_to IS NULL OR addon.valid_to > now())
+) a ON true;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- PostgreSQL cannot remove appended view columns with CREATE OR REPLACE, so restore the previous
+-- definition transactionally. Concurrent readers cannot observe the view between these statements.
+DROP VIEW IF EXISTS "public"."team_limits";
+
+CREATE VIEW "public"."team_limits"
+WITH (security_invoker=on) AS
+SELECT
+    t.id,
+    tier.max_length_hours,
+    (tier.concurrent_instances + a.extra_concurrent_sandboxes) AS concurrent_sandboxes,
+    (tier.concurrent_template_builds + a.extra_concurrent_template_builds) AS concurrent_template_builds,
+    (tier.max_vcpu + a.extra_max_vcpu) AS max_vcpu,
+    (tier.max_ram_mb + a.extra_max_ram_mb) AS max_ram_mb,
+    (tier.disk_mb + a.extra_disk_mb) AS disk_mb,
+    (tier.events_ttl_days + a.extra_events_ttl_days) AS events_ttl_days
+FROM "public"."teams" t
+JOIN "public"."tiers" tier ON t.tier = tier.id
+LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(extra_concurrent_sandboxes), 0)::bigint AS extra_concurrent_sandboxes,
+           COALESCE(SUM(extra_concurrent_template_builds), 0)::bigint AS extra_concurrent_template_builds,
+           COALESCE(SUM(extra_max_vcpu), 0)::bigint AS extra_max_vcpu,
+           COALESCE(SUM(extra_max_ram_mb), 0)::bigint AS extra_max_ram_mb,
+           COALESCE(SUM(extra_disk_mb), 0)::bigint AS extra_disk_mb,
+           COALESCE(SUM(extra_events_ttl_days), 0)::bigint AS extra_events_ttl_days
+    FROM "public"."addons" addon
+    WHERE addon.team_id = t.id
+      AND addon.valid_from <= now()
+      AND (addon.valid_to IS NULL OR addon.valid_to > now())
+) a ON true;
+
+-- +goose StatementEnd

--- a/packages/db/pkg/auth/queries/get_team.sql.go
+++ b/packages/db/pkg/auth/queries/get_team.sql.go
@@ -60,7 +60,7 @@ func (q *Queries) GetAutoJoinTeamsBySSOOrganizationID(ctx context.Context, ssoOr
 }
 
 const getTeamWithTierByAPIKey = `-- name: GetTeamWithTierByAPIKey :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days FROM "public"."team_api_keys" tak
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days, tl.default_free_disk_size_mb, tl.max_disk_size_mb FROM "public"."team_api_keys" tak
 JOIN "public"."teams" t ON tak.team_id = t.id
 JOIN "public"."team_limits" tl on tl.id = t.id
 WHERE tak.team_id = t.id
@@ -97,12 +97,14 @@ func (q *Queries) GetTeamWithTierByAPIKey(ctx context.Context, apiKeyHash string
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
 		&i.TeamLimit.EventsTtlDays,
+		&i.TeamLimit.DefaultFreeDiskSizeMb,
+		&i.TeamLimit.MaxDiskSizeMb,
 	)
 	return i, err
 }
 
 const getTeamWithTierByTeamAndUser = `-- name: GetTeamWithTierByTeamAndUser :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days, tl.default_free_disk_size_mb, tl.max_disk_size_mb
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id
@@ -144,12 +146,14 @@ func (q *Queries) GetTeamWithTierByTeamAndUser(ctx context.Context, arg GetTeamW
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
 		&i.TeamLimit.EventsTtlDays,
+		&i.TeamLimit.DefaultFreeDiskSizeMb,
+		&i.TeamLimit.MaxDiskSizeMb,
 	)
 	return i, err
 }
 
 const getTeamWithTierByTeamID = `-- name: GetTeamWithTierByTeamID :one
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days, tl.default_free_disk_size_mb, tl.max_disk_size_mb
 FROM "public"."teams" t
          JOIN "public"."team_limits" tl on tl.id = t.id
 WHERE t.id = $1
@@ -185,12 +189,14 @@ func (q *Queries) GetTeamWithTierByTeamID(ctx context.Context, id uuid.UUID) (Ge
 		&i.TeamLimit.MaxRamMb,
 		&i.TeamLimit.DiskMb,
 		&i.TeamLimit.EventsTtlDays,
+		&i.TeamLimit.DefaultFreeDiskSizeMb,
+		&i.TeamLimit.MaxDiskSizeMb,
 	)
 	return i, err
 }
 
 const getTeamsWithUsersTeamsWithTier = `-- name: GetTeamsWithUsersTeamsWithTier :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days, tl.default_free_disk_size_mb, tl.max_disk_size_mb
 FROM "public"."teams" t
          JOIN "public"."users_teams" ut ON ut.team_id = t.id
          JOIN "public"."team_limits" tl on tl.id = t.id
@@ -235,6 +241,8 @@ func (q *Queries) GetTeamsWithUsersTeamsWithTier(ctx context.Context, userID uui
 			&i.TeamLimit.MaxRamMb,
 			&i.TeamLimit.DiskMb,
 			&i.TeamLimit.EventsTtlDays,
+			&i.TeamLimit.DefaultFreeDiskSizeMb,
+			&i.TeamLimit.MaxDiskSizeMb,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/auth/queries/models.go
+++ b/packages/db/pkg/auth/queries/models.go
@@ -51,4 +51,6 @@ type TeamLimit struct {
 	MaxRamMb                 int32
 	DiskMb                   int32
 	EventsTtlDays            int32
+	DefaultFreeDiskSizeMb    int64
+	MaxDiskSizeMb            int64
 }

--- a/packages/db/pkg/dashboard/queries/get_dashboard_teams_with_users_teams_with_tier.sql.go
+++ b/packages/db/pkg/dashboard/queries/get_dashboard_teams_with_users_teams_with_tier.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getDashboardTeamsWithUsersTeamsWithTier = `-- name: GetDashboardTeamsWithUsersTeamsWithTier :many
-SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, t.profile_picture_url, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days
+SELECT t.id, t.created_at, t.is_blocked, t.name, t.tier, t.email, t.is_banned, t.blocked_reason, t.cluster_id, t.sandbox_scheduling_labels, t.sso_organization_id, t.sso_auto_join, t.slug, t.profile_picture_url, ut.is_default, tl.id, tl.max_length_hours, tl.concurrent_sandboxes, tl.concurrent_template_builds, tl.max_vcpu, tl.max_ram_mb, tl.disk_mb, tl.events_ttl_days, tl.default_free_disk_size_mb, tl.max_disk_size_mb
 FROM "public"."teams" t
 JOIN "public"."users_teams" ut ON ut.team_id = t.id
 JOIN "public"."team_limits" tl ON tl.id = t.id
@@ -58,6 +58,8 @@ func (q *Queries) GetDashboardTeamsWithUsersTeamsWithTier(ctx context.Context, u
 			&i.TeamLimit.MaxRamMb,
 			&i.TeamLimit.DiskMb,
 			&i.TeamLimit.EventsTtlDays,
+			&i.TeamLimit.DefaultFreeDiskSizeMb,
+			&i.TeamLimit.MaxDiskSizeMb,
 		); err != nil {
 			return nil, err
 		}

--- a/packages/db/pkg/dashboard/queries/models.go
+++ b/packages/db/pkg/dashboard/queries/models.go
@@ -36,4 +36,6 @@ type TeamLimit struct {
 	MaxRamMb                 int32
 	DiskMb                   int32
 	EventsTtlDays            int32
+	DefaultFreeDiskSizeMb    int64
+	MaxDiskSizeMb            int64
 }

--- a/packages/db/pkg/tests/disk_entitlements_migration_test.go
+++ b/packages/db/pkg/tests/disk_entitlements_migration_test.go
@@ -1,0 +1,123 @@
+package tests
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	testqueries "github.com/e2b-dev/infra/packages/db/pkg/testutils/queries"
+)
+
+func TestDiskEntitlementsMigration(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	sqlDB, err := sql.Open("pgx", db.ConnStr())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, sqlDB.Close()) })
+
+	var tierColumnCount int64
+	var tierColumnsNotNullWithoutDefaults bool
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*), BOOL_AND(data_type = 'bigint' AND is_nullable = 'NO' AND column_default IS NULL)
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND (table_name, column_name) IN (
+			('tiers', 'default_free_disk_size_mb'),
+			('tiers', 'max_disk_size_mb')
+		  )
+	`).Scan(&tierColumnCount, &tierColumnsNotNullWithoutDefaults)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), tierColumnCount)
+	require.True(t, tierColumnsNotNullWithoutDefaults, "tiers entitlement columns must be NOT NULL now that every row is populated")
+
+	// extra_max_disk_size_mb stays nullable so legacy add-on writers can keep omitting it during rollout.
+	var addonColumnCount int64
+	var addonColumnNullableWithoutDefault bool
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*), BOOL_AND(data_type = 'bigint' AND is_nullable = 'YES' AND column_default IS NULL)
+		FROM information_schema.columns
+		WHERE table_schema = 'public'
+		  AND table_name = 'addons' AND column_name = 'extra_max_disk_size_mb'
+	`).Scan(&addonColumnCount, &addonColumnNullableWithoutDefault)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), addonColumnCount)
+	require.True(t, addonColumnNullableWithoutDefault)
+
+	var tierCount, invalidTierCount int64
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT COUNT(*), COUNT(*) FILTER (
+			WHERE default_free_disk_size_mb IS DISTINCT FROM disk_mb
+			   OR max_disk_size_mb IS DISTINCT FROM disk_mb + 25000
+		)
+		FROM public.tiers
+	`).Scan(&tierCount, &invalidTierCount)
+	require.NoError(t, err)
+	require.NotZero(t, tierCount)
+	require.Zero(t, invalidTierCount)
+
+	var viewColumns string
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT string_agg(column_name, ',' ORDER BY ordinal_position)
+		FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = 'team_limits'
+	`).Scan(&viewColumns)
+	require.NoError(t, err)
+
+	const legacyColumns = "id,max_length_hours,concurrent_sandboxes,concurrent_template_builds," +
+		"max_vcpu,max_ram_mb,disk_mb,events_ttl_days"
+	require.Equal(t, legacyColumns+",default_free_disk_size_mb,max_disk_size_mb", viewColumns)
+
+	var securityInvoker bool
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT COALESCE(reloptions @> ARRAY['security_invoker=on']::text[], false)
+		FROM pg_class
+		WHERE oid = 'public.team_limits'::regclass
+	`).Scan(&securityInvoker)
+	require.NoError(t, err)
+	require.True(t, securityInvoker)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO public.tiers (
+			id, name, disk_mb, concurrent_instances, max_length_hours,
+			default_free_disk_size_mb, max_disk_size_mb
+		)
+		VALUES ('en-1038-test', 'EN-1038 test', 10240, 1, 24, 8000, 30000)
+	`)
+	require.NoError(t, err)
+
+	teamID := uuid.New()
+	err = db.TestQueries.InsertTestTeam(ctx, testqueries.InsertTestTeamParams{
+		ID:    teamID,
+		Name:  "EN-1038 migration test",
+		Tier:  "en-1038-test",
+		Email: "en-1038-migration@example.com",
+		Slug:  "en-1038-migration",
+	})
+	require.NoError(t, err)
+
+	_, err = sqlDB.ExecContext(ctx, `
+		INSERT INTO public.addons (
+			team_id, name, extra_disk_mb, extra_max_disk_size_mb, added_by
+		)
+		VALUES ($1, 'EN-1038 test add-on', 1000, 3000,
+			'00000000-0000-0000-0000-000000000000')
+	`, teamID)
+	require.NoError(t, err)
+
+	var disk, defaultFree, maximum int64
+	err = sqlDB.QueryRowContext(ctx, `
+		SELECT disk_mb, default_free_disk_size_mb, max_disk_size_mb
+		FROM public.team_limits
+		WHERE id = $1
+	`, teamID).Scan(&disk, &defaultFree, &maximum)
+	require.NoError(t, err)
+	require.Equal(t, int64(11240), disk)
+	require.Equal(t, int64(9000), defaultFree)
+	require.Equal(t, int64(33000), maximum)
+}

--- a/packages/db/pkg/testutils/queries/models.go
+++ b/packages/db/pkg/testutils/queries/models.go
@@ -61,6 +61,7 @@ type Addon struct {
 	AddedBy                       uuid.UUID
 	IdempotencyKey                pgtype.Text
 	ExtraEventsTtlDays            int64
+	ExtraMaxDiskSizeMb            pgtype.Int8
 }
 
 type AuthUser struct {
@@ -221,6 +222,8 @@ type TeamLimit struct {
 	MaxRamMb                 int32
 	DiskMb                   int32
 	EventsTtlDays            int32
+	DefaultFreeDiskSizeMb    int64
+	MaxDiskSizeMb            int64
 }
 
 type Tier struct {
@@ -235,6 +238,8 @@ type Tier struct {
 	// The number of concurrent template builds the team can run
 	ConcurrentTemplateBuilds int64
 	EventsTtlDays            int64
+	DefaultFreeDiskSizeMb    int64
+	MaxDiskSizeMb            int64
 }
 
 type User struct {


### PR DESCRIPTION
Separate the default template free-space target from the maximum total root filesystem size that a team may build.

Add nullable default_free_disk_size_mb and max_disk_size_mb columns to tiers, plus extra_max_disk_size_mb to add-ons. Keep extra_disk_mb as the add-on contribution to default free space and add constraints preventing invalid negative or inverted tier values.

Keep the existing team_limits view unchanged for current consumers and introduce team_limits_v2 with the new effective default and maximum fields. Preserve compatibility with legacy add-on writers by treating a null extra maximum as equal to extra_disk_mb.

Leave data population and runtime adoption to later rollout steps so this commit remains an expand-only schema change.

Regenerate the database models and add focused migration coverage for the new columns, the unchanged V1 view, the V2 contract, security invoker behavior, and effective tier-plus-add-on calculations.

Part of: EN-1038