### PR TITLE
db: drop duplicate team_api_keys hash index

### DIFF
--- a/packages/db/migrations/20260727041300_drop_duplicate_team_api_keys_hash_index.sql
+++ b/packages/db/migrations/20260727041300_drop_duplicate_team_api_keys_hash_index.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP waits on in-flight lock holders rather than building anything; bound
+-- it so it neither hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Two unique indexes cover the same key column: the UNIQUE constraint's own
+-- index (team_api_keys_api_key_hash_key) and this standalone unique copy.
+-- Identical indexes are interchangeable to the planner, so lookups simply
+-- continue on the constraint's index, uniqueness enforcement is untouched,
+-- and every key write stops paying for the second copy. The standalone one
+-- is the droppable twin (the constraint-backed index cannot be dropped by
+-- DROP INDEX, which makes this fail-loud safe).
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_team_api_keys_api_key_hash;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+SET statement_timeout = '1h';
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_team_api_keys_api_key_hash;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_team_api_keys_api_key_hash
+    ON public.team_api_keys (api_key_hash);
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
team_api_keys.api_key_hash carries two identical unique indexes: the UNIQUE constraint's own and a standalone copy. Identical indexes are interchangeable to the planner, so lookups continue on the constraint's index and uniqueness is untouched; every key write stops maintaining the second copy. The standalone twin is the droppable one — the constraint-backed index refuses DROP INDEX, making a mixed-up drop fail loud instead of silently.

Schema proof, both definitions in this repo: the standalone unique index ([20250825102440 L5-L6](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20250825102440_add_hash_indexes.sql#L5-L6)) and the column's UNIQUE constraint that already carries its own index ([20250211160814 L6](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20250211160814_add_token_hashes.sql#L6)) — identical key `(api_key_hash)`. Background: [PostgreSQL wiki — duplicate indexes](https://wiki.postgresql.org/wiki/Index_Maintenance#Duplicate_indexes).