### PR TITLE
db: drop duplicate snapshots sandbox_id index

### DIFF
--- a/packages/db/migrations/20260727041100_drop_duplicate_snapshots_sandbox_id_index.sql
+++ b/packages/db/migrations/20260727041100_drop_duplicate_snapshots_sandbox_id_index.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP waits on in-flight lock holders rather than building anything; bound
+-- it so it neither hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Exact duplicate of snapshots_sandbox_id_unique (same key column): the
+-- unique, constraint-backed twin serves every lookup, while this plain copy
+-- shows no scans over a multi-month usage window and every snapshot write
+-- maintains both. Uniqueness enforcement is untouched.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- The concurrent rebuild can legitimately run long at this table's size; a
+-- mid-build timeout would strand an INVALID index. Rolling back is a
+-- deliberate manual operation with an operator present — unbounded on
+-- purpose.
+SET statement_timeout = 0;
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_snapshots_sandbox_id;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_snapshots_sandbox_id
+    ON public.snapshots (sandbox_id);
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
idx_snapshots_sandbox_id is an exact duplicate of the constraint-backed snapshots_sandbox_id_unique (same key column). The unique twin serves every lookup; the plain copy shows no scans over a multi-month usage window while every snapshot write maintains both. Dropped CONCURRENTLY; uniqueness enforcement is untouched. Fresh, isolated re-roll of the earlier closed draft (#3390).

Schema proof, both definitions in this repo: the dropped index ([20250708135400 L3](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20250708135400_snapshots_migrations.sql#L3)) and the surviving unique constraint ([20251009170758 L4-L5](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20251009170758_unique_snapshots.sql#L4-L5)) — identical key `(sandbox_id)`. Background on why identical indexes are redundant: [PostgreSQL wiki — duplicate indexes](https://wiki.postgresql.org/wiki/Index_Maintenance#Duplicate_indexes).