### PR TITLE
test: deflake TestDedupedMemfdCache_MemfdHeldUntilSwap

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -368,14 +368,17 @@ func TestDedupedMemfdCache_MemfdHeldUntilSwap(t *testing.T) {
 	require.Equal(t, int(ps), n)
 	require.Equal(t, srcData[3*ps:4*ps], buf)
 
-	// Once the swap is signaled the memfd is released and provisional reads fail.
+	// Once the swap is signaled the memfd is released and provisional reads
+	// fail. The release runs on the drain goroutine, which parallel tests in
+	// this package can starve on a loaded runner — the window is generous for
+	// that reason (the poll exits early on success).
 	cache.MarkSwapped()
 	require.Eventually(t, func() bool {
 		_, e := cache.ServeMemfd(buf, 3*ps)
 		var bna BytesNotAvailableError
 
 		return errors.As(e, &bna)
-	}, time.Second, time.Millisecond)
+	}, 15*time.Second, 5*time.Millisecond)
 }
 
 func TestDedupedMemfdCache_InflightConcurrentDrainRace(t *testing.T) {


### PR DESCRIPTION
## Summary
- The memfd release after `MarkSwapped` runs on the drain goroutine, which `t.Parallel()` neighbors (the concurrent-drain stress test runs 8 goroutines on a large page set) can starve past the 1-second `Eventually` window on a loaded CI runner — seen failing on an unrelated PR whose previous run was green on identical content.
- Widen the window to 15s with a 5ms poll; the poll returns on first success, so healthy runs are as fast as before.