### PR TITLE
feat(orch): count pages served from in-flight memfd during dedup

### DIFF
--- a/packages/orchestrator/pkg/sandbox/block/memfd.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd.go
@@ -276,6 +276,27 @@ var swapGraceElapsedCounter = utils.Must(otel.Meter("github.com/e2b-dev/infra/pa
 	Int64Counter("orchestrator.memfd.swap_grace_elapsed",
 		metric.WithDescription("Dedup memfd releases that timed out on the swap grace without a swap signal")))
 
+// inflightServePagesCounter counts guest pages (header.PageSize units) served
+// from the still-mapped memfd during the dedup window. A single serve can copy a
+// multi-page contiguous dirty run, so it is incremented by the number of pages
+// in the copy, not once per call — otherwise the count would track mapping
+// fragmentation rather than pages served. Unlike swapGraceElapsedCounter (a
+// failure signal), this is the positive engagement signal: a nonzero rate means
+// resumes overlapping an in-flight pause are reading pages from the memfd
+// instead of blocking on dedup. The phase label separates the two serving paths.
+var inflightServePagesCounter = utils.Must(otel.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block").
+	Int64Counter("orchestrator.memfd.inflight_serve_pages",
+		metric.WithDescription("Guest pages served from the still-mapped memfd during dedup (in-flight memfd serving)")))
+
+// inflightServe{Provisional,Drain}Attr tag which serving path recorded a page:
+// the provisional compare window (ServeMemfd, identity offsets) or the in-flight
+// drain window (tryInflightRead, packed offsets). Precomputed as attribute-set
+// options so the per-page Add allocates nothing.
+var (
+	inflightServeProvisionalAttr = metric.WithAttributeSet(attribute.NewSet(attribute.String("phase", "provisional")))
+	inflightServeDrainAttr       = metric.WithAttributeSet(attribute.NewSet(attribute.String("phase", "drain")))
+)
+
 func NewCacheFromMemfdDeduped(
 	ctx context.Context,
 	base ReadonlyDevice,
@@ -495,6 +516,7 @@ func (d *DedupedMemfdCache) tryInflightRead(b []byte, off int64) (int, bool) {
 		return 0, false
 	}
 	copy(b, src)
+	inflightServePagesCounter.Add(context.Background(), int64(len(b))/int64(header.PageSize), inflightServeDrainAttr)
 
 	return len(b), true
 }
@@ -558,6 +580,7 @@ func (d *DedupedMemfdCache) ServeMemfd(b []byte, off int64) (int, error) {
 		return 0, err
 	}
 	copy(b, src)
+	inflightServePagesCounter.Add(context.Background(), int64(len(b))/int64(header.PageSize), inflightServeProvisionalAttr)
 
 	return len(b), nil
 }

--- a/packages/orchestrator/pkg/sandbox/block/memfd_test.go
+++ b/packages/orchestrator/pkg/sandbox/block/memfd_test.go
@@ -16,7 +16,10 @@ import (
 	"time"
 
 	"github.com/RoaringBitmap/roaring/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"golang.org/x/sys/unix"
 
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage/header"
@@ -322,6 +325,92 @@ func TestDedupedMemfdCache_InflightServesFromMemfd(t *testing.T) {
 	require.NoError(t, d.done.SetValue(nil))
 	_, ok := d.tryInflightRead(make([]byte, ps), 0)
 	require.False(t, ok)
+}
+
+// Pages served from the memfd increment inflight_serve_pages by the page count
+// (not once per call) and are tagged by phase: the drain-window path
+// (tryInflightRead, via ReadAt/Slice) as "drain", the provisional compare-window
+// path (ServeMemfd) as "provisional". A read bypassed after the drain resolves
+// must not be counted.
+//
+//nolint:paralleltest // swaps the package-level inflightServePagesCounter
+func TestDedupedMemfdCache_InflightServeMetric(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+
+	prev := inflightServePagesCounter
+	inflightServePagesCounter = utils.Must(mp.Meter("github.com/e2b-dev/infra/packages/orchestrator/pkg/sandbox/block").
+		Int64Counter("orchestrator.memfd.inflight_serve_pages"))
+	t.Cleanup(func() { inflightServePagesCounter = prev })
+
+	ps := int64(header.PageSize)
+	memfd, _ := newTestMemfd(t, ps*6)
+	t.Cleanup(func() { _ = memfd.Close() })
+
+	dirty := roaring.New()
+	dirty.AddMany([]uint32{0, 2, 5})
+
+	d := &DedupedMemfdCache{
+		done:     utils.NewSetOnce[*Cache](),
+		inflight: true,
+		memfd:    memfd,
+		index:    buildPackedIndex(dirty),
+	}
+
+	// Drain-window path (tryInflightRead via ReadAt/Slice): 3 ReadAt + 1 Slice,
+	// each one page → 4 pages tagged phase=drain.
+	for i := range 3 {
+		_, err := d.ReadAt(make([]byte, ps), int64(i)*ps)
+		require.NoError(t, err)
+	}
+	_, err := d.Slice(ps, ps)
+	require.NoError(t, err)
+
+	// Provisional compare-window path (ServeMemfd): a two-page serve then a
+	// one-page serve → 3 pages tagged phase=provisional, across 2 calls. The
+	// two-page call proves pages are counted per page, not once per call.
+	_, err = d.ServeMemfd(make([]byte, 2*ps), 0)
+	require.NoError(t, err)
+	_, err = d.ServeMemfd(make([]byte, ps), ps)
+	require.NoError(t, err)
+
+	// A read bypassed after the drain resolves is not served from the memfd.
+	require.NoError(t, d.done.SetValue(nil))
+	_, ok := d.tryInflightRead(make([]byte, ps), 0)
+	require.False(t, ok)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	byPhase := collectCounterByPhase(t, rm, "orchestrator.memfd.inflight_serve_pages")
+	assert.Equal(t, int64(4), byPhase["drain"], "drain pages: 3 ReadAt + 1 Slice")
+	assert.Equal(t, int64(3), byPhase["provisional"], "provisional pages: a 2-page serve + a 1-page serve")
+}
+
+// collectCounterByPhase totals a named int64 monotonic-sum metric's datapoints
+// keyed by their "phase" label value.
+func collectCounterByPhase(t *testing.T, rm metricdata.ResourceMetrics, name string) map[string]int64 {
+	t.Helper()
+
+	out := map[string]int64{}
+	found := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			found = true
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %q is not an int64 sum", name)
+			for _, dp := range sum.DataPoints {
+				phase, ok := dp.Attributes.Value("phase")
+				require.True(t, ok, "datapoint missing phase attribute")
+				out[phase.AsString()] += dp.Value
+			}
+		}
+	}
+	require.True(t, found, "metric %q not found in collected metrics", name)
+
+	return out
 }
 
 // End-to-end: drive a real dedup goroutine with inflight serving on and hammer


### PR DESCRIPTION
# feat(orch): count pages served from in-flight memfd during dedup

## Why

The in-flight memfd serving feature (`memfd-dedup-inflight-serve`, merged in #3166) has no positive telemetry. Its only metric, `orchestrator.memfd.swap_grace_elapsed`, fires *solely on the failure path* (a memfd release that hit the 30s grace with no swap signal), so when the feature works correctly nothing observable happens — there is no way to tell from metrics whether resumes are actually being served from the still-mapped memfd, or how many pages.

This gap was confirmed against a live environment with the flag enabled: there are **zero series** for any `orchestrator_memfd*` / `*provisional*` / `*inflight*` metric, and a 6h Loki scan (48.5M orchestrator log lines) matched **none** of the feature's log strings — its success path emits no logs, and the spans it touches (`export-memory-from-memfd`, `dedup-pages`) run on every pause regardless of the flag, so neither Loki nor Tempo can show the feature engaging. The rollout dashboard's "feature health" row is empty by design (`swap_grace ≈ 0` is the healthy state), which leaves no signal that the mechanism is doing any work.

## What

Add `orchestrator.memfd.inflight_serve_pages`, a counter of guest pages served from the still-mapped memfd while dedup is in flight. It is bumped at both serving points, immediately after the page `copy(b, src)` (already under the cache read lock), **by the number of pages in that copy** (`len(b) / header.PageSize`) — a single serve can span a multi-page contiguous dirty run, so incrementing once per call would track mapping fragmentation instead of pages served. The two serving paths are tagged with a `phase` label:

- **Provisional compare window** — `ServeMemfd`, which serves dirty pages at their identity (device) offset for the provisional local header; `phase="provisional"`.
- **Drain window** — `tryInflightRead`, which serves at packed offsets via the deduped index, reached through `ReadAt` / `Slice`; `phase="drain"`.

| Metric | Type | Prometheus name | Labels |
| --- | --- | --- | --- |
| `orchestrator.memfd.inflight_serve_pages` | counter | `orchestrator_memfd_inflight_serve_pages_total` | `phase` (`provisional` \| `drain`) + standard resource labels |

Unlike `swap_grace_elapsed`, a nonzero rate here is the *positive* engagement signal for the rollout — the headline query it enables:

```promql
sum(rate(orchestrator_memfd_inflight_serve_pages_total{deployment_environment=~"$deployment_variable", service_version=~"$service_version"}[$__rate_interval]))
```

> `> 0` means resumes overlapping an in-flight pause of the same sandbox are reading pages from the memfd instead of blocking on the dedup. Keep the `phase` label (`by (phase)`) to split the compare-window vs drain-window volumes.

## Key decisions

- **Per-page increment, not once-per-window first-touch.** Per-page gives magnitude (pages absorbed) on top of incidence, and its cost is negligible against the page copy it sits beside, so the extra state/branch of a first-touch guard wasn't worth it.
- **Count by page, not by call.** A serve can copy a multi-page contiguous dirty run; incrementing once per call would make the metric track mapping fragmentation rather than pages served. Pages are counted in `header.PageSize` units, which needs no block-size plumbing through the serve methods.
- **`phase` label over two separate metrics.** One counter tagged `provisional` / `drain` keeps the aggregate trivially queryable (`sum without(phase)`) while exposing the compare-vs-drain split — chiefly to answer whether the provisional-header path (the feature's most complex part) is ever load-bearing in practice or is dead weight. The two `attribute.Set`s are precomputed as package vars, so the per-page `Add` allocates nothing; cardinality adds one label with two values.
- **`context.Background()` for the `Add`.** `tryInflightRead` / `ServeMemfd` follow `io.ReaderAt`-style signatures with no `ctx`; threading one through would ripple into interface methods, and metric recording needs no request context here.
- **Additive and safe.** Metric-only change with no behavioral effect on the feature; nothing to gate or roll back. Pairs with a matching `inflight_serve_pages` panel (with a `by (phase)` breakdown) to be added to the rollout dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
