### PR TITLE
[EN-1673] feat(orchestrator): trace the slow steps of the resize-disk…

### DIFF
--- a/packages/orchestrator/pkg/sandbox/nbd/path_direct.go
+++ b/packages/orchestrator/pkg/sandbox/nbd/path_direct.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/Merovius/nbd/nbdnl"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 
@@ -95,11 +97,21 @@ func NewDirectPathMount(b block.Device, devicePool *DevicePool, featureFlags *fe
 }
 
 func (d *DirectPathMount) Open(ctx context.Context) (retDeviceIndex uint32, err error) {
+	// The connect + wait-for-connected poll loop (and device-pool contention) are
+	// otherwise invisible; both add up when this is opened once per measure/resize.
+	ctx, span := tracer.Start(ctx, "direct-path-mount-open")
+
 	ctx, d.cancelfn = context.WithCancel(ctx)
 
 	defer func() {
 		// Set the device index to the one returned, correctly capture error values
 		d.deviceIndex = retDeviceIndex
+		span.SetAttributes(attribute.Int64("nbd.device_index", int64(retDeviceIndex)))
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
 		logger.L().Debug(ctx, "opening direct path mount", zap.Uint32("device_index", d.deviceIndex), zap.Error(err))
 	}()
 

--- a/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
+++ b/packages/orchestrator/pkg/template/build/core/filesystem/ext4.go
@@ -15,6 +15,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -229,7 +230,20 @@ func GetFreeSpace(ctx context.Context, rootfsPath string, blockSize int64) (int6
 	return freeBytes, nil
 }
 
-func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (string, error) {
+func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (out string, err error) {
+	// e2fsck reads the whole filesystem metadata (and lazily fetches the backing
+	// rootfs chunks), so it usually dominates the resize-disk phase wall time.
+	ctx, span := tracer.Start(ctx, "e2fsck", trace.WithAttributes(
+		attribute.Bool("filesystem.e2fsck.fix", fix),
+	))
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	LogMetadata(ctx, rootfsPath)
 	accExitCode := 0
 	args := "-nfv"
@@ -241,33 +255,45 @@ func CheckIntegrity(ctx context.Context, rootfsPath string, fix bool) (string, e
 		args = "-pfv"
 	}
 	cmd := exec.CommandContext(ctx, "e2fsck", args, rootfsPath)
-	out, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
+	if cmd.ProcessState != nil {
+		span.SetAttributes(attribute.Int("filesystem.e2fsck.exit_code", cmd.ProcessState.ExitCode()))
+	}
 	if err != nil {
 		exitCode := cmd.ProcessState.ExitCode()
 
 		if exitCode > accExitCode {
-			return string(out), fmt.Errorf("error running e2fsck [exit %d]\n%s", exitCode, out)
+			return string(output), fmt.Errorf("error running e2fsck [exit %d]\n%s", exitCode, output)
 		}
 	}
 
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 // ReplayJournal applies committed ext4 journal transactions without a full
 // filesystem check. Guest sync makes journal commits durable but may leave
 // them uncheckpointed, while debugfs reads raw free-block metadata without
 // replaying the journal. Replaying first reflects the latest durable state.
-func ReplayJournal(ctx context.Context, rootfsPath string) (string, error) {
+func ReplayJournal(ctx context.Context, rootfsPath string) (out string, err error) {
+	ctx, span := tracer.Start(ctx, "replay-journal")
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	cmd := exec.CommandContext(ctx, "e2fsck", "-p", "-E", "journal_only", rootfsPath)
-	out, err := cmd.CombinedOutput()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if !errors.As(err, &exitErr) || exitErr.ExitCode() < 0 || exitErr.ExitCode()&^(1|2) != 0 {
-			return string(out), fmt.Errorf("error replaying ext4 journal: %w\n%s", err, out)
+			return string(output), fmt.Errorf("error replaying ext4 journal: %w\n%s", err, output)
 		}
 	}
 
-	return strings.TrimSpace(string(out)), nil
+	return strings.TrimSpace(string(output)), nil
 }
 
 func ReadFile(ctx context.Context, rootfsPath string, filePath string) (string, error) {

--- a/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/grow.go
+++ b/packages/orchestrator/pkg/template/build/phases/ensurefreedisk/grow.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block"
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/build"
@@ -22,6 +25,8 @@ import (
 )
 
 const offlineCleanupTimeout = time.Minute
+
+var tracer = otel.Tracer("github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/phases/ensurefreedisk")
 
 type growResult struct {
 	freeBefore int64
@@ -213,6 +218,18 @@ func (b *EnsureFreeDiskBuilder) resizeOffline(
 	backend block.Device,
 	newSize int64,
 ) (freeAfter int64, e error) {
+	// Group the two e2fsck runs and the resize2fs so the grow target and result
+	// are visible without drilling into individual e2fsprogs spans.
+	ctx, span := tracer.Start(ctx, "resize-offline")
+	span.SetAttributes(attribute.Int64("template.resize_disk.new_size_bytes", newSize))
+	defer func() {
+		if e != nil {
+			span.RecordError(e)
+			span.SetStatus(codes.Error, e.Error())
+		}
+		span.End()
+	}()
+
 	// Expose the detached overlay as a normal host block device for e2fsprogs.
 	device, err := b.openOfflineDevice(ctx, backend)
 	if err != nil {
@@ -236,6 +253,7 @@ func (b *EnsureFreeDiskBuilder) resizeOffline(
 	if err != nil {
 		return 0, fmt.Errorf("measure grown free space: %w", err)
 	}
+	span.SetAttributes(attribute.Int64("template.resize_disk.free_after_bytes", freeAfter))
 	if err := device.mnt.Flush(ctx); err != nil {
 		return 0, fmt.Errorf("flush grown device: %w", err)
 	}


### PR DESCRIPTION
… phase

   The resize-disk phase can take minutes, but its span attributed almost none
   of that wall time: the visible children (get template, mount flush/close,
   stat-ext4-file, resize-ext4) summed to tens of milliseconds against a
   multi-minute parent. The expensive work ran inside operations that emitted
   no span at all, leaving the phase effectively undebuggable from a trace.

   Add the minimum set of spans that cover the previously invisible time and
   the few attributes needed to tell why a resize is slow or how far it grew:

   - filesystem.CheckIntegrity: wrap each e2fsck in an "e2fsck" span. This forced full check runs twice per grow (before and after resize2fs), reads the whole filesystem metadata, and lazily faults in the backing rootfs chunks from object storage, so it usually dominates the phase. Record filesystem.e2fsck.fix and filesystem.e2fsck.exit_code so a slow run can be told apart from one that corrected errors.
   - filesystem.ReplayJournal: wrap the journal-only e2fsck (run during the free-space measurement) in a "replay-journal" span.
   - nbd.DirectPathMount.Open: wrap the netlink connect and wait-for-connected poll loop in a "direct-path-mount-open" span with nbd.device_index. It is opened once to measure and once to resize, and device-pool contention plus the poll loop were previously untraced.
   - ensurefreedisk.resizeOffline: add a "resize-offline" span that groups the two e2fscks and resize2fs and carries the only otherwise-invisible sizing data: template.resize_disk.new_size_bytes and free_after_bytes.

   Together with the existing resize-disk parent attributes (requested/free
   before/after), stat-ext4-file, resize-ext4, export-to-diff, and upload
   snapshot spans, the trace now accounts for the full phase duration and shows
   whether a build is e2fsck-bound, connect-bound, or driven by the grow size.

   Deliberately do not add per-read spans around StorageDiff.ReadAt: that would
   be span explosion on the hot read path. The e2fsck span duration plus the
   existing orchestrator.file.read_at metric already reveal backing-store fetch
   cost.

   No behavior change; instrumentation only.

   Part of: EN-1673