### PR TITLE
fix(api): remove ReadTimeout to prevent premature body-read failures under high concurrency

### DIFF
--- a/packages/api/main.go
+++ b/packages/api/main.go
@@ -57,7 +57,6 @@ const (
 	maxUploadLimit     = 1 << 24 // 16 MiB
 
 	maxReadHeaderTimeout = 5 * time.Second
-	maxReadTimeout       = 10 * time.Second
 	maxWriteTimeout      = 75 * time.Second
 
 	// requestTimeout is the context deadline applied to each request.
@@ -218,7 +217,6 @@ func NewGinServer(ctx context.Context, config cfg.Config, tel *telemetry.Client,
 
 		// Configure request timeouts.
 		ReadHeaderTimeout: maxReadHeaderTimeout,
-		ReadTimeout:       maxReadTimeout,
 		WriteTimeout:      maxWriteTimeout,
 
 		// Configure timeouts to be greater than the proxy timeouts.


### PR DESCRIPTION
Closes #3415

## Summary

- Remove `ReadTimeout: maxReadTimeout` (10s) from `http.Server` in `packages/api/main.go`
- Remove the now-unused `maxReadTimeout` constant
- `ReadHeaderTimeout: 5s` is retained for slowloris protection

## Why

`ReadTimeout` starts from TCP accept, including scheduler queue time. Under high concurrency goroutines queue for >10s before being scheduled, so the deadline fires before `io.ReadAll` ever executes — producing `i/o timeout` errors that look like client disconnects or auth failures. The intended per-request ceiling is `requestTimeout: 70s` (middleware context deadline), which is never reached in practice because `ReadTimeout` fires first.

Request bodies on this API are small JSON payloads sent in a single TCP segment. Once headers arrive (guarded by `ReadHeaderTimeout`), there is no meaningful slow-body attack surface to protect against.

## Test plan

- [ ] Build passes: `go build ./packages/api/...`
- [ ] Deploy to staging, replay high-concurrency load (≥ 100 simultaneous sandbox creates); confirm `i/o timeout` body-read errors disappear from logs
- [ ] Confirm `/health` still responds correctly under load
- [ ] Confirm slowloris protection still active: a client that opens a TCP connection but never sends headers is rejected within 5s (`ReadHeaderTimeout`)
/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.