### PR TITLE
fix(nbd): downgrade broken-pipe socket errors from ERROR to WARN

### DIFF
--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -362,25 +362,18 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 			select {
 			case d.fatal <- err:
 			default:
+				logFn := logger.L().Error
 				if isSocketClosed(err) {
-					logger.L().Warn(ctx, "nbd error cmd read",
-						zap.Error(err),
-						zap.String("nbd_op", "read"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Uint32("nbd_length", cmdLength),
-					)
-				} else {
-					logger.L().Error(ctx, "nbd error cmd read",
-						zap.Error(err),
-						zap.String("nbd_op", "read"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Uint32("nbd_length", cmdLength),
-					)
+					logFn = logger.L().Warn
 				}
+				logFn(ctx, "nbd error cmd read",
+					zap.Error(err),
+					zap.String("nbd_op", "read"),
+					zap.String("nbd_provider", d.provName),
+					zap.Uint64("nbd_handle", cmdHandle),
+					zap.Uint64("nbd_offset", cmdFrom),
+					zap.Uint32("nbd_length", cmdLength),
+				)
 			}
 		}
 		d.pendingResponses.Done()
@@ -440,25 +433,18 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 			select {
 			case d.fatal <- err:
 			default:
+				logFn := logger.L().Error
 				if isSocketClosed(err) {
-					logger.L().Warn(ctx, "nbd error cmd write",
-						zap.Error(err),
-						zap.String("nbd_op", "write"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Int("nbd_length", len(cmdData)),
-					)
-				} else {
-					logger.L().Error(ctx, "nbd error cmd write",
-						zap.Error(err),
-						zap.String("nbd_op", "write"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Int("nbd_length", len(cmdData)),
-					)
+					logFn = logger.L().Warn
 				}
+				logFn(ctx, "nbd error cmd write",
+					zap.Error(err),
+					zap.String("nbd_op", "write"),
+					zap.String("nbd_provider", d.provName),
+					zap.Uint64("nbd_handle", cmdHandle),
+					zap.Uint64("nbd_offset", cmdFrom),
+					zap.Int("nbd_length", len(cmdData)),
+				)
 			}
 		}
 		d.pendingResponses.Done()
@@ -529,25 +515,18 @@ func (d *Dispatch) cmdWriteZeroes(ctx context.Context, cmdHandle uint64, cmdFrom
 			select {
 			case d.fatal <- err:
 			default:
+				logFn := logger.L().Error
 				if isSocketClosed(err) {
-					logger.L().Warn(ctx, "nbd error cmd write-zeroes",
-						zap.Error(err),
-						zap.String("nbd_op", "write-zeroes"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Int64("nbd_length", cmdLength),
-					)
-				} else {
-					logger.L().Error(ctx, "nbd error cmd write-zeroes",
-						zap.Error(err),
-						zap.String("nbd_op", "write-zeroes"),
-						zap.String("nbd_provider", d.provName),
-						zap.Uint64("nbd_handle", cmdHandle),
-						zap.Uint64("nbd_offset", cmdFrom),
-						zap.Int64("nbd_length", cmdLength),
-					)
+					logFn = logger.L().Warn
 				}
+				logFn(ctx, "nbd error cmd write-zeroes",
+					zap.Error(err),
+					zap.String("nbd_op", "write-zeroes"),
+					zap.String("nbd_provider", d.provName),
+					zap.Uint64("nbd_handle", cmdHandle),
+					zap.Uint64("nbd_offset", cmdFrom),
+					zap.Int64("nbd_length", cmdLength),
+				)
 			}
 		}
 

--- a/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/dispatch.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"syscall"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -34,6 +35,12 @@ var (
 )
 
 var ErrShuttingDown = errors.New("shutting down. Cannot serve any new requests")
+
+// isSocketClosed returns true when err indicates the NBD Unix socket was
+// closed by the peer — expected during normal sandbox shutdown.
+func isSocketClosed(err error) bool {
+	return errors.Is(err, syscall.EPIPE) || errors.Is(err, io.ErrClosedPipe)
+}
 
 var dispatchBufPool = sync.Pool{
 	New: func() any {
@@ -355,14 +362,25 @@ func (d *Dispatch) cmdRead(ctx context.Context, cmdHandle uint64, cmdFrom uint64
 			select {
 			case d.fatal <- err:
 			default:
-				logger.L().Error(ctx, "nbd error cmd read",
-					zap.Error(err),
-					zap.String("nbd_op", "read"),
-					zap.String("nbd_provider", d.provName),
-					zap.Uint64("nbd_handle", cmdHandle),
-					zap.Uint64("nbd_offset", cmdFrom),
-					zap.Uint32("nbd_length", cmdLength),
-				)
+				if isSocketClosed(err) {
+					logger.L().Warn(ctx, "nbd error cmd read",
+						zap.Error(err),
+						zap.String("nbd_op", "read"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Uint32("nbd_length", cmdLength),
+					)
+				} else {
+					logger.L().Error(ctx, "nbd error cmd read",
+						zap.Error(err),
+						zap.String("nbd_op", "read"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Uint32("nbd_length", cmdLength),
+					)
+				}
 			}
 		}
 		d.pendingResponses.Done()
@@ -422,14 +440,25 @@ func (d *Dispatch) cmdWrite(ctx context.Context, cmdHandle uint64, cmdFrom uint6
 			select {
 			case d.fatal <- err:
 			default:
-				logger.L().Error(ctx, "nbd error cmd write",
-					zap.Error(err),
-					zap.String("nbd_op", "write"),
-					zap.String("nbd_provider", d.provName),
-					zap.Uint64("nbd_handle", cmdHandle),
-					zap.Uint64("nbd_offset", cmdFrom),
-					zap.Int("nbd_length", len(cmdData)),
-				)
+				if isSocketClosed(err) {
+					logger.L().Warn(ctx, "nbd error cmd write",
+						zap.Error(err),
+						zap.String("nbd_op", "write"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Int("nbd_length", len(cmdData)),
+					)
+				} else {
+					logger.L().Error(ctx, "nbd error cmd write",
+						zap.Error(err),
+						zap.String("nbd_op", "write"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Int("nbd_length", len(cmdData)),
+					)
+				}
 			}
 		}
 		d.pendingResponses.Done()
@@ -500,14 +529,25 @@ func (d *Dispatch) cmdWriteZeroes(ctx context.Context, cmdHandle uint64, cmdFrom
 			select {
 			case d.fatal <- err:
 			default:
-				logger.L().Error(ctx, "nbd error cmd write-zeroes",
-					zap.Error(err),
-					zap.String("nbd_op", "write-zeroes"),
-					zap.String("nbd_provider", d.provName),
-					zap.Uint64("nbd_handle", cmdHandle),
-					zap.Uint64("nbd_offset", cmdFrom),
-					zap.Int64("nbd_length", cmdLength),
-				)
+				if isSocketClosed(err) {
+					logger.L().Warn(ctx, "nbd error cmd write-zeroes",
+						zap.Error(err),
+						zap.String("nbd_op", "write-zeroes"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Int64("nbd_length", cmdLength),
+					)
+				} else {
+					logger.L().Error(ctx, "nbd error cmd write-zeroes",
+						zap.Error(err),
+						zap.String("nbd_op", "write-zeroes"),
+						zap.String("nbd_provider", d.provName),
+						zap.Uint64("nbd_handle", cmdHandle),
+						zap.Uint64("nbd_offset", cmdFrom),
+						zap.Int64("nbd_length", cmdLength),
+					)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Problem

When a sandbox VM terminates, the NBD dispatch loop has in-flight goroutines that try to write responses back to the kernel via the Unix socket. Since the socket is already closed, these writes fail with EPIPE ("broken pipe"). The first failure is sent to the `fatal` channel; all subsequent concurrent goroutines hit the `default:` branch and log at ERROR:

```
ERROR nbd error cmd write  {error: write unix @- write: broken pipe, nbd_op: write, ...}
ERROR nbd error cmd write  {error: write unix @- write: broken pipe, nbd_op: write, ...}
...
```

This generates a burst of ERROR-level log noise on every normal sandbox shutdown, making it harder to spot real failures.

## Fix

Add `isSocketClosed()` to detect `syscall.EPIPE` and `io.ErrClosedPipe` and emit WARN instead of ERROR in the `default:` branches of `cmdRead`, `cmdWrite`, and `cmdWriteZeroes`. Unexpected non-EPIPE errors remain at ERROR.

This is the write-side counterpart of the read-side `ErrObjectNotExist` downgrade already in dispatch.go.

## Test plan

- [ ] Deploy to staging and confirm EPIPE response errors appear as WARN in logs during sandbox shutdown
- [ ] Confirm unexpected write errors (non-EPIPE) still appear as ERROR
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.