### PR TITLE
db: drop unused plain env_builds status index

### DIFF
--- a/packages/db/migrations/20260727041200_drop_unused_env_builds_status_index.sql
+++ b/packages/db/migrations/20260727041200_drop_unused_env_builds_status_index.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP waits on in-flight lock holders rather than building anything; bound
+-- it so it neither hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- The plain status index is effectively unread (single-digit scans over a
+-- multi-month usage window): status-filtered queries run through per-entity
+-- joins or the status_group family of indexes instead, while every build
+-- write maintains this copy on one of the hottest-write tables in the
+-- schema. status_group remains separately indexed and is not touched.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- The concurrent rebuild legitimately runs for a long time at this table's
+-- size; a mid-build timeout would strand an INVALID index. Rolling back is
+-- a deliberate manual operation with an operator present — unbounded on
+-- purpose.
+SET statement_timeout = 0;
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_env_builds_status;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_builds_status
+    ON public.env_builds (status);
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
idx_env_builds_status is effectively unread (single-digit scans over a multi-month usage window): status-filtered queries drive through per-entity joins or the status_group index family, while every build write maintains this copy on one of the hottest-write tables. status_group indexes are untouched. Needs platform sign-off that no seldom-run tooling depends on a bare status scan — hence draft. Fresh, isolated re-roll of the earlier closed draft (#3391).