### PR TITLE
fix(db): insert-driven autovacuum tuning on env_build_assignments

### DIFF
--- a/packages/db/migrations/20260724051130_env_build_assignments_autovacuum.sql
+++ b/packages/db/migrations/20260724051130_env_build_assignments_autovacuum.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Insert-mostly table: dead-tuple triggers never fire here, so the
+-- INSERT-driven autovacuum threshold is the one that matters. The default
+-- fraction lets a large table go a long time between passes, leaving the
+-- visibility map and planner statistics stale for scan-heavy access. Same
+-- per-table override family as env_builds (20260723030000). Scheduling-only
+-- storage-parameter change; brief ShareUpdateExclusive lock, no rewrite.
+ALTER TABLE public.env_build_assignments SET (
+    autovacuum_vacuum_insert_scale_factor = 0.02,
+    autovacuum_analyze_scale_factor = 0.01
+);
+
+-- +goose Down
+ALTER TABLE public.env_build_assignments RESET (
+    autovacuum_vacuum_insert_scale_factor,
+    autovacuum_analyze_scale_factor
+);

--- a/packages/db/migrations/20260724051130_env_build_assignments_autovacuum.sql
+++ b/packages/db/migrations/20260724051130_env_build_assignments_autovacuum.sql
@@ -1,17 +1,20 @@
 -- +goose Up
--- Insert-mostly table: dead-tuple triggers never fire here, so the
--- INSERT-driven autovacuum threshold is the one that matters. The default
--- fraction lets a large table go a long time between passes, leaving the
--- visibility map and planner statistics stale for scan-heavy access. Same
--- per-table override family as env_builds (20260723030000). Scheduling-only
--- storage-parameter change; brief ShareUpdateExclusive lock, no rewrite.
+-- Append-mostly table (rows are never updated; deletes happen only as
+-- occasional cascades), so the INSERT-driven threshold is the trigger that
+-- matters day to day and the analyze factor is what keeps planner stats
+-- fresh on a hot join table. The dead-tuple factor is lowered too so a
+-- large cascade-delete burst triggers cleanup promptly instead of waiting
+-- for insert volume. Same per-table override family as env_builds
+-- (20260723030000). Scheduling-only; brief ShareUpdateExclusive lock.
 ALTER TABLE public.env_build_assignments SET (
     autovacuum_vacuum_insert_scale_factor = 0.02,
+    autovacuum_vacuum_scale_factor = 0.02,
     autovacuum_analyze_scale_factor = 0.01
 );
 
 -- +goose Down
 ALTER TABLE public.env_build_assignments RESET (
     autovacuum_vacuum_insert_scale_factor,
+    autovacuum_vacuum_scale_factor,
     autovacuum_analyze_scale_factor
 );


### PR DESCRIPTION
Autovacuum tuning for `public.env_build_assignments`, in the same per-table override family as `env_builds` (20260723030000), `snapshots` (#3368), and `envs` (#3372) — shaped for this table's write pattern: rows are appended, never updated, and deleted only via occasional cascades.

**Why this is correct:** scheduling-only storage-parameter change; brief ShareUpdateExclusive lock; revertible via `RESET`. On an append-mostly table the insert-driven threshold governs routine passes (dead tuples barely accrue), so that is the primary knob; the ordinary dead-tuple factor is lowered alongside it so a large cascade-delete burst triggers cleanup promptly rather than waiting for unrelated insert volume.

**What it improves:** two freshness properties that decay between passes. Planner statistics matter most — this table is joined by several hot queries and its analyze cadence at defaults is extremely sparse for its size, which risks plan-quality drift on exactly those paths; a lower analyze factor keeps plan choices stable. Fresh visibility maps additionally keep index-only scans cheap for the read paths that qualify.