### PR TITLE
fix(nomad-nodepool-apm): retain ineligible nodes

### DIFF
--- a/packages/nomad-nodepool-apm/README.md
+++ b/packages/nomad-nodepool-apm/README.md
@@ -6,10 +6,10 @@ Custom plugins for the [Nomad Autoscaler](https://github.com/hashicorp/nomad-aut
 
 The package builds two plugins because Nomad Autoscaler supports only one plugin type per external binary:
 
-- `nomad-nodepool-apm` reports the number of ready, eligible nodes in a pool.
+- `nomad-nodepool-apm` reports the number of ready nodes in a pool.
 - `nomad-deployment-aware-target` fails an active deployment before applying the requested task-group count.
 
-Together they let service jobs replicate system-job placement while retaining rolling updates. The deployment-aware target is used by the `orchestrator-ee` service job. When the task-group count must change, scaling intentionally abandons a conflicting in-progress rollout (Nomad rejects scaling while a deployment is active); Nomad records that deployment as `failed`, rather than `cancelled`. The rollout spawned by the scale itself is left to run, and no deployment is touched when the count already matches. The target requires `auto_revert = false` on the scaled group (otherwise failing a deployment would restore an older job version and ping-pong); it refuses to scale groups with `auto_revert = true` and returns an error on every attempt.
+Together they let service jobs replicate system-job placement while retaining rolling updates. The deployment-aware target is used by the `template-manager` and `orchestrator-ee` service jobs. When the task-group count must change, scaling intentionally abandons a conflicting in-progress rollout (Nomad rejects scaling while a deployment is active); Nomad records that deployment as `failed`, rather than `cancelled`. The rollout spawned by the scale itself is left to run, and no deployment is touched when the count already matches. The target requires `auto_revert = false` on the scaled group (otherwise failing a deployment would restore an older job version and ping-pong); it refuses to scale groups with `auto_revert = true` and returns an error on every attempt.
 
 ## Usage
 
@@ -77,8 +77,7 @@ scaling {
 
 1. The plugin queries the Nomad API to list nodes filtered by the specified node pool
 2. It counts only nodes that are:
-   - Status: `ready`
-   - Scheduling eligibility: `eligible`
+    - Status: `ready`
 3. Returns the count as a metric for the autoscaler to use
 4. With the `pass-through` strategy, this count becomes the desired number of allocations
 5. The target serializes scaling per namespaced job and is a no-op when the durable count already matches
@@ -92,7 +91,7 @@ Dry-run actions do not fail deployments or write task-group counts.
 
 The `query` parameter should be the name of the node pool you want to count nodes from.
 
-Example: `query = "orchestrator"` counts all ready, eligible nodes in the `orchestrator` node pool.
+Example: `query = "orchestrator"` counts all ready nodes in the `orchestrator` node pool.
 
 ## Configuration Options
 

--- a/packages/nomad-nodepool-apm/plugin/plugin.go
+++ b/packages/nomad-nodepool-apm/plugin/plugin.go
@@ -127,18 +127,12 @@ func (p *NodePoolPlugin) Query(query string, _ sdk.TimeRange) (sdk.TimestampedMe
 		return nil, fmt.Errorf("failed to list nodes in pool %q: %w", nodePool, err)
 	}
 
-	// Count only nodes that are ready and eligible for scheduling
-	readyCount := 0
-	for _, node := range nodes {
-		if node.Status == api.NodeStatusReady && node.SchedulingEligibility == api.NodeSchedulingEligible {
-			readyCount++
-		}
-	}
+	readyCount := countReadyNodes(nodes)
 
 	p.logger.Info("node count query completed",
 		"node_pool", nodePool,
 		"total_nodes", len(nodes),
-		"ready_eligible_nodes", readyCount,
+		"ready_nodes", readyCount,
 	)
 
 	return sdk.TimestampedMetrics{
@@ -147,6 +141,19 @@ func (p *NodePoolPlugin) Query(query string, _ sdk.TimeRange) (sdk.TimestampedMe
 			Value:     float64(readyCount),
 		},
 	}, nil
+}
+
+// countReadyNodes keeps nodes that are temporarily ineligible in the desired
+// allocation count until they have actually left the pool.
+func countReadyNodes(nodes []*api.NodeListStub) int {
+	count := 0
+	for _, node := range nodes {
+		if node.Status == api.NodeStatusReady {
+			count++
+		}
+	}
+
+	return count
 }
 
 // QueryMultiple satisfies the QueryMultiple function on the apm.APM interface.

--- a/packages/nomad-nodepool-apm/plugin/plugin_test.go
+++ b/packages/nomad-nodepool-apm/plugin/plugin_test.go
@@ -1,0 +1,21 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+)
+
+func TestCountReadyNodesIncludesIneligibleNodes(t *testing.T) {
+	t.Parallel()
+
+	nodes := []*api.NodeListStub{
+		{Status: api.NodeStatusReady, SchedulingEligibility: api.NodeSchedulingEligible},
+		{Status: api.NodeStatusReady, SchedulingEligibility: api.NodeSchedulingIneligible},
+		{Status: api.NodeStatusDown, SchedulingEligibility: api.NodeSchedulingEligible},
+	}
+
+	if got := countReadyNodes(nodes); got != 2 {
+		t.Fatalf("ready node count = %d, want 2", got)
+	}
+}

--- a/packages/nomad-nodepool-apm/target/plugin.go
+++ b/packages/nomad-nodepool-apm/target/plugin.go
@@ -224,7 +224,7 @@ func (p *Plugin) Status(config map[string]string) (*sdk.TargetStatus, error) {
 		meta[sdk.TargetStatusMetaKeyLastEvent] = strconv.FormatUint(groupStatus.Events[0].Time, 10)
 	}
 
-	return &sdk.TargetStatus{Ready: !status.JobStopped, Count: int64(groupStatus.Running), Meta: meta}, nil
+	return &sdk.TargetStatus{Ready: !status.JobStopped, Count: int64(groupStatus.Desired), Meta: meta}, nil
 }
 
 func (p *Plugin) target(config map[string]string) (string, string, string, error) {

--- a/packages/nomad-nodepool-apm/target/plugin_test.go
+++ b/packages/nomad-nodepool-apm/target/plugin_test.go
@@ -44,7 +44,7 @@ func newNomadStub(t *testing.T) *nomadStub {
 			Namespace:  testNamespace,
 			JobStopped: true,
 			TaskGroups: map[string]api.TaskGroupScaleStatus{
-				"web": {Running: 2, Events: []api.ScalingEvent{{Time: 12345}}},
+				"web": {Desired: 3, Running: 2, Events: []api.ScalingEvent{{Time: 12345}}},
 			},
 		},
 	}
@@ -490,7 +490,7 @@ func TestScaleRetriesCASRaceFromFreshJob(t *testing.T) {
 	}
 }
 
-func TestStatusPreservesNomadTargetSemantics(t *testing.T) {
+func TestStatusUsesDurableTaskGroupCount(t *testing.T) {
 	t.Parallel()
 
 	stub := newNomadStub(t)
@@ -500,7 +500,7 @@ func TestStatusPreservesNomadTargetSemantics(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Status: %v", err)
 	}
-	if status.Ready || status.Count != 2 {
+	if status.Ready || status.Count != 3 {
 		t.Fatalf("status ready/count = %v/%d", status.Ready, status.Count)
 	}
 	if status.Meta["nomad_autoscaler.target.nomad.example.stopped"] != "true" {


### PR DESCRIPTION
Fix downscaling nodepool causing nomad to shoot a random allocation.