### PR TITLE
feat(metrics): label pause/resume telemetry by fs_only

### DIFF
--- a/packages/orchestrator/pkg/server/main.go
+++ b/packages/orchestrator/pkg/server/main.go
@@ -79,6 +79,7 @@ type Server struct {
 	uploadedBuilds        *ttlcache.Cache[string, struct{}]
 	uploads               *sandbox.Uploads
 	sandboxCreateDuration metric.Int64Histogram
+	sandboxPauseDuration  metric.Int64Histogram
 	sandboxKilledCounter  metric.Int64Counter
 	uploadFailedCounter   metric.Int64Counter
 
@@ -145,6 +146,12 @@ func New(ctx context.Context, cfg ServiceConfig) (*Server, error) {
 		return nil, fmt.Errorf("failed to register sandbox create duration histogram: %w", err)
 	}
 	server.sandboxCreateDuration = sandboxCreateDuration
+
+	sandboxPauseDuration, err := telemetry.GetHistogram(meter, telemetry.PauseDurationHistogramName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register sandbox pause duration histogram: %w", err)
+	}
+	server.sandboxPauseDuration = sandboxPauseDuration
 
 	sandboxKilledCounter, err := telemetry.GetCounter(meter, telemetry.OrchestratorSandboxKilledCounterName)
 	if err != nil {

--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -82,15 +82,19 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 	defer childSpan.End()
 
 	isResume := req.GetSandbox().GetSnapshot()
+	// fsOnly is set at the resume fork below when this takes the filesystem-only
+	// reboot path (vs a memory restore), so create/resume e2e latency can be
+	// split reboot vs memory — mirroring the fs_only pause label. Combined with
+	// sandbox.resume: resume=false → fresh create; resume=true,fs_only=false →
+	// memory resume; resume=true,fs_only=true → filesystem-only reboot.
+	var fsOnly bool
 	createStart := time.Now()
 	defer func() {
-		if createErr != nil {
-			return
-		}
-
 		s.sandboxCreateDuration.Record(ctx, time.Since(createStart).Milliseconds(),
 			metric.WithAttributes(
 				attribute.Bool("sandbox.resume", isResume),
+				attribute.Bool("fs_only", fsOnly),
+				attribute.Bool("success", createErr == nil),
 			),
 		)
 	}()
@@ -228,6 +232,7 @@ func (s *Server) Create(ctx context.Context, req *orchestrator.SandboxCreateRequ
 
 	var sbx *sandbox.Sandbox
 	if meta.IsFilesystemOnly() {
+		fsOnly = true
 		sbx, err = s.sandboxFactory.RebootSandbox(
 			ctx,
 			template,
@@ -645,9 +650,22 @@ func recordSandboxKill(ctx context.Context, counter metric.Int64Counter, killRea
 	counter.Add(ctx, 1, metric.WithAttributes(attribute.String("kill_reason", killReason)))
 }
 
-func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest) (*orchestrator.SandboxPauseResponse, error) {
+func (s *Server) Pause(ctx context.Context, in *orchestrator.SandboxPauseRequest) (resp *orchestrator.SandboxPauseResponse, err error) {
 	ctx, childSpan := tracer.Start(ctx, "sandbox-pause")
 	defer childSpan.End()
+
+	// Record pause duration split by fs_only vs memory (the gRPC RPC metric
+	// can't distinguish them) and success, so dashboards can scope pause
+	// call-count / error-rate / latency to filesystem-only pauses.
+	pauseStart := time.Now()
+	defer func() {
+		s.sandboxPauseDuration.Record(ctx, time.Since(pauseStart).Milliseconds(),
+			metric.WithAttributes(
+				attribute.Bool("fs_only", in.GetFilesystemOnly()),
+				attribute.Bool("success", err == nil),
+			),
+		)
+	}()
 
 	childSpan.SetAttributes(
 		telemetry.WithSandboxID(in.GetSandboxId()),
@@ -948,6 +966,9 @@ type snapshotResult struct {
 	// with. The prefetch harvest reuses it verbatim when re-uploading the
 	// metadata object, so the two can never drift.
 	objectMetadata storage.ObjectMetadata
+	// filesystemOnly records whether this was a filesystem-only (memoryless)
+	// pause, so the async upload can label its failure counter with fs_only.
+	filesystemOnly bool
 }
 
 // snapshotAndCacheSandbox creates a snapshot of a sandbox and adds it to the
@@ -1050,6 +1071,7 @@ func (s *Server) snapshotAndCacheSandbox(
 		upload:             upload,
 		completeUpload:     completeUpload,
 		objectMetadata:     objectMetadata,
+		filesystemOnly:     filesystemOnly,
 	}, nil
 }
 
@@ -1084,7 +1106,7 @@ func (s *Server) uploadSnapshotAsync(ctx context.Context, sbx *sandbox.Sandbox, 
 		)
 		if err != nil {
 			sbxlogger.I(sbx).Error(spanCtx, "snapshot upload did not durably land", zap.Error(err))
-			s.uploadFailedCounter.Add(spanCtx, 1)
+			s.uploadFailedCounter.Add(spanCtx, 1, metric.WithAttributes(attribute.Bool("fs_only", res.filesystemOnly)))
 		} else {
 			sbxlogger.I(sbx).Info(spanCtx, "snapshot finished uploading successfully")
 		}

--- a/packages/shared/pkg/telemetry/meters.go
+++ b/packages/shared/pkg/telemetry/meters.go
@@ -106,6 +106,7 @@ const (
 	OrchestratorSandboxCreateDurationName HistogramType = "orchestrator.sandbox.create.duration"
 	WaitForEnvdDurationHistogramName      HistogramType = "orchestrator.sandbox.envd.init.duration"
 	GuestSyncDurationHistogramName        HistogramType = "orchestrator.sandbox.guest_sync.duration"
+	PauseDurationHistogramName            HistogramType = "orchestrator.sandbox.pause.duration"
 
 	// Pre-pause envd heap collapse round-trip duration (the pause-path cost of
 	// POST /collapse: network plus envd's madvise work), recorded once per pause
@@ -451,6 +452,7 @@ var histogramDesc = map[HistogramType]string{
 	WaitForEnvdDurationHistogramName:      "Time taken for Envd to initialize successfully",
 	EnvdCollapseDurationHistogramName:     "Time taken for the pre-pause envd heap collapse round-trip",
 	GuestSyncDurationHistogramName:        "Time taken for the mandatory pre-pause guest sync (filesystem-only pause)",
+	PauseDurationHistogramName:            "Time taken to pause a sandbox, labeled by fs_only (filesystem-only vs memory) and success",
 
 	PauseResumePrefetchHarvestDurationName: "Time taken for a pause-resume prefetch harvest run (slot-hold cost)",
 	PauseResumePrefetchHarvestPagesName:    "Harvested resume-prefetch trace size in 2 MiB blocks, per successful harvest",
@@ -501,6 +503,7 @@ var histogramUnits = map[HistogramType]string{
 	WaitForEnvdDurationHistogramName:              "ms",
 	EnvdCollapseDurationHistogramName:             "ms",
 	GuestSyncDurationHistogramName:                "ms",
+	PauseDurationHistogramName:                    "ms",
 	PauseResumePrefetchHarvestDurationName:        "ms",
 	PauseResumePrefetchHarvestPagesName:           "{page}",
 	UffdStartupPagesHistogramName:                 "{page}",


### PR DESCRIPTION
Makes filesystem-only **pause and resume** distinguishable in metrics, so the Filesystem-only Snapshots dashboard can stop relying on "(all pauses)" context panels.

## Change
- **New histogram `orchestrator.sandbox.pause.duration`** — Pause handler, attrs `fs_only` + `success` → fs-only pause call-count / error-rate / e2e latency.
- **`fs_only` on `orchestrator.snapshot.upload.failed`** — threaded via `snapshotResult`.
- **`fs_only` on `orchestrator.sandbox.create.duration`** — set at the reboot/resume fork, so e2e create/resume latency splits **filesystem-only reboot vs memory restore**. Combined with the existing `sandbox.resume` bool: `resume=false`→fresh create; `resume=true,fs_only=false`→memory resume; `resume=true,fs_only=true`→fs-only reboot.

## Why
fs-only-ness was recorded only as a *span* attribute (`fs-only-snapshot`), never a metric label, so pause/resume e2e latency, error rate, and upload failures couldn't be scoped to fs-only. Reboot-vs-resume was already distinguishable on the envd-init/uffd metrics (`start_type`); this adds it to the **e2e** `create.duration` as well.

## Notes
- `Pause` uses named returns so the deferred metric can read the final error.
- Pure additive instrumentation; no pause/resume/snapshot logic changed.
- Follow-up: monitoring-repo PR to switch the dashboard's pause/upload/resume panels to `fs_only="true"` once this deploys.

Verified: `go build`/`vet`/`golangci-lint` clean, `go test ./pkg/server/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)