### PR TITLE
fix(api): copy auth/internal into api and dashboard-api image builds

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -24,6 +24,7 @@ RUN cd /build/shared && go mod download && \
 WORKDIR /build
 
 COPY ./auth/pkg ./auth/pkg
+COPY ./auth/internal ./auth/internal
 COPY ./clickhouse/pkg ./clickhouse/pkg
 COPY ./shared/pkg ./shared/pkg
 COPY ./db/client ./db/client

--- a/packages/dashboard-api/Dockerfile
+++ b/packages/dashboard-api/Dockerfile
@@ -30,6 +30,7 @@ RUN go mod download
 WORKDIR /build
 
 COPY ./auth/pkg ./auth/pkg
+COPY ./auth/internal ./auth/internal
 COPY ./clickhouse/pkg ./clickhouse/pkg
 COPY ./shared/pkg ./shared/pkg
 COPY ./db/client ./db/client


### PR DESCRIPTION
## Problem

`Build and upload images` has been failing on main for every environment since #3314 merged (first red run: [29827113375](https://github.com/e2b-dev/infra/actions/runs/29827113375), still red on the next push: [29827995997](https://github.com/e2b-dev/infra/actions/runs/29827995997)). No images have shipped since ~07:04 UTC and the staging envd promote hasn't run.

#3314 refactored `packages/auth` so the public `pkg/auth` package re-exports from new `packages/auth/internal/*` packages (`service`, `team`, `token`, `token/jwks`, `middleware`, `authcontext`). The api image build copies the auth module selectively — `COPY ./auth/pkg ./auth/pkg` only — so `make build` inside the container fails:

```
../auth/pkg/auth/service.go:9:2: no required module provides package github.com/e2b-dev/infra/packages/auth/internal/service
```

PR CI can't catch this class of breakage: unit/integration tests build from a full checkout, and the image Dockerfiles only build post-merge in `build-and-upload-images.yml`.

## Fix

Add `COPY ./auth/internal ./auth/internal` next to the existing `auth/pkg` copy in:

- `packages/api/Dockerfile` (actively failing)
- `packages/dashboard-api/Dockerfile` (same bug, latent — fails as soon as that image is built)

`auth/internal` only imports `db/pkg` and `shared/pkg`, which both Dockerfiles already copy, so nothing else is needed.

## Verification

Replicated the exact Docker build context (only the `COPY`'d paths, no `go.work`) in a clean directory with go 1.26.5 and `CGO_ENABLED=0 GOOS=linux`:

- **With this fix**: `go build` succeeds for both api and dashboard-api
- **Without `auth/internal`** (negative control): reproduces the exact CI error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3323"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787227846&installation_model_id=14389&pr_number=3323&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3323&signature=64edf20a2f3d46ecdbaf5674ca6dcc1d5ebd7d5c5ea1ad87289c0dc652162483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->