### PR TITLE
fix(api): delete GCS/S3 artifacts when template is deleted

### DIFF
--- a/packages/api/internal/handlers/sandbox_kill.go
+++ b/packages/api/internal/handlers/sandbox_kill.go
@@ -33,6 +33,10 @@ func (a *APIStore) deleteSnapshot(ctx context.Context, sandboxID string, teamID 
 	a.templateCache.InvalidateAliasesByTemplateID(context.WithoutCancel(ctx), snapshot.TemplateID, aliasKeys)
 	a.snapshotCache.Invalidate(context.WithoutCancel(ctx), sandboxID)
 
+	// Delete GCS/S3 artifacts in the background; DB deletion is already committed
+	// so artifact cleanup failures must not block or fail the response.
+	go a.deleteTemplateArtifacts(context.WithoutCancel(ctx), snapshot.TemplateID)
+
 	return nil
 }
 

--- a/packages/api/internal/handlers/sandbox_kill_test.go
+++ b/packages/api/internal/handlers/sandbox_kill_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	dbtypes "github.com/e2b-dev/infra/packages/db/pkg/types"
+	"github.com/e2b-dev/infra/packages/db/queries"
+	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
+)
+
+// createTestSnapshotForHandler inserts a snapshot and returns (sandboxID, templateID).
+// Uses UpsertSnapshot which also creates the env and env_build_assignment rows that
+// GetExclusiveBuildsForTemplateDeletion relies on.
+func createTestSnapshotForHandler(t *testing.T, db *testutils.Database, teamID uuid.UUID, baseEnvID string) (string, string) {
+	t.Helper()
+
+	sandboxID := "sbx-" + uuid.New().String()[:8]
+	templateID := "env-" + uuid.New().String()
+	envdVersion := "v1.0.0"
+	totalDisk := int64(1024)
+	allowInternet := true
+
+	sourceBuildID := testutils.CreateTestBuild(t, t.Context(), db, baseEnvID, "success")
+
+	result, err := db.SqlcClient.UpsertSnapshot(t.Context(), queries.UpsertSnapshotParams{
+		TemplateID:          templateID,
+		TeamID:              teamID,
+		SandboxID:           sandboxID,
+		BaseTemplateID:      baseEnvID,
+		StartedAt:           pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		Vcpu:                2,
+		RamMb:               2048,
+		TotalDiskSizeMb:     &totalDisk,
+		Metadata:            dbtypes.JSONBStringMap{},
+		KernelVersion:       "6.1.0",
+		FirecrackerVersion:  "1.4.0",
+		EnvdVersion:         &envdVersion,
+		Secure:              true,
+		AllowInternetAccess: &allowInternet,
+		AutoPause:           false,
+		OriginNodeID:        "test-node",
+		SourceBuildID:       sourceBuildID,
+		Status:              "success",
+	})
+	require.NoError(t, err)
+
+	return sandboxID, result.TemplateID
+}
+
+// TestDeleteTemplateArtifacts_SnapshotBuildIsDeleted verifies that the snapshot
+// path (paused sandbox deletion) also triggers artifact cleanup.
+// UpsertSnapshot creates an env + env_build_assignment row, so the SQL query
+// picks up the build and the deleter is called.
+func TestDeleteTemplateArtifacts_SnapshotBuildIsDeleted(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	baseEnvID := testutils.CreateTestTemplate(t, db, teamID)
+	_, snapshotTemplateID := createTestSnapshotForHandler(t, db, teamID, baseEnvID)
+
+	// Simulate what deleteSnapshot does: soft-delete then call the artifact cleanup.
+	err := db.SqlcClient.TestsRawSQL(ctx,
+		`UPDATE public.envs SET deleted_at = NOW() WHERE id = $1`,
+		snapshotTemplateID,
+	)
+	require.NoError(t, err)
+
+	store := &APIStore{
+		sqlcDB:        db.SqlcClient,
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+
+	var mu sync.Mutex
+	deleted := []uuid.UUID{}
+	deleteFn := func(_ context.Context, buildID uuid.UUID, _ string, _ uuid.UUID, _ string) error {
+		mu.Lock()
+		deleted = append(deleted, buildID)
+		mu.Unlock()
+
+		return nil
+	}
+
+	store.deleteTemplateArtifactsWithDeleter(ctx, snapshotTemplateID, deleteFn)
+
+	assert.Len(t, deleted, 1, "snapshot build should be passed to the deleter")
+}

--- a/packages/api/internal/handlers/template_delete.go
+++ b/packages/api/internal/handlers/template_delete.go
@@ -8,11 +8,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/api"
 	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
 	"github.com/e2b-dev/infra/packages/db/pkg/dberrors"
 	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
@@ -52,6 +54,48 @@ func (a *APIStore) softDeleteTemplate(ctx context.Context, teamID uuid.UUID, tem
 	}
 
 	return aliasKeys, nil
+}
+
+type deleteBuildFn func(ctx context.Context, buildID uuid.UUID, templateID string, clusterID uuid.UUID, nodeID string) error
+
+// deleteTemplateArtifacts removes GCS/S3 build artifacts for builds that are
+// exclusively owned by the given template. It is called after the template has
+// been soft-deleted from the database; failures are logged but do not affect the
+// HTTP response because the DB deletion is already committed.
+func (a *APIStore) deleteTemplateArtifacts(ctx context.Context, templateID string) {
+	a.deleteTemplateArtifactsWithDeleter(ctx, templateID, a.templateManager.DeleteBuild)
+}
+
+func (a *APIStore) deleteTemplateArtifactsWithDeleter(ctx context.Context, templateID string, deleteFn deleteBuildFn) {
+	builds, err := a.sqlcDB.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	if err != nil {
+		logger.L().Error(ctx, "Failed to query exclusive builds for artifact cleanup",
+			logger.WithTemplateID(templateID),
+			zap.Error(err),
+		)
+
+		return
+	}
+
+	for _, b := range builds {
+		if b.ClusterNodeID == nil {
+			continue
+		}
+
+		clusterID := clusters.WithClusterFallback(b.ClusterID)
+		if err := deleteFn(ctx, b.BuildID, templateID, clusterID, *b.ClusterNodeID); err != nil {
+			logger.L().Warn(ctx, "Failed to delete build artifacts",
+				logger.WithTemplateID(templateID),
+				zap.String("build_id", b.BuildID.String()),
+				zap.Error(err),
+			)
+		} else {
+			logger.L().Info(ctx, "Deleted build artifacts",
+				logger.WithTemplateID(templateID),
+				zap.String("build_id", b.BuildID.String()),
+			)
+		}
+	}
 }
 
 // DeleteTemplatesTemplateID serves to delete a template (e.g. in CLI)
@@ -128,6 +172,10 @@ func (a *APIStore) DeleteTemplatesTemplateID(c *gin.Context, aliasOrTemplateID a
 
 	a.templateCache.InvalidateAllTags(context.WithoutCancel(ctx), templateID)
 	a.templateCache.InvalidateAliasesByTemplateID(context.WithoutCancel(ctx), templateID, aliasKeys)
+
+	// Delete GCS/S3 artifacts in the background; DB deletion is already committed
+	// so artifact cleanup failures must not block or fail the HTTP response.
+	go a.deleteTemplateArtifacts(context.WithoutCancel(ctx), templateID)
 
 	telemetry.ReportEvent(ctx, "deleted template from db")
 

--- a/packages/api/internal/handlers/template_delete_test.go
+++ b/packages/api/internal/handlers/template_delete_test.go
@@ -1,0 +1,194 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+	redis_utils "github.com/e2b-dev/infra/packages/shared/pkg/redis"
+)
+
+// TestDeleteTemplateArtifacts_ExclusiveBuildsAreDeleted verifies that
+// deleteTemplateArtifactsWithDeleter calls the deleter for each build that has a
+// ClusterNodeID (i.e. is materialized on a node) and that it skips builds without
+// a ClusterNodeID.
+func TestDeleteTemplateArtifacts_ExclusiveBuildsAreDeleted(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Build with a node: should be passed to the deleter
+	buildWithNode := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildWithNode, "v1")
+
+	// Build without a node: CreateTestBuild uses cluster_node_id = 'test-node',
+	// so create a second one without cluster_node_id via raw SQL.
+	buildNoNode := uuid.New()
+	err := db.SqlcClient.TestsRawSQL(ctx,
+		`INSERT INTO public.env_builds
+		(id, env_id, status, vcpu, ram_mb, free_disk_size_mb, kernel_version, firecracker_version, created_at, updated_at)
+		VALUES ($1, $2, 'success', 2, 2048, 512, '6.1.0', '1.4.0', NOW(), NOW())`,
+		buildNoNode, templateID,
+	)
+	require.NoError(t, err)
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildNoNode, "v2")
+
+	store := &APIStore{
+		sqlcDB:        db.SqlcClient,
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+
+	var mu sync.Mutex
+	deleted := []uuid.UUID{}
+	deleteFn := func(_ context.Context, buildID uuid.UUID, _ string, _ uuid.UUID, _ string) error {
+		mu.Lock()
+		deleted = append(deleted, buildID)
+		mu.Unlock()
+
+		return nil
+	}
+
+	store.deleteTemplateArtifactsWithDeleter(ctx, templateID, deleteFn)
+
+	assert.Equal(t, []uuid.UUID{buildWithNode}, deleted,
+		"only the build with a cluster node should be passed to the deleter")
+}
+
+// TestDeleteTemplateArtifacts_SharedBuildsSkipped verifies that builds assigned
+// to multiple templates are not passed to the deleter.
+func TestDeleteTemplateArtifacts_SharedBuildsSkipped(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateA := testutils.CreateTestTemplate(t, db, teamID)
+	templateB := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Shared build: belongs to both templates
+	shared := testutils.CreateTestBuild(t, ctx, db, templateA, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateA, shared, "latest")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateB, shared, "latest")
+
+	// Exclusive build: only on templateA
+	exclusive := testutils.CreateTestBuild(t, ctx, db, templateA, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateA, exclusive, "v2")
+
+	store := &APIStore{
+		sqlcDB:        db.SqlcClient,
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+
+	var mu sync.Mutex
+	deleted := []uuid.UUID{}
+	deleteFn := func(_ context.Context, buildID uuid.UUID, _ string, _ uuid.UUID, _ string) error {
+		mu.Lock()
+		deleted = append(deleted, buildID)
+		mu.Unlock()
+
+		return nil
+	}
+
+	store.deleteTemplateArtifactsWithDeleter(ctx, templateA, deleteFn)
+
+	assert.Equal(t, []uuid.UUID{exclusive}, deleted,
+		"shared build must not be deleted; only the exclusive build should be")
+}
+
+// TestDeleteTemplateArtifacts_DeleterErrorIsNonFatal verifies that when the
+// deleter returns an error the function continues and does not panic or propagate
+// the error (artifact deletion is best-effort after DB soft-delete).
+func TestDeleteTemplateArtifacts_DeleterErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	build1 := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, build1, "v1")
+
+	build2 := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, build2, "v2")
+
+	store := &APIStore{
+		sqlcDB:        db.SqlcClient,
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+
+	var mu sync.Mutex
+	attempted := []uuid.UUID{}
+	deleteFn := func(_ context.Context, buildID uuid.UUID, _ string, _ uuid.UUID, _ string) error {
+		mu.Lock()
+		attempted = append(attempted, buildID)
+		mu.Unlock()
+
+		return errors.New("storage backend unavailable")
+	}
+
+	// Must not panic or return early; all builds should be attempted.
+	assert.NotPanics(t, func() {
+		store.deleteTemplateArtifactsWithDeleter(ctx, templateID, deleteFn)
+	})
+
+	assert.Len(t, attempted, 2, "both builds should be attempted even when the first fails")
+}
+
+// TestDeleteTemplateArtifacts_WorksAfterSoftDelete verifies that the artifact
+// cleanup still finds builds after the template row has been soft-deleted.
+func TestDeleteTemplateArtifacts_WorksAfterSoftDelete(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	redis := redis_utils.SetupInstance(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "latest")
+
+	// Simulate what softDeleteTemplate does
+	err := db.SqlcClient.TestsRawSQL(ctx,
+		`UPDATE public.envs SET deleted_at = NOW() WHERE id = $1`,
+		templateID,
+	)
+	require.NoError(t, err)
+
+	store := &APIStore{
+		sqlcDB:        db.SqlcClient,
+		templateCache: templatecache.NewTemplateCache(db.SqlcClient, redis),
+	}
+
+	var mu sync.Mutex
+	deleted := []uuid.UUID{}
+	deleteFn := func(_ context.Context, id uuid.UUID, _ string, _ uuid.UUID, _ string) error {
+		mu.Lock()
+		deleted = append(deleted, id)
+		mu.Unlock()
+
+		return nil
+	}
+
+	store.deleteTemplateArtifactsWithDeleter(ctx, templateID, deleteFn)
+
+	assert.Equal(t, []uuid.UUID{buildID}, deleted,
+		"build should still be found and deleted after the template is soft-deleted")
+}

--- a/packages/db/queries/builds/get_exclusive_builds_for_template_deletion.sql
+++ b/packages/db/queries/builds/get_exclusive_builds_for_template_deletion.sql
@@ -2,9 +2,11 @@
 -- Returns builds that are ONLY assigned to this template (safe to delete).
 -- Builds shared with other templates are excluded.
 -- DISTINCT needed because builds may have multiple tag assignments to the same template.
-SELECT DISTINCT eb.id as build_id, eb.cluster_node_id
+-- Joins envs (not active_envs) so the query works after the template is soft-deleted.
+SELECT DISTINCT eb.id as build_id, eb.cluster_node_id, e.cluster_id
 FROM "public"."env_build_assignments" eba
 JOIN "public"."env_builds" eb ON eb.id = eba.build_id
+JOIN "public"."envs" e ON e.id = eba.env_id
 WHERE eba.env_id = @template_id
   AND NOT EXISTS (
     -- Exclude builds that have assignments to OTHER templates

--- a/packages/db/queries/get_exclusive_builds_for_template_deletion.sql.go
+++ b/packages/db/queries/get_exclusive_builds_for_template_deletion.sql.go
@@ -12,9 +12,10 @@ import (
 )
 
 const getExclusiveBuildsForTemplateDeletion = `-- name: GetExclusiveBuildsForTemplateDeletion :many
-SELECT DISTINCT eb.id as build_id, eb.cluster_node_id
+SELECT DISTINCT eb.id as build_id, eb.cluster_node_id, e.cluster_id
 FROM "public"."env_build_assignments" eba
 JOIN "public"."env_builds" eb ON eb.id = eba.build_id
+JOIN "public"."envs" e ON e.id = eba.env_id
 WHERE eba.env_id = $1
   AND NOT EXISTS (
     -- Exclude builds that have assignments to OTHER templates
@@ -26,11 +27,13 @@ WHERE eba.env_id = $1
 type GetExclusiveBuildsForTemplateDeletionRow struct {
 	BuildID       uuid.UUID
 	ClusterNodeID *string
+	ClusterID     *uuid.UUID
 }
 
 // Returns builds that are ONLY assigned to this template (safe to delete).
 // Builds shared with other templates are excluded.
 // DISTINCT needed because builds may have multiple tag assignments to the same template.
+// Joins envs (not active_envs) so the query works after the template is soft-deleted.
 func (q *Queries) GetExclusiveBuildsForTemplateDeletion(ctx context.Context, templateID string) ([]GetExclusiveBuildsForTemplateDeletionRow, error) {
 	rows, err := q.db.Query(ctx, getExclusiveBuildsForTemplateDeletion, templateID)
 	if err != nil {
@@ -40,7 +43,7 @@ func (q *Queries) GetExclusiveBuildsForTemplateDeletion(ctx context.Context, tem
 	var items []GetExclusiveBuildsForTemplateDeletionRow
 	for rows.Next() {
 		var i GetExclusiveBuildsForTemplateDeletionRow
-		if err := rows.Scan(&i.BuildID, &i.ClusterNodeID); err != nil {
+		if err := rows.Scan(&i.BuildID, &i.ClusterNodeID, &i.ClusterID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/packages/db/queries/get_exclusive_builds_for_template_deletion_test.go
+++ b/packages/db/queries/get_exclusive_builds_for_template_deletion_test.go
@@ -1,0 +1,160 @@
+package queries_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/e2b-dev/infra/packages/db/pkg/testutils"
+)
+
+// TestGetExclusiveBuildsForTemplateDeletion_ExclusiveBuild verifies that a build
+// assigned only to the target template is returned by the query.
+func TestGetExclusiveBuildsForTemplateDeletion_ExclusiveBuild(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "latest")
+
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, buildID, rows[0].BuildID)
+	assert.Equal(t, "test-node", *rows[0].ClusterNodeID)
+}
+
+// TestGetExclusiveBuildsForTemplateDeletion_SharedBuildExcluded verifies that a
+// build assigned to multiple templates is NOT returned (it would break the other template).
+func TestGetExclusiveBuildsForTemplateDeletion_SharedBuildExcluded(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateA := testutils.CreateTestTemplate(t, db, teamID)
+	templateB := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Shared build: assigned to both templates
+	sharedBuildID := testutils.CreateTestBuild(t, ctx, db, templateA, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateA, sharedBuildID, "latest")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateB, sharedBuildID, "latest")
+
+	// Exclusive build: only on templateA
+	exclusiveBuildID := testutils.CreateTestBuild(t, ctx, db, templateA, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateA, exclusiveBuildID, "v2")
+
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateA)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "only the exclusive build should be returned")
+	assert.Equal(t, exclusiveBuildID, rows[0].BuildID)
+}
+
+// TestGetExclusiveBuildsForTemplateDeletion_WorksAfterSoftDelete verifies that
+// the query still returns builds after the template has been soft-deleted, because
+// it joins the raw envs table rather than the active_envs view.
+func TestGetExclusiveBuildsForTemplateDeletion_WorksAfterSoftDelete(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "latest")
+
+	// Soft-delete the template
+	err := db.SqlcClient.TestsRawSQL(ctx,
+		`UPDATE public.envs SET deleted_at = NOW() WHERE id = $1`,
+		templateID,
+	)
+	require.NoError(t, err, "soft-delete template")
+
+	// The query must still work after soft-delete
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, buildID, rows[0].BuildID)
+}
+
+// TestGetExclusiveBuildsForTemplateDeletion_ReturnsClusterID verifies that
+// cluster_id from the envs table is included in the result.
+func TestGetExclusiveBuildsForTemplateDeletion_ReturnsClusterID(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	// Insert a cluster record first (FK constraint) then link the template to it
+	clusterID := uuid.New()
+	err := db.SqlcClient.TestsRawSQL(ctx,
+		`INSERT INTO public.clusters (id, endpoint, endpoint_tls, token, name) VALUES ($1, 'https://cluster.local', false, 'tok', 'test-cluster')`,
+		clusterID,
+	)
+	require.NoError(t, err, "insert cluster")
+
+	err = db.SqlcClient.TestsRawSQL(ctx,
+		`UPDATE public.envs SET cluster_id = $1 WHERE id = $2`,
+		clusterID, templateID,
+	)
+	require.NoError(t, err, "set cluster_id")
+
+	buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+	testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, "latest")
+
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.NotNil(t, rows[0].ClusterID)
+	assert.Equal(t, clusterID, *rows[0].ClusterID)
+}
+
+// TestGetExclusiveBuildsForTemplateDeletion_NoBuilds verifies that templates
+// with no builds return an empty result without error.
+func TestGetExclusiveBuildsForTemplateDeletion_NoBuilds(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+// TestGetExclusiveBuildsForTemplateDeletion_MultipleExclusiveBuilds verifies
+// that all exclusive builds for a template are returned, not just the first.
+func TestGetExclusiveBuildsForTemplateDeletion_MultipleExclusiveBuilds(t *testing.T) {
+	t.Parallel()
+
+	db := testutils.SetupDatabase(t)
+	ctx := t.Context()
+
+	teamID := testutils.CreateTestTeam(t, db)
+	templateID := testutils.CreateTestTemplate(t, db, teamID)
+
+	buildIDs := make([]uuid.UUID, 3)
+	for i := range buildIDs {
+		buildID := testutils.CreateTestBuild(t, ctx, db, templateID, "success")
+		testutils.CreateTestBuildAssignment(t, ctx, db, templateID, buildID, uuid.New().String())
+		buildIDs[i] = buildID
+	}
+
+	rows, err := db.SqlcClient.GetExclusiveBuildsForTemplateDeletion(ctx, templateID)
+	require.NoError(t, err)
+	assert.Len(t, rows, 3)
+}


### PR DESCRIPTION
## Problem

`GetExclusiveBuildsForTemplateDeletion` SQL query was written and documented but had **zero Go callers**. As a result, deleting a template only soft-deleted the DB row — the corresponding GCS/S3 build artifacts (rootfs images, kernel blobs, FC snapshots) were left behind indefinitely, silently growing storage costs.

Fixes #3239

## Changes

### SQL (`get_exclusive_builds_for_template_deletion.sql`)
- Added `JOIN public.envs e` to also return `e.cluster_id` — needed to route the `DeleteBuild` gRPC call to the correct cluster.
- Intentionally joins `envs` (not `active_envs` view) so the query works **after** the template's `deleted_at` is stamped by `softDeleteTemplate`.

### Generated Go (`get_exclusive_builds_for_template_deletion.sql.go`)
- Added `ClusterID *uuid.UUID` to `GetExclusiveBuildsForTemplateDeletionRow` and the corresponding `Scan` call (hand-updated since sqlc is not in CI).

### Handler (`template_delete.go`)
- Added `deleteTemplateArtifactsWithDeleter` — queries the exclusive builds then calls `DeleteBuild` for each build that has a `ClusterNodeID`.
- `deleteTemplateArtifacts` wraps it with the real `templateManager.DeleteBuild`.
- Called in a **detached goroutine** after the DB transaction commits: storage errors are logged but never affect the `204 No Content` HTTP response.
- Builds with `ClusterNodeID == nil` are skipped (not yet on a node).
- The SQL exclusivity guard prevents deleting builds shared with other templates.

## Safety properties

| Property | How enforced |
|---|---|
| HTTP response unaffected by storage errors | Background goroutine + warn-only logging |
| Shared builds not deleted | SQL `NOT EXISTS` exclusivity check |
| Works after soft-delete | Joins raw `envs`, not `active_envs` view |
| Nil node ID handled | `if b.ClusterNodeID == nil { continue }` |

## Test plan

### SQL query tests (`get_exclusive_builds_for_template_deletion_test.go`) — all backed by a real Postgres container

- [x] Exclusive build is returned
- [x] Shared build (assigned to two templates) is excluded
- [x] Query returns correct `cluster_id` from the `envs` row
- [x] Query still works after the template is soft-deleted
- [x] Template with no builds returns empty result
- [x] Multiple exclusive builds all returned

### Handler tests (`template_delete_test.go`) — testcontainers DB + injected mock deleter

- [x] Only builds with `ClusterNodeID` trigger a `DeleteBuild` call; nil-node builds are skipped
- [x] Shared builds are not passed to the deleter
- [x] Deleter errors are non-fatal — remaining builds still attempted
- [x] Artifact cleanup finds builds even after template is soft-deleted

All 10 tests pass locally.

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.