### PR TITLE
fix(api): classify client-disconnect body-read errors separately from auth failures

### DIFF
--- a/packages/api/internal/utils/error.go
+++ b/packages/api/internal/utils/error.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -16,15 +17,31 @@ import (
 )
 
 const (
-	securityErrPrefix  = "error in openapi3filter.SecurityRequirementsError: security requirements failed: "
-	forbiddenErrPrefix = "team forbidden: "
-	blockedErrPrefix   = "team blocked: "
+	securityErrPrefix      = "error in openapi3filter.SecurityRequirementsError: security requirements failed: "
+	forbiddenErrPrefix     = "team forbidden: "
+	blockedErrPrefix       = "team blocked: "
+	clientDisconnectPrefix = "client disconnected: "
 )
 
 func ErrorHandler(c *gin.Context, message string, statusCode int) {
-	var errMsg error
-
 	ctx := c.Request.Context()
+
+	// Client dropped the connection before the request body was fully received.
+	// kin-openapi reads the body before calling auth; when the TCP read fails
+	// it wraps the net.Error in a SecurityRequirementsError, which would otherwise
+	// be logged/traced as an auth failure. This is a client-side network event,
+	// not a server error — record informationally and return 499 so metrics
+	// distinguish it from real auth failures.
+	if after, ok := strings.CutPrefix(message, clientDisconnectPrefix); ok {
+		telemetry.ReportEvent(ctx, "client disconnected before request body received",
+			attribute.String("disconnect.reason", after),
+		)
+		c.AbortWithStatus(499)
+
+		return
+	}
+
+	var errMsg error
 
 	switch {
 	case strings.HasPrefix(c.Request.URL.Path, "/instances"),
@@ -136,6 +153,18 @@ func processCustomErrors(e *openapi3filter.SecurityRequirementsError) error {
 
 		if errors.As(errW, &teamBlocked) {
 			return fmt.Errorf("%s%s", blockedErrPrefix, teamBlocked.Error())
+		}
+
+		// kin-openapi reads the entire request body before invoking auth functions.
+		// When that TCP read fails (client timeout / server ReadTimeout), it returns
+		// a RequestError{Reason:"reading failed"} wrapped in SecurityRequirementsError.
+		// Detect this case so it isn't misclassified as an authentication failure.
+		var reqErr *openapi3filter.RequestError
+		if errors.As(errW, &reqErr) && reqErr.Reason == "reading failed" {
+			var netErr net.Error
+			if errors.As(reqErr.Err, &netErr) {
+				return fmt.Errorf("%s%s", clientDisconnectPrefix, reqErr.Err.Error())
+			}
 		}
 
 		err = errW


### PR DESCRIPTION
Closes #3413

## Summary

- Add `clientDisconnectPrefix` constant to `packages/api/internal/utils/error.go`
- In `processCustomErrors`: detect `RequestError{Reason:"reading failed"}` with an underlying `net.Error` and return it under the new prefix — preventing it from being reported as an auth failure
- In `ErrorHandler`: handle the new prefix before the telemetry/c.Error path — record a span event via `telemetry.ReportEvent` (informational, not error), respond 499, skip `c.Errors`

## Why

`kin-openapi` reads the full request body (`io.ReadAll`) **before** calling any auth function. Under high concurrency the server `ReadTimeout: 10s` can expire while goroutines queue, producing `net.Error` wrapped in `SecurityRequirementsError`. Without this fix those network timeouts are logged as WARN with a `SecurityRequirementsError` message, counted as 400 auth errors in metrics, and set OTel span error status — all misleading.

## Test plan

- [ ] Build passes: `go build ./packages/api/...`
- [ ] Deploy to staging, generate high concurrency (≥ 100 simultaneous sandbox creates); confirm 499 responses appear and no `SecurityRequirementsError` WARN lines are emitted for client disconnects
- [ ] Verify genuine auth failures (bad API key, expired token) still produce 401/403 with `SecurityRequirementsError` logged as before

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.