### PR TITLE
fix(orchestrator): remove hardcoded customer template IDs from GetDefaultReadyCommand

### DIFF
--- a/packages/orchestrator/pkg/template/build/config/config.go
+++ b/packages/orchestrator/pkg/template/build/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/template/build/core/oci/auth"
 	templatemanager "github.com/e2b-dev/infra/packages/shared/pkg/grpc/template-manager"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
@@ -51,6 +53,10 @@ type TemplateConfig struct {
 
 	// Command to run to check if the template is ready.
 	ReadyCmd string
+
+	// Maximum time to wait for StartCmd when no ReadyCmd is provided.
+	// Zero means use the built-in default (20s).
+	StartCmdTimeout time.Duration
 
 	// FromImage is the base image to use for building the template.
 	FromImage string

--- a/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/builder.go
@@ -317,7 +317,7 @@ func (ppb *PostProcessingBuilder) postProcessingFn(userLogger logger.Logger) lay
 			if meta.Start.StartCmd == "" {
 				readyCmd = "sleep 0"
 			} else {
-				readyCmd = GetDefaultReadyCommand(ppb.Config.TemplateID)
+				readyCmd = GetDefaultReadyCommand(ppb.Config.StartCmdTimeout)
 			}
 		}
 		err = ppb.runReadyCommand(

--- a/packages/orchestrator/pkg/template/build/phases/finalize/ready.go
+++ b/packages/orchestrator/pkg/template/build/phases/finalize/ready.go
@@ -74,13 +74,12 @@ func (ppb *PostProcessingBuilder) runReadyCommand(
 	}
 }
 
-func GetDefaultReadyCommand(templateID string) string {
-	// HACK: This is a temporary fix for a customer that needs a bigger time to start the command.
-	// TODO: Remove this after we can add customizable wait time for building templates.
-	// TODO: Make this user configurable, with health check too
-	if templateID == "zegbt9dl3l2ixqem82mm" || templateID == "ot5bidkk3j2so2j02uuz" || templateID == "0zeou1s7agaytqitvmzc" {
-		return fmt.Sprintf("sleep %d", int((120 * time.Second).Seconds()))
+// GetDefaultReadyCommand returns a ready command that sleeps for the given duration.
+// Pass 0 to use the built-in default (20s).
+func GetDefaultReadyCommand(startCmdTimeout time.Duration) string {
+	if startCmdTimeout <= 0 {
+		startCmdTimeout = defaultReadyWait
 	}
 
-	return fmt.Sprintf("sleep %d", int(defaultReadyWait.Seconds()))
+	return fmt.Sprintf("sleep %d", int(startCmdTimeout.Seconds()))
 }


### PR DESCRIPTION
## Problem

`GetDefaultReadyCommand` hard-codes three customer template IDs to extend the default ready-wait from 20 s to 120 s:

```go
// HACK: This is a temporary fix for a customer that needs a bigger time to start the command.
// TODO: Remove this after we can add customizable wait time for building templates.
if templateID == "zegbt9dl3l2ixqem82mm" || templateID == "ot5bidkk3j2so2j02uuz" || templateID == "0zeou1s7agaytqitvmzc" {
    return fmt.Sprintf("sleep %d", int((120 * time.Second).Seconds()))
}
```

This is a security concern (customer IDs in source), makes the function untestable, and blocks the TODO to make the timeout user-configurable.

Fixes #3349.

## Solution

- Add `StartCmdTimeout time.Duration` to `TemplateConfig`. Zero (the zero value) means "use the built-in default (20 s)", preserving backward-compatibility for every existing build request that omits the field.
- Change `GetDefaultReadyCommand(templateID string)` → `GetDefaultReadyCommand(startCmdTimeout time.Duration)` and remove the three hardcoded IDs.
- Update the sole call-site in `builder.go` to pass `ppb.Config.StartCmdTimeout`.

`StartCmdTimeout` is intentionally left un-wired from the proto/API in this PR so the diff stays minimal. A follow-up can expose it as `start_cmd_timeout_sec` in `TemplateConfig`.

## Migration

The three previously hard-coded templates should add an explicit `ready_cmd` to their build configuration (e.g. `ready_cmd: "sleep 120"` in their `e2b.toml`) so their 120 s wait is preserved after this change.

## Test plan

- [ ] `go build ./packages/orchestrator/pkg/template/...` passes
- [ ] A template build with no `ready_cmd` and no `start_cmd` still uses `sleep 0`
- [ ] A template build with a `start_cmd` and no `ready_cmd` uses `sleep 20`
- [ ] A template build with `StartCmdTimeout: 120*time.Second` uses `sleep 120`

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.