### PR TITLE
fix(api): track background goroutines so shutdown drains in-flight events

### DIFF
--- a/packages/api/internal/handlers/store.go
+++ b/packages/api/internal/handlers/store.go
@@ -502,3 +502,15 @@ func (a *APIStore) GetTeamFromAdminToken(ctx context.Context, _ *gin.Context, te
 
 	return team, nil
 }
+
+// GoBackground starts fn in a background goroutine tracked by the orchestrator's
+// WaitGroup, so the shutdown path can drain all in-flight events.
+func (a *APIStore) GoBackground(fn func()) {
+	a.orchestrator.GoBackground(fn)
+}
+
+// WaitBackground waits for all tracked background goroutines to finish or until
+// ctx is done. Returns true if all goroutines finished before the deadline.
+func (a *APIStore) WaitBackground(ctx context.Context) bool {
+	return a.orchestrator.WaitBackground(ctx)
+}

--- a/packages/api/internal/handlers/volume_create.go
+++ b/packages/api/internal/handlers/volume_create.go
@@ -137,11 +137,12 @@ func (a *APIStore) PostVolumes(c *gin.Context) {
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		go func(ctx context.Context) {
-			if err := a.deleteVolume(ctx, clusterID, volume); err != nil {
-				telemetry.ReportCriticalError(ctx, "failed to clean up volume after failing to commit transaction", err)
+		bgCtx := context.WithoutCancel(ctx)
+		a.GoBackground(func() {
+			if err := a.deleteVolume(bgCtx, clusterID, volume); err != nil {
+				telemetry.ReportCriticalError(bgCtx, "failed to clean up volume after failing to commit transaction", err)
 			}
-		}(context.WithoutCancel(ctx))
+		})
 
 		a.sendAPIStoreError(c, http.StatusInternalServerError, "Failed to commit transaction")
 		telemetry.ReportCriticalError(ctx, "failed to commit transaction", err)

--- a/packages/api/internal/handlers/volume_delete.go
+++ b/packages/api/internal/handlers/volume_delete.go
@@ -42,12 +42,13 @@ func (a *APIStore) DeleteVolumesVolumeID(c *gin.Context, volumeID api.VolumeID) 
 		Set("volume_name", volume.Name),
 	)
 
-	go func(ctx context.Context) {
+	bgCtx := context.WithoutCancel(ctx)
+	a.GoBackground(func() {
 		// if this fails, we can clean it up later
-		if err := a.deleteVolume(ctx, clusterID, volume); err != nil {
-			telemetry.ReportCriticalError(ctx, fmt.Sprintf("failed to delete data in volume %q", volume.ID.String()), err)
+		if err := a.deleteVolume(bgCtx, clusterID, volume); err != nil {
+			telemetry.ReportCriticalError(bgCtx, fmt.Sprintf("failed to delete data in volume %q", volume.ID.String()), err)
 		}
-	}(context.WithoutCancel(ctx))
+	})
 
 	c.Status(http.StatusNoContent)
 }

--- a/packages/api/internal/orchestrator/background_wg_test.go
+++ b/packages/api/internal/orchestrator/background_wg_test.go
@@ -1,0 +1,85 @@
+package orchestrator
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests use an empty Orchestrator value — only the bgWg field is needed.
+
+func TestGoBackgroundTracksGoroutine(t *testing.T) {
+	t.Parallel()
+
+	var o Orchestrator
+	var done atomic.Bool
+
+	o.GoBackground(func() {
+		time.Sleep(30 * time.Millisecond)
+		done.Store(true)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	finished := o.WaitBackground(ctx)
+	require.True(t, finished, "WaitBackground should return true when goroutine finishes")
+	assert.True(t, done.Load(), "goroutine should have completed")
+}
+
+func TestWaitBackgroundTimesOutOnSlow(t *testing.T) {
+	t.Parallel()
+
+	var o Orchestrator
+
+	blocker := make(chan struct{})
+	o.GoBackground(func() { <-blocker })
+	t.Cleanup(func() { close(blocker) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	finished := o.WaitBackground(ctx)
+	assert.False(t, finished, "WaitBackground should return false when ctx expires first")
+}
+
+func TestGoBackgroundMultipleGoroutines(t *testing.T) {
+	t.Parallel()
+
+	var o Orchestrator
+	const n = 20
+	var count atomic.Int32
+
+	for i := 0; i < n; i++ {
+		o.GoBackground(func() {
+			time.Sleep(10 * time.Millisecond)
+			count.Add(1)
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.True(t, o.WaitBackground(ctx))
+	assert.Equal(t, int32(n), count.Load())
+}
+
+func TestWaitBackgroundNoGoroutinesReturnsImmediately(t *testing.T) {
+	t.Parallel()
+
+	var o Orchestrator
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	start := time.Now()
+	finished := o.WaitBackground(ctx)
+	elapsed := time.Since(start)
+
+	require.True(t, finished)
+	assert.Less(t, elapsed, 50*time.Millisecond, "no goroutines pending — should be instant")
+}

--- a/packages/api/internal/orchestrator/create_instance.go
+++ b/packages/api/internal/orchestrator/create_instance.go
@@ -422,7 +422,7 @@ func (o *Orchestrator) CreateSandbox(
 		// Clean up the sandbox from the node
 		// Copy to a new variable to avoid race conditions
 		sbxToRemove := sbx
-		go func() {
+		o.GoBackground(func() {
 			killErr := o.removeSandboxFromNode(
 				context.WithoutCancel(ctx),
 				sbxToRemove,
@@ -437,7 +437,7 @@ func (o *Orchestrator) CreateSandbox(
 					zap.String("kill_reason", sandbox.KillReasonUnknown.String()),
 				)
 			}
-		}()
+		})
 
 		return sandbox.Sandbox{}, &api.APIError{
 			Code:      http.StatusInternalServerError,

--- a/packages/api/internal/orchestrator/delete_instance.go
+++ b/packages/api/internal/orchestrator/delete_instance.go
@@ -94,13 +94,19 @@ func (o *Orchestrator) RemoveSandbox(ctx context.Context, teamID uuid.UUID, sand
 
 		if time.Since(sbx.EndTime) > sandbox.StaleCutoff && opts.Action.Effect == sandbox.TransitionExpires {
 			o.sandboxStore.Remove(context.WithoutCancel(ctx), teamID, sandboxID)
-			go o.analyticsRemove(context.WithoutCancel(ctx), sbx, opts.Action)
+			o.GoBackground(func() {
+				o.analyticsRemove(context.WithoutCancel(ctx), sbx, opts.Action)
+			})
 		}
 
 		return nil
 	}
 
-	defer func() { go o.analyticsRemove(context.WithoutCancel(ctx), sbx, opts.Action) }()
+	defer func() {
+		o.GoBackground(func() {
+			o.analyticsRemove(context.WithoutCancel(ctx), sbx, opts.Action)
+		})
+	}()
 	// Once we start the removal process, we want to make sure it gets removed from the store
 	defer o.sandboxStore.Remove(context.WithoutCancel(ctx), teamID, sandboxID)
 	err = o.removeSandboxFromNode(ctx, sbx, opts.Action, opts.Reason, opts.FilesystemOnly)

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"sync"
 	"fmt"
 	"net/http"
 	"time"
@@ -73,6 +74,11 @@ type Orchestrator struct {
 	// connectToNode / connectToClusterNode, so it guards every connection path
 	// regardless of what triggered the attempt.
 	connectGroup singleflight.Group
+
+	// bgWg tracks short-lived background goroutines spawned during request handling
+	// (analytics events, volume cleanup) so the shutdown path can drain them with a
+	// bounded wait instead of silently abandoning in-flight work.
+	bgWg sync.WaitGroup
 
 	// discoveryGroup deduplicates concurrent on-demand discovery attempts in
 	// getOrConnectNode that target the same missing orchestrator node. It is
@@ -158,6 +164,7 @@ func New(
 		redisStorage,
 		redisreservations.NewReservationStorage(redisClient, redisStorage.Notifier()),
 		sandbox.Callbacks{
+			BackgroundWG:             &o.bgWg,
 			AddSandboxToRoutingTable: o.addSandboxToRoutingTable,
 			AsyncNewlyCreatedSandbox: o.handleNewlyCreatedSandbox,
 			RemoveSandboxFromNode:    o.killOrphanSandbox,
@@ -323,5 +330,32 @@ func getBestOfKConfig(ctx context.Context, featureFlagsClient *featureflags.Clie
 		R:     maxOvercommit,
 		K:     k,
 		Alpha: alpha,
+	}
+}
+
+// GoBackground starts fn in a background goroutine tracked by bgWg. Callers
+// must invoke this instead of a bare "go" whenever the goroutine must finish
+// before process exit (analytics events, storage cleanup, etc.).
+func (o *Orchestrator) GoBackground(fn func()) {
+	o.bgWg.Add(1)
+	go func() {
+		defer o.bgWg.Done()
+		fn()
+	}()
+}
+
+// WaitBackground waits for all background goroutines to finish or until ctx
+// is done, whichever comes first. Returns true if all goroutines finished.
+func (o *Orchestrator) WaitBackground(ctx context.Context) bool {
+	ch := make(chan struct{})
+	go func() {
+		o.bgWg.Wait()
+		close(ch)
+	}()
+	select {
+	case <-ch:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }

--- a/packages/api/internal/sandbox/store.go
+++ b/packages/api/internal/sandbox/store.go
@@ -47,6 +47,10 @@ type Callbacks struct {
 	// RemoveSandboxFromNode kills an orphaned sandbox on the orchestrator node via gRPC.
 	// Used during sync when the Redis backend detects sandboxes running on a node but not present in the store.
 	RemoveSandboxFromNode RemoveCallback
+	// BackgroundWG, if non-nil, is incremented before the AsyncNewlyCreatedSandbox goroutine
+	// starts and decremented when the goroutine returns, allowing callers to drain all
+	// in-flight creation events before process exit.
+	BackgroundWG *sync.WaitGroup
 }
 
 type Store struct {
@@ -91,7 +95,15 @@ func (s *Store) Add(ctx context.Context, sandbox Sandbox, creation *CreationMeta
 
 	if creation != nil {
 		meta := *creation
-		go s.callbacks.AsyncNewlyCreatedSandbox(context.WithoutCancel(ctx), sandbox, meta)
+		if wg := s.callbacks.BackgroundWG; wg != nil {
+			wg.Add(1)
+		}
+		go func() {
+			if wg := s.callbacks.BackgroundWG; wg != nil {
+				defer wg.Done()
+			}
+			s.callbacks.AsyncNewlyCreatedSandbox(context.WithoutCancel(ctx), sandbox, meta)
+		}()
 	}
 
 	return nil

--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -91,6 +91,11 @@ const (
 
 	// pprofShutdownTimeout is a best-effort bound for pprof drain.
 	pprofShutdownTimeout = 5 * time.Second
+
+	// bgShutdownTimeout bounds how long we wait for tracked background goroutines
+	// (analytics events, volume cleanup) after the HTTP/gRPC drain completes. Most
+	// goroutines finish in milliseconds; the cap protects against stuck external calls.
+	bgShutdownTimeout = 30 * time.Second
 )
 
 var (
@@ -611,17 +616,20 @@ func run() int {
 	// termination in one of these background threads.
 	wg.Wait()
 
+	// Drain background goroutines (analytics events, volume cleanup) that were
+	// launched during HTTP request handling with a detached context. These have
+	// already been tracked by the orchestrator's WaitGroup; give them a bounded
+	// budget before proceeding to resource teardown.
+	bgCtx, bgCancel := context.WithTimeout(context.Background(), bgShutdownTimeout)
+	defer bgCancel()
+	if !apiStore.WaitBackground(bgCtx) {
+		l.Warn(ctx, "background goroutines did not finish within budget",
+			zap.Duration("budget", bgShutdownTimeout))
+	}
+
 	// call cleanup explicitly because defers (from above) do not
 	// run on os.Exit.
 	cleanup()
-
-	// TODO: wait for additional work to coalesce
-	//
-	// currently we only wait for the HTTP handlers to return, and
-	// then cancel the remaining context and run all of the
-	// cleanup functions. Background go routines at this point
-	// terminate. Would need to have a goroutine pool or worker
-	// coordinator running to manage and track that work.
 
 	// Exit, with appropriate code.
 	return int(exitCode.Load())


### PR DESCRIPTION
## Summary

Fixes #3357.

The API shutdown path waited for HTTP/gRPC handlers to return but silently abandoned background goroutines spawned during request handling (analytics events, volume cleanup). This PR introduces a `sync.WaitGroup` on `Orchestrator` to track those goroutines and waits for them with a 30-second budget after the HTTP drain completes.

### What is tracked

| Goroutine | Site | Why it matters |
|-----------|------|----------------|
| `handleNewlyCreatedSandbox` | `sandbox/store.go` | analytics insert + posthog event per sandbox created |
| `analyticsRemove` (x2) | `orchestrator/delete_instance.go` | billing-critical analytics event per sandbox deleted |
| `removeSandboxFromNode` cleanup | `orchestrator/create_instance.go` | kills orphaned sandboxes on store-add failure |
| `deleteVolume` | `handlers/volume_delete.go`, `volume_create.go` | removes volume data from orchestrator node |

### What is intentionally NOT tracked

- `BuildStatusSync` in `template-manager/create_template.go` — can run up to 1 hour; cancellation via context is the correct shutdown signal for long-running polling loops.
- Lifecycle goroutines (`keepInSync`, `startStatusLogging`, etc.) — managed by the root context and terminate when it is cancelled.

### New API surface

```go
// Orchestrator
func (o *Orchestrator) GoBackground(fn func())              // replaces bare "go"
func (o *Orchestrator) WaitBackground(ctx context.Context) bool

// APIStore (delegates to orchestrator)
func (a *APIStore) GoBackground(fn func())
func (a *APIStore) WaitBackground(ctx context.Context) bool
```

### Shutdown sequence (after)

```
signal -> 15s health drain -> HTTP+gRPC parallel drain (up to 75s)
       -> background goroutine drain (up to 30s, new)
       -> cleanup()
```

## Test plan

- [x] 4 new unit tests in `orchestrator/background_wg_test.go`:
  - `TestGoBackgroundTracksGoroutine` — goroutine is awaited
  - `TestWaitBackgroundTimesOutOnSlow` — ctx expiry returns false
  - `TestGoBackgroundMultipleGoroutines` — N concurrent goroutines all drained
  - `TestWaitBackgroundNoGoroutinesReturnsImmediately` — zero-goroutine fast path
- [x] `go build ./packages/api/...` clean
- [x] All existing `./packages/api/...` tests pass

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.