### PR TITLE
fix(clickhouse): avoid server-tz drift in sandbox/team metrics filters

### DIFF
--- a/packages/clickhouse/pkg/sandbox.go
+++ b/packages/clickhouse/pkg/sandbox.go
@@ -24,6 +24,28 @@ type Metrics struct {
 	DiskUsed       float64   `ch:"disk_used"`
 }
 
+// maxUnixSecondsForCH is the largest Unix-second value whose nanosecond
+// representation fits in a signed int64. time.Time.UnixNano() is undefined
+// beyond ~2262-04-11; API handlers accept Unix-second query params without
+// an upper bound, so far-future sentinels (e.g. 9999999999 = year 2286)
+// must be clamped before conversion to avoid wrapping to negative int64
+// and silently breaking fromUnixTimestamp64Nano filter windows.
+const maxUnixSecondsForCH = (1<<63 - 1) / int64(time.Second)
+
+// unixNanoForCH returns t as nanoseconds since the Unix epoch, clamped to
+// the int64-representable range. Always use this instead of t.UTC().UnixNano()
+// when feeding values to ClickHouse's fromUnixTimestamp64Nano.
+func unixNanoForCH(t time.Time) int64 {
+	s := t.UTC().Unix()
+	switch {
+	case s > maxUnixSecondsForCH:
+		s = maxUnixSecondsForCH
+	case s < -maxUnixSecondsForCH:
+		s = -maxUnixSecondsForCH
+	}
+	return time.Unix(s, 0).UTC().UnixNano()
+}
+
 var latestMetricsSelectQuery = fmt.Sprintf(`
 SELECT sandbox_id,
        team_id,
@@ -114,8 +136,8 @@ func (c *Client) QuerySandboxMetrics(ctx context.Context, sandboxID string, team
 	rows, err := c.conn.Query(ctx, sandboxMetricsSelectQuery,
 		clickhouse.Named("sandbox_id", sandboxID),
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", start.UTC().UnixNano()),
-		clickhouse.Named("end_time", end.UTC().UnixNano()),
+		clickhouse.Named("start_time", unixNanoForCH(start)),
+		clickhouse.Named("end_time", unixNanoForCH(end)),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {

--- a/packages/clickhouse/pkg/sandbox.go
+++ b/packages/clickhouse/pkg/sandbox.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/timestamp"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -22,28 +23,6 @@ type Metrics struct {
 	MemCache       float64   `ch:"ram_cache"`
 	DiskTotal      float64   `ch:"disk_total"`
 	DiskUsed       float64   `ch:"disk_used"`
-}
-
-// maxUnixSecondsForCH is the largest Unix-second value whose nanosecond
-// representation fits in a signed int64. time.Time.UnixNano() is undefined
-// beyond ~2262-04-11; API handlers accept Unix-second query params without
-// an upper bound, so far-future sentinels (e.g. 9999999999 = year 2286)
-// must be clamped before conversion to avoid wrapping to negative int64
-// and silently breaking fromUnixTimestamp64Nano filter windows.
-const maxUnixSecondsForCH = (1<<63 - 1) / int64(time.Second)
-
-// unixNanoForCH returns t as nanoseconds since the Unix epoch, clamped to
-// the int64-representable range. Always use this instead of t.UTC().UnixNano()
-// when feeding values to ClickHouse's fromUnixTimestamp64Nano.
-func unixNanoForCH(t time.Time) int64 {
-	s := t.UTC().Unix()
-	switch {
-	case s > maxUnixSecondsForCH:
-		s = maxUnixSecondsForCH
-	case s < -maxUnixSecondsForCH:
-		s = -maxUnixSecondsForCH
-	}
-	return time.Unix(s, 0).UTC().UnixNano()
 }
 
 var latestMetricsSelectQuery = fmt.Sprintf(`
@@ -136,8 +115,8 @@ func (c *Client) QuerySandboxMetrics(ctx context.Context, sandboxID string, team
 	rows, err := c.conn.Query(ctx, sandboxMetricsSelectQuery,
 		clickhouse.Named("sandbox_id", sandboxID),
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", unixNanoForCH(start)),
-		clickhouse.Named("end_time", unixNanoForCH(end)),
+		clickhouse.Named("start_time", timestamp.UnixNano(start)),
+		clickhouse.Named("end_time", timestamp.UnixNano(end)),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {

--- a/packages/clickhouse/pkg/sandbox.go
+++ b/packages/clickhouse/pkg/sandbox.go
@@ -90,8 +90,8 @@ SELECT   toStartOfInterval(timestamp, interval {step:UInt32} second) AS ts,
 FROM     sandbox_metrics_gauge s
 WHERE    sandbox_id = {sandbox_id:String}
 AND      team_id = {team_id:String}
-AND      timestamp >= {start_time:DateTime64}
-AND      timestamp <= {end_time:DateTime64}
+AND      timestamp >= fromUnixTimestamp64Nano({start_time:Int64})
+AND      timestamp <= fromUnixTimestamp64Nano({end_time:Int64})
 GROUP BY ts
 ORDER BY ts;
 `, telemetry.SandboxCpuTotalGaugeName, telemetry.SandboxCpuUsedGaugeName, telemetry.SandboxRamTotalGaugeName, telemetry.SandboxRamUsedGaugeName, telemetry.SandboxRamCacheGaugeName, telemetry.SandboxDiskTotalGaugeName, telemetry.SandboxDiskUsedGaugeName)
@@ -114,8 +114,8 @@ func (c *Client) QuerySandboxMetrics(ctx context.Context, sandboxID string, team
 	rows, err := c.conn.Query(ctx, sandboxMetricsSelectQuery,
 		clickhouse.Named("sandbox_id", sandboxID),
 		clickhouse.Named("team_id", teamID),
-		clickhouse.DateNamed("start_time", start, clickhouse.Seconds),
-		clickhouse.DateNamed("end_time", end, clickhouse.Seconds),
+		clickhouse.Named("start_time", start.UTC().UnixNano()),
+		clickhouse.Named("end_time", end.UTC().UnixNano()),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {

--- a/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
+++ b/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
@@ -104,8 +104,26 @@ func atLeastLevels(minLevel logs.LogLevel) []string {
 	}
 }
 
+// maxUnixSecondsForCH mirrors the constant in packages/clickhouse/pkg/sandbox.go
+// and lives here separately to avoid pulling the parent package into this
+// subpackage. Consolidate into a shared timeutil package if a third caller
+// appears.
+const maxUnixSecondsForCH = (1<<63 - 1) / int64(time.Second)
+
+// unixNano returns t as nanoseconds since the Unix epoch, clamped to the
+// int64-representable range. Handlers accept Unix-second query params without
+// an upper bound, so far-future sentinels like 9999999999 (= year 2286) must
+// be clamped before conversion to avoid wrapping to negative int64 and
+// silently breaking fromUnixTimestamp64Nano filter windows.
 func unixNano(t time.Time) int64 {
-	return t.UTC().UnixNano()
+	s := t.UTC().Unix()
+	switch {
+	case s > maxUnixSecondsForCH:
+		s = maxUnixSecondsForCH
+	case s < -maxUnixSecondsForCH:
+		s = -maxUnixSecondsForCH
+	}
+	return time.Unix(s, 0).UTC().UnixNano()
 }
 
 const sandboxLogsSelect = `

--- a/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
+++ b/packages/clickhouse/pkg/sandboxlogs/sandboxlogs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/timestamp"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logs"
 )
@@ -104,28 +105,6 @@ func atLeastLevels(minLevel logs.LogLevel) []string {
 	}
 }
 
-// maxUnixSecondsForCH mirrors the constant in packages/clickhouse/pkg/sandbox.go
-// and lives here separately to avoid pulling the parent package into this
-// subpackage. Consolidate into a shared timeutil package if a third caller
-// appears.
-const maxUnixSecondsForCH = (1<<63 - 1) / int64(time.Second)
-
-// unixNano returns t as nanoseconds since the Unix epoch, clamped to the
-// int64-representable range. Handlers accept Unix-second query params without
-// an upper bound, so far-future sentinels like 9999999999 (= year 2286) must
-// be clamped before conversion to avoid wrapping to negative int64 and
-// silently breaking fromUnixTimestamp64Nano filter windows.
-func unixNano(t time.Time) int64 {
-	s := t.UTC().Unix()
-	switch {
-	case s > maxUnixSecondsForCH:
-		s = maxUnixSecondsForCH
-	case s < -maxUnixSecondsForCH:
-		s = -maxUnixSecondsForCH
-	}
-	return time.Unix(s, 0).UTC().UnixNano()
-}
-
 const sandboxLogsSelect = `
 SELECT
     timestamp,
@@ -153,8 +132,8 @@ func (r *Reader) QuerySandboxLogs(ctx context.Context, teamID uuid.UUID, sandbox
 	args := []any{
 		clickhouse.Named("team_id", teamID.String()),
 		clickhouse.Named("sandbox_id", sandboxID),
-		clickhouse.Named("start", unixNano(start)),
-		clickhouse.Named("end", unixNano(end)),
+		clickhouse.Named("start", timestamp.UnixNano(start)),
+		clickhouse.Named("end", timestamp.UnixNano(end)),
 	}
 
 	if level != nil {
@@ -190,8 +169,8 @@ func (r *Reader) QueryBuildLogs(ctx context.Context, templateID, buildID string,
 	args := []any{
 		clickhouse.Named("build_id", buildID),
 		clickhouse.Named("template_id", templateID),
-		clickhouse.Named("start", unixNano(start)),
-		clickhouse.Named("end", unixNano(end)),
+		clickhouse.Named("start", timestamp.UnixNano(start)),
+		clickhouse.Named("end", timestamp.UnixNano(end)),
 	}
 
 	if level != nil {

--- a/packages/clickhouse/pkg/sandboxlogs/sandboxlogs_test.go
+++ b/packages/clickhouse/pkg/sandboxlogs/sandboxlogs_test.go
@@ -28,18 +28,6 @@ func TestAtLeastLevels(t *testing.T) {
 	assert.Equal(t, []string{"", "debug", "info", "warn", "error"}, atLeastLevels(logs.LevelDebug))
 }
 
-func TestUnixNano(t *testing.T) {
-	t.Parallel()
-
-	ts := time.Date(2024, 1, 2, 3, 4, 5, 6, time.UTC)
-	assert.Equal(t, ts.UnixNano(), unixNano(ts))
-
-	// Non-UTC input must be normalized to the same instant.
-	loc := time.FixedZone("test", 3600)
-	local := ts.In(loc)
-	assert.Equal(t, ts.UnixNano(), unixNano(local))
-}
-
 func TestRowToLogEntry(t *testing.T) {
 	t.Parallel()
 

--- a/packages/clickhouse/pkg/team.go
+++ b/packages/clickhouse/pkg/team.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 
+	"github.com/e2b-dev/infra/packages/clickhouse/pkg/timestamp"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -57,8 +58,8 @@ ORDER BY all_ts.ts ASC;
 func (c *Client) QueryTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time, step time.Duration) ([]TeamMetrics, error) {
 	rows, err := c.conn.Query(ctx, teamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", unixNanoForCH(start)),
-		clickhouse.Named("end_time", unixNanoForCH(end)),
+		clickhouse.Named("start_time", timestamp.UnixNano(start)),
+		clickhouse.Named("end_time", timestamp.UnixNano(end)),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {
@@ -109,8 +110,8 @@ func (c *Client) QueryMaxStartRateTeamMetrics(ctx context.Context, teamID string
 	rows, err := c.conn.Query(ctx, maxStartRateTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
-		clickhouse.Named("start_time", unixNanoForCH(start)),
-		clickhouse.Named("end_time", unixNanoForCH(end)),
+		clickhouse.Named("start_time", timestamp.UnixNano(start)),
+		clickhouse.Named("end_time", timestamp.UnixNano(end)),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max start rate team metrics: %w", err)
@@ -151,8 +152,8 @@ WHERE metric_name = '%s'
 func (c *Client) QueryMaxConcurrentTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time) (MaxTeamMetric, error) {
 	rows, err := c.conn.Query(ctx, maxConcurrentTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", unixNanoForCH(start)),
-		clickhouse.Named("end_time", unixNanoForCH(end)),
+		clickhouse.Named("start_time", timestamp.UnixNano(start)),
+		clickhouse.Named("end_time", timestamp.UnixNano(end)),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max concurrent team metrics: %w", err)

--- a/packages/clickhouse/pkg/team.go
+++ b/packages/clickhouse/pkg/team.go
@@ -57,8 +57,8 @@ ORDER BY all_ts.ts ASC;
 func (c *Client) QueryTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time, step time.Duration) ([]TeamMetrics, error) {
 	rows, err := c.conn.Query(ctx, teamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", start.UTC().UnixNano()),
-		clickhouse.Named("end_time", end.UTC().UnixNano()),
+		clickhouse.Named("start_time", unixNanoForCH(start)),
+		clickhouse.Named("end_time", unixNanoForCH(end)),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {
@@ -109,8 +109,8 @@ func (c *Client) QueryMaxStartRateTeamMetrics(ctx context.Context, teamID string
 	rows, err := c.conn.Query(ctx, maxStartRateTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
-		clickhouse.Named("start_time", start.UTC().UnixNano()),
-		clickhouse.Named("end_time", end.UTC().UnixNano()),
+		clickhouse.Named("start_time", unixNanoForCH(start)),
+		clickhouse.Named("end_time", unixNanoForCH(end)),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max start rate team metrics: %w", err)
@@ -151,8 +151,8 @@ WHERE metric_name = '%s'
 func (c *Client) QueryMaxConcurrentTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time) (MaxTeamMetric, error) {
 	rows, err := c.conn.Query(ctx, maxConcurrentTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.Named("start_time", start.UTC().UnixNano()),
-		clickhouse.Named("end_time", end.UTC().UnixNano()),
+		clickhouse.Named("start_time", unixNanoForCH(start)),
+		clickhouse.Named("end_time", unixNanoForCH(end)),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max concurrent team metrics: %w", err)

--- a/packages/clickhouse/pkg/team.go
+++ b/packages/clickhouse/pkg/team.go
@@ -26,7 +26,7 @@ WITH
     FROM team_metrics_sum
     WHERE metric_name = '%s'
       AND team_id = {team_id:String}
-      AND timestamp BETWEEN {start_time:DateTime64} AND {end_time:DateTime64}
+      AND timestamp BETWEEN fromUnixTimestamp64Nano({start_time:Int64}) AND fromUnixTimestamp64Nano({end_time:Int64})
 	GROUP BY ts
   ),
   concurrent AS (
@@ -36,7 +36,7 @@ WITH
     FROM team_metrics_gauge
     WHERE metric_name = '%s'
       AND team_id = {team_id:String}
-      AND timestamp BETWEEN {start_time:DateTime64} AND {end_time:DateTime64}
+      AND timestamp BETWEEN fromUnixTimestamp64Nano({start_time:Int64}) AND fromUnixTimestamp64Nano({end_time:Int64})
 	GROUP BY ts
   ),
   all_ts AS (
@@ -57,8 +57,8 @@ ORDER BY all_ts.ts ASC;
 func (c *Client) QueryTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time, step time.Duration) ([]TeamMetrics, error) {
 	rows, err := c.conn.Query(ctx, teamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.DateNamed("start_time", start, clickhouse.Seconds),
-		clickhouse.DateNamed("end_time", end, clickhouse.Seconds),
+		clickhouse.Named("start_time", start.UTC().UnixNano()),
+		clickhouse.Named("end_time", end.UTC().UnixNano()),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
 	)
 	if err != nil {
@@ -96,7 +96,7 @@ WITH
 	FROM team_metrics_sum
 	WHERE metric_name = '%s'
 	  AND team_id = {team_id:String}
-	  AND timestamp BETWEEN {start_time:DateTime64} AND {end_time:DateTime64}
+	  AND timestamp BETWEEN fromUnixTimestamp64Nano({start_time:Int64}) AND fromUnixTimestamp64Nano({end_time:Int64})
 	GROUP BY agg_ts
 	)
 SELECT
@@ -109,8 +109,8 @@ func (c *Client) QueryMaxStartRateTeamMetrics(ctx context.Context, teamID string
 	rows, err := c.conn.Query(ctx, maxStartRateTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
 		clickhouse.Named("step", strconv.Itoa(int(step.Seconds()))),
-		clickhouse.DateNamed("start_time", start, clickhouse.Seconds),
-		clickhouse.DateNamed("end_time", end, clickhouse.Seconds),
+		clickhouse.Named("start_time", start.UTC().UnixNano()),
+		clickhouse.Named("end_time", end.UTC().UnixNano()),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max start rate team metrics: %w", err)
@@ -145,14 +145,14 @@ SELECT
 FROM team_metrics_gauge
 WHERE metric_name = '%s'
   AND team_id = {team_id:String}
-  AND timestamp BETWEEN {start_time:DateTime64} AND {end_time:DateTime64};
+  AND timestamp BETWEEN fromUnixTimestamp64Nano({start_time:Int64}) AND fromUnixTimestamp64Nano({end_time:Int64});
 `, telemetry.TeamSandboxRunningGaugeName)
 
 func (c *Client) QueryMaxConcurrentTeamMetrics(ctx context.Context, teamID string, start time.Time, end time.Time) (MaxTeamMetric, error) {
 	rows, err := c.conn.Query(ctx, maxConcurrentTeamMetricsSelectQuery,
 		clickhouse.Named("team_id", teamID),
-		clickhouse.DateNamed("start_time", start, clickhouse.Seconds),
-		clickhouse.DateNamed("end_time", end, clickhouse.Seconds),
+		clickhouse.Named("start_time", start.UTC().UnixNano()),
+		clickhouse.Named("end_time", end.UTC().UnixNano()),
 	)
 	if err != nil {
 		return MaxTeamMetric{}, fmt.Errorf("query max concurrent team metrics: %w", err)

--- a/packages/clickhouse/pkg/timestamp/timestamp.go
+++ b/packages/clickhouse/pkg/timestamp/timestamp.go
@@ -3,21 +3,26 @@ package timestamp
 
 import "time"
 
-// maxUnixSeconds is the largest Unix-second value whose nanosecond
-// representation fits in a signed int64. time.Time.UnixNano is undefined
-// beyond approximately 2262-04-11.
-const maxUnixSeconds = (1<<63 - 1) / int64(time.Second)
+const (
+	minUnixNano int64 = -1 << 63
+	maxUnixNano int64 = 1<<63 - 1
+)
 
-// UnixNano returns t as whole-second nanoseconds since the Unix epoch, clamped
-// to the int64 range accepted by ClickHouse's fromUnixTimestamp64Nano.
+var (
+	minUnixNanoTime = time.Unix(0, minUnixNano).UTC()
+	maxUnixNanoTime = time.Unix(0, maxUnixNano).UTC()
+)
+
+// UnixNano returns t as nanoseconds since the Unix epoch, clamped to the int64
+// range accepted by ClickHouse's fromUnixTimestamp64Nano.
 func UnixNano(t time.Time) int64 {
-	seconds := t.UTC().Unix()
+	t = t.UTC()
 	switch {
-	case seconds > maxUnixSeconds:
-		seconds = maxUnixSeconds
-	case seconds < -maxUnixSeconds:
-		seconds = -maxUnixSeconds
+	case t.Before(minUnixNanoTime):
+		return minUnixNano
+	case t.After(maxUnixNanoTime):
+		return maxUnixNano
+	default:
+		return t.UnixNano()
 	}
-
-	return time.Unix(seconds, 0).UTC().UnixNano()
 }

--- a/packages/clickhouse/pkg/timestamp/timestamp.go
+++ b/packages/clickhouse/pkg/timestamp/timestamp.go
@@ -1,0 +1,23 @@
+// Package timestamp converts Go timestamps for use in ClickHouse queries.
+package timestamp
+
+import "time"
+
+// maxUnixSeconds is the largest Unix-second value whose nanosecond
+// representation fits in a signed int64. time.Time.UnixNano is undefined
+// beyond approximately 2262-04-11.
+const maxUnixSeconds = (1<<63 - 1) / int64(time.Second)
+
+// UnixNano returns t as whole-second nanoseconds since the Unix epoch, clamped
+// to the int64 range accepted by ClickHouse's fromUnixTimestamp64Nano.
+func UnixNano(t time.Time) int64 {
+	seconds := t.UTC().Unix()
+	switch {
+	case seconds > maxUnixSeconds:
+		seconds = maxUnixSeconds
+	case seconds < -maxUnixSeconds:
+		seconds = -maxUnixSeconds
+	}
+
+	return time.Unix(seconds, 0).UTC().UnixNano()
+}

--- a/packages/clickhouse/pkg/timestamp/timestamp_test.go
+++ b/packages/clickhouse/pkg/timestamp/timestamp_test.go
@@ -1,0 +1,28 @@
+package timestamp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnixNano(t *testing.T) {
+	t.Parallel()
+
+	timestamp := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	assert.Equal(t, timestamp.UnixNano(), UnixNano(timestamp))
+
+	location := time.FixedZone("test", 3600)
+	assert.Equal(t, timestamp.UnixNano(), UnixNano(timestamp.In(location)))
+}
+
+func TestUnixNanoClampsToInt64Range(t *testing.T) {
+	t.Parallel()
+
+	max := time.Unix(maxUnixSeconds, 0).UTC().UnixNano()
+	min := time.Unix(-maxUnixSeconds, 0).UTC().UnixNano()
+
+	assert.Equal(t, max, UnixNano(time.Date(2299, 12, 31, 23, 59, 59, 0, time.UTC)))
+	assert.Equal(t, min, UnixNano(time.Date(1600, 1, 1, 0, 0, 0, 0, time.UTC)))
+}

--- a/packages/clickhouse/pkg/timestamp/timestamp_test.go
+++ b/packages/clickhouse/pkg/timestamp/timestamp_test.go
@@ -10,7 +10,7 @@ import (
 func TestUnixNano(t *testing.T) {
 	t.Parallel()
 
-	timestamp := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	timestamp := time.Date(2024, 1, 2, 3, 4, 5, 500_000_123, time.UTC)
 	assert.Equal(t, timestamp.UnixNano(), UnixNano(timestamp))
 
 	location := time.FixedZone("test", 3600)
@@ -20,9 +20,8 @@ func TestUnixNano(t *testing.T) {
 func TestUnixNanoClampsToInt64Range(t *testing.T) {
 	t.Parallel()
 
-	max := time.Unix(maxUnixSeconds, 0).UTC().UnixNano()
-	min := time.Unix(-maxUnixSeconds, 0).UTC().UnixNano()
-
-	assert.Equal(t, max, UnixNano(time.Date(2299, 12, 31, 23, 59, 59, 0, time.UTC)))
-	assert.Equal(t, min, UnixNano(time.Date(1600, 1, 1, 0, 0, 0, 0, time.UTC)))
+	assert.Equal(t, maxUnixNano, UnixNano(time.Date(2299, 12, 31, 23, 59, 59, 0, time.UTC)))
+	assert.Equal(t, minUnixNano, UnixNano(time.Date(1600, 1, 1, 0, 0, 0, 0, time.UTC)))
+	assert.Equal(t, maxUnixNano, UnixNano(maxUnixNanoTime))
+	assert.Equal(t, minUnixNano, UnixNano(minUnixNanoTime))
 }


### PR DESCRIPTION
## Summary

- Replace `DateTime64` query parameters with `Int64` Unix-nanosecond parameters converted through `fromUnixTimestamp64Nano`.
- Apply the fix to:
  - `sandbox_metrics_gauge` queries in `packages/clickhouse/pkg/sandbox.go`
  - `team_metrics_sum` and `team_metrics_gauge` queries in `packages/clickhouse/pkg/team.go`
  - Existing sandbox and build log queries
- Centralize ClickHouse timestamp conversion in `packages/clickhouse/pkg/timestamp`, including safe clamping for dates outside the `int64` nanosecond range.

## Why

`clickhouse.DateNamed(..., clickhouse.Seconds)` serializes a UTC `time.Time` as a wall-clock string without an offset, such as `'2025-02-17 00:00:00'`.

When a `DateTime64(9)` column has no explicit timezone, ClickHouse interprets that value using the server timezone. On a non-UTC server such as `Asia/Shanghai`, the query window shifts by the timezone offset. This can produce empty results for short ranges and stale or incorrect results for longer ranges.

The issue has existed since the original metrics migrations:

- `20250717135224_sandbox_metrics.sql`
- `20250801113224_team_metrics.sql`

The sandbox logs reader introduced in #3236 already used Unix nanoseconds. This PR applies the same timezone-independent approach to the older metrics readers and moves the shared conversion into a dedicated package.

## Affected Endpoints

- `GET /sandboxes/{sandboxID}/metrics`
- `GET /teams/{teamID}/metrics`
- `GET /teams/{teamID}/metrics/max`

## Implementation

Unix nanoseconds represent an absolute instant. Passing them as `Int64` values and converting them with `fromUnixTimestamp64Nano` avoids timezone-dependent string parsing:

```sql
timestamp >= fromUnixTimestamp64Nano({start_time:Int64})
AND timestamp <= fromUnixTimestamp64Nano({end_time:Int64})
```

The shared `timestamp.UnixNano` helper also clamps far-future and far-past values before conversion, preventing `time.Time.UnixNano` overflow.

Returned timestamps and their JSON serialization are unchanged.

## Testing

- Added focused tests for timestamp conversion, timezone normalization, and `int64` range clamping.
- Verified the ClickHouse timestamp, sandbox logs, and root client packages.

No schema changes or migrations are required.