### PR TITLE
fix(orchestrator): order egress config/firewall updates to close BYOP enable race

### DIFF
--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -395,21 +395,18 @@ func (s *Server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequ
 	if req.GetEgress() != nil {
 		updates = append(updates, func(ctx context.Context) (func(context.Context), error) {
 			oldEgress := sbx.Config.GetNetworkEgress()
-
-			if err := sbx.Slot.UpdateInternet(ctx, req.GetEgress()); err != nil {
-				return nil, fmt.Errorf("failed to update sandbox network: %w", err)
-			}
-
 			egress := req.GetEgress()
-			if len(egress.GetAllowedCidrs()) == 0 && len(egress.GetDeniedCidrs()) == 0 && len(egress.GetAllowedDomains()) == 0 && len(egress.GetRules()) == 0 && egress.GetEgressProxyAddress() == "" {
-				sbx.Config.SetNetworkEgress(nil)
-			} else {
-				sbx.Config.SetNetworkEgress(egress)
+
+			if err := transitionEgress(ctx, sbx.Config, sbx.Slot.UpdateInternet, oldEgress, egress); err != nil {
+				return nil, err
 			}
 
 			return func(ctx context.Context) {
-				_ = sbx.Slot.UpdateInternet(ctx, oldEgress)
-				sbx.Config.SetNetworkEgress(oldEgress)
+				// Fails closed: a failed kernel re-drop never publishes the
+				// weaker config. Rollbacks cannot propagate errors, so report.
+				if err := transitionEgress(ctx, sbx.Config, sbx.Slot.UpdateInternet, sbx.Config.GetNetworkEgress(), oldEgress); err != nil {
+					telemetry.ReportCriticalError(ctx, "failed to roll back sandbox egress update", err)
+				}
 			}, nil
 		})
 	}
@@ -462,6 +459,48 @@ func (s *Server) Update(ctx context.Context, req *orchestrator.SandboxUpdateRequ
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+// transitionEgress moves the in-memory egress config (read per-connection by
+// the userspace proxy) and the in-netns kernel firewall from one state to
+// another. Loosen last, tighten first: the kernel must never be more relaxed
+// than the config the proxy sees. On failure both layers stay consistent.
+// updateInternet is a parameter so tests can observe the ordering.
+func transitionEgress(
+	ctx context.Context,
+	cfg *sandbox.Config,
+	updateInternet func(context.Context, *orchestrator.SandboxNetworkEgressConfig) error,
+	from, to *orchestrator.SandboxNetworkEgressConfig,
+) error {
+	if to.GetEgressProxyAddress() != "" {
+		applyNetworkEgress(cfg, to)
+		if err := updateInternet(ctx, to); err != nil {
+			// The kernel kept its rules (atomic flush); undo the publish.
+			applyNetworkEgress(cfg, from)
+
+			return fmt.Errorf("failed to update sandbox network: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := updateInternet(ctx, to); err != nil {
+		return fmt.Errorf("failed to update sandbox network: %w", err)
+	}
+	applyNetworkEgress(cfg, to)
+
+	return nil
+}
+
+// applyNetworkEgress publishes the egress config to the in-memory sandbox
+// config, collapsing an all-empty egress (no CIDRs, domains, rules, or proxy)
+// to nil so readers treat it as "no custom egress".
+func applyNetworkEgress(cfg *sandbox.Config, egress *orchestrator.SandboxNetworkEgressConfig) {
+	if len(egress.GetAllowedCidrs()) == 0 && len(egress.GetDeniedCidrs()) == 0 && len(egress.GetAllowedDomains()) == 0 && len(egress.GetRules()) == 0 && egress.GetEgressProxyAddress() == "" {
+		cfg.SetNetworkEgress(nil)
+	} else {
+		cfg.SetNetworkEgress(egress)
+	}
 }
 
 func (s *Server) List(ctx context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListResponse, error) {

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -473,6 +473,9 @@ func transitionEgress(
 	from, to *orchestrator.SandboxNetworkEgressConfig,
 ) error {
 	if to.GetEgressProxyAddress() != "" {
+		// BYOP loosens the kernel firewall: internal-destined TCP is handed
+		// to the userspace proxy instead of dropped, so the proxy must see
+		// the config before the kernel lets that traffic through.
 		applyNetworkEgress(cfg, to)
 		if err := updateInternet(ctx, to); err != nil {
 			// The kernel kept its rules (atomic flush); undo the publish.

--- a/packages/orchestrator/pkg/server/sandboxes_update_test.go
+++ b/packages/orchestrator/pkg/server/sandboxes_update_test.go
@@ -3,6 +3,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -107,6 +109,138 @@ func TestUpdate_EndTimeAndEgress_EgressFails_RevertsEndTime(t *testing.T) {
 	assert.Empty(t, egress.GetAllowedCidrs())
 	assert.Empty(t, egress.GetDeniedCidrs())
 	assert.Empty(t, egress.GetAllowedDomains())
+}
+
+// TestUpdate_NonBYOPEgress_FirewallFails_ConfigUntouched exercises the
+// tighten-first (disable / no-BYOP) branch: UpdateInternet runs FIRST, so when
+// the firewall apply fails (no real netns here) the in-memory egress config is
+// never published. This is the kernel-before-userspace order that keeps the
+// kernel from being relaxed ahead of userspace on the tighten direction.
+func TestUpdate_NonBYOPEgress_FirewallFails_ConfigUntouched(t *testing.T) {
+	t.Parallel()
+
+	slot, err := network.NewSlot("test", 1, network.Config{}, network.NoopEgressProxy{})
+	require.NoError(t, err)
+
+	sbx := &sandbox.Sandbox{
+		Metadata: &sandbox.Metadata{
+			Config:  sandbox.NewConfig(sandbox.Config{}),
+			Runtime: sandbox.RuntimeMetadata{SandboxID: id.Generate()},
+		},
+		Resources: &sandbox.Resources{Slot: slot},
+	}
+	sbx.SetStartedAt(time.Now())
+	sbx.SetEndAt(time.Now().Add(time.Hour))
+
+	sandboxMap := sandbox.NewSandboxesMap()
+	sandboxMap.AssignNetwork(t.Context(), sbx)
+	sandboxMap.MarkRunning(t.Context(), sbx)
+
+	s := &Server{
+		sandboxFactory:   &sandbox.Factory{Sandboxes: sandboxMap},
+		info:             &service.ServiceInfo{},
+		sbxEventsService: internalevents.NewEventsService(nil),
+	}
+
+	// Sanity: no egress configured to start.
+	require.Nil(t, sbx.Config.GetNetworkEgress())
+
+	_, err = s.Update(t.Context(), &orchestrator.SandboxUpdateRequest{
+		SandboxId: sbx.Runtime.SandboxID,
+		Egress: &orchestrator.SandboxNetworkEgressConfig{
+			AllowedCidrs: []string{"1.2.3.4/32"},
+		},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	// Firewall apply ran first and failed, so config must never have been set.
+	assert.Nil(t, sbx.Config.GetNetworkEgress())
+}
+
+// TestTransitionEgress verifies the loosen-last / tighten-first ordering: the
+// fake updateInternet records the config the proxy sees at the moment the
+// kernel firewall would be mutated.
+func TestTransitionEgress(t *testing.T) {
+	t.Parallel()
+
+	byop := &orchestrator.SandboxNetworkEgressConfig{EgressProxyAddress: "socks5://proxy.example:1080"}
+	plain := &orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"1.2.3.4/32"}}
+	empty := &orchestrator.SandboxNetworkEgressConfig{}
+
+	errFirewall := errors.New("firewall apply failed")
+
+	tests := []struct {
+		name        string
+		from, to    *orchestrator.SandboxNetworkEgressConfig
+		firewallErr error
+		wantSeen    *orchestrator.SandboxNetworkEgressConfig // config published when the firewall is updated
+		wantFinal   *orchestrator.SandboxNetworkEgressConfig // config published after the transition
+		wantErr     bool
+	}{
+		{
+			name: "enable BYOP publishes config before relaxing firewall",
+			from: nil, to: byop,
+			wantSeen: byop, wantFinal: byop,
+		},
+		{
+			name: "enable BYOP failure unpublishes config",
+			from: nil, to: byop, firewallErr: errFirewall,
+			wantSeen: byop, wantFinal: nil, wantErr: true,
+		},
+		{
+			name: "tighten updates firewall before publishing config",
+			from: byop, to: plain,
+			wantSeen: byop, wantFinal: plain,
+		},
+		{
+			name: "tighten failure leaves config untouched",
+			from: byop, to: plain, firewallErr: errFirewall,
+			wantSeen: byop, wantFinal: byop, wantErr: true,
+		},
+		{
+			name: "all-empty egress collapses to nil",
+			from: plain, to: empty,
+			wantSeen: plain, wantFinal: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := sandbox.NewConfig(sandbox.Config{})
+			cfg.SetNetworkEgress(tt.from)
+
+			var seen *orchestrator.SandboxNetworkEgressConfig
+			updateInternet := func(context.Context, *orchestrator.SandboxNetworkEgressConfig) error {
+				seen = cfg.GetNetworkEgress()
+
+				return tt.firewallErr
+			}
+
+			err := transitionEgress(t.Context(), cfg, updateInternet, tt.from, tt.to)
+
+			if tt.wantErr {
+				require.ErrorIs(t, err, errFirewall)
+			} else {
+				require.NoError(t, err)
+			}
+			assertSameEgress(t, tt.wantSeen, seen)
+			assertSameEgress(t, tt.wantFinal, cfg.GetNetworkEgress())
+		})
+	}
+}
+
+// assertSameEgress asserts pointer identity, tolerating nil.
+func assertSameEgress(t *testing.T, want, got *orchestrator.SandboxNetworkEgressConfig) {
+	t.Helper()
+
+	if want == nil {
+		assert.Nil(t, got)
+	} else {
+		assert.Same(t, want, got)
+	}
 }
 
 func TestUpdate_SerializesUpdatesPerSandbox(t *testing.T) {


### PR DESCRIPTION
The Update RPC mutates the in-netns kernel firewall and the in-memory egress config non-atomically. Since 1fc3820d7319 ("feat(api): SOCKS5 egress proxy on sandbox network config (BYOP) (#2642)"), the kernel was relaxed before the userspace proxy learned about the SOCKS5 tunnel, so internal-destined TCP could briefly be direct-dialed from the host.

Order the two by direction: enabling BYOP publishes the proxy config before relaxing the firewall; disabling re-drops internal TCP first. The ordering lives in a single transitionEgress helper used by both the forward path and the rollback. The rollback fails closed - a failed kernel re-drop never publishes the weaker config - and reports the error instead of discarding it. Create/resume is already safe: the firewall is configured before the sandbox is visible to the proxy.

The helper takes the kernel-update func as a parameter so tests can observe the ordering; TestTransitionEgress pins publish-before-relax on enable, kernel-first on tighten, and both failure modes.