### PR TITLE
fix(api): downgrade sandbox 404 log noise from WARN to INFO

### DIFF
--- a/packages/api/internal/handlers/sandbox_timeout.go
+++ b/packages/api/internal/handlers/sandbox_timeout.go
@@ -11,6 +11,7 @@ import (
 	"github.com/e2b-dev/infra/packages/api/internal/utils"
 	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
 	"github.com/e2b-dev/infra/packages/shared/pkg/ginutils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -51,7 +52,11 @@ func (a *APIStore) PostSandboxesSandboxIDTimeout(
 
 	_, apiErr := a.orchestrator.KeepAliveFor(ctx, teamID, sandboxID, duration, true)
 	if apiErr != nil {
-		telemetry.ReportError(ctx, "error when setting timeout", apiErr.Err)
+		if apiErr.Code == http.StatusNotFound {
+			logger.L().Info(ctx, "sandbox not found for timeout update", logger.WithSandboxID(sandboxID))
+		} else {
+			telemetry.ReportError(ctx, "error when setting timeout", apiErr.Err)
+		}
 		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
 
 		return

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -86,8 +86,7 @@ func NewLogger(loggerConfig LoggerConfig) (Logger, error) {
 	cores := make([]zapcore.Core, 0)
 	cores = append(cores, loggerConfig.Cores...)
 
-	logger, err := config.Build(
-		zap.AddStacktrace(zapcore.ErrorLevel),
+	opts := []zap.Option{
 		zap.WrapCore(func(c zapcore.Core) zapcore.Core {
 			cores = append(cores, c)
 
@@ -99,7 +98,11 @@ func NewLogger(loggerConfig LoggerConfig) (Logger, error) {
 			zap.Int("pid", os.Getpid()),
 		),
 		zap.Fields(loggerConfig.InitialFields...),
-	)
+	}
+	if !loggerConfig.DisableStacktrace {
+		opts = append([]zap.Option{zap.AddStacktrace(zapcore.ErrorLevel)}, opts...)
+	}
+	logger, err := config.Build(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error building logger: %w", err)
 	}

--- a/packages/shared/pkg/logger/logger.go
+++ b/packages/shared/pkg/logger/logger.go
@@ -87,6 +87,7 @@ func NewLogger(loggerConfig LoggerConfig) (Logger, error) {
 	cores = append(cores, loggerConfig.Cores...)
 
 	logger, err := config.Build(
+		zap.AddStacktrace(zapcore.ErrorLevel),
 		zap.WrapCore(func(c zapcore.Core) zapcore.Core {
 			cores = append(cores, c)
 

--- a/packages/shared/pkg/middleware/logging.go
+++ b/packages/shared/pkg/middleware/logging.go
@@ -111,6 +111,8 @@ func LoggingMiddleware(logger logger.Logger, conf Config) gin.HandlerFunc {
 			switch {
 			case status >= http.StatusInternalServerError:
 				level = zapcore.ErrorLevel
+			case status == http.StatusNotFound:
+				level = zapcore.InfoLevel
 			case status >= http.StatusBadRequest:
 				level = zapcore.WarnLevel
 			}


### PR DESCRIPTION
## Summary

Sandbox timeout/pause requests on already-expired sandboxes are normal SDK-side race behavior — the client cannot always know a sandbox has expired before issuing a cleanup call. The current code treats these expected 404s identically to internal errors, generating noisy WARN logs with full stack traces that obscure real failures.

- **sandbox_timeout.go**: log at INFO instead of WARN when  returns 404 (sandbox not found is expected, not an error)
- **logging.go**: HTTP 404 responses use  instead of  in the request access log
- **logger.go**: restrict automatic stack trace capture to  and above via  — previously  attached stack traces to every WARN

## Test plan

- [x] Deploy to dev and confirm  404s no longer appear as WARN in logs
- [x] Confirm real 5xx errors still log at ERROR with stack traces
- [x] Confirm other 4xx errors (400, 401, 403, 409) still log at WARN
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.