### PR TITLE
fix(api): let the analytics collector address carry a port

### DIFF
--- a/packages/api/internal/analytics_collector/auth.go
+++ b/packages/api/internal/analytics_collector/auth.go
@@ -2,16 +2,19 @@ package analyticscollector
 
 import (
 	"context"
-
-	"github.com/e2b-dev/infra/packages/shared/pkg/env"
 )
 
 type gRPCApiKey struct {
 	apiKey string
+	// requireTransportSecurity mirrors the transport credentials the
+	// connection was created with. gRPC refuses to attach per-RPC credentials
+	// that require transport security to a plaintext connection, so a
+	// plaintext collector (local development) must relax this.
+	requireTransportSecurity bool
 }
 
-func newGRPCAPIKey(apiKey string) *gRPCApiKey {
-	return &gRPCApiKey{apiKey: apiKey}
+func newGRPCAPIKey(apiKey string, requireTransportSecurity bool) *gRPCApiKey {
+	return &gRPCApiKey{apiKey: apiKey, requireTransportSecurity: requireTransportSecurity}
 }
 
 func (a *gRPCApiKey) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
@@ -19,5 +22,5 @@ func (a *gRPCApiKey) GetRequestMetadata(_ context.Context, _ ...string) (map[str
 }
 
 func (a *gRPCApiKey) RequireTransportSecurity() bool {
-	return !env.IsLocal()
+	return a.requireTransportSecurity
 }

--- a/packages/api/internal/analytics_collector/client.go
+++ b/packages/api/internal/analytics_collector/client.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	e2bgrpc "github.com/e2b-dev/infra/packages/shared/pkg/grpc"
@@ -20,28 +21,49 @@ type Analytics struct {
 	connection *grpc.ClientConn
 }
 
-func NewAnalytics(host, grpcAPIKey string) (*Analytics, error) {
+// NewAnalytics creates a client for the analytics collector.
+//
+// host is either a bare hostname, in which case the collector is assumed to be
+// served on the default HTTPS port (the managed deployment puts it behind a
+// load balancer on 443), or an explicit "host:port" address. An empty host
+// returns a no-op client that drops every event.
+//
+// useTLS must be false for collectors that speak plaintext gRPC, such as the
+// one running in local development; the per-RPC API key is then sent over an
+// unencrypted connection, so only do that on loopback.
+func NewAnalytics(host, grpcAPIKey string, useTLS bool) (*Analytics, error) {
 	var client AnalyticsCollectorClient
 	var connection *grpc.ClientConn
 
 	// Run dummy client if host is not provided
 	if host != "" {
-		systemRoots, err := x509.SystemCertPool()
-		if err != nil {
-			errMsg := fmt.Errorf("failed to read system root certificate pool: %w", err)
-
-			return nil, errMsg
+		target := host
+		if _, _, err := net.SplitHostPort(host); err != nil {
+			// No port in host, default to the HTTPS one.
+			target = net.JoinHostPort(host, "443")
 		}
 
-		cred := credentials.NewTLS(&tls.Config{
-			RootCAs:    systemRoots,
-			MinVersion: tls.VersionTLS13,
-		})
+		var cred credentials.TransportCredentials
+		if useTLS {
+			systemRoots, err := x509.SystemCertPool()
+			if err != nil {
+				errMsg := fmt.Errorf("failed to read system root certificate pool: %w", err)
+
+				return nil, errMsg
+			}
+
+			cred = credentials.NewTLS(&tls.Config{
+				RootCAs:    systemRoots,
+				MinVersion: tls.VersionTLS13,
+			})
+		} else {
+			cred = insecure.NewCredentials()
+		}
 
 		conn, err := grpc.NewClient(
-			net.JoinHostPort(host, "443"),
+			target,
 			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-			grpc.WithPerRPCCredentials(newGRPCAPIKey(grpcAPIKey)),
+			grpc.WithPerRPCCredentials(newGRPCAPIKey(grpcAPIKey, useTLS)),
 			grpc.WithAuthority(host),
 			grpc.WithTransportCredentials(cred),
 		)

--- a/packages/api/internal/analytics_collector/client_test.go
+++ b/packages/api/internal/analytics_collector/client_test.go
@@ -1,0 +1,71 @@
+package analyticscollector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAnalyticsTarget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		host       string
+		useTLS     bool
+		wantTarget string
+	}{
+		{
+			name:       "bare hostname defaults to the HTTPS port",
+			host:       "collector.example.com",
+			useTLS:     true,
+			wantTarget: "collector.example.com:443",
+		},
+		{
+			name:       "explicit port is kept",
+			host:       "collector.example.com:8443",
+			useTLS:     true,
+			wantTarget: "collector.example.com:8443",
+		},
+		{
+			// The local Belt collector: plaintext gRPC on loopback. Joining
+			// :443 onto this used to produce "[localhost:5051]:443", which the
+			// resolver could not resolve.
+			name:       "plaintext local collector",
+			host:       "localhost:5051",
+			useTLS:     false,
+			wantTarget: "localhost:5051",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			analytics, err := NewAnalytics(tt.host, "api-token", tt.useTLS)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { _ = analytics.Close() })
+
+			require.NotNil(t, analytics.connection)
+			assert.Equal(t, tt.wantTarget, analytics.connection.Target())
+		})
+	}
+}
+
+func TestNewAnalyticsWithoutHostIsNoop(t *testing.T) {
+	t.Parallel()
+
+	analytics, err := NewAnalytics("", "", true)
+	require.NoError(t, err)
+
+	assert.Nil(t, analytics.client)
+	assert.Nil(t, analytics.connection)
+
+	res, err := analytics.InstanceStarted(t.Context(), &InstanceStartedEvent{})
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+
+	assert.NoError(t, analytics.Close())
+}

--- a/packages/api/internal/analytics_collector/client_test.go
+++ b/packages/api/internal/analytics_collector/client_test.go
@@ -64,7 +64,7 @@ func TestNewAnalyticsWithoutHostIsNoop(t *testing.T) {
 	assert.Nil(t, analytics.connection)
 
 	res, err := analytics.InstanceStarted(t.Context(), &InstanceStartedEvent{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, res)
 
 	assert.NoError(t, analytics.Close())

--- a/packages/api/internal/cfg/model.go
+++ b/packages/api/internal/cfg/model.go
@@ -30,7 +30,14 @@ type Config struct {
 	AdminToken string `env:"ADMIN_TOKEN"`
 
 	AnalyticsCollectorAPIToken string `env:"ANALYTICS_COLLECTOR_API_TOKEN"`
-	AnalyticsCollectorHost     string `env:"ANALYTICS_COLLECTOR_HOST"`
+	// AnalyticsCollectorHost is the hostname, or "host:port" address, of the
+	// analytics collector. Without a port, 443 is used. Empty disables
+	// analytics reporting entirely.
+	AnalyticsCollectorHost string `env:"ANALYTICS_COLLECTOR_HOST"`
+	// AnalyticsCollectorTLS controls whether the collector connection uses
+	// TLS. Set to false only for a plaintext collector on loopback, as the
+	// local development one is; the API token is sent unencrypted then.
+	AnalyticsCollectorTLS bool `env:"ANALYTICS_COLLECTOR_TLS" envDefault:"true"`
 
 	ClickhouseConnectionString  string   `env:"CLICKHOUSE_CONNECTION_STRING"`
 	ClickhouseConnectionStrings []string `env:"CLICKHOUSE_CONNECTION_STRINGS" envSeparator:";"`

--- a/packages/api/internal/orchestrator/orchestrator.go
+++ b/packages/api/internal/orchestrator/orchestrator.go
@@ -115,6 +115,7 @@ func New(
 	analyticsInstance, err := analyticscollector.NewAnalytics(
 		config.AnalyticsCollectorHost,
 		config.AnalyticsCollectorAPIToken,
+		config.AnalyticsCollectorTLS,
 	)
 	if err != nil {
 		logger.L().Error(ctx, "Error initializing Analytics client", zap.Error(err))


### PR DESCRIPTION
## Problem

Every sandbox start/stop against a collector configured as `host:port` logs:

```
ERROR error sending Analytics event {"error": "rpc error: code = Unavailable desc = name resolver error: produced zero addresses"}
```

`NewAnalytics` did `net.JoinHostPort(host, "443")` unconditionally, so `ANALYTICS_COLLECTOR_HOST=localhost:5051` became the target `[localhost:5051]:443`, which cannot resolve. Analytics events are dropped; only the log line surfaces it.

## Changes

- Default the port to 443 only when the host has none, so the managed deployment's bare hostname behaves exactly as before while an explicit `host:port` is used as-is.
- Add `ANALYTICS_COLLECTOR_TLS` (`envDefault:"true"`). The transport was hardcoded to TLS 1.3 with the system root pool, which no plaintext collector can serve; setting it to `false` selects insecure credentials. Deployed configs are unaffected by the default.
- `gRPCApiKey.RequireTransportSecurity()` now mirrors that flag rather than `!env.IsLocal()`. The old check only recognized `ENVIRONMENT=local`, so any other non-prod environment name would have made gRPC refuse to attach the API key to a plaintext connection, failing at client creation.
- Tests for target resolution and the no-op client returned for an empty host.

## Testing

`go test ./internal/analytics_collector/... ./internal/cfg/...`

Manually verified against a plaintext collector on `localhost:5051`: the connection reaches `READY` at target `localhost:5051`, and a deliberately wrong API key comes back as `Unauthenticated: invalid API key`, confirming the per-RPC credentials are attached over the insecure transport.