### PR TITLE
db: lower env_builds autovacuum scale factor

### DIFF
--- a/packages/db/migrations/20260723030000_env_builds_autovacuum_scale.sql
+++ b/packages/db/migrations/20260723030000_env_builds_autovacuum_scale.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- The default autovacuum scale factors trigger a pass only after dead tuples
+-- reach a fixed fraction of the table, which on a large, update-heavy table is
+-- far too late: index lookups pay visibility checks on the accumulated dead
+-- entries long before a pass starts. Trigger vacuum/analyze much earlier
+-- instead. Storage-parameter change only: takes a brief ShareUpdateExclusive
+-- lock, rewrites nothing, affects autovacuum scheduling alone.
+ALTER TABLE public.env_builds SET (
+    autovacuum_vacuum_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.01
+);
+
+-- +goose Down
+ALTER TABLE public.env_builds RESET (
+    autovacuum_vacuum_scale_factor,
+    autovacuum_analyze_scale_factor
+);


### PR DESCRIPTION
## Summary
- At the default `autovacuum_vacuum_scale_factor`, a large table only vacuums after dead tuples reach a fixed fraction of its row count; under heavy update churn the table carries a substantial dead-tuple backlog between passes, and every index lookup pays visibility checks on the dead entries. Lowering the factor triggers passes much earlier; the analyze factor likewise keeps planner stats current under churn.
- Storage-parameter change only — brief ShareUpdateExclusive lock, no rewrite, no behavior change beyond autovacuum scheduling.