### PR TITLE
ci: test KVM-dependent jobs on Blacksmith runners

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,8 +16,11 @@ on:
       CODECOV_TOKEN: { required: false }
 jobs:
   run:
+    # host-init modprobes nbd and the orchestrator boots Firecracker via
+    # /dev/kvm — needs Blacksmith's x64 nested virtualization. 32vcpu matches
+    # the 32-core/128GB infra-tests runner this previously ran on.
     if: ${{ inputs.run-tests == true }}
-    runs-on: infra-tests
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/pr-tests-arm64.yml
+++ b/.github/workflows/pr-tests-arm64.yml
@@ -73,8 +73,9 @@ jobs:
   arm64-unit-tests:
     name: Run ARM64 test shards
     if: ${{ inputs.run-tests == true }}
-    # Shards that only need Docker run on Blacksmith arm64. The orchestrator
-    # shard stays on infra-runner-arm: it needs modprobe nbd.
+    # All shards run on Blacksmith arm64. The orchestrator shard needs
+    # modprobe nbd. Blacksmith arm runners have no nested virtualization, but
+    # neither do GitHub's — the KVM smoketest already skips on arm64.
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
@@ -120,7 +121,7 @@ jobs:
             flag: arm64-orchestrator
             test_path: ./...
             sudo: true
-            runner: infra-runner-arm
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
           - package: packages/shared
             flag: arm64-shared
             test_path: ./pkg/...

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -18,8 +18,9 @@ jobs:
   run-tests:
     name: Run unit test shards
     if: ${{ inputs.run-tests == true }}
-    # Shards that only need Docker run on Blacksmith. The orchestrator shard
-    # stays on infra-tests: it needs modprobe nbd and /dev/kvm (smoketest).
+    # All shards run on Blacksmith. The orchestrator shard needs modprobe nbd
+    # and /dev/kvm (smoketest); Blacksmith x64 runners support nested
+    # virtualization — verify TestSmokeAllFCVersions runs (not skips) there.
     runs-on: ${{ matrix.runner }}
     env:
       GIN_MODE: test
@@ -60,11 +61,13 @@ jobs:
             test_path: ./...
             sudo: true
             runner: blacksmith-4vcpu-ubuntu-2404
+          # 8vcpu: this shard boots Firecracker VMs (smoketest) and ran on a
+          # 32-core infra-tests runner before; bump if the 20m timeout nears.
           - package: packages/orchestrator
             flag: unit-orchestrator
             test_path: ./...
             sudo: true
-            runner: infra-tests
+            runner: blacksmith-8vcpu-ubuntu-2404
           - package: packages/shared
             flag: unit-shared
             test_path: ./pkg/...


### PR DESCRIPTION
## What

Follow-up to #3322. Blacksmith x64 runners support nested virtualization ([docs](https://docs.blacksmith.sh/blacksmith-runners/overview): "Blacksmith can run KVM-dependent and other VM-backed CI workloads on our x64 Linux runners"), so this tests moving the remaining KVM/modprobe-gated jobs:

| Job | Before | After | Requirements being tested |
|---|---|---|---|
| orchestrator unit shard (x64) | `infra-tests` | `blacksmith-8vcpu-ubuntu-2404` | `modprobe nbd`, uffd sysctl, hugepages, **/dev/kvm** (FC smoketest) |
| orchestrator unit shard (arm64) | `infra-runner-arm` | `blacksmith-4vcpu-ubuntu-2404-arm` | `modprobe nbd` only — smoketest already skips on GitHub arm64 (no /dev/kvm there either), so nothing is lost |
| integration tests (×3) | `infra-tests` | `blacksmith-32vcpu-ubuntu-2404` | full stack: host-init modprobes nbd (4096 devices), orchestrator boots real Firecracker sandboxes |

Sizing: `infra-tests` is a 32-core/128GB machine (from host-init logs), hence 32vcpu for integration; 8vcpu for the unit shard as a starting point.

## Success criteria — check these in the logs, not just green checks

- [ ] x64 orchestrator shard: `TestSmokeAllFCVersions` **runs and passes** — if /dev/kvm is missing it *silently skips* and the check still goes green. Baseline on `infra-tests`: it runs.
- [ ] `sudo modprobe nbd` succeeds on both x64 and arm64 (kernel module availability on Blacksmith VM kernels is undocumented — this is the main unknown)
- [ ] Integration shards boot sandboxes end-to-end; compare durations vs `infra-tests` baseline (uncompressed ~10 min, zstd1 ~18 min)
- [ ] Hugepages allocation works (host-init sizes it from available RAM)

If arm64 modprobe fails: pin the arm64 orchestrator shard back to `infra-runner-arm` and keep the rest.
If x64 KVM/nbd fails: don't merge; #3322's split stays as is.

## Impact if this works

Integration tests are ~80% of paid larger-runner minutes (~45 min/PR). This PR would move effectively all remaining GitHub larger-runner usage except `ci-builder` (image builds, separate follow-up since it only triggers on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787231288&installation_model_id=14389&pr_number=3326&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3326&signature=e433a4fbb12f77f23a6bea511d0340c5f90fb628f0c49f7c7e188b6390d0905d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->