### PR TITLE
fix(db): make rare status groups visible to the planner on env_builds

### DIFF
--- a/packages/db/migrations/20260725100500_env_builds_status_group_statistics.sql
+++ b/packages/db/migrations/20260725100500_env_builds_status_group_statistics.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- ANALYZE cannot run inside a transaction; bound the pass so it neither
+-- hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- status_group='pending' rows are ~0.006% of the table (measured 19,906 of
+-- ~333M), which the default statistics sample (~30k rows) statistically
+-- never catches: 'pending' is absent from the column's MCV list, so the
+-- planner estimates ~11 rows and drives InvalidateUnstartedTemplateBuilds
+-- from the pending-scan side — ~20k index probes into env_build_assignments
+-- per execution instead of one selective (env_id, tag) lookup. A larger
+-- per-column sample makes rare-but-hot status groups visible and flips the
+-- join order back.
+ALTER TABLE public.env_builds ALTER COLUMN status_group SET STATISTICS 2000;
+
+-- Rebuild the column stats immediately: autoanalyze would otherwise wait
+-- for the change threshold, leaving the misestimate live for hours.
+ANALYZE public.env_builds;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+SET statement_timeout = '1h';
+
+ALTER TABLE public.env_builds ALTER COLUMN status_group SET STATISTICS -1;
+
+ANALYZE public.env_builds;
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
## Summary

`InvalidateUnstartedTemplateBuilds` intermittently runs orders of magnitude slower than it should because of a statistics blind spot, not scan cost: `status_group='pending'` is rare (well under a hundredth of a percent of a very large table), so the default statistics sample statistically never catches it — the value is absent from the column's MCV list and the planner underestimates its cardinality by roughly three orders of magnitude (EXPLAIN below). That drives the update's join from the pending-scan side — tens of thousands of index probes into `env_build_assignments` per execution instead of one selective `(env_id, tag)` lookup. Every template-build registration then queues behind it on the `envs` row lock — a lock convoy on template builds.

Raising the per-column statistics target to 2000 (a proportionally larger sample) makes rare-but-hot status groups visible and flips the join order; the migration ANALYZEs immediately so the fix takes effect at promote rather than at the next autoanalyze. Same per-table-settings precedent as the autovacuum migrations.

Fresh-session plan (store-resident columnar unit present and unused — the misestimate, not columnar, is the bug):
`Index Scan using idx_env_builds_status_group (rows=11 estimated, actual ~2,000× that)` → nested-loop probing env_build_assignments once per actual row.

## Verification (post-draft)

- **Scratch replay**: full migration chain via `scripts/migrator.go` on Postgres 16 applies cleanly; `goose down` (SET STATISTICS -1 + ANALYZE) and re-up also clean.
- **Live read-only plan capture** (`PREPARE` + `EXPLAIN EXECUTE` ×7): custom plans (executions 1–5) are the pending-driven nested loop — the convoy plan; the generic plan (execution 6+) already flips to the assignments `(env_id, tag)` drive at roughly a third of the estimated cost. Production's pooled prepared statements re-run custom plans on every fresh connection, so busy templates keep landing on the bad side — this migration corrects the one wrong number in that comparison.
- **Worst case bounded**: with truthful stats on both sides the planner picks the cheaper of the two known join orders — ≈ status-quo cost for the single heaviest template, orders-of-magnitude improvement for typical ones.
- **Lock envelope**: ALTER…SET STATISTICS and ANALYZE both take SHARE UPDATE EXCLUSIVE (no read/DML blocking; queues behind a concurrent autovacuum on the same table at worst), bounded by the 1h timeout and rerunnable. Down is an instant revert.

## Postscript: the mechanism was observed live the same day

A routine autoanalyze later happened to catch 'pending' into the MCV and the slow executions vanished within the half-hour — no deploy, no other change, workload unchanged. That is the dice roll this migration removes: at its tiny frequency the value is one bad sample away from disappearing from the MCV again, and every autoanalyze re-flips the coin. The larger target makes the catch deterministic.
