### PR TITLE
Add CODEOWNERS rule for packages/clickhouse/migrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 # the repo. Unless a later match takes precedence.
 * @ValentaTomas @jakubno @dobrac
 /packages/dashboard-api/ @ben-fornefeld
+/packages/clickhouse/migrations/ @e2b-dev/clickhouse


### PR DESCRIPTION
Makes @infra-clickhouse the owner of `packages/clickhouse/migrations/`.