### PR TITLE
db: add completed env_build_assignments tip-lookup index and harden its statistics

### DIFF
--- a/packages/db/migrations/20260727032500_env_build_assignments_tip_lookup_index.sql
+++ b/packages/db/migrations/20260727032500_env_build_assignments_tip_lookup_index.sql
@@ -2,8 +2,7 @@
 -- +goose NO TRANSACTION
 
 -- CREATE INDEX CONCURRENTLY and ANALYZE cannot run inside a transaction;
--- bound each pass so it neither hangs unbounded nor dies to a short default.
-SET statement_timeout = '2h';
+-- the migrator's session default (3h, scripts/migrator.go) bounds them.
 
 -- The current-tip lookup orders by (created_at DESC, build_id DESC) under an
 -- (env_id, tag) equality. That exact shape belongs to an internal
@@ -34,14 +33,8 @@ ALTER TABLE public.env_build_assignments ALTER COLUMN tag SET STATISTICS 2000;
 -- Rebuild stats immediately rather than waiting for the next autoanalyze.
 ANALYZE public.env_build_assignments;
 
--- The migrator session is reused for subsequent migrations: restore its
--- baseline (scripts/migrator.go sets 3h per connection).
-SET statement_timeout = '3h';
-
 -- +goose Down
 -- +goose NO TRANSACTION
-
-SET statement_timeout = '2h';
 
 DROP INDEX CONCURRENTLY IF EXISTS idx_env_build_assignments_env_tag_created_build;
 
@@ -49,5 +42,3 @@ ALTER TABLE public.env_build_assignments ALTER COLUMN env_id SET STATISTICS -1;
 ALTER TABLE public.env_build_assignments ALTER COLUMN tag SET STATISTICS -1;
 
 ANALYZE public.env_build_assignments;
-
-SET statement_timeout = '3h';

--- a/packages/db/migrations/20260727032500_env_build_assignments_tip_lookup_index.sql
+++ b/packages/db/migrations/20260727032500_env_build_assignments_tip_lookup_index.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- CREATE INDEX CONCURRENTLY and ANALYZE cannot run inside a transaction;
+-- bound each pass so it neither hangs unbounded nor dies to a short default.
+SET statement_timeout = '2h';
+
+-- The current-tip lookup orders by (created_at DESC, build_id DESC) under an
+-- (env_id, tag) equality. That exact shape belongs to an internal
+-- first-party consumer of this table whose queries are not in this
+-- repository's tree (searching only this repo won't find it); the
+-- latest-build laterals here order by created_at alone and ride the same
+-- prefix unchanged. The existing index stops at created_at: the planner
+-- still needs a top-N sort, so its plan choice rides on per-column
+-- estimates that every autoanalyze re-samples. Completing the index to the
+-- full sort key turns the lookup into a descend-and-stop ordered index scan
+-- (LIMIT 1, no sort), which stays the cheapest plan under any statistics
+-- roll; newer-assignment probes ride the same prefix.
+-- This migration is deliberately ADDITIVE: the superseded 3-column index
+-- (idx_env_build_assignments_env_tag_created, identical ordering prefix) is
+-- dropped by a separate follow-up migration once the new index has soaked.
+-- A failed CONCURRENTLY build leaves an INVALID index that a plain retry
+-- would trip over; drop it first.
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_build_assignments_env_tag_created_build;
+CREATE INDEX CONCURRENTLY idx_env_build_assignments_env_tag_created_build
+    ON public.env_build_assignments (env_id, tag, created_at DESC, build_id DESC);
+
+-- Stabilize the estimate inputs themselves: larger per-column samples cut the
+-- roll-to-roll variance of n_distinct/MCV on the lookup's key columns (same
+-- treatment as env_builds.status_group).
+ALTER TABLE public.env_build_assignments ALTER COLUMN env_id SET STATISTICS 2000;
+ALTER TABLE public.env_build_assignments ALTER COLUMN tag SET STATISTICS 2000;
+
+-- Rebuild stats immediately rather than waiting for the next autoanalyze.
+ANALYZE public.env_build_assignments;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+SET statement_timeout = '2h';
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_build_assignments_env_tag_created_build;
+
+ALTER TABLE public.env_build_assignments ALTER COLUMN env_id SET STATISTICS -1;
+ALTER TABLE public.env_build_assignments ALTER COLUMN tag SET STATISTICS -1;
+
+ANALYZE public.env_build_assignments;
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
The current-tip lookup orders by (created_at DESC, build_id DESC) within an (env_id, tag) equality, but the existing index stops at created_at, leaving a top-N sort whose plan choice depends on sampled statistics — an autoanalyze re-sample can temporarily flip it to a much slower plan. Completing the index to the full sort key makes the lookup a pure ordered index scan (LIMIT 1, no sort) that stays cheapest under any statistics roll. Also raises the statistics targets on the key columns and re-analyzes, same treatment as env_builds.status_group.

This PR is deliberately ADDITIVE — it only creates the new index and hardens statistics. Dropping the superseded 3-column index (identical ordering prefix, redundant write maintenance) is split into a follow-up PR (#3409) to merge only after this one has soaked in production.

Query-shape check across every first-party consumer of this table: each query falls into (a) the (env_id[, tag]) prefix family — served identically or better by the new index, since it shares the exact ordering prefix; (b) build_id lookups — served by idx_env_build_assignments_build, untouched; or (c) primary-key/uniqueness paths. The (created_at DESC, build_id DESC) tie-break matches the high-frequency tip check that motivated this change; this repository's own latest-build laterals order by created_at alone and ride the same prefix unchanged. Latest-default-build laterals that select build_id can now run index-only.