### PR TITLE
test(api): deflake storage locker pub/sub wake-up test

### DIFF
--- a/packages/api/internal/sandbox/storage/redis/lock_test.go
+++ b/packages/api/internal/sandbox/storage/redis/lock_test.go
@@ -20,6 +20,18 @@ const (
 	testPollInterval = 10 * time.Millisecond
 )
 
+// testPubSubWakeupTimeout bounds the waiter's Obtain in the test asserting
+// the pub/sub wake-up path. It has to satisfy two constraints:
+//   - long enough for the register/release/notify/re-acquire choreography
+//     (several Redis round-trips plus goroutine scheduling) on small, loaded
+//     CI runners - the previous 25ms flaked regularly on 4vcpu machines;
+//   - strictly below the earliest possible backoff retry,
+//     lockRetryMinInterval*(1-lockRetryJitter), so the waiter can only
+//     succeed via the pub/sub notification: if lock holders stop publishing
+//     release notifications, the test still fails instead of passing via
+//     the polling fallback.
+var testPubSubWakeupTimeout = time.Duration(0.9 * (1 - lockRetryJitter) * float64(lockRetryMinInterval))
+
 func TestStorageLocker_ObtainAfterReleaseNotification(t *testing.T) {
 	t.Parallel()
 
@@ -81,7 +93,7 @@ func TestStorageLocker_ObtainUsesProvidedContext(t *testing.T) {
 
 	waiterDone := make(chan error, 1)
 	go func() {
-		waiterLock, obtainErr := locker.Obtain(t.Context(), lockKey, 25*time.Millisecond)
+		waiterLock, obtainErr := locker.Obtain(t.Context(), lockKey, testPubSubWakeupTimeout)
 		if obtainErr != nil {
 			waiterDone <- obtainErr
 


### PR DESCRIPTION
## Problem

`TestStorageLocker_ObtainUsesProvidedContext` is the single source of every recurring Blacksmith shard failure since the unit shards moved there (#3322): **16 api-shard failures in ~30h** (13 arm64, 3 x64) — always this one test, always `context deadline exceeded`.

The waiter gets `Obtain(ctx, key, 25*time.Millisecond)`, and `Obtain` uses that value as the **overall wait deadline** (`context.WithTimeout`). Inside those 25ms the test needs: the waiter's failed `tryLock` + pub/sub subscribe → the main goroutine's `require.Eventually` (10ms poll ticks) to notice the registration → parent `Release` (Redis round-trip) → pub/sub publish + delivery → waiter re-acquire (another round-trip) — all under `-race` with ~300 parallel tests sharing the runner. On the old 32-core `infra-tests` machine that fit; on a 4vcpu runner it frequently doesn't.

## Why not just use a big timeout

The 25ms was doing real work: the lock retry backoff first fires at `lockRetryMinInterval ± jitter` = **150–250ms**, so a sub-150ms deadline proves the waiter was woken by the **pub/sub notification**, not the polling fallback (`TestStorageLocker_ObtainAfterReleaseNotification` already covers the lax "succeeds eventually" case). A 1s timeout would keep this test green even if release notifications broke entirely.

## Fix

Set the waiter deadline to `0.9 × lockRetryMinInterval × (1 − lockRetryJitter)` = **135ms**, computed from the constants so it tracks future tuning:

- still strictly below the earliest possible backoff fire (150ms) → the pub/sub-regression signal is preserved
- ~5× more headroom for the choreography on small runners