### PR TITLE
db: drop duplicate access_tokens hash index

### DIFF
--- a/packages/db/migrations/20260727041400_drop_duplicate_access_tokens_hash_index.sql
+++ b/packages/db/migrations/20260727041400_drop_duplicate_access_tokens_hash_index.sql
@@ -1,0 +1,33 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP waits on in-flight lock holders rather than building anything; bound
+-- it so it neither hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Two unique indexes cover the same key column: the UNIQUE constraint's own
+-- index (access_tokens_access_token_hash_key) and this standalone unique
+-- copy. Identical indexes are interchangeable to the planner, so lookups
+-- continue on the constraint's index, uniqueness enforcement is untouched,
+-- and every token write stops paying for the second copy. The standalone
+-- one is the droppable twin (the constraint-backed index cannot be dropped
+-- by DROP INDEX, which makes this fail-loud safe).
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_access_tokens_access_token_hash;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+SET statement_timeout = '1h';
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS public.idx_access_tokens_access_token_hash;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_access_tokens_access_token_hash
+    ON public.access_tokens (access_token_hash);
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
access_tokens.access_token_hash carries two identical unique indexes: the UNIQUE constraint's own and a standalone copy. Identical indexes are interchangeable to the planner, so lookups continue on the constraint's index and uniqueness is untouched; every token write stops maintaining the second copy. The standalone twin is the droppable one — the constraint-backed index refuses DROP INDEX, making a mixed-up drop fail loud instead of silently.

Schema proof, both definitions in this repo: the standalone unique index ([20250825102440 L9-L10](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20250825102440_add_hash_indexes.sql#L9-L10)) and the column's UNIQUE constraint that already carries its own index ([20250211160814 L12](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20250211160814_add_token_hashes.sql#L12)) — identical key `(access_token_hash)`. Background: [PostgreSQL wiki — duplicate indexes](https://wiki.postgresql.org/wiki/Index_Maintenance#Duplicate_indexes).