### PR TITLE
Allow enabling guest console

### DIFF
--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -396,13 +396,17 @@ func wrapTemplate(tmpl template.Template, noPrefetch, forceFsOnly bool) template
 // -force-reboot is set.
 func (r *runner) startSandbox(ctx context.Context, runtime sandbox.RuntimeMetadata, start, end time.Time) (*sandbox.Sandbox, error) {
 	if r.reboot || r.forceReboot {
-		var opts []sandbox.CreateOption
+		var procOpts []func(*fc.ProcessOptions)
 		if r.console {
 			// Forward the guest kernel console (tty) + FC output to this process.
-			opts = append(opts, sandbox.WithConsoleOutput(os.Stdout, os.Stderr))
+			procOpts = append(procOpts, func(o *fc.ProcessOptions) {
+				o.KernelLogs = true
+				o.Stdout = os.Stdout
+				o.Stderr = os.Stderr
+			})
 		}
 
-		return r.factory.RebootSandbox(ctx, r.tmpl, r.sbxConfig, runtime, end, nil, opts...)
+		return r.factory.RebootSandbox(ctx, r.tmpl, r.sbxConfig, runtime, end, nil, procOpts...)
 	}
 
 	return r.factory.ResumeSandbox(ctx, r.tmpl, r.sbxConfig, runtime, start, end, nil)

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -62,6 +62,7 @@ func main() {
 	memfileDiffDedup := flag.Bool("memfile-diff-dedup", false, "enable 4KiB-page deduplication of memfile diff against the base template")
 	verbose := flag.Bool("v", false, "verbose logging")
 	console := flag.Bool("console", false, "forward Firecracker's output and the guest kernel serial console (tty) to stdout (fresh boot / -reboot only)")
+	firecracker := flag.String("firecracker", "", "override the build's Firecracker version (e.g. when the baked version isn't on this node); safe for a cold boot/-reboot, risky for a memory resume")
 
 	// Command execution (no pause)
 	cmd := flag.String("cmd", "", "execute command in sandbox and exit (no snapshot)")
@@ -226,9 +227,10 @@ func main() {
 	}
 
 	runOpts := runOptions{
-		cmd:        *cmd,
-		iterations: *iterations,
-		console:    *console,
+		cmd:                *cmd,
+		iterations:         *iterations,
+		console:            *console,
+		firecrackerVersion: *firecracker,
 	}
 
 	benchIters := *iterations
@@ -284,9 +286,10 @@ type pauseTimings struct {
 }
 
 type runOptions struct {
-	cmd        string // command to run and exit (no pause)
-	iterations int    // number of iterations (0 = single run)
-	console    bool   // forward the guest kernel console + FC output to stdout/stderr (fresh boot)
+	cmd                string // command to run and exit (no pause)
+	iterations         int    // number of iterations (0 = single run)
+	console            bool   // forward the guest kernel console + FC output to stdout/stderr (fresh boot)
+	firecrackerVersion string // override the build's Firecracker version (empty = use the build's own)
 }
 
 func (r runOptions) enabled() bool {
@@ -1254,6 +1257,12 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 	}
 	tmpl = wrapTemplate(tmpl, noPrefetch, forceReboot)
 
+	fcVersion := meta.Template.FirecrackerVersion
+	if runOpts.firecrackerVersion != "" {
+		fmt.Printf("   Overriding Firecracker version: %s -> %s\n", meta.Template.FirecrackerVersion, runOpts.firecrackerVersion)
+		fcVersion = runOpts.firecrackerVersion
+	}
+
 	token := "local"
 	sbxCfg := sandbox.NewConfig(sandbox.Config{
 		BaseTemplateID:    buildID,
@@ -1263,7 +1272,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 		Envd:              sandbox.EnvdMetadata{Vars: map[string]string{}, AccessToken: &token, Version: "1.0.0"},
 		FirecrackerConfig: fc.Config{
 			KernelVersion:      meta.Template.KernelVersion,
-			FirecrackerVersion: meta.Template.FirecrackerVersion,
+			FirecrackerVersion: fcVersion,
 		},
 	})
 

--- a/packages/orchestrator/cmd/resume-build/main.go
+++ b/packages/orchestrator/cmd/resume-build/main.go
@@ -61,6 +61,7 @@ func main() {
 	disableMemfd := flag.Bool("disable-memfd", false, "disable memfd-backed guest memory")
 	memfileDiffDedup := flag.Bool("memfile-diff-dedup", false, "enable 4KiB-page deduplication of memfile diff against the base template")
 	verbose := flag.Bool("v", false, "verbose logging")
+	console := flag.Bool("console", false, "forward Firecracker's output and the guest kernel serial console (tty) to stdout (fresh boot / -reboot only)")
 
 	// Command execution (no pause)
 	cmd := flag.String("cmd", "", "execute command in sandbox and exit (no snapshot)")
@@ -227,6 +228,7 @@ func main() {
 	runOpts := runOptions{
 		cmd:        *cmd,
 		iterations: *iterations,
+		console:    *console,
 	}
 
 	benchIters := *iterations
@@ -284,6 +286,7 @@ type pauseTimings struct {
 type runOptions struct {
 	cmd        string // command to run and exit (no pause)
 	iterations int    // number of iterations (0 = single run)
+	console    bool   // forward the guest kernel console + FC output to stdout/stderr (fresh boot)
 }
 
 func (r runOptions) enabled() bool {
@@ -366,6 +369,7 @@ type runner struct {
 	shell       bool
 	reboot      bool
 	forceReboot bool
+	console     bool
 	config      cfg.BuilderConfig
 	storage     storage.StorageProvider
 }
@@ -389,7 +393,13 @@ func wrapTemplate(tmpl template.Template, noPrefetch, forceFsOnly bool) template
 // -force-reboot is set.
 func (r *runner) startSandbox(ctx context.Context, runtime sandbox.RuntimeMetadata, start, end time.Time) (*sandbox.Sandbox, error) {
 	if r.reboot || r.forceReboot {
-		return r.factory.RebootSandbox(ctx, r.tmpl, r.sbxConfig, runtime, end, nil)
+		var opts []sandbox.CreateOption
+		if r.console {
+			// Forward the guest kernel console (tty) + FC output to this process.
+			opts = append(opts, sandbox.WithConsoleOutput(os.Stdout, os.Stderr))
+		}
+
+		return r.factory.RebootSandbox(ctx, r.tmpl, r.sbxConfig, runtime, end, nil, opts...)
 	}
 
 	return r.factory.ResumeSandbox(ctx, r.tmpl, r.sbxConfig, runtime, start, end, nil)
@@ -1267,6 +1277,7 @@ func run(ctx context.Context, buildID string, iterations int, coldStart, noPrefe
 		shell:       shell,
 		reboot:      reboot,
 		forceReboot: forceReboot,
+		console:     runOpts.console,
 		config:      config.BuilderConfig,
 		storage:     persistence,
 		sbxConfig:   sbxCfg,

--- a/packages/orchestrator/pkg/sandbox/reboot.go
+++ b/packages/orchestrator/pkg/sandbox/reboot.go
@@ -35,6 +35,8 @@ const (
 // guest RAM, processes, and sockets are lost; only the filesystem survives.
 // The sandbox is marked running only after envd is ready, matching
 // ResumeSandbox's routing guarantees; endAt is the caller's absolute end time.
+// procOpts, if any, adjust the fc.ProcessOptions of the cold boot after the
+// defaults are set (e.g. debugging tools forwarding the guest kernel console).
 // IMPORTANT: You must Close() the sandbox after you are done with it.
 func (f *Factory) RebootSandbox(
 	ctx context.Context,
@@ -43,7 +45,7 @@ func (f *Factory) RebootSandbox(
 	runtime RuntimeMetadata,
 	endAt time.Time,
 	apiConfigToStore *orchestrator.SandboxConfig,
-	opts ...CreateOption,
+	procOpts ...func(*fc.ProcessOptions),
 ) (*Sandbox, error) {
 	ctx, span := tracer.Start(ctx, "reboot sandbox")
 	defer span.End()
@@ -115,6 +117,16 @@ func (f *Factory) RebootSandbox(
 		return nil, fmt.Errorf("sandbox end time %s is in the past", endAt)
 	}
 
+	processOptions := fc.ProcessOptions{
+		InitScriptPath: constants.SystemdInitPath,
+		KvmClock:       kvmClock,
+		IoEngine:       &ioEngine,
+		AccessToken:    &accessToken,
+	}
+	for _, opt := range procOpts {
+		opt(&processOptions)
+	}
+
 	sbx, err := f.CreateSandbox(
 		ctx,
 		config,
@@ -125,18 +137,11 @@ func (f *Factory) RebootSandbox(
 		// resume, so guest TRIM keeps working and a later pause exports the
 		// overlay diff exactly like a normal resume.
 		"",
-		fc.ProcessOptions{
-			InitScriptPath: constants.SystemdInitPath,
-			KvmClock:       kvmClock,
-			IoEngine:       &ioEngine,
-			AccessToken:    &accessToken,
-		},
+		processOptions,
 		apiConfigToStore,
 		nil,
-		append([]CreateOption{
-			WithDeferredMarkRunning(),
-			withNetworkAssignReason(NetworkAssignReasonReboot),
-		}, opts...)...,
+		WithDeferredMarkRunning(),
+		withNetworkAssignReason(NetworkAssignReasonReboot),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create sandbox from rootfs: %w", err)

--- a/packages/orchestrator/pkg/sandbox/reboot.go
+++ b/packages/orchestrator/pkg/sandbox/reboot.go
@@ -43,6 +43,7 @@ func (f *Factory) RebootSandbox(
 	runtime RuntimeMetadata,
 	endAt time.Time,
 	apiConfigToStore *orchestrator.SandboxConfig,
+	opts ...CreateOption,
 ) (*Sandbox, error) {
 	ctx, span := tracer.Start(ctx, "reboot sandbox")
 	defer span.End()
@@ -132,8 +133,10 @@ func (f *Factory) RebootSandbox(
 		},
 		apiConfigToStore,
 		nil,
-		WithDeferredMarkRunning(),
-		withNetworkAssignReason(NetworkAssignReasonReboot),
+		append([]CreateOption{
+			WithDeferredMarkRunning(),
+			withNetworkAssignReason(NetworkAssignReasonReboot),
+		}, opts...)...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create sandbox from rootfs: %w", err)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -431,11 +430,6 @@ type PreBootFn func(ctx context.Context, rootfsPath string) error
 type createOptions struct {
 	deferMarkRunning    bool
 	networkAssignReason NetworkAssignReason
-	// consoleStdout/consoleStderr, when set, forward the guest serial console
-	// (kernel tty) and Firecracker's own output to these writers (and enable
-	// kernel logs on the boot). For debugging tools; unused by the orchestrator.
-	consoleStdout io.Writer
-	consoleStderr io.Writer
 }
 
 type CreateOption func(*createOptions)
@@ -450,17 +444,6 @@ func WithDeferredMarkRunning() CreateOption {
 
 func withNetworkAssignReason(reason NetworkAssignReason) CreateOption {
 	return func(o *createOptions) { o.networkAssignReason = reason }
-}
-
-// WithConsoleOutput forwards the guest serial console (kernel tty) and
-// Firecracker's own stdout/stderr to the given writers, enabling kernel logs on
-// a fresh boot. Intended for debugging tools (e.g. cmd/resume-build watching a
-// cold boot); the orchestrator itself never sets it.
-func WithConsoleOutput(stdout, stderr io.Writer) CreateOption {
-	return func(o *createOptions) {
-		o.consoleStdout = stdout
-		o.consoleStderr = stderr
-	}
 }
 
 // CreateSandbox creates the sandbox.
@@ -484,14 +467,6 @@ func (f *Factory) CreateSandbox(
 	createOpts := createOptions{networkAssignReason: NetworkAssignReasonCreate}
 	for _, opt := range opts {
 		opt(&createOpts)
-	}
-
-	// Debug console wiring (opt-in via WithConsoleOutput): forward the guest
-	// kernel tty + FC output to the caller's writers. Only affects a fresh boot.
-	if createOpts.consoleStdout != nil || createOpts.consoleStderr != nil {
-		processOptions.KernelLogs = true
-		processOptions.Stdout = createOpts.consoleStdout
-		processOptions.Stderr = createOpts.consoleStderr
 	}
 
 	execCtx, execSpan := startExecutionSpan(ctx)

--- a/packages/orchestrator/pkg/sandbox/sandbox.go
+++ b/packages/orchestrator/pkg/sandbox/sandbox.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -430,6 +431,11 @@ type PreBootFn func(ctx context.Context, rootfsPath string) error
 type createOptions struct {
 	deferMarkRunning    bool
 	networkAssignReason NetworkAssignReason
+	// consoleStdout/consoleStderr, when set, forward the guest serial console
+	// (kernel tty) and Firecracker's own output to these writers (and enable
+	// kernel logs on the boot). For debugging tools; unused by the orchestrator.
+	consoleStdout io.Writer
+	consoleStderr io.Writer
 }
 
 type CreateOption func(*createOptions)
@@ -444,6 +450,17 @@ func WithDeferredMarkRunning() CreateOption {
 
 func withNetworkAssignReason(reason NetworkAssignReason) CreateOption {
 	return func(o *createOptions) { o.networkAssignReason = reason }
+}
+
+// WithConsoleOutput forwards the guest serial console (kernel tty) and
+// Firecracker's own stdout/stderr to the given writers, enabling kernel logs on
+// a fresh boot. Intended for debugging tools (e.g. cmd/resume-build watching a
+// cold boot); the orchestrator itself never sets it.
+func WithConsoleOutput(stdout, stderr io.Writer) CreateOption {
+	return func(o *createOptions) {
+		o.consoleStdout = stdout
+		o.consoleStderr = stderr
+	}
 }
 
 // CreateSandbox creates the sandbox.
@@ -467,6 +484,14 @@ func (f *Factory) CreateSandbox(
 	createOpts := createOptions{networkAssignReason: NetworkAssignReasonCreate}
 	for _, opt := range opts {
 		opt(&createOpts)
+	}
+
+	// Debug console wiring (opt-in via WithConsoleOutput): forward the guest
+	// kernel tty + FC output to the caller's writers. Only affects a fresh boot.
+	if createOpts.consoleStdout != nil || createOpts.consoleStderr != nil {
+		processOptions.KernelLogs = true
+		processOptions.Stdout = createOpts.consoleStdout
+		processOptions.Stderr = createOpts.consoleStderr
 	}
 
 	execCtx, execSpan := startExecutionSpan(ctx)


### PR DESCRIPTION
Add a `-console` flag to `resume-build` command. It works along with `-reboot` flag and enables kernel console output on the sandbox which gets redirected to stdout.

Also, add a way to override the firecracker version stored in the template

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787314421&installation_model_id=14389&pr_number=3335&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3335&signature=aed7255be5399034a7bb05b4170917b1c0b29c196d4f066e7fbccdacd6105c57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->