### PR TITLE
chore(ci): bump golangci-lint-action to v9 for node24 runtime

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
         uses: wistia/parse-tool-versions@v2.1.1
 
       - name: golangci-lint ${{ matrix.modules }}
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
           version: "v${{ env.GOLANGCI_LINT }}"
           working-directory: ${{ matrix.modules }}


### PR DESCRIPTION
`golangci/golangci-lint-action@v8` declares `using: node20`, which triggers the Node 20 deprecation warning on GitHub Actions runners.

`v9.0.0` was released specifically to switch the action's runtime from node20 to node24. All inputs used here (`version`, `working-directory`, `only-new-issues`, `verify`) are unchanged in v9; the other v9 changes are additive (`install-only`, module plugin support).

`wistia/parse-tool-versions@v2.1.1` in the same job is a composite action and is unaffected.