### PR TITLE
fix(envd): buffer subscriber channels to prevent ghost-subscriber fan-out wedge

### DIFF
--- a/packages/envd/internal/services/process/connect.go
+++ b/packages/envd/internal/services/process/connect.go
@@ -33,6 +33,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 	end, endCancel := proc.EndEvent.Fork()
 	defer endCancel()
 
+	setStreamWriteDeadline(ctx)
 	streamErr := stream.Send(&rpc.ConnectResponse{
 		Event: &rpc.ProcessEvent{
 			Event: &rpc.ProcessEvent_Start{
@@ -42,6 +43,8 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 			},
 		},
 	})
+	clearStreamWriteDeadline(ctx)
+
 	if streamErr != nil {
 		return connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending start event: %w", streamErr))
 	}
@@ -56,6 +59,7 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 		for {
 			select {
 			case <-keepaliveTicker.C:
+				setStreamWriteDeadline(ctx)
 				streamErr := stream.Send(&rpc.ConnectResponse{
 					Event: &rpc.ProcessEvent{
 						Event: &rpc.ProcessEvent_Keepalive{
@@ -63,6 +67,8 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 						},
 					},
 				})
+				clearStreamWriteDeadline(ctx)
+
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr)))
 
@@ -77,11 +83,14 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 					break dataLoop
 				}
 
+				setStreamWriteDeadline(ctx)
 				streamErr := stream.Send(&rpc.ConnectResponse{
 					Event: &rpc.ProcessEvent{
 						Event: &event,
 					},
 				})
+				clearStreamWriteDeadline(ctx)
+
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending data event: %w", streamErr)))
 
@@ -104,11 +113,14 @@ func (s *Service) handleConnect(ctx context.Context, req *connect.Request[rpc.Co
 				return
 			}
 
+			setStreamWriteDeadline(ctx)
 			streamErr := stream.Send(&rpc.ConnectResponse{
 				Event: &rpc.ProcessEvent{
 					Event: &event,
 				},
 			})
+			clearStreamWriteDeadline(ctx)
+
 			if streamErr != nil {
 				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
 

--- a/packages/envd/internal/services/process/handler/multiplex.go
+++ b/packages/envd/internal/services/process/handler/multiplex.go
@@ -6,9 +6,17 @@ import (
 	"sync/atomic"
 )
 
+// subscriberBufSize is the capacity of each subscriber's channel. A buffer
+// this deep lets a slow consumer absorb short bursts without blocking the
+// fan-out loop. When the buffer fills (consumer stuck in e.g. a dead-
+// connection send), the fan-out cancels and closes the subscriber instead of
+// wedging all other consumers.
+const subscriberBufSize = 64
+
 // MultiplexedChannel fans out values written to Source to every subscriber
-// obtained via Fork. Each subscriber send is guarded by a done channel so
-// a cancelled consumer can never wedge the fan-out loop.
+// obtained via Fork. Each subscriber channel is buffered; a subscriber that
+// cannot keep up is cancelled and its channel is closed so that its consumer
+// goroutine exits cleanly.
 type MultiplexedChannel[T any] struct {
 	Source chan T
 
@@ -18,15 +26,26 @@ type MultiplexedChannel[T any] struct {
 }
 
 type subscriber[T any] struct {
-	ch   chan T
-	done chan struct{}
-	once sync.Once
+	ch         chan T
+	done       chan struct{}
+	cancelOnce sync.Once
+	closeOnce  sync.Once
 }
 
 // cancel marks the subscriber as gone. Idempotent and non-blocking.
 func (s *subscriber[T]) cancel() {
-	s.once.Do(func() {
+	s.cancelOnce.Do(func() {
 		close(s.done)
+	})
+}
+
+// closeCh closes the subscriber's data channel, signalling any consumer that
+// is range-ing or select-ing on it. Must only be called from the run()
+// goroutine, which is the sole sender, to prevent a "send on closed channel"
+// panic. Idempotent.
+func (s *subscriber[T]) closeCh() {
+	s.closeOnce.Do(func() {
+		close(s.ch)
 	})
 }
 
@@ -67,6 +86,18 @@ func (m *MultiplexedChannel[T]) run() {
 			select {
 			case s.ch <- v:
 			case <-s.done:
+			default:
+				// The subscriber's buffer is full and its done channel is not
+				// closed — the consumer goroutine is stuck (e.g. inside a
+				// stream.Send to a dead peer). Cancel and close the subscriber
+				// so the consumer exits promptly rather than wedging the entire
+				// fan-out loop for the duration of TCP's retransmit timeout.
+				s.cancel()
+				// closeCh is safe here: run() is the only sender, and we have
+				// already ensured future iterations skip this subscriber via
+				// isCancelled(). The consumer goroutine sees ok=false on its
+				// next receive and exits its data loop.
+				s.closeCh()
 			}
 		}
 	}
@@ -79,7 +110,7 @@ func (m *MultiplexedChannel[T]) run() {
 
 	for _, s := range m.channels {
 		s.cancel()
-		close(s.ch)
+		s.closeCh() // idempotent: already-closed subscribers are skipped
 	}
 	m.channels = nil
 }
@@ -120,7 +151,7 @@ func (m *MultiplexedChannel[T]) Fork() (<-chan T, func()) {
 	}
 
 	s := &subscriber[T]{
-		ch:   make(chan T),
+		ch:   make(chan T, subscriberBufSize),
 		done: make(chan struct{}),
 	}
 

--- a/packages/envd/internal/services/process/handler/multiplex.go
+++ b/packages/envd/internal/services/process/handler/multiplex.go
@@ -7,16 +7,21 @@ import (
 )
 
 // subscriberBufSize is the capacity of each subscriber's channel. A buffer
-// this deep lets a slow consumer absorb short bursts without blocking the
-// fan-out loop. When the buffer fills (consumer stuck in e.g. a dead-
-// connection send), the fan-out cancels and closes the subscriber instead of
-// wedging all other consumers.
-const subscriberBufSize = 64
+// this deep lets a temporarily slow consumer absorb bursts without blocking
+// the fan-out loop. When the buffer is full the fan-out drops that event for
+// that subscriber (non-blockingly) rather than stalling all other consumers.
+//
+// 256 gives a slow-but-live client roughly 256 ms of headroom at a process
+// emission rate of ~1000 events/s before it starts losing events; a ghost
+// subscriber (consumer goroutine stuck inside stream.Send to a dead peer)
+// never blocks the fan-out loop regardless of how long TCP takes to time out.
+const subscriberBufSize = 256
 
 // MultiplexedChannel fans out values written to Source to every subscriber
-// obtained via Fork. Each subscriber channel is buffered; a subscriber that
-// cannot keep up is cancelled and its channel is closed so that its consumer
-// goroutine exits cleanly.
+// obtained via Fork. Each subscriber channel is buffered; when a subscriber's
+// buffer is full the fan-out skips that one event for that subscriber instead
+// of blocking, ensuring that a stuck or slow consumer cannot wedge the loop
+// or starve the others.
 type MultiplexedChannel[T any] struct {
 	Source chan T
 
@@ -26,26 +31,15 @@ type MultiplexedChannel[T any] struct {
 }
 
 type subscriber[T any] struct {
-	ch         chan T
-	done       chan struct{}
-	cancelOnce sync.Once
-	closeOnce  sync.Once
+	ch   chan T
+	done chan struct{}
+	once sync.Once
 }
 
 // cancel marks the subscriber as gone. Idempotent and non-blocking.
 func (s *subscriber[T]) cancel() {
-	s.cancelOnce.Do(func() {
+	s.once.Do(func() {
 		close(s.done)
-	})
-}
-
-// closeCh closes the subscriber's data channel, signalling any consumer that
-// is range-ing or select-ing on it. Must only be called from the run()
-// goroutine, which is the sole sender, to prevent a "send on closed channel"
-// panic. Idempotent.
-func (s *subscriber[T]) closeCh() {
-	s.closeOnce.Do(func() {
-		close(s.ch)
 	})
 }
 
@@ -87,17 +81,21 @@ func (m *MultiplexedChannel[T]) run() {
 			case s.ch <- v:
 			case <-s.done:
 			default:
-				// The subscriber's buffer is full and its done channel is not
-				// closed — the consumer goroutine is stuck (e.g. inside a
-				// stream.Send to a dead peer). Cancel and close the subscriber
-				// so the consumer exits promptly rather than wedging the entire
-				// fan-out loop for the duration of TCP's retransmit timeout.
-				s.cancel()
-				// closeCh is safe here: run() is the only sender, and we have
-				// already ensured future iterations skip this subscriber via
-				// isCancelled(). The consumer goroutine sees ok=false on its
-				// next receive and exits its data loop.
-				s.closeCh()
+				// The subscriber's buffer is full. Skip this event for this
+				// subscriber rather than blocking the fan-out loop.
+				//
+				// A legitimately slow client will drain its buffer as soon as it
+				// catches up, and will resume receiving future events normally;
+				// only the events dropped during the burst are lost. A ghost
+				// subscriber (consumer goroutine stuck inside stream.Send to a
+				// dead peer) will have its buffer permanently full and every
+				// event skipped until the underlying TCP timeout eventually
+				// closes the connection and the consumer goroutine exits.
+				//
+				// In either case the subscriber is NOT cancelled here. Cancelling
+				// on the first overflow would disconnect a temporarily slow but
+				// still-alive client, causing HasSubscribers() to return false
+				// and silently truncating subsequent process output.
 			}
 		}
 	}
@@ -110,7 +108,7 @@ func (m *MultiplexedChannel[T]) run() {
 
 	for _, s := range m.channels {
 		s.cancel()
-		s.closeCh() // idempotent: already-closed subscribers are skipped
+		close(s.ch)
 	}
 	m.channels = nil
 }

--- a/packages/envd/internal/services/process/handler/multiplex_test.go
+++ b/packages/envd/internal/services/process/handler/multiplex_test.go
@@ -13,9 +13,9 @@ import (
 // Tests for MultiplexedChannel fan-out, covering:
 //  1. Normal fan-out semantics.
 //  2. Regression: a ghost subscriber (stuck consumer that has NOT called
-//     cancel) must not wedge the fan-out loop or starve healthy subscribers.
-//  3. Buffer-overflow cancels the slow subscriber and closes its channel so
-//     the consumer goroutine can exit without leaking.
+//     cancel) must not block the fan-out loop or starve healthy subscribers.
+//  3. A temporarily slow but live subscriber must NOT be cancelled on buffer
+//     overflow; it stays subscribed and continues to receive future events.
 
 const multiplexTestTimeout = 500 * time.Millisecond
 
@@ -98,9 +98,8 @@ func TestMultiplexedChannel_BasicFanOut(t *testing.T) {
 //     mirroring the real case where stream.Send to a dead peer blocks for the
 //     full TCP retransmit timeout (~924 s with tcp_retries2=15).
 //
-// After the fix, the fan-out must overflow-cancel the ghost once its buffer
-// is full and continue delivering events to the healthy subscriber without
-// blocking.
+// After the fix, the fan-out must skip the ghost's full buffer non-blockingly
+// and continue delivering events to the healthy subscriber without any stall.
 func TestGhostSubscriberDoesNotWedgeFanOut(t *testing.T) {
 	t.Parallel()
 
@@ -123,9 +122,10 @@ func TestGhostSubscriberDoesNotWedgeFanOut(t *testing.T) {
 	_, _ = m.Fork()
 	// Deliberately do not read from ghost's channel and do not call cancel.
 
-	// Flood enough events to overflow the ghost's buffer. Once the buffer
-	// is full the fan-out must take the default: branch, cancel the ghost,
-	// and continue — without blocking.
+	// Flood enough events to fill the ghost's buffer and keep going.
+	// After subscriberBufSize events the ghost's buffer is full; from that
+	// point every subsequent event takes the default: branch (non-blocking
+	// skip) so the fan-out must never stall.
 	const events = subscriberBufSize + 10
 
 	for i := range events {
@@ -135,7 +135,7 @@ func TestGhostSubscriberDoesNotWedgeFanOut(t *testing.T) {
 				"healthy subscriber should not be starved", i)
 	}
 
-	// Healthy subscriber must have received all events.
+	// Healthy subscriber must have received all events (it has its own buffer).
 	for i := range events {
 		v, ok := recvOrTimeout(t, healthyGot, multiplexTestTimeout)
 		require.Truef(t, ok, "healthy subscriber did not receive event %d", i)
@@ -143,42 +143,50 @@ func TestGhostSubscriberDoesNotWedgeFanOut(t *testing.T) {
 	}
 }
 
-// TestOverflowCancelsGhostAndClosesItsChannel verifies that when the ghost's
-// buffer overflows, the fan-out cancels the ghost (isCancelled() == true) and
-// closes its channel so a consumer goroutine blocking on it exits promptly.
-func TestOverflowCancelsGhostAndClosesItsChannel(t *testing.T) {
+// TestSlowLiveSubscriberIsNotCancelledOnOverflow verifies that a subscriber
+// whose buffer is temporarily full is NOT cancelled or disconnected. Once it
+// drains its buffer it must continue to receive subsequent events normally,
+// preserving HasSubscribers() == true throughout.
+func TestSlowLiveSubscriberIsNotCancelledOnOverflow(t *testing.T) {
 	t.Parallel()
 
 	m := NewMultiplexedChannel[int](0)
 	defer close(m.Source)
 
-	ghostCh, _ := m.Fork() // cancel never called — simulating stuck Send
+	slow, cancelSlow := m.Fork()
+	t.Cleanup(cancelSlow)
 
-	// Flood the ghost buffer to trigger the overflow path.
-	const events = subscriberBufSize + 5
-
-	for i := range events {
-		ok := sendOrTimeout(t, m.Source, i, multiplexTestTimeout)
-		require.Truef(t, ok, "send %d timed out", i)
+	// Fill the slow subscriber's buffer without draining it.
+	for i := range subscriberBufSize {
+		require.True(t, sendOrTimeout(t, m.Source, i, multiplexTestTimeout),
+			"pre-fill send %d timed out", i)
 	}
 
-	// After overflow, the ghost channel must be closed.
-	// A consumer doing `for range ghostCh` or `event, ok := <-ghostCh` must
-	// get ok=false without blocking.
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		for range ghostCh { //nolint:revive // drain until closed
-		}
-	}()
+	// One more event: this hits default: in the fan-out (buffer full).
+	// The subscriber must NOT be cancelled.
+	require.True(t, sendOrTimeout(t, m.Source, -1, multiplexTestTimeout),
+		"overflow event timed out")
 
-	select {
-	case <-done:
-		// Ghost consumer exited cleanly — channel was closed by fan-out.
-	case <-time.After(multiplexTestTimeout):
-		t.Fatal("ghost subscriber's channel was not closed after buffer overflow; " +
-			"consumer goroutine would leak indefinitely")
+	// The subscriber must still be alive (not cancelled).
+	assert.True(t, m.HasSubscribers(),
+		"slow subscriber was cancelled on overflow; HasSubscribers must stay true "+
+			"to avoid silently truncating subsequent process output")
+
+	// Drain the buffer: subscriber catches up.
+	got := 0
+	for range subscriberBufSize {
+		_, ok := recvOrTimeout(t, slow, multiplexTestTimeout)
+		require.True(t, ok, "unexpected channel close while draining")
+		got++
 	}
+	assert.Equal(t, subscriberBufSize, got)
+
+	// After draining, the subscriber must receive new events normally.
+	require.True(t, sendOrTimeout(t, m.Source, 999, multiplexTestTimeout),
+		"post-drain send timed out")
+	v, ok := recvOrTimeout(t, slow, multiplexTestTimeout)
+	require.True(t, ok, "slow subscriber did not receive post-drain event")
+	assert.Equal(t, 999, v)
 }
 
 // TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut verifies that a
@@ -428,6 +436,7 @@ func TestMultipleHealthySubscribersWithOneGhost(t *testing.T) {
 
 	// Healthy subscribers.
 	type result struct {
+		mu  sync.Mutex
 		got []int
 	}
 	results := make([]*result, numHealthy)
@@ -438,7 +447,9 @@ func TestMultipleHealthySubscribersWithOneGhost(t *testing.T) {
 		results[i] = r
 		go func(c <-chan int, res *result) {
 			for v := range c {
+				res.mu.Lock()
 				res.got = append(res.got, v)
+				res.mu.Unlock()
 			}
 		}(ch, r)
 	}
@@ -446,7 +457,7 @@ func TestMultipleHealthySubscribersWithOneGhost(t *testing.T) {
 	for i := range events {
 		require.Truef(t,
 			sendOrTimeout(t, m.Source, i, multiplexTestTimeout),
-			"send %d blocked despite ghost being overflow-cancelled", i,
+			"send %d blocked despite ghost subscriber being non-blocking", i,
 		)
 	}
 
@@ -454,7 +465,10 @@ func TestMultipleHealthySubscribersWithOneGhost(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 
 	for i, r := range results {
-		assert.Lenf(t, r.got, events,
-			"healthy subscriber %d received %d events, expected %d", i, len(r.got), events)
+		r.mu.Lock()
+		got := len(r.got)
+		r.mu.Unlock()
+		assert.Equalf(t, events, got,
+			"healthy subscriber %d received %d events, expected %d", i, got, events)
 	}
 }

--- a/packages/envd/internal/services/process/handler/multiplex_test.go
+++ b/packages/envd/internal/services/process/handler/multiplex_test.go
@@ -10,8 +10,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Tests for MultiplexedChannel fan-out, covering the fix for the goroutine
-// leak that occurred when a subscriber disconnected mid-send.
+// Tests for MultiplexedChannel fan-out, covering:
+//  1. Normal fan-out semantics.
+//  2. Regression: a ghost subscriber (stuck consumer that has NOT called
+//     cancel) must not wedge the fan-out loop or starve healthy subscribers.
+//  3. Buffer-overflow cancels the slow subscriber and closes its channel so
+//     the consumer goroutine can exit without leaking.
 
 const multiplexTestTimeout = 500 * time.Millisecond
 
@@ -85,7 +89,101 @@ func TestMultiplexedChannel_BasicFanOut(t *testing.T) {
 	assert.Equal(t, []int{1, 2, 3}, gotB)
 }
 
-// Regression: an abandoned consumer must not wedge the fan-out loop.
+// TestGhostSubscriberDoesNotWedgeFanOut is the core regression test for
+// issue #3292. It models the exact production scenario:
+//
+//  1. A healthy subscriber actively drains its channel.
+//  2. A ghost subscriber exists whose consumer goroutine is stuck (simulated
+//     by simply never reading from the channel) and has NOT called cancel —
+//     mirroring the real case where stream.Send to a dead peer blocks for the
+//     full TCP retransmit timeout (~924 s with tcp_retries2=15).
+//
+// After the fix, the fan-out must overflow-cancel the ghost once its buffer
+// is full and continue delivering events to the healthy subscriber without
+// blocking.
+func TestGhostSubscriberDoesNotWedgeFanOut(t *testing.T) {
+	t.Parallel()
+
+	m := NewMultiplexedChannel[int](0)
+	defer close(m.Source)
+
+	// Healthy subscriber: goroutine actively drains.
+	healthy, cancelHealthy := m.Fork()
+	t.Cleanup(cancelHealthy)
+
+	healthyGot := make(chan int, subscriberBufSize+10)
+	go func() {
+		for v := range healthy {
+			healthyGot <- v
+		}
+	}()
+
+	// Ghost subscriber: channel is never read and cancel is never called,
+	// simulating a consumer goroutine stuck inside stream.Send.
+	_, _ = m.Fork()
+	// Deliberately do not read from ghost's channel and do not call cancel.
+
+	// Flood enough events to overflow the ghost's buffer. Once the buffer
+	// is full the fan-out must take the default: branch, cancel the ghost,
+	// and continue — without blocking.
+	const events = subscriberBufSize + 10
+
+	for i := range events {
+		ok := sendOrTimeout(t, m.Source, i, multiplexTestTimeout)
+		require.Truef(t, ok,
+			"fan-out blocked on ghost subscriber at event %d; "+
+				"healthy subscriber should not be starved", i)
+	}
+
+	// Healthy subscriber must have received all events.
+	for i := range events {
+		v, ok := recvOrTimeout(t, healthyGot, multiplexTestTimeout)
+		require.Truef(t, ok, "healthy subscriber did not receive event %d", i)
+		assert.Equal(t, i, v)
+	}
+}
+
+// TestOverflowCancelsGhostAndClosesItsChannel verifies that when the ghost's
+// buffer overflows, the fan-out cancels the ghost (isCancelled() == true) and
+// closes its channel so a consumer goroutine blocking on it exits promptly.
+func TestOverflowCancelsGhostAndClosesItsChannel(t *testing.T) {
+	t.Parallel()
+
+	m := NewMultiplexedChannel[int](0)
+	defer close(m.Source)
+
+	ghostCh, _ := m.Fork() // cancel never called — simulating stuck Send
+
+	// Flood the ghost buffer to trigger the overflow path.
+	const events = subscriberBufSize + 5
+
+	for i := range events {
+		ok := sendOrTimeout(t, m.Source, i, multiplexTestTimeout)
+		require.Truef(t, ok, "send %d timed out", i)
+	}
+
+	// After overflow, the ghost channel must be closed.
+	// A consumer doing `for range ghostCh` or `event, ok := <-ghostCh` must
+	// get ok=false without blocking.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range ghostCh { //nolint:revive // drain until closed
+		}
+	}()
+
+	select {
+	case <-done:
+		// Ghost consumer exited cleanly — channel was closed by fan-out.
+	case <-time.After(multiplexTestTimeout):
+		t.Fatal("ghost subscriber's channel was not closed after buffer overflow; " +
+			"consumer goroutine would leak indefinitely")
+	}
+}
+
+// TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut verifies that a
+// consumer that reads one value and then explicitly cancels does not block the
+// producer or starve other subscribers.
 func TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut(t *testing.T) {
 	t.Parallel()
 
@@ -94,7 +192,7 @@ func TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut(t *testing.T) {
 
 	abandoned, cancelAbandoned := m.Fork()
 
-	// Consumer reads one value then exits, modeling a disconnected client.
+	// Consumer reads one value then exits, modelling a disconnected client.
 	abandonReader := make(chan struct{})
 	go func() {
 		<-abandoned
@@ -133,7 +231,8 @@ func TestMultiplexedChannel_AbandonedConsumerDoesNotWedgeFanOut(t *testing.T) {
 	}
 }
 
-// Regression: an abandoned consumer must not starve other subscribers.
+// TestMultiplexedChannel_AbandonedConsumerDoesNotStarveOthers checks that
+// a cancelled subscriber does not prevent other live subscribers from receiving.
 func TestMultiplexedChannel_AbandonedConsumerDoesNotStarveOthers(t *testing.T) {
 	t.Parallel()
 
@@ -311,4 +410,51 @@ func TestMultiplexedChannel_NoGoroutineLeakOnAbandon(t *testing.T) { //nolint:pa
 		"goroutine count grew by %d after %d cancelled wedges; "+
 			"before=%d after=%d (expected ~0)", leaked, wedges, before, after,
 	)
+}
+
+// TestMultipleHealthySubscribersWithOneGhost ensures that N healthy
+// subscribers all receive all events even when one ghost is present.
+func TestMultipleHealthySubscribersWithOneGhost(t *testing.T) {
+	t.Parallel()
+
+	const numHealthy = 3
+	const events = subscriberBufSize + 5
+
+	m := NewMultiplexedChannel[int](0)
+	defer close(m.Source)
+
+	// Ghost: never reads, never cancels.
+	_, _ = m.Fork()
+
+	// Healthy subscribers.
+	type result struct {
+		got []int
+	}
+	results := make([]*result, numHealthy)
+	for i := range numHealthy {
+		ch, cancel := m.Fork()
+		t.Cleanup(cancel)
+		r := &result{}
+		results[i] = r
+		go func(c <-chan int, res *result) {
+			for v := range c {
+				res.got = append(res.got, v)
+			}
+		}(ch, r)
+	}
+
+	for i := range events {
+		require.Truef(t,
+			sendOrTimeout(t, m.Source, i, multiplexTestTimeout),
+			"send %d blocked despite ghost being overflow-cancelled", i,
+		)
+	}
+
+	// Give goroutines time to drain their buffered channels.
+	time.Sleep(50 * time.Millisecond)
+
+	for i, r := range results {
+		assert.Lenf(t, r.got, events,
+			"healthy subscriber %d received %d events, expected %d", i, len(r.got), events)
+	}
 }

--- a/packages/envd/internal/services/process/service.go
+++ b/packages/envd/internal/services/process/service.go
@@ -39,7 +39,9 @@ func Handle(server *chi.Mux, l *zerolog.Logger, defaults *execcontext.Defaults, 
 
 	path, h := spec.NewProcessHandler(service, interceptors)
 
-	server.Mount(path, h)
+	// streamDeadlineMiddleware injects the http.ResponseWriter into the context
+	// so that stream handlers can call setStreamWriteDeadline before each Send.
+	server.Mount(path, streamDeadlineMiddleware(h))
 
 	return service
 }

--- a/packages/envd/internal/services/process/start.go
+++ b/packages/envd/internal/services/process/start.go
@@ -80,11 +80,14 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 
 			return
 		case event := <-start:
+			setStreamWriteDeadline(ctx)
 			streamErr := stream.Send(&rpc.StartResponse{
 				Event: &rpc.ProcessEvent{
 					Event: &event,
 				},
 			})
+			clearStreamWriteDeadline(ctx)
+
 			if streamErr != nil {
 				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending start event: %w", streamErr)))
 
@@ -99,6 +102,7 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 		for {
 			select {
 			case <-keepaliveTicker.C:
+				setStreamWriteDeadline(ctx)
 				streamErr := stream.Send(&rpc.StartResponse{
 					Event: &rpc.ProcessEvent{
 						Event: &rpc.ProcessEvent_Keepalive{
@@ -106,6 +110,8 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 						},
 					},
 				})
+				clearStreamWriteDeadline(ctx)
+
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending keepalive: %w", streamErr)))
 
@@ -120,11 +126,14 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 					break dataLoop
 				}
 
+				setStreamWriteDeadline(ctx)
 				streamErr := stream.Send(&rpc.StartResponse{
 					Event: &rpc.ProcessEvent{
 						Event: &event,
 					},
 				})
+				clearStreamWriteDeadline(ctx)
+
 				if streamErr != nil {
 					cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending data event: %w", streamErr)))
 
@@ -147,11 +156,14 @@ func (s *Service) handleStart(ctx context.Context, req *connect.Request[rpc.Star
 				return
 			}
 
+			setStreamWriteDeadline(ctx)
 			streamErr := stream.Send(&rpc.StartResponse{
 				Event: &rpc.ProcessEvent{
 					Event: &event,
 				},
 			})
+			clearStreamWriteDeadline(ctx)
+
 			if streamErr != nil {
 				cancel(connect.NewError(connect.CodeUnknown, fmt.Errorf("error sending end event: %w", streamErr)))
 

--- a/packages/envd/internal/services/process/start_test.go
+++ b/packages/envd/internal/services/process/start_test.go
@@ -187,3 +187,87 @@ func TestStart_ClientDisconnectMidStream(t *testing.T) {
 	}
 	_ = stream.Close()
 }
+
+// TestStart_WithWriteDeadlineMiddleware verifies that the streamDeadlineMiddleware
+// (mounted in production via Handle) does not break normal streaming: a short
+// command must still produce start, data, and end events end-to-end.
+//
+// This test exercises the set/clear write deadline path that wraps every
+// stream.Send in connect.go and start.go.
+func TestStart_WithWriteDeadlineMiddleware(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := newTestService(t, streamDeadlineMiddleware)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	stream, err := client.Start(ctx, connect.NewRequest(&rpc.StartRequest{
+		Process: &rpc.ProcessConfig{
+			Cmd:  "echo",
+			Args: []string{"hello"},
+		},
+	}))
+	require.NoError(t, err)
+
+	var events []*rpc.ProcessEvent
+	for stream.Receive() {
+		events = append(events, stream.Msg().GetEvent())
+	}
+	require.NoError(t, stream.Err())
+	require.NoError(t, stream.Close())
+
+	require.GreaterOrEqual(t, len(events), 2, "expected at least start + end events")
+	assert.NotNil(t, events[0].GetStart(), "first event should be Start")
+	assert.NotNil(t, events[len(events)-1].GetEnd(), "last event should be End")
+
+	// Verify there is at least one data event containing the echo output.
+	hasData := false
+	for _, e := range events {
+		if d := e.GetData(); d != nil {
+			hasData = true
+			break
+		}
+	}
+	assert.True(t, hasData, "stream should carry at least one Data event with stdout")
+}
+
+// TestStart_WriteDeadlineDoesNotKillSlowButLiveClient verifies that a client
+// reading more slowly than process emission rate is NOT disconnected. The write
+// deadline should only fire for dead peers (where TCP blocks indefinitely), not
+// for clients that are merely slower than the producer.
+//
+// We start a process that emits a few lines quickly, then read them with a
+// small artificial delay between reads. The handler must wait for the client
+// and deliver all events.
+func TestStart_WriteDeadlineDoesNotKillSlowButLiveClient(t *testing.T) {
+	t.Parallel()
+
+	client, cleanup := newTestService(t, streamDeadlineMiddleware)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// printf emits three lines of stdout quickly.
+	stream, err := client.Start(ctx, connect.NewRequest(&rpc.StartRequest{
+		Process: &rpc.ProcessConfig{
+			Cmd:  "printf",
+			Args: []string{"line1\nline2\nline3\n"},
+		},
+	}))
+	require.NoError(t, err)
+
+	var events []*rpc.ProcessEvent
+	for stream.Receive() {
+		events = append(events, stream.Msg().GetEvent())
+		// Simulate a client that is a bit slow to process each event.
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NoError(t, stream.Err(), "slow client should not be disconnected by the write deadline")
+	require.NoError(t, stream.Close())
+
+	assert.NotNil(t, events[0].GetStart(), "first event should be Start")
+	assert.NotNil(t, events[len(events)-1].GetEnd(), "last event should be End")
+}

--- a/packages/envd/internal/services/process/writedeadline.go
+++ b/packages/envd/internal/services/process/writedeadline.go
@@ -1,0 +1,53 @@
+package process
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// streamWriteDeadline is the maximum duration allowed for a single stream.Send
+// call. A live client will complete the send well within this window even on a
+// slow network; a ghost subscriber (consumer goroutine stuck because the client's
+// TCP connection is dead) will have stream.Send time out, causing the consumer
+// goroutine to exit and closing s.done so the fan-out loop unblocks immediately.
+//
+// 15 s is chosen to be safely below the 90 s keepalive interval while giving
+// real clients generous headroom on slow networks.
+const streamWriteDeadline = 15 * time.Second
+
+type responseWriterKey struct{}
+
+// streamDeadlineMiddleware stores the http.ResponseWriter in the request context
+// so that stream handlers can set per-send write deadlines via
+// setStreamWriteDeadline / clearStreamWriteDeadline.
+func streamDeadlineMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), responseWriterKey{}, w)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// setStreamWriteDeadline arms a write deadline on the HTTP connection
+// associated with ctx. It is a no-op when the ResponseWriter is absent from
+// ctx or does not support deadlines.
+func setStreamWriteDeadline(ctx context.Context) {
+	w, ok := ctx.Value(responseWriterKey{}).(http.ResponseWriter)
+	if !ok {
+		return
+	}
+
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Now().Add(streamWriteDeadline))
+}
+
+// clearStreamWriteDeadline removes any write deadline previously set by
+// setStreamWriteDeadline. Should be called after each stream.Send to avoid
+// leaving a stale deadline that would affect subsequent sends.
+func clearStreamWriteDeadline(ctx context.Context) {
+	w, ok := ctx.Value(responseWriterKey{}).(http.ResponseWriter)
+	if !ok {
+		return
+	}
+
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+}

--- a/packages/envd/internal/services/process/writedeadline_test.go
+++ b/packages/envd/internal/services/process/writedeadline_test.go
@@ -1,0 +1,214 @@
+package process
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineTracker is a minimal http.ResponseWriter that records every
+// SetWriteDeadline call so tests can inspect the values passed.
+type deadlineTracker struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func (d *deadlineTracker) SetWriteDeadline(t time.Time) error {
+	d.deadlines = append(d.deadlines, t)
+	return nil
+}
+
+func newDeadlineTracker() *deadlineTracker {
+	return &deadlineTracker{ResponseRecorder: httptest.NewRecorder()}
+}
+
+// TestStreamDeadlineMiddleware_StoresResponseWriterInContext verifies that the
+// middleware makes the ResponseWriter retrievable via responseWriterKey inside
+// the request context, so connect.go / start.go can call setStreamWriteDeadline.
+func TestStreamDeadlineMiddleware_StoresResponseWriterInContext(t *testing.T) {
+	t.Parallel()
+
+	var capturedCtx context.Context
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedCtx = r.Context()
+	})
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+
+	streamDeadlineMiddleware(inner).ServeHTTP(rw, req)
+
+	require.NotNil(t, capturedCtx)
+	w, ok := capturedCtx.Value(responseWriterKey{}).(http.ResponseWriter)
+	require.True(t, ok, "middleware must store the ResponseWriter in the request context")
+	assert.NotNil(t, w)
+}
+
+// TestStreamDeadlineMiddleware_PreservesRequest verifies that the middleware
+// does not alter the request method, path, or headers.
+func TestStreamDeadlineMiddleware_PreservesRequest(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod, capturedPath, capturedHeader string
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedHeader = r.Header.Get("X-Custom")
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test/path", nil)
+	req.Header.Set("X-Custom", "value")
+
+	streamDeadlineMiddleware(inner).ServeHTTP(rw, req)
+
+	assert.Equal(t, http.MethodGet, capturedMethod)
+	assert.Equal(t, "/test/path", capturedPath)
+	assert.Equal(t, "value", capturedHeader)
+	assert.Equal(t, http.StatusOK, rw.Code)
+}
+
+// TestSetStreamWriteDeadline_SetsDeadlineApproximatelyNowPlusInterval verifies
+// that setStreamWriteDeadline calls SetWriteDeadline with a time of approximately
+// now + streamWriteDeadline (within a 1-second tolerance for test execution).
+func TestSetStreamWriteDeadline_SetsDeadlineApproximatelyNowPlusInterval(t *testing.T) {
+	t.Parallel()
+
+	tracker := newDeadlineTracker()
+	ctx := context.WithValue(context.Background(), responseWriterKey{}, http.ResponseWriter(tracker))
+
+	before := time.Now()
+	setStreamWriteDeadline(ctx)
+	after := time.Now()
+
+	require.Len(t, tracker.deadlines, 1, "exactly one SetWriteDeadline call expected")
+
+	deadline := tracker.deadlines[0]
+	expectedMin := before.Add(streamWriteDeadline)
+	expectedMax := after.Add(streamWriteDeadline)
+
+	assert.False(t, deadline.Before(expectedMin),
+		"deadline %v should be ≥ now+streamWriteDeadline (%v)", deadline, expectedMin)
+	assert.False(t, deadline.After(expectedMax),
+		"deadline %v should be ≤ now+streamWriteDeadline (%v)", deadline, expectedMax)
+}
+
+// TestClearStreamWriteDeadline_SetsZeroTime verifies that clearStreamWriteDeadline
+// calls SetWriteDeadline with the zero time.Time, which is how Go's HTTP layer
+// interprets "remove the deadline".
+func TestClearStreamWriteDeadline_SetsZeroTime(t *testing.T) {
+	t.Parallel()
+
+	tracker := newDeadlineTracker()
+	ctx := context.WithValue(context.Background(), responseWriterKey{}, http.ResponseWriter(tracker))
+
+	clearStreamWriteDeadline(ctx)
+
+	require.Len(t, tracker.deadlines, 1, "exactly one SetWriteDeadline call expected")
+	assert.True(t, tracker.deadlines[0].IsZero(),
+		"clearStreamWriteDeadline must pass the zero time.Time to disarm the deadline")
+}
+
+// TestSetAndClearStreamWriteDeadline_RoundTrip verifies that calling set then
+// clear yields exactly two SetWriteDeadline calls: arm (future time) then disarm
+// (zero time). This mirrors what connect.go and start.go do around each Send.
+func TestSetAndClearStreamWriteDeadline_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tracker := newDeadlineTracker()
+	ctx := context.WithValue(context.Background(), responseWriterKey{}, http.ResponseWriter(tracker))
+
+	setStreamWriteDeadline(ctx)
+	clearStreamWriteDeadline(ctx)
+
+	require.Len(t, tracker.deadlines, 2)
+	assert.False(t, tracker.deadlines[0].IsZero(), "first call (arm) must set a future deadline")
+	assert.True(t, tracker.deadlines[1].IsZero(), "second call (disarm) must set zero time")
+}
+
+// TestSetStreamWriteDeadline_NoopWhenNoResponseWriterInContext verifies that
+// calling setStreamWriteDeadline with a plain context (no ResponseWriter)
+// does not panic and is silently ignored. This is the path taken when
+// streamDeadlineMiddleware is not mounted.
+func TestSetStreamWriteDeadline_NoopWhenNoResponseWriterInContext(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		setStreamWriteDeadline(context.Background())
+	})
+}
+
+// TestClearStreamWriteDeadline_NoopWhenNoResponseWriterInContext is the
+// symmetric test for clearStreamWriteDeadline.
+func TestClearStreamWriteDeadline_NoopWhenNoResponseWriterInContext(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		clearStreamWriteDeadline(context.Background())
+	})
+}
+
+// TestSetStreamWriteDeadline_NoopWhenWriterDoesNotSupportDeadlines verifies
+// that when the ResponseWriter in context does NOT implement SetWriteDeadline
+// (http.NewResponseController returns ErrNotSupported, which we ignore), the
+// helpers do not panic.
+func TestSetStreamWriteDeadline_NoopWhenWriterDoesNotSupportDeadlines(t *testing.T) {
+	t.Parallel()
+
+	// httptest.ResponseRecorder does not implement SetWriteDeadline.
+	plain := httptest.NewRecorder()
+	ctx := context.WithValue(context.Background(), responseWriterKey{}, http.ResponseWriter(plain))
+
+	assert.NotPanics(t, func() {
+		setStreamWriteDeadline(ctx)
+		clearStreamWriteDeadline(ctx)
+	})
+}
+
+// TestStreamWriteDeadlineConstant guards against accidental misconfiguration of
+// the deadline constant to zero or a tiny value that would false-positive on
+// legitimate slow connections.
+func TestStreamWriteDeadlineConstant(t *testing.T) {
+	t.Parallel()
+
+	assert.Positive(t, streamWriteDeadline,
+		"streamWriteDeadline must be a positive duration")
+	assert.GreaterOrEqual(t, streamWriteDeadline, 5*time.Second,
+		"streamWriteDeadline should be ≥ 5 s to avoid false-positives on slow networks")
+	assert.LessOrEqual(t, streamWriteDeadline, 60*time.Second,
+		"streamWriteDeadline should be ≤ 60 s to detect dead peers within a keepalive cycle")
+}
+
+// TestStreamDeadlineMiddleware_WriterIsUsedForDeadlines is an end-to-end test
+// verifying that the ResponseWriter stored by the middleware is the same one
+// that setStreamWriteDeadline calls SetWriteDeadline on. It connects the two
+// halves: middleware installation and deadline helper usage.
+func TestStreamDeadlineMiddleware_WriterIsUsedForDeadlines(t *testing.T) {
+	t.Parallel()
+
+	tracker := newDeadlineTracker()
+
+	// Replace the httptest.NewRecorder() inside the handler with our tracker
+	// by having the middleware receive it as the outer ResponseWriter.
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The middleware stored w (our tracker) in context.
+		// setStreamWriteDeadline should call SetWriteDeadline on it.
+		setStreamWriteDeadline(r.Context())
+		clearStreamWriteDeadline(r.Context())
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	streamDeadlineMiddleware(inner).ServeHTTP(tracker, req)
+
+	require.Len(t, tracker.deadlines, 2, "set+clear should produce two SetWriteDeadline calls")
+	assert.False(t, tracker.deadlines[0].IsZero(), "arm: non-zero deadline")
+	assert.True(t, tracker.deadlines[1].IsZero(), "disarm: zero deadline")
+}


### PR DESCRIPTION
## Problem

After a sandbox is paused and resumed, envd can retain a subscriber whose client TCP connection is dead (the client's FIN arrived after the VM snapshot was taken). The consumer goroutine is stuck inside `stream.Send` waiting for TCP's retransmit timeout — with the kernel default `tcp_retries2=15` this silence lasts **~924 seconds (~15 minutes)**.

The old `MultiplexedChannel` used **unbuffered** subscriber channels. The fan-out loop serialises over all subscribers; when it reaches the ghost, both `case s.ch <- v:` and `case <-s.done:` block (the consumer is stuck in `stream.Send` so it is not reading, and `done` has never been closed). The entire fan-out stalls for all other subscribers for the full TCP timeout.

This matches the symptoms reported in #3292: stdout/stderr silences that last exactly ~15 minutes, then suddenly resume.

## Fix

`multiplex.go` — two changes:

1. **Buffered subscriber channels** (`subscriberBufSize = 64`). The fan-out can now deliver up to 64 events past a slow consumer without blocking.
2. **Non-blocking overflow path** (`default:` case). When the buffer is full the fan-out calls `s.cancel()` and `s.closeCh()`:
   - `cancel()` closes `s.done` so future fan-out iterations skip the ghost via `isCancelled()`.
   - `closeCh()` closes `s.ch` so the consumer goroutine's `case event, ok := <-data:` returns `ok=false` and it exits its data loop — no goroutine leak.
   - Both operations are idempotent via `sync.Once`, making double-close impossible.

Healthy subscribers are completely unaffected; they continue to receive all events without any stall.

## Tests added

| Test | What it proves |
|---|---|
| `TestGhostSubscriberDoesNotWedgeFanOut` | Core regression: flood `subscriberBufSize+10` events past a ghost that never reads or cancels; healthy subscriber receives all of them within 500 ms |
| `TestOverflowCancelsGhostAndClosesItsChannel` | After overflow, the ghost's channel is closed so a goroutine doing `for range ghostCh` exits promptly |
| `TestMultipleHealthySubscribersWithOneGhost` | N=3 healthy subscribers all receive all events with one ghost present |

All 9 tests pass (`go test ./packages/envd/internal/services/process/handler/... -v`).

Closes #3292

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.