### PR TITLE
[EN-1885] feat(dashboard-api): use project naming for default teams and provisioning errors

### DIFF
--- a/packages/dashboard-api/internal/provisioning/bootstrap_test.go
+++ b/packages/dashboard-api/internal/provisioning/bootstrap_test.go
@@ -54,8 +54,8 @@ func TestBootstrapAuthProviderUser_CreatesIdentityAndDefaultTeam(t *testing.T) {
 	if defaultTeam.ID != team.ID {
 		t.Fatalf("expected response team %s, got %s", defaultTeam.ID, team.ID)
 	}
-	if defaultTeam.Name != "Default Team" {
-		t.Fatalf("expected team name %q, got %q", "Default Team", defaultTeam.Name)
+	if defaultTeam.Name != "Personal Project" {
+		t.Fatalf("expected team name %q, got %q", "Personal Project", defaultTeam.Name)
 	}
 	if defaultTeam.Email != "ada@example.test" {
 		t.Fatalf("expected team email %q, got %q", "ada@example.test", defaultTeam.Email)

--- a/packages/dashboard-api/internal/provisioning/names.go
+++ b/packages/dashboard-api/internal/provisioning/names.go
@@ -7,10 +7,10 @@ import (
 
 func defaultTeamNameFromOIDCUserName(name *string) string {
 	if name == nil || strings.TrimSpace(*name) == "" {
-		return "Default Team"
+		return "Personal Project"
 	}
 
-	return capitalizeFirstLetter(firstWord(*name)) + "'s Default Team"
+	return capitalizeFirstLetter(firstWord(*name)) + "'s Project"
 }
 
 func firstWord(value string) string {

--- a/packages/dashboard-api/internal/provisioning/names_test.go
+++ b/packages/dashboard-api/internal/provisioning/names_test.go
@@ -1,0 +1,56 @@
+package provisioning
+
+import "testing"
+
+func TestDefaultTeamNameFromOIDCUserName(t *testing.T) {
+	t.Parallel()
+
+	stringPtr := func(value string) *string { return &value }
+
+	tests := []struct {
+		name     string
+		userName *string
+		want     string
+	}{
+		{
+			name:     "nil name falls back",
+			userName: nil,
+			want:     "Personal Project",
+		},
+		{
+			name:     "empty name falls back",
+			userName: stringPtr(""),
+			want:     "Personal Project",
+		},
+		{
+			name:     "whitespace-only name falls back",
+			userName: stringPtr("   "),
+			want:     "Personal Project",
+		},
+		{
+			name:     "multi-word name uses capitalized first word",
+			userName: stringPtr("jakub kracina"),
+			want:     "Jakub's Project",
+		},
+		{
+			name:     "single word is capitalized",
+			userName: stringPtr("ada"),
+			want:     "Ada's Project",
+		},
+		{
+			name:     "unicode first letter is capitalized",
+			userName: stringPtr("žofia novak"),
+			want:     "Žofia's Project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := defaultTeamNameFromOIDCUserName(tt.userName); got != tt.want {
+				t.Fatalf("expected generated name %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/packages/dashboard-api/internal/provisioning/sso.go
+++ b/packages/dashboard-api/internal/provisioning/sso.go
@@ -47,7 +47,7 @@ func (s *Service) ensureNotSSOManaged(ctx context.Context, userID uuid.UUID) err
 	if orgID != uuid.Nil {
 		return &internalteamprovision.ProvisionError{
 			StatusCode: http.StatusForbidden,
-			Message:    "SSO-managed accounts can't create teams. Contact your organization admin.",
+			Message:    "SSO-managed accounts can't create projects. Contact your organization admin.",
 		}
 	}
 

--- a/packages/dashboard-api/internal/provisioning/team.go
+++ b/packages/dashboard-api/internal/provisioning/team.go
@@ -151,20 +151,20 @@ func validateTeamCreationAllowed(ctx context.Context, authTxDB *authqueries.Quer
 		if row.IsBanned {
 			return &internalteamprovision.ProvisionError{
 				StatusCode: http.StatusBadRequest,
-				Message:    "You're unable to create a team right now. Please contact support if this persists.",
+				Message:    "You're unable to create a project right now. Please contact support if this persists.",
 			}
 		}
 	}
 
 	teamLimit := maxTeamsPerUser
 	limitMessage := fmt.Sprintf(
-		"You can't create more than %d teams, you can upgrade to Pro tier to create up to %d teams",
+		"You can't create more than %d projects, you can upgrade to Pro tier to create up to %d projects",
 		maxTeamsPerUser,
 		maxTeamsPerUserWithProTier,
 	)
 	if hasProTier {
 		teamLimit = maxTeamsPerUserWithProTier
-		limitMessage = fmt.Sprintf("You can't create more than %d teams", maxTeamsPerUserWithProTier)
+		limitMessage = fmt.Sprintf("You can't create more than %d projects", maxTeamsPerUserWithProTier)
 	}
 
 	if len(teams) >= teamLimit {

--- a/packages/dashboard-api/internal/provisioning/team_test.go
+++ b/packages/dashboard-api/internal/provisioning/team_test.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -91,5 +92,119 @@ func TestCreateTeam_ConcurrentRequestsRespectLocalPolicyWithZeroMemberships(t *t
 	}
 	if badRequestCount != 1 {
 		t.Fatalf("expected one bad request, got %d", badRequestCount)
+	}
+}
+
+func provisionErrorMessage(t *testing.T, err error) string {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected team creation to fail")
+	}
+
+	var provisionErr *internalteamprovision.ProvisionError
+	if !errors.As(err, &provisionErr) {
+		t.Fatalf("expected provisioning error, got %T: %v", err, err)
+	}
+	if provisionErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, provisionErr.StatusCode)
+	}
+
+	return provisionErr.Message
+}
+
+func TestCreateTeam_BaseTierLimitReturnsUpgradeMessage(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	userID := createTestUser(t, testDB)
+
+	svc := New(testDB.AuthDB, testIdentityProvider{}, &fakeTeamProvisionSink{})
+
+	for i := 1; i < maxTeamsPerUser; i++ {
+		if _, err := svc.CreateTeam(ctx, userID, fmt.Sprintf("Acme-%d", i)); err != nil {
+			t.Fatalf("expected team creation %d to succeed, got %v", i, err)
+		}
+	}
+
+	_, err := svc.CreateTeam(ctx, userID, "Acme-over-limit")
+	expected := fmt.Sprintf(
+		"You can't create more than %d projects, you can upgrade to Pro tier to create up to %d projects",
+		maxTeamsPerUser,
+		maxTeamsPerUserWithProTier,
+	)
+	if message := provisionErrorMessage(t, err); message != expected {
+		t.Fatalf("expected limit message %q, got %q", expected, message)
+	}
+}
+
+func TestCreateTeam_ProTierLimitReturnsLimitMessage(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	userID := createTestUser(t, testDB)
+
+	if err := testDB.AuthDB.TestsRawSQL(ctx, `
+		INSERT INTO public.tiers (
+			id, name, disk_mb, concurrent_instances, max_length_hours,
+			default_free_disk_size_mb, max_disk_size_mb
+		)
+		VALUES ('pro_test_v1', 'Pro test tier', 10240, 20, 24, 8000, 30000)
+	`); err != nil {
+		t.Fatalf("failed to create pro tier: %v", err)
+	}
+
+	defaultTeam, err := testDB.AuthDB.Read.GetDefaultTeamByUserID(ctx, userID)
+	if err != nil {
+		t.Fatalf("expected default team: %v", err)
+	}
+	if err := testDB.AuthDB.TestsRawSQL(ctx,
+		`UPDATE public.teams SET tier = 'pro_test_v1' WHERE id = $1`,
+		defaultTeam.ID,
+	); err != nil {
+		t.Fatalf("failed to upgrade team tier: %v", err)
+	}
+
+	svc := New(testDB.AuthDB, testIdentityProvider{}, &fakeTeamProvisionSink{})
+
+	for i := 1; i < maxTeamsPerUserWithProTier; i++ {
+		if _, err := svc.CreateTeam(ctx, userID, fmt.Sprintf("Acme-%d", i)); err != nil {
+			t.Fatalf("expected team creation %d to succeed, got %v", i, err)
+		}
+	}
+
+	_, err = svc.CreateTeam(ctx, userID, "Acme-over-limit")
+	expected := fmt.Sprintf("You can't create more than %d projects", maxTeamsPerUserWithProTier)
+	if message := provisionErrorMessage(t, err); message != expected {
+		t.Fatalf("expected limit message %q, got %q", expected, message)
+	}
+}
+
+func TestCreateTeam_BannedTeamReturnsSupportMessage(t *testing.T) {
+	t.Parallel()
+
+	testDB := testutils.SetupDatabase(t)
+	ctx := t.Context()
+	userID := createTestUser(t, testDB)
+
+	defaultTeam, err := testDB.AuthDB.Read.GetDefaultTeamByUserID(ctx, userID)
+	if err != nil {
+		t.Fatalf("expected default team: %v", err)
+	}
+	if err := testDB.AuthDB.TestsRawSQL(ctx,
+		`UPDATE public.teams SET is_banned = true WHERE id = $1`,
+		defaultTeam.ID,
+	); err != nil {
+		t.Fatalf("failed to ban team: %v", err)
+	}
+
+	svc := New(testDB.AuthDB, testIdentityProvider{}, &fakeTeamProvisionSink{})
+
+	_, err = svc.CreateTeam(ctx, userID, "Acme")
+	expected := "You're unable to create a project right now. Please contact support if this persists."
+	if message := provisionErrorMessage(t, err); message != expected {
+		t.Fatalf("expected banned message %q, got %q", expected, message)
 	}
 }


### PR DESCRIPTION
## Summary
Part 2 of the Teams→Projects rename stack (PR 1: dashboard copy + banner · PR 3: data migration). Strings-only — no schema, API-contract, identifier, or behavioral changes.

- Default-entity name generator now produces `<FirstName>'s Project` when the OIDC token carries a name claim, and `Personal Project` when it doesn't (previously `<FirstName>'s Default Team` / `Default Team`). First-word extraction and capitalization unchanged.
- Four user-facing provisioning messages reworded team→project: both creation-limit variants, the banned-account message, and the SSO-managed-account message. These surface verbatim as dashboard toasts.
- Internal wrapped errors, `maxTeamsPerUser*` constants, log fields, and query names deliberately untouched.

## Tests
- New table-driven generator tests (nil/empty/whitespace fallback, first-word capitalization, unicode).
- New `CreateTeam` tests pinning the exact message text for the base-tier limit, Pro-tier limit, and banned paths.
- Updated the pinned name literal in `bootstrap_test.go`.

## Notes
- Known pre-existing edge case, accepted: no truncation is added, so first names longer than ~13 chars can generate a name exceeding the dashboard's 32-char rename validation (user must edit before re-saving). Rare, and not new to this PR in kind.
- Deploy the same day as PR 1's dashboard deploy — these strings render inside the renamed UI.
- Existing rows still named `Default Team` (~2k) are migrated in PR 3.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787238752&installation_model_id=14389&pr_number=3328&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3328&signature=e64b06fdec75aa35402a43ce6b123d1005df01c03da48cafd8b85b3e54bbe669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->