### PR TITLE
db: drop the superseded env_build_assignments tip-lookup index

### DIFF
--- a/packages/db/migrations/20260727060500_drop_superseded_eba_tip_index.sql
+++ b/packages/db/migrations/20260727060500_drop_superseded_eba_tip_index.sql
@@ -1,0 +1,35 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+-- DROP waits on in-flight lock holders rather than building anything; bound
+-- it so it neither hangs unbounded nor dies to a short session default.
+SET statement_timeout = '1h';
+
+-- Follow-up to 20260727032500 (the additive half): the 4-column
+-- idx_env_build_assignments_env_tag_created_build shares this index's exact
+-- ordering prefix, so every scan the 3-column copy served runs identically
+-- on it — keeping both only doubles write maintenance on a hot-insert
+-- table. Merge only after the 4-column index has soaked in production.
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_build_assignments_env_tag_created;
+
+-- The migrator session is reused for subsequent migrations: restore its
+-- baseline (scripts/migrator.go sets 3h per connection).
+SET statement_timeout = '3h';
+
+-- +goose Down
+-- +goose NO TRANSACTION
+
+-- The concurrent rebuild legitimately runs long at this table's size; a
+-- mid-build timeout would strand an INVALID index. Rolling back is a
+-- deliberate manual operation with an operator present — unbounded on
+-- purpose.
+SET statement_timeout = 0;
+
+-- An interrupted CONCURRENTLY build leaves an INVALID index that IF NOT
+-- EXISTS would then skip forever — clear any leftover before rebuilding.
+DROP INDEX CONCURRENTLY IF EXISTS idx_env_build_assignments_env_tag_created;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_env_build_assignments_env_tag_created
+    ON public.env_build_assignments (env_id, tag, created_at DESC);
+
+SET statement_timeout = '3h';


### PR DESCRIPTION
Follow-up to #3403 (the additive half): the 4-column index shares the 3-column index's exact ordering prefix, so every scan it served runs identically on the new one — keeping both only doubles write maintenance on a hot-insert table. DO NOT merge until #3403 has soaked in production; goose orders this migration after it by timestamp either way.

Schema proof, both definitions in this repo: the 3-column index ([20251218160000 L42-L43](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20251218160000_allow_m_n_builds_with_tags.sql#L42-L43), `(env_id, tag, created_at DESC)`) is the exact leading prefix of the 4-column one ([20260727032500 L24-L25](https://github.com/e2b-dev/infra/blob/7c23f7bd724e9217be27c5eca1bd8c8402a2fae1/packages/db/migrations/20260727032500_env_build_assignments_tip_lookup_index.sql#L24-L25), `(env_id, tag, created_at DESC, build_id DESC)`). Why a leading prefix makes the shorter index redundant: [PostgreSQL docs — multicolumn indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html).