### PR TITLE
feat(auth): re-export OIDC and provider verifiers through the public facade

### DIFF
--- a/packages/auth/pkg/auth/token.go
+++ b/packages/auth/pkg/auth/token.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/e2b-dev/infra/packages/auth/internal/token"
 	"github.com/e2b-dev/infra/packages/auth/internal/token/jwks"
+	"github.com/e2b-dev/infra/packages/auth/internal/token/oidc"
 )
 
 type ProviderConfig = token.ProviderConfig
@@ -26,4 +27,35 @@ func ParseProviderConfig(value string) (ProviderConfig, error) {
 
 func NewAdminVerifier(ctx context.Context, config ProviderConfig, httpClient *http.Client) (*AdminVerifier, error) {
 	return token.NewAdminVerifier(ctx, config, httpClient)
+}
+
+// IdentityLookup resolves an OIDC identity (issuer + subject) to an internal
+// user UUID. Implementations should return ErrIdentityNotFound when no
+// matching identity exists.
+type IdentityLookup = oidc.IdentityLookup
+
+// OIDCVerifier verifies auth-provider user JWTs for a single issuer and
+// resolves the internal user identity through an IdentityLookup.
+type OIDCVerifier = oidc.Verifier
+
+// ErrIdentityNotFound is returned by OIDC verification when the token is
+// valid but no matching identity exists.
+var ErrIdentityNotFound = oidc.ErrIdentityNotFound
+
+// NewOIDCVerifier constructs an OIDCVerifier for the given issuer config.
+// External consumers (e.g. belt) use this to verify auth-provider tokens with
+// their own identity storage.
+func NewOIDCVerifier(ctx context.Context, config JWTConfig, httpClient *http.Client, identities IdentityLookup) (*OIDCVerifier, error) {
+	return oidc.NewVerifier(ctx, config, httpClient, identities)
+}
+
+// ProviderVerifier verifies auth-provider user JWTs across every issuer in a
+// ProviderConfig.
+type ProviderVerifier = token.ProviderVerifier
+
+// NewProviderVerifier constructs a ProviderVerifier for the given provider
+// config. When the config has no JWT issuers it returns (nil, nil); a nil
+// ProviderVerifier denies all verification attempts at runtime.
+func NewProviderVerifier(ctx context.Context, config ProviderConfig, httpClient *http.Client, identities IdentityLookup) (*ProviderVerifier, error) {
+	return token.NewProviderVerifier(ctx, config, httpClient, identities)
 }


### PR DESCRIPTION
## Summary

Restores the auth surface external consumers lost in #3314, without touching the package layout.

Belt imports this module and used `pkg/auth/oidc` (`oidc.NewVerifier`, `oidc.IdentityLookup`, `oidc.ErrIdentityNotFound`) plus the old facade's `auth.Verifier`/`auth.NewVerifier`. #3314 moved both behind Go `internal` packages, so belt's daily `sync-infra-repo` workflow fails at `go mod tidy`:

> module …/packages/auth found, but does not contain package …/packages/auth/pkg/auth/oidc

This PR re-exports the equivalents through the `auth.*` facade with identical signatures:

- `auth.IdentityLookup`, `auth.ErrIdentityNotFound`
- `auth.OIDCVerifier` / `auth.NewOIDCVerifier` (single issuer)
- `auth.ProviderVerifier` / `auth.NewProviderVerifier` (multi-issuer; keeps the `(nil, nil)` no-provider semantics of the old `auth.NewVerifier`)

Config/issuer types were already exposed as `auth.JWTConfig`/`auth.JWTIssuer`.

Companion belt PR migrating its imports to the facade: e2b-dev/belt#1145. A follow-up PR (#3338) restructures the auth package layout separately.

## Testing

- `go build ./… && go vet ./… && go test ./…` in `packages/auth`
- `golangci-lint run ./packages/auth/…` — 0 issues
- Belt compiled and tested against this commit (all 16 workspace modules build; `shared/pkg/auth`, `billing-server/internal/auth`, `argus-api/internal/handlers` green with `-race`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/e2b-dev/codesmith/infra/pr/3339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787336953&installation_model_id=14389&pr_number=3339&repository=e2b-dev%2Finfra&return_to=https%3A%2F%2Fgithub.com%2Fe2b-dev%2Finfra%2Fpull%2F3339&signature=5551f98aca8e66952d8160dd7d79e3502f3e6cd0cc1c464e571035de4efef169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->