### PR TITLE
feat(api): add POST /snapshots/{snapshotID}/fork — fork N sandboxes from a named snapshot

### DIFF
--- a/packages/api/internal/api/api.gen.go
+++ b/packages/api/internal/api/api.gen.go
@@ -1518,6 +1518,9 @@ type PaginationNextToken = string
 // SandboxID defines model for sandboxID.
 type SandboxID = string
 
+// SnapshotID Identifier of the snapshot (template ID)
+type SnapshotID = string
+
 // TeamID defines model for teamID.
 type TeamID = string
 
@@ -1763,6 +1766,9 @@ type PostSandboxesSandboxIDSnapshotsJSONRequestBody = SandboxSnapshotRequest
 
 // PostSandboxesSandboxIDTimeoutJSONRequestBody defines body for PostSandboxesSandboxIDTimeout for application/json ContentType.
 type PostSandboxesSandboxIDTimeoutJSONRequestBody = SandboxTimeoutRequest
+
+// PostSnapshotsSnapshotIDForkJSONRequestBody defines body for PostSnapshotsSnapshotIDFork for application/json ContentType.
+type PostSnapshotsSnapshotIDForkJSONRequestBody = SandboxForkRequest
 
 // PostTemplatesJSONRequestBody defines body for PostTemplates for application/json ContentType.
 type PostTemplatesJSONRequestBody = TemplateBuildRequest
@@ -2103,6 +2109,11 @@ type ClientInterface interface {
 
 	// GetSnapshots request
 	GetSnapshots(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostSnapshotsSnapshotIDForkWithBody request with any body
+	PostSnapshotsSnapshotIDForkWithBody(ctx context.Context, snapshotID SnapshotID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostSnapshotsSnapshotIDFork(ctx context.Context, snapshotID SnapshotID, body PostSnapshotsSnapshotIDForkJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTeams request
 	GetTeams(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2727,6 +2738,30 @@ func (c *Client) PostSandboxesSandboxIDTimeout(ctx context.Context, sandboxID Sa
 
 func (c *Client) GetSnapshots(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSnapshotsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostSnapshotsSnapshotIDForkWithBody(ctx context.Context, snapshotID SnapshotID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSnapshotsSnapshotIDForkRequestWithBody(c.Server, snapshotID, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostSnapshotsSnapshotIDFork(ctx context.Context, snapshotID SnapshotID, body PostSnapshotsSnapshotIDForkJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostSnapshotsSnapshotIDForkRequest(c.Server, snapshotID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -4588,6 +4623,53 @@ func NewGetSnapshotsRequest(server string, params *GetSnapshotsParams) (*http.Re
 	return req, nil
 }
 
+// NewPostSnapshotsSnapshotIDForkRequest calls the generic PostSnapshotsSnapshotIDFork builder with application/json body
+func NewPostSnapshotsSnapshotIDForkRequest(server string, snapshotID SnapshotID, body PostSnapshotsSnapshotIDForkJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostSnapshotsSnapshotIDForkRequestWithBody(server, snapshotID, "application/json", bodyReader)
+}
+
+// NewPostSnapshotsSnapshotIDForkRequestWithBody generates requests for PostSnapshotsSnapshotIDFork with any type of body
+func NewPostSnapshotsSnapshotIDForkRequestWithBody(server string, snapshotID SnapshotID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "snapshotID", snapshotID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/snapshots/%s/fork", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetTeamsRequest generates requests for GetTeams
 func NewGetTeamsRequest(server string) (*http.Request, error) {
 	var err error
@@ -6256,6 +6338,11 @@ type ClientWithResponsesInterface interface {
 	// GetSnapshotsWithResponse request
 	GetSnapshotsWithResponse(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*GetSnapshotsResponse, error)
 
+	// PostSnapshotsSnapshotIDForkWithBodyWithResponse request with any body
+	PostSnapshotsSnapshotIDForkWithBodyWithResponse(ctx context.Context, snapshotID SnapshotID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSnapshotsSnapshotIDForkResponse, error)
+
+	PostSnapshotsSnapshotIDForkWithResponse(ctx context.Context, snapshotID SnapshotID, body PostSnapshotsSnapshotIDForkJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSnapshotsSnapshotIDForkResponse, error)
+
 	// GetTeamsWithResponse request
 	GetTeamsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetTeamsResponse, error)
 
@@ -7339,6 +7426,40 @@ func (r GetSnapshotsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetSnapshotsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type PostSnapshotsSnapshotIDForkResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *[]SandboxForkResult
+	JSON400      *N400
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r PostSnapshotsSnapshotIDForkResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostSnapshotsSnapshotIDForkResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r PostSnapshotsSnapshotIDForkResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -8644,6 +8765,23 @@ func (c *ClientWithResponses) GetSnapshotsWithResponse(ctx context.Context, para
 		return nil, err
 	}
 	return ParseGetSnapshotsResponse(rsp)
+}
+
+// PostSnapshotsSnapshotIDForkWithBodyWithResponse request with arbitrary body returning *PostSnapshotsSnapshotIDForkResponse
+func (c *ClientWithResponses) PostSnapshotsSnapshotIDForkWithBodyWithResponse(ctx context.Context, snapshotID SnapshotID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostSnapshotsSnapshotIDForkResponse, error) {
+	rsp, err := c.PostSnapshotsSnapshotIDForkWithBody(ctx, snapshotID, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSnapshotsSnapshotIDForkResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostSnapshotsSnapshotIDForkWithResponse(ctx context.Context, snapshotID SnapshotID, body PostSnapshotsSnapshotIDForkJSONRequestBody, reqEditors ...RequestEditorFn) (*PostSnapshotsSnapshotIDForkResponse, error) {
+	rsp, err := c.PostSnapshotsSnapshotIDFork(ctx, snapshotID, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostSnapshotsSnapshotIDForkResponse(rsp)
 }
 
 // GetTeamsWithResponse request returning *GetTeamsResponse
@@ -10346,6 +10484,60 @@ func ParseGetSnapshotsResponse(rsp *http.Response) (*GetSnapshotsResponse, error
 	return response, nil
 }
 
+// ParsePostSnapshotsSnapshotIDForkResponse parses an HTTP response from a PostSnapshotsSnapshotIDForkWithResponse call
+func ParsePostSnapshotsSnapshotIDForkResponse(rsp *http.Response) (*PostSnapshotsSnapshotIDForkResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostSnapshotsSnapshotIDForkResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest []SandboxForkResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest N400
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetTeamsResponse parses an HTTP response from a GetTeamsWithResponse call
 func ParseGetTeamsResponse(rsp *http.Response) (*GetTeamsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -11719,6 +11911,9 @@ type ServerInterface interface {
 	// List snapshots
 	// (GET /snapshots)
 	GetSnapshots(c *gin.Context, params GetSnapshotsParams)
+	// Fork snapshot
+	// (POST /snapshots/{snapshotID}/fork)
+	PostSnapshotsSnapshotIDFork(c *gin.Context, snapshotID SnapshotID)
 	// List teams
 	// (GET /teams)
 	GetTeams(c *gin.Context)
@@ -12798,6 +12993,41 @@ func (siw *ServerInterfaceWrapper) GetSnapshots(c *gin.Context) {
 	}
 
 	siw.Handler.GetSnapshots(c, params)
+}
+
+// PostSnapshotsSnapshotIDFork operation middleware
+func (siw *ServerInterfaceWrapper) PostSnapshotsSnapshotIDFork(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "snapshotID" -------------
+	var snapshotID SnapshotID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "snapshotID", c.Param("snapshotID"), &snapshotID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter snapshotID: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(string(ApiKeyAuthScopes), []string{})
+
+	c.Set(string(AuthProviderBearerAuthScopes), []string{})
+
+	c.Set(string(AuthProviderTeamAuthScopes), []string{})
+
+	c.Set(string(AdminApiKeyAuthScopes), []string{})
+
+	c.Set(string(AdminTeamAuthScopes), []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.PostSnapshotsSnapshotIDFork(c, snapshotID)
 }
 
 // GetTeams operation middleware
@@ -14008,6 +14238,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/sandboxes/:sandboxID/snapshots", wrapper.PostSandboxesSandboxIDSnapshots)
 	router.POST(options.BaseURL+"/sandboxes/:sandboxID/timeout", wrapper.PostSandboxesSandboxIDTimeout)
 	router.GET(options.BaseURL+"/snapshots", wrapper.GetSnapshots)
+	router.POST(options.BaseURL+"/snapshots/:snapshotID/fork", wrapper.PostSnapshotsSnapshotIDFork)
 	router.GET(options.BaseURL+"/teams", wrapper.GetTeams)
 	router.GET(options.BaseURL+"/teams/:teamID/metrics", wrapper.GetTeamsTeamIDMetrics)
 	router.GET(options.BaseURL+"/teams/:teamID/metrics/max", wrapper.GetTeamsTeamIDMetricsMax)
@@ -14043,212 +14274,214 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 // const string: with thousands of chunks the chained `+` fold is several
 // times slower for the Go compiler than parsing a slice literal.
 var swaggerSpec = []string{
-	"7L19Uxw3tjD+VVTzu1XX3t8wYJxs3ZDaPzDYWW4wpgAn2Sf2k9V0a2a0dEu9khqYdfHdn9KR1K3uVr/M",
-	"AAN2qK3amGm9HB0dHR2d1y+jiKcZZ4QpOdr7MloQHBMB//zthNyoC35JmP4rJjISNFOUs9He6CAXkguk",
-	"OJoRFS2QWhDEyI1CGZ4TxGdIEJknSo4RnaGUC4LIDZVqNB7JaEFSrEdUy4yM9kZSCcrmo9vb8ei3C65w",
-	"cpYzpn9pTHqSp1MiYHTTBEnM4im/IRKlWEUL/ZOGZEYTRYQcoymZ6bkzPKcM61EQlQhnWUJJPEEfWLJE",
-	"mSCSMIWuF4QFxr0mgiBB/p0TqUg8+cQqS5hxkWI12htRpl7vjsZuTZQpMididKtXlWGBU6IsVnEUESkB",
-	"rUeH+geql5ZhtRiNRwynunu1zXik56eCxKM9JXLSjUOc0Z/Jsn1o93m1Uac5TeLWQd3X1cZkPCatQ9qP",
-	"q41Y7vMxTalqUtB7fEPTPEWsoCSqSCo1HQuicsFQRgTQ8GhsoPp3TsSyBCuBcX0oYjLDeaJGe692dsZN",
-	"gkjNjPZzSpn9K0AqPvyDjp5UWCgg+IRKhWaCpy1gs2K4bgRaum/dlfL7ahujCE5bB7UfVx0xzRKsSMeo",
-	"RYPVRr7iSZ62j1t8XmXUW91YZpxJAkzgu50d/Z+IM0UY0CkwpQj2fvtfksO+l+P9lyCz0d7o/9sumfW2",
-	"+Sq33wrBLaepEsobHDvONbodj77befXwc+7nakGYsqMiYtrpyV8//OTvuJjSOCbMzPjdw894whWa8ZzF",
-	"ZsYfHn7GA85mCY3Mjr7aABX9xBnRk32/CZI9J+KKCEc2t+5IwZnZ//X8jMypVGKp/8wEz4hQ1BwofC33",
-	"4dLUl1vcZJr7v54j0wD9TJbo6BDNuEBvD84QrlBseYW7szvWY+uJOQsPa75p+UEQYMZ6VGEh1fJGwiOs",
-	"SNwy9DmJBFEF8OE5TCN/BcPBNz/UR71YZlZOs4A2BiJMX1S/axhHn8cBRlmyv9/N13F9G4IL9BFajsun",
-	"/yKGqvfjlLI3WqI4wCwiyRlIks0tj+BrQuIDnjPVJS2CeCKRzAGGWZ4kS1T0Dght49EM0xUGVguskOmi",
-	"r2Uz9Ch4w/s4qy2gOutnh4lzc+X+TJNWTAyEthRqawBf0iQJokF/WGngCopN7348+LMEkCAlnbMLe5tf",
-	"4Lk8s3daAw8Kz2WA0vEcBDwMA+l/6UPqxAMtMGkRMHBrF4BjIfAS/sZiTlRoCv17MSaiDH0CeWFP4fmn",
-	"EbJSYe8hMsOPzULKxZPYX35z3Z5wXoXrKNYnekbNNullQ1ONCh5RzZTQNVXwepMEwayeCJvnNMi0wmh2",
-	"oMIwbro1sNzACQDllqiRArzhmM/fsuBVkJArkvTdQMd8fgztbsejlEipJf7Gko75HNmPyN17AXxIRbJm",
-	"53NFMk0IJdYzwYF9C5IA6i0lJnyOCCwlhGuaEqlwGpjgwn1yyPYHKjYxxops6VH6qa+YqkTJ2GKzQPu5",
-	"wiqXZwTb+76GerMp9q/iZfT753EAs8S0rKNDwgxImCk8uunazipJBE5u6x6/t/vrzkF1/jGKciEIU8kS",
-	"CZJxoSibI84ScwGDnGJ7rEgZHgvu3RkHvN6Fg9OPLfz44PQjirggEkCDpRi+PAo9SzseomMtZDISKXv1",
-	"BBgtTQnPVZgmea403UsScRZLeJUCNBaTSHdGeKaIQNcLanVHFlQkFzxPYkRuMipIJ+A7vfeKgzIkZBwI",
-	"ooluv1S0BAQM20b1nD2jrUFKj4KgkxGghpzB8YjGQ/i2P8cQHp1iedl3aMpZ3mN5Sdn8kChME6n7m8du",
-	"48rHKWmBqMm5wtqLiwVBVgIz6O0ZqLansFoAzs1g1zr2tutzucEXBKf7p0dWsF5vf/dPj9AlWa6+tXaC",
-	"NzA3TpIPs9He7917ouH9KDUxfx6PWJ4keJoQo18YTCsW3iFkchl6cJzha3SFk5w0B2wMkGCpPkoSgOsY",
-	"S3vW1YLKAonXWKJcAtMLIrG65keh7NblhmjRNLQkaAmzSomHJCGKDBJg+2HzBKqBcpkTf2MAY31BzB06",
-	"J5oeUnn5nihBo4BEGpMrGgWWcgi/IzdWHYAZTYhcSkXSi+Cj9V3xHem+6AWZzCdjRG7Ud2N0M5Mvg6xQ",
-	"X5ennIbuzPf6G8r0R4fhmMJWBviZwsmbpSIhHOtvSGY4Atl/Cq3840eZ+ut3wSeWPgsto+pztc6gdemh",
-	"XP/YbUwD1T4glbW6rT6n/yHv3wR2lMpLJOl/SF3q0DC/p29WvcPHo7fs6hdsbSVxTPU8ODmtkZcPwlt2",
-	"RQVnqRYurrCgmn2EhKDmaX7LruJfiJBB3Y794OiCsKu4sA9Zub517PHIqLiadw6PA3QNjRF8G/fblDqk",
-	"WTNrH+OyE/li5TvB06MUz4mvYoupHjulDCuzlhRnmbXM4WvZxn19Rd14NI+ytoY/HZx6DUUxc0trwojA",
-	"SdHjduxwuzyxKn+96tvxiDMy4Kr1wbwdd7f1Ie1tW4dT49cfoEEUkgh9KvejSB/V/5Uhajw3bZBthP73",
-	"/MMJ0PhPB6cbUALqXRyqBAwsJySC1/HUQEuGpbzmIiBbnNov+l7LZcl6RElN946BYuzPgcFzSUT48v5o",
-	"vwwHNYzUYoZxiZcQVltFnwZ6tcxC4l+0oHcqyIzeBPAMv4O8plme6YGuqozRvHu4aBMRvXnO81lwHvP7",
-	"HefJuhcBD27qsCMbQyKL6Ma4IAofEzZXi4CUC793g9h2MVuAqzOMA/sSwqFmKsdUKhK3vtJxQnFIUad/",
-	"HiJPRgklTDm9YiaIMWNYwbzvFWJ6B8fN8kKF0cVIC1XH7VhfRZ4I0tXLE1Zu9eltfd8Zjw9fYrmmSRJQ",
-	"PXS+8UhVhOi0enlN4RJPuVj2L+i9awd9FI6x6jWwWZp475rXTft9m9ch2IDTAVkFq1gi22kwVqXSNDls",
-	"kefQtuES0LfEQlkPCiqjiaKyArl9xwWZAngBwPMBjtggLaUF+Jeyb7/62/di8L0visPp74h3tjz6qpwe",
-	"dyQcjqsUDFzFqcYDikuNrwaJuBsyJtN8Dg4oMz4aj66xgPsTRNLQpXnM5/KQChKpoPxdfPL029Z0ZbWE",
-	"U2K9dmCPHBgzLq6x0L9McXQJ/2zMPh7dbOn2W1cYblWpO1bgeVeMUvn5TTGkXcA5z0XopWt+XxF0vdtc",
-	"YJAKMr0lEmwOw8E3s154w5S/nnoD3o5H73G0oIwc6c1qPlOyfF9EC6pIpHJBwspm7LVwC2XmaRHi+e9w",
-	"SpNleKgZfBswyHsehyhTj5HqT0OHOAkKa+UwzNO5hMeqv6mKBXpw1uYbN/BqNuLmguDU6FICTJXgFKXw",
-	"0RopPDtNUy3vGYu6b+yG+cjOsYoFybNPfWQh2atzEi3q6W5GS/jCGQwkZRFBJOPR4mXtOdyiQwH5Kaxq",
-	"tu53VX1m4c7pwLHP+Tm9IgzpgcUV9izixluw02BWxYMDCbY3yjpUGQ0PmPcHpyjibEbnuTA+VE1FRouO",
-	"tHwEvPdEi7q5S39ZR1fzavd/Qrg/IdedRpS7GhJCWsjPZt4OwTfh13/APjKi/jAThAThhF8XKFC8gGRB",
-	"kOs8Qb9qeUYSBb7OOJFkjKhCU7LAV8SJCylBWsjJSERnS8rmKCZs+SGHPjsT+N/2jqMyRtQ1F5d2lyfl",
-	"kqecJwSDbIhzxU9xLknFjmqmb3rc8RTrB2uSLFGmO1WlGGNqA5HHGsQ6ZzQUUpk3xD4OOFOCJ3YqhjO5",
-	"4ApdUhYjhfUrqCEH6hm2LHycOWDQC7CmCpKQK+zcsAtgQCITOXlp98FuAJBNMRyKBc/ctm0ZsQeMsgRh",
-	"FiN7kUpjtrXu4U6N/AJ7f21BC7eYlz+CE3sK+j6FIp7EW1POlUQvBIF/vKysD+RILWlN0HkeLRAu0RJh",
-	"xrgmGgM1DEtiNF0iJfBsRiMANM2lMoKB+UxusoRGVCXLMZIcYCjGiXg6pcz5b+hRz6DXBB2aXQOdv0Yd",
-	"ejHLkwQ5tLjFtdOdGWigLLtfdDgAcrZPIqfA7XkOQbPb8YjidOB8RziFd5Bhqp3Ppii744vJHtSBPU9M",
-	"6xINkkRB0ekcfkc4SZAlwoinac6czyzsaOMB5m3Sau8cxz27TUe+Qd/5s38fEhk0WSX0Kqjutzf4ZHWd",
-	"/yM8p+wl0mUgvj9ToX9tGXjXmc1gCTSASl9Po73R//0db/1nf+v/7Gz98MfW5///vwZCEpAZTqxlovYQ",
-	"SHKpiBhGarZxUO7maTAg4wB+dwNwES2IVALsDa0G9XdOn9njj2jf7+BlM9QcZ7qcGzdGssossugzbKZh",
-	"tvy2d0xafb11MkKvqWGIzmbb1UuTgzPvltqjFVxBnamMM38hFcy0WLdkodcBd6v+OW1DdO4mrzGg8CzG",
-	"SnHEpMIsCjJTZ3Ohtk2pPu7dH+sTNgDJxqOu7HOwwGw+RL+mp3beatdYogRLhSLTe/D77Wqg9bP7ZIYc",
-	"I5r4HXvcpMBQc9k1Yisptnk6qxyhhXLKRRZsqHp+PlvuZywlIUfzaEFicDEMMIRjKoF/mVbOJZzGNcIf",
-	"7mT8zHKfWe7GWe4zM/xKmGGFGfVzxBDrK9hpiAl6Ll31ULfYqe9kQ/OIExvkdHD6sYtWi3ao8FYeSKFF",
-	"T6OfaHGZ2gdnp+pM9uW7ol+Wb6QMOXuVEcSl3/Xq5y7K8lMiIhI84RrhevAcHNQz08545Q8ZO6byUoZc",
-	"8JQJ/LF7aRzZcbQA3cV2WnrEDXW+9z0BA/fZIp+TUzwn5/Q/pGXb9CfYNCQpmycE6T6QSWDFXXNzyTOi",
-	"j1zIL9VLImDbFLNJ9MKcEgUXuUKMK7QkCsGLmMQvV4UCSKWfgjJBSnItgekgp76Jwy655dLLSSgDt5QX",
-	"4PKHttBMEDJ0neZkXfQ6RjLDOtY5hqbXx3YnyRNvbOc/srarZIWNtfCcyqFtAhgwwXoIcqeyQSP1vQuR",
-	"cugoObZ9XlyxTZNtLv0LevKJbaFYYKpFhb3y8qQSTXnOwKdqSpBc5ArF/JpN0JEynhH6NOAoIplCjFx7",
-	"cgdmsWkhFc8Q18IBBk8KKlU1mwYWBMWcGSD0XRhPl1UYzCSKXpHEbOgYTqJRfrokDZCuAcdLmDniTFGW",
-	"EwSXLJs7narJ1VG6b+F4qfFvVw43IkS5mD9ytiA4UYuluYQ1YAPtriX6z+wc5S+H5Wzljwf+vOXPHz0I",
-	"yl/PHSyVjTYCwr2pa3rjBFaX4Gonyw6gV2HUxR1uS1XbR7cV856sH4+r/9TI+uq8uGKeYhqQld9gqc+4",
-	"/ujFxBdWNmvvoNJa2+g0GRT2QdhVPVqrhhA/CgtuAhBs2FVc1a/frxPXfXlVbdJ3ye5BJzbh59J2oFFp",
-	"96vk5+iKYpQJfrOc9O/gGn5NdcekNpNTkxRKI1vAlg5MIi4vpUnjNUOYXki8sgnsre1XX6wbL6R2bx1k",
-	"kOHXrdLOgGYJnocX6eyCxoQatv5ZWNr0YHflRGCWP7KG9f0Wo/yvC6IWRBQGeGeU14/60iBaLJgL/Wyx",
-	"i69y5Ak6MYZPzKSWH/QIWrrwRpFEdZCuh5lvwRV24wx7A563T/BGSOiMRMsoGWpBPy7ab94n+K4W7meX",
-	"4meX4iEuxRbKt3NBpDzVEkPb1X3+4eDn8++NVAHH1SGOQN8J+pAr80y9ODgF5OaMEchjsxA8n5tsAqa7",
-	"Ef3h1tmOCVvatJCUzX+sSu4S5QxfY0Em6BD44BZkk4T7lF9DvDISJOWKoMOTc/Ri/+Ifp38zHPNl6P6o",
-	"XZtxLIJXXWWttpV+Riy4VHsZF8rmjTFhrujTyMha5AanWUImEU/3Xu38z86nke/M48XDtIZPfciMJyJy",
-	"ELhwqhdn7w7Qqx92f3g5Rim+Qbvff2+UKROTydBFwex+//1KQVD1CV3LO01Y191YNDeELP1oZ1xtUY21",
-	"lLDi4i4J8x0Xl61B2VGpBnYvw3GrYm3GxaUvd0E+KDjzE7SfJPBdoinnqkyMAf6DzjELXL0qPnVUoghn",
-	"KtdyOOhWBJljESeaWvgMAXgT9BZHCxjdWMVILLVsBHY4RFlMMsJiyGNiaJ/nKuLGswR0v1Ta/CZGg0aV",
-	"tD66hReRyV4ImSbDD9zBiS7v9Nxm5LqJ5Lu8vdtlckMVLuVWLUcC/K6xw5nvUKxBm6C3NzjS8qX+5pkt",
-	"i4wxVGrRc6+8z9wFZzbQMN9KMq2x7QktqZ+8C1oH3jAu/nhAHr7iGhh423Ri7cj48tVYnVsoF5cJx7E1",
-	"Hqpl9X02QfuIcbZF0kwtx+gKJzQ28ptEKc6s1C8Dw9Rl/6ZvPIwy3MvwwrTvWWmL0zPOY0pYKCxk335x",
-	"56pYCcA3RlJxAa6fhoCw1NfDFY1JPGlNshLOlfBrZWSIbpz0GisLwP2hP/ejoDNafwWEj5oZNnFK4gJN",
-	"W2YxMZlRBnPJMbokS+NLi1GEk4SIrWjBpV4ytNX3jLfwxhKOfXk9TLWFSI8yntBoWYTu6FlL/d+MN8mu",
-	"6lAbfupW5EPMfB/h8Duds4uSgQ7A7oeifXO/C/D8YTt2/JjPw4nSzHVRjVAB/XxCGWngBX4MjqO/dGVb",
-	"e6SMaADw5woeWvLPzSixjkJtB6LNBahE9sZz2D0WVgF+P9+cxV4V07I/1VzV6CXyyAhMEHjXeIGu8rTq",
-	"yiqX8FDGneP7mLP3GQdzj3081HD2y+6ZFdqC2OtL0VcwP70aWWD03rAXWo63gveeVmNYGhjXo1fhUJkk",
-	"GHP33o9SG8rS2j1GTpq+IsPyvERZ/lGS+DRqSffX5RkyS7ifctTFsJmXe6djQgwpfVrzDrUb63XHsOcB",
-	"ZAlqNc93mv8PcLQIhWoad0tr+X8BziLgG/Vy9Sk6sdHht9A5aBgR73s8FdqH/HMGd64QcunpqbxzU+6F",
-	"t9UeYXlU6x8NjxNV1Z7hYMMPoWSYzjMYWpAYxUQqW97Bel2BTqvwVzBveIM9LQdOCcLo4OjwDE0THl0W",
-	"aqD/mcD/tl/vfhq9HCOMplgQdHRa6JBqDaEVFwg7Lb9RvdhGnjrp02iMPo3+Mqn89BIUF7AAl7EVJ9d4",
-	"KSHOD2k6JLF50lwRgWLCaNl0spLnMyDqNJ8mNLowOOkNQzw3MZeIVng++nh2LL1Q+9JyYYIAXdCcl+kn",
-	"LGnbOM72vbXLLXcJ1C7lXpDwTh+WG2GcYhhXSOaZ1cDoLqCxFHmyKhJJqWQdnnayVUF725QLvkYNbbsG",
-	"MMXSqf7+zmVgpx2FLbhUkJnIKvbBZDUlpWEJAvoswFYhFEwKDHvaJdasIl9Z5nSWG/tRnRhqmZCI2LIs",
-	"QAnMpOa+hsRcTSSkeFlJyRLt3y8uTrf1/50Xy5qgn8nSeXPp8UqegzM6abCUBkNxnCiBDEYIrI7O+avi",
-	"0eN45xZsseO1GsyMiJSa6jcVh6/aW6pDf+Pjrnm5VRDk48eixeGixFfBX214XkAJ5QZdbXcLWIYs58Kf",
-	"o2VN9g7q2PRidbaClk2qQtm8uSqvZNjgF28VME1dyA6joaFMr01zUn2nCBoTkxbMwliS4T4rvQxNfy+R",
-	"t77l4Kozyu0ERySeIEiiZWg3S/RuGaDkj0iaIhuCSJ7k4C6ywFlGmLQG/C2pAbEIkYTF4GzIXSDomuT3",
-	"MdMyWJs97KSSLMC5seTQx3Cdes2yCToza5WVrNtuX+G0FzhyysW6GvZDSpUyNA0PchQlBAuJaEDT/CwA",
-	"3a8A9FUnrngWmL51gekpii8ez6s4nltupw9CwIwygEd/8DXtde8iYMUtyU7gcYp4DvzS+aDbOjvgmxfM",
-	"iGZnBe/nVnt0OixBS2Fd4M58rJl5IBVINbVKKEkKlS6JColB/1XkRamYLkIJUqgq86KMUcKlyZ5cydIy",
-	"Lq4wWyGFyDFMwzPCkPPS5wy2GdwdqbJPOFZ48zmhAL2wHTRbMUaUlz/6JpWxld/tBaMEnc+JsBYkMaVK",
-	"YFHkZRkjQWbgUy5tShd3ydbTrITYYQdhnZGZIHLRusmxvYoDqjTfl7W1gMaUoEuSKYTBeF7ax31D/eu/",
-	"Viz1qxnHzy31rJjLvvAEgSu4sNo6XwfnmzRBRzM/gU7hWWUlF/1WgMsrMXEgcOI11YB/gCm34x5ouChM",
-	"ZES1gjt45ZqkIjgGbwqo8QCCjx6JsxajaStanJfZSpkTLf073hB3MQfLkNqLYH31tVkCPm13SZYScIwK",
-	"ZfI9xWUe37a+4ZIIMF7HQoj8lapFa62Ewo3ljjZ0a8y4bYTeFOODUtMeqXDeRxvU1Ki7oK8NI3s5Gm6c",
-	"TMqiJDdPIoJT0xpsCBhSgs2tvK0/bskkn2+nyy03yt7V7suVZDbXcaDraRewCyh8NkEfNZcvoN4GZ3eb",
-	"jczwmmvPGaNzMfZa1m8OfQNfU0n07ZpINMXRpWNDAl+X8Bwd2hHxNHq1+7oYot9jw8PE2G5fiBQviHHL",
-	"qT3doBh0QLaxxVocf9brDNYukodOBOlybgCCsI6wdmW1Ib0XxJAaKGFoyiLD/Y66oREafrK2LLE95hZZ",
-	"/qo/W8w+VxhqjRz80xcIstQTLFJ1T3lfI87sBX7u3yXNbKhlyHnZxXOjrB33AQZqP+HOWVDyCVYJtQ6O",
-	"GRFWFBlkuH62gPZZQAN0ENgjR3nABRo8i6Q2+KsPw291Q7fwXEIgce/hHMZf7Gg9zCV02gz0ZoU2Ei0c",
-	"x+aOSE94sWl6h3KmtnRpr2eIURhUokg0J9Sd1bCzuEIVWMiOU7oX2weTPv4mBXJXFN+0LAPax2XdFniV",
-	"Q9cNeuu5SUsFTAV7ZbTNI12n65etWDv8DEt1nuFrtjKygCjudvOuEb3W8uI48R8bBZgv6vK5DZCBBRXf",
-	"4tXeEhk4HPRJsO7hIJFpD8Yplix934LpMiBdeqKt1PuyLieo70yHp9BaQWuh82DsTOsRkum6pouoH6Lm",
-	"+NqgSDS7mT7D8JfhH/H6WansT4VtV8/juLhAHPVWmaJ/+cD90e6GuTnSuy+a6Noouxp//cD5716wfMhD",
-	"40FvFatRXONK2fwNMKOMysVqq3J9Bi9rHVYv7yI0DGZF5aLuzodK1lMk6GvlKwHe1DgJ72hCPmYJx4Ez",
-	"kQkig3ngfGYwowkwAqf3tp2chTayLo3N85+LgIPrR5F4Ef8wdmk+yAFOUJv34snB3lhwWMu4xvFv6hWG",
-	"lpoHONb1Yu+tKz/Akb4EYCWxRBQ19nsBrBTlv+tB28RNEThX4XCGCozHfC7vFNLwkKTQFs5QWUGr0ebO",
-	"SZ7WySPCo0si9KkPGBmLb55SqH36dW4DYGAHaRyKrdWsLVqQ6BISdWCTlI7ckCgH3X1VLiozfLUyC1A4",
-	"BecCrcg9zXLP+mdvf9oI6Zfdp0FK6+y/j61VE+oMwp9BRCvqXneiboBaqI7MCTosuo3BwcY4Hxrjci2h",
-	"gV9NafO4H15nfoIOMLPmMoIwGPJAGx3xhDMkSYYhDXLhTZcut1zfTyP9Uqn8tHf1ChzqjmYwEpVu6Hhs",
-	"nDqMyV4ZIQth6Rz7YV7fAOfOJ55LBCx4EIK7S+QbTwFnoCuOvjvww+/uB6DtOhkD4wqd/xkv6hF2ZQ/z",
-	"pcrrBU+c4FwKgDAQ8ESRs1rSiW5hc+aKiQd4of7Z1ULGEnw3ZfOSaWeys1Ch8i66b1Y2t6P4CuK66cVC",
-	"cQc4v73rTSqS9UlYzssT2nbN1zhTQyTVc0WyoOQVMHc3Zdue3LgN0JxzDvxtvHOuMbVpW1062fbqpg6E",
-	"YzLH0bLHCvFsc7h3meTZYvCNWgye9fXP+vr19PX+W8A+A5w+ofU5sGE78cPz0lUMbk/UjtYhxdedfe8k",
-	"xG9SEVYchKZxCZbr0y7IQQFxhmRhOcv51TdDt0SvzmxfzPNU8+LSWVvPvgoiIZLg71gGnG71rw6D0KzI",
-	"jODN1HwDrP7E0UPdy9tGBZNtXSyz0r07CHWdCiCxlrenF3h+d0W5Jn8eUXg7l57yCs8HGdAGC0z2Le7O",
-	"2nBvKjwP+6XpEa2fXA/aYCneDVNzpzO4NCGVrcrWTTGq2wBIbdrrx3aDCHi2V3nOr1QtyhJ4j39RdlTi",
-	"syX4AorrlV6bxnYdKtC3kZfFY4rlz045z0L+IF+PkLjSJsn3S++G4xhWuUZdZnJdjSpbuTjzPVRmbsnq",
-	"Hdz1wxXDjYqhxu1VnM0S9lnckpm0rQiAja8uFZ4mVqOI1wekGgBcGsEiDcP4EzPpFVw8jYvx+CfO6ORT",
-	"vrPzOnq7++aPww/v949O4G/yzwn6YOr+20yajmo/MRctYuM4jZiGUZRLxVP04s0/Phy8dLWLfkR4Cg4Q",
-	"RaTNGFH2ibkQT0kqANnoYWoObiVhQ5X5rbvbqqUSQa5lMZOH1WBYoxNC9TEUgjLSWhW/G6YmB/znUHw0",
-	"1LKnanmu70hDSV7pBb08EFcJFkS8c6zFMOE/zLB1QeAvfymtZZO//AVVijVUUzPp/SrlirLa2JRowkv5",
-	"lXkxYDTLIcxZkIRgSSCkqwgrqQ354p+/be2fHm39TJb/fPmJOSMdUAQIAnBLwHpKTC6UAv3zfpxStg/h",
-	"QG7p+kzZRCgOoXuj37ag5daFxYC75EwgkRsIOF33MLrJFmxVc4hBYJiVBvvnanFqjGriDax32G72I8kb",
-	"+C5L1ORHrRuRokpLLaO3u2/0xnr1TfdGO5NXkx3IjpsRhjM62hu9nuxMdmyAJtDstlnEVpkMOityPnXL",
-	"rQem4rCJCsYerfpW3x8N82QF0b3QbG//9OiPn9/+46VvCdYsGQjxKB7tjU65VN5xkiNzUolUb3i8tBE+",
-	"yjqHQdIeQ8Xb/7IeQkZ07S3PRq79eim1QFGX3sE+UQA7uzuv7m32AysW1CHoqNliJYlKInS9w98ZsEKz",
-	"FeBv60a67audAW1fAeV8vzOgrW7ks0TQ97edot8/334ej2SeplgsPTLyVukUPHu/j6rU+VnPUqXY7S+4",
-	"RN/R4a2h3ISEjJiH8LumxtpsVdozzXzq2/engNMjcEoUZHhqMW2UTbYrAIKJo0ZR3/UU6jHrueOmm1n6",
-	"2n63mU13O7HCput7YVsLQnL7i3EmuN3GGd26JMsa22oyKYmwibj1o3hNWiCcIFuJGjKqQyqYFnbkbiZ5",
-	"AdOba0Y2ySEQtAhUA2weIuMLJl8E1FaZzthjIH0RX58fjDN6743HYYx1AAKIrYQJB4/IEF63s7P6cXo9",
-	"pO3rDR69ugTWwmgr5wBLBAfLP3zw94BDt/3FyCODmO6dT6BlyuEzuG8BeeyzOO6/Cxykw66BCo23XwMP",
-	"ReNPgm7tXXFnujX6lO0Is8gUEmi5MeC7yZpF2VYmuMm7pt9Ymc1wWFOnmmRxkDbSqNT6Lw+jNzZzPYkb",
-	"pEKJO/fGyWHdsFizVls8KMDOzz2qRmaTEqg5D1qwr5N0zZqBlDySwYXmdSjpFnkCtiFfWivt/kwTS7nN",
-	"DAZrEGkRMv+zy9L2LVOpXa1e60Aq1ZvhF936SqlUrzhANN1k6knec9KW3FIP6vNt2SC7n4gq5eg77e9A",
-	"Q1YpUTbsfd2bXahlm4tacdsf4nnVplz6/bMWSgIk0NC01akCNrC+eQUpuO3/fDvufHlZ9ZA/Tpj1eETw",
-	"/Ji5ByXPhoms76URph2fk6z0nKi9JtpeC32vg0cR1r8enc39M5WALN/KVbCKAu5RxhTat/+nuvM9b//9",
-	"s6WGWXcQZ9rpoTxrYH6mvArlWboZxpMWBCfGNBOUbf4On028SkiiMd9Hg3iGlsyt9oNKZCZecbtu/XVW",
-	"YIPFMB6TAXKaaRZYzYn90Cn9hyr8gznavQf+nRNIMmYfBParCXje2BtgkIyo13s36dCgcnMXdp+AD3vs",
-	"9jckzcO37S/6P/b6DdLKT8QMA4U9W0nlBEZZmduayUf6fH+NpNVHUSab4nA6guoClhK/wjfliUcmdYpr",
-	"fTEsMJsTJIsYNGwwEHov3AelPZTlhMfExNGZBek9vx16F8DxshgAF0kYYnOX+Xc7Pwxp+8NDK84MKXjY",
-	"aOFclUzRBdPqdlworrxamRgijX/MT28v0PbV7rZfTL3FTeEnUskr2XlFFsU4gV8Zr37FbbkKP6s4Kau1",
-	"5JKIv+Fp9Cnf2dn9K86yv2WCxxAvDoVhQBfOYnRlKvikuVRoStDHs2NEWMRtcYcQl0xdMVGfST7KfXsM",
-	"RRSKOup3uXgbG/qQ5pE7kH+V8sePoNhpYqo8X9Xs6D3aHZcJv8ib7/npNtm2f1geSNFTFuTfqJanMm1A",
-	"xnfV/ku3943Z8b5WQrU05hUtDhBo5RLYTsuKAu2vHdvICw70T0E7g3flCnr4/AFPU7xl04CQGAr6ecme",
-	"0dEhpAGYkwoko/GI3GSJlndc6FaIbdtB/qCx7LSmtIcVpPjmyHx8tbNTY7bjUc7ov3NiG8CZeVDJOFgO",
-	"4m4s3/gNO0J4PlZh/u+IMS1ouv9wfbH/7NHQGnOSd2xDqtli48/dmCuL8QU0Q9WzNTbsrHdPX032qOQC",
-	"29nNg8ft6oJSQJguETy82/nrA5HCvXOrdZ7yshRvnwmsSmDnK9zvHgvatsEw7d4QZ7ABsqDA2BS0MKm2",
-	"qpUBTY2pSsItUxotnqCLi2PdBILoyI0izL6qOqTbgpIPLIx3Jej7l5QtZCtJyzuPIS27vK6uINjt+LHk",
-	"dksR35r/3ePK+LYyoVyTCcy4uGznAO+4uPSP+p6xi2ScMlMmuyY9IsoQFM1EL6jSh34qKJkly4I/uNJS",
-	"RTYBqmS1gqSp3lhUhCQx4gxaMR6TMbokJIN6j0qio0NoB8XjbBFjpngeLUj8Er6YhyKKeM4UuFF4Djrm",
-	"uY2VV7PS8TvODPdKFJSTsdzDlIS9HCOCIQ5QCKhuS2gRPFy8Sy0yrOMY5PMyc2WCXEHp06KIJeRZo2w+",
-	"QfuIcba1u/PKqS9TgpkJmnR1KGeYgkufKReNGXgBX5pTrhRJMzWcs+qtfYJs1cKnoXPJFoLq31f3r0er",
-	"TG381/p1aXUe5xM45MdbQGDmpUTXRO+Z26YfDRmZqj6CZFwoQ3i68X9DmdeIp+QbUFU/KnsEBrYub3Tp",
-	"nweqxbW47khBdzXK8IoivDH8MM14cWiPTUbrtQ/tOJjMEWKs62WnADrDIIsUN4VEThlKaZLQsgJsUNei",
-	"Bw8bEV1Sg+7yng0LgCkz69Uc64KyBaqEprQKVZHy59XOzs6qNUg38F6CXV/ntWQyxD9LTW1PJpdBfzW2",
-	"0Kcj9flAqR4acLpb9aN3OOBFtThzuMuEW1god9QhjOgKJ2Ovju+4Vgu6XMgDnfTQsASq+PkHdcDSCIvX",
-	"W9hqIG/EtFcrw7uuac9nCRtQ7P6ZOMia+t9tRtS1e3qFKms7d7sFQbYpijib0blfqh3X31/6DQPvL1kp",
-	"wU1MBJbIE6fe11+LvOeVgSfoQ0oVyAQzSpIYRQnBQiKqAi+LPMDFTuzKnuzbwgJoMHwAax+mvgnoxCvn",
-	"zTmO+sctuHnPUv29+KLWcLzyGQSlRLvy41R/rlXXH/Kyhn5Pl/wBvM639QDbj9HnVDR5RuOCmaf7fabz",
-	"u9G5ocB1n6+CzASRCyK7NPzQpMKxjIre6dhMMW2OEnpFBtL/WTHvkz0DFsRVT0FNujLL3JB96mlRpiOc",
-	"9WlTurR4A7MlnUGPNdix6fgEadEAFj99f6t2u80za1//AAE5r3t+nJq5N3MPwigjQlIJ6RVdt9Lb0I75",
-	"37J4LIAFZoLO3QzuTnf+ttaoUjWnmOQOMA+akiW3mm8u6JxCgpJimoTOiL5UhtopCjie7m3iQPSuk42e",
-	"ZDs9FMYM6QTcpm8+x8+fwP5qfSwtjlc+yPoo8LzDCeOcGEurbVhq8NyLv8KtaZIYeyhBN07j5bkW0zLh",
-	"qD0PE3SAk8RkWaUSpUQteIzSPFE0S4jNUcyviLgWVFm1wsXFsbWCwoC5dElaHQsplXI266uzciJrOeYo",
-	"JVjmtkqsW1rsVBADWcOFxd2TZQwWwDuJmdLuv9tiRzDPZ7Gpk/MU76qgjdbz6F+h3aGdRVMvAXwgBcxP",
-	"RHXcVh3eyLVQu5oPholvKWGYLpHkuYiI5xEdzqXVPxAkt+YCHR2OEYeGWBOdwvOtf+c4MfluvDqMrvOn",
-	"0dhVYcTpduVDUaDR/WQLNLaYDmyi4PYYmv6cYBme25TSx2DbW6nLCblRNnXoZlT6ldt6XY2+9OjMJL6F",
-	"iX/b0svZKhJ1hwCxzbd/81Z++6dy3fZwVzCH4jfDHCB/1LDcPEHj3oX9sJmMPHfPxbPJaOt6ku8+MmhJ",
-	"q1OJaNRNvZ0rM38NMdb68SxdzN3L7LWuqdbm8Xq2035bdlpNFPdhpIXsGhux0A7Pvvq18voLH5crsIrt",
-	"FN90sgugRuuJFGIdrtSYCY1ztD2MobzHN8885cnzlHEgNF3QCGq/6X+RK1KhEogut0GKLbHkAirftMcj",
-	"usrBEWf2lf2HH3TpwhphM/4QWJFAAeEH9VV7j298LvjM9R6H6zkXSTWA+5k487UyP5Sdg2yt/DjgEVzk",
-	"Nm077IML2m/orrfx+XcUuh2OHvPptaoo/mBZMkuCcZRa/lZNorBCTZXOTAo+kT6ECrBS8m8ly8DuvcNg",
-	"68W3mPpMmU8IIokikinnt/Hkor7vkVrD6TbLAnkBIqzwzG1bo277C/yjPeXXwYJEl4jOvMp5VC2sbGhq",
-	"G5IbKlU3I7UlLuE/LUy1mi8a25btAkU9AaKFznXcpOjgJoflFfVM+9ipvkVMNm5Xl3hpoV+Zep9cKYrH",
-	"NWkByaoGRfSeibKGdmfq2dK4hOfOONUqTpg+xUG4wPOHYtjVmfREK3Ht71qqh3+jRScelUKLLLiWRBWu",
-	"hHEUxc3DFtV9qDGtO72QL00hyEZJ9w554QFJ0EC2Ngm+umdASOyDEhQf8Lwsj/9M4fdH4Y5Guym8yn6/",
-	"lNV0h2YAb5GP60y3UqV3Rd1U0XV4kplKkeH7yAP+jb2Zauyv9dHUbbuqFVRpIQVfCr0nOljTOruGHXgT",
-	"QqtXxH5FpZf/HqBKuko9zwbdddUHJQZblAhlRvxuLUKR67xNf6AHehD2+HB6CLOmleSJnQHsuT1Z/leQ",
-	"NO7xWXmT0u6m/zojRpuD2UDt19dBvF+vEu2rVow5alpJM+aLoa5m4Bf4r5VLh9Iy5KaAu3LIq6yY1FzG",
-	"b8yEDyyo2GWFJI3dMPM0CF1gacyw3wSZ2I2qv6HvSCrN9CsNQ3xlRpfMYYj8WqGRtZKqrEknm03AEuVC",
-	"gtH5a8rAEkrAYma1n9fxJoipIBGsYTyQ7WuqOCx6tQ6ckCsoQDp40GPoEEDtufHpHbL7M8HTNm8MGGWl",
-	"VZqJN6TjhzOnZx2s5w+/mrwj/zTVRy3M9pFdokIM86582taXWIFTt5W/6ePU566SxePw6iMWkxt3QIuQ",
-	"lgKXrce1yLjhyVFBXsLn8sNsJkkLc1w5N9U3w77X5rIbY2mtwXe9rOyZf63LvxqFbQZysBlN9E8LLBfd",
-	"tbowQ3mWcByjhLJLpyrFAukRkCYiTJnHA/CSmG9D5dB3uu3fsVzclacFXAAWZtihHgAaCsfb3BL6nQBe",
-	"Pcxp0nj5CJhve2/7+3K9IAKSVNgf4XTZXfoGDFFfwUmE82Cx//HsePUj6VwHesJtwGFgHYOFNdrep/Hq",
-	"AV0LL/D8rnEEvt3wAd1k/wy22KqNod0S6yd6HRBT2lUy55fdb7kqWmtkagHodAm5kLlAKRemgh1gYlCF",
-	"H2XYwnqpFs9V0LV3PJJqmegftHT7NdkwH7+E3L0YNMej37YuuMLJ1pmtY9DXGVq7xtYg+lzIqK2QkeYO",
-	"V7svO+LlO/NYD0qG26ag9bjdV5rp+qtUtPY91XdWhblQlw7BbAvI96KoraHSLAJUNKBIsHFauWATpHuj",
-	"KUn4tUmAYhpgQRC5iZI8bsftvSl+D7AkW5IwSRW9IkjmU3NTohSraIE4A8hTIiWem1enZvwtlx/BIlpU",
-	"wErxzTFhc80Adr//62Y9u70E5r/srqfxfU5lPjyV+QAWHo76Wj3G65fdR4vy+sZkr/uOJ7tH/7FvLAzz",
-	"qUW71Y/rQ4e8Vc/spvx1ftl96h47ZYGn54rCg7LdFcqQDgKu3zcN93TPG3Nl30uPkr9t78sHAaJdDHt2",
-	"73xQ9861z0uPH92qXnPB4/N4fnMPfA8BRla6hZ6W297jPi8Cvn29ZPy6+szoyU/cL7e8fhS55fVjyS0W",
-	"AMeoHSBPS4T5MyRTaYo7rzvpnid5SgamDUSudehxXXx6+OenmWvlx2cCFoPmav5ccUeVbXRk4X5pj0Cu",
-	"sb5ilDD384jh/jnfCbl2FLDZEGMz6z6LPY1DB7253OVNnD0/09r5lk9ZTfL0eNb2F/OP4aHD7URrGlmy",
-	"/cUOu7JA6eAZGDdcIRYXM4ybhPKsPA5GEncTyrjLs7fo2urW+5CksPNYDMkl+numsmGZOLv4EIArrhw5",
-	"5CIZ7Y0WSmVyb3sbZ3RCdqcTnGVAALb/l9KwUGZS+1JLrF79EZLf+X/Ddm4pvd/VhhnduiTLym/Wk6r4",
-	"uxB4Pt/+vwAAAP//",
+	"7L17c9w2sij+VVDzO1XH3t9oJMvJ1lmnzh+y7GR1ItsqSU5ybuybhcieGaxIgEuAkmZd+u630ABIkAQf",
+	"M3raUW3Vxhri0Wg0Go1+fplEIs0EB67k5NWXyRJoDDn+87f3cKVOxTlw/VcMMspZppjgk1eT/SKXIidK",
+	"kDmoaEnUEgiHK0UyugAi5iQHWSRKTgmbk1TkQOCKSTWZTmS0hJTqEdUqg8mriVQ544vJ9fV08tupUDQ5",
+	"LjjXv7QmfV+kZ5Dj6KYJkZTHZ+IKJEmpipb6Jw3JnCUKcjklZzDXc2d0wTjVoxAmCc2yhEE8Ix94siJZ",
+	"DhK4IpdL4IFxLyEHksO/CpAK4tknXlvCXOQpVZNXE8bVy93J1K2JcQULyCfXelUZzWkKymKVRhFIiWg9",
+	"eKN/YHppGVXLyXTCaaq719tMJ3p+lkM8eaXyAvpxSDP2M6y6h3af1xv1rGBJ3Dmo+7remFzE0Dmk/bje",
+	"iNU+H7KUqTYFvaNXLC1SwktKYgpSqek4B1XknGSQIw1PpgaqfxWQryqwEhzXhyKGOS0SNXn1Ymdn2iaI",
+	"1MxoP6eM278CpOLDP+roSUVzhQSfMKnIPBdpB9i8HK4fgZbuO3el+r7exkhOM7kUqnvgqkHfyHVMHMTA",
+	"FZszs5MaD24Y8kxBmiVUATl487w6lx5ICmjaCY79uN4i3ZQ9o5YN1hv5QiRF2j1u+XmdUa91Y5kJLgH5",
+	"0nc7O/o/keAKOB4d5JMRkuP2P6VAUqzG+48c5pNXk/9vu7o/ts1Xuf02z4VlfvUde01jx0wn19PJdzsv",
+	"7n7OvUItNZ2YUQmYdnryl3c/+Y8iP2NxDNzM+N3dz/heKDIXBY/NjH+7+xn3BZ8nLDI7+uIeqOgnwUFP",
+	"9v19kOwJ5BeQO7K5dkcKz8zeryfHsGBS5Sv9Z5aLDHLFzIGil3IP73F938Zt7rX36wkxDcjPsCIHb8hc",
+	"5OTt/jGhNYptc6+pHltPLHh4WPNNizQ5IF/Uo+YWUi0CJSKiCuKOoU8gykGVwIfnMI38FYwH3/zQHPV0",
+	"lVnR0QLaGgi4vjt/1zBOPoeYesX+fjdfp81tCC7QR2g1rjj7Jxiq3otTxl9rIWef8giSYxRu21se4dcE",
+	"4n1RcNUnwKLEJIksEIZ5kSQrUvYOyJHTyZyyNQZWS6qI6aIlBTP0JCh0+DhrLKA+62eHiRMjBfzMkk5M",
+	"jIS2krMbAJ+zJAmiQX9Ya+Aaik3vYTz4swSQICVb8FN7m5/ShTy2d1oLD4ouZIDS6QJlTooD6X/pQ+rE",
+	"Ay3Daak0cGuXgNM8pyv8m+YLUKEp9O/lmIRx8gnlhVeKLj5NiBVUBw+RGX5qFlItHmJ/+e11e++FIZkN",
+	"m2pUiIhppkQumcIHpQSCs3pSdVGwINMKo9mBisO46TbAcgsnCJRbokYK8oZDsXjLg1dBAheQDN1Ah2Jx",
+	"iO2up5MUpNSPkNaSDsWC2I/E3XsBfEgFWbvziYJME0KF9SwXyL5zSBD1lhITsSCASwnhmqUgFU0DE5y6",
+	"Tw7Z/kDlJsZUwZYeZZj6yqkqlEwtNku0nyiqCnkM1N73DdSbTbF/lY+13z9PA5gF07KJDokzkNxM4dFN",
+	"33bWSSJwcjv3+J3dX3cO6vNPSVTkOXCVrEgOmcgV4wsieGIuYJRTbI81KcNjwYM744DXu7B/9LGDH+8f",
+	"fSSRyEEiaLgUw5cnoZdyz9t4qoVMDpGyV0+A0bIURKHCNCkKpeleQiR4LPGhjNBYTBLdmdC5gpxcLplV",
+	"Z1lQiVyKIokJXGUsh17AdwbvFQdlSMjYz0ET3V6l+wkIGLaNGjh7RoFElB6FYCcjQI05g9MJi8fwbX+O",
+	"MTw6pfJ86NBUs7yj8pzxxRtQlCVS9zeP3daVT1PogKjNucIKldMlECuBGfQODNTYU1wtAudmsGudetv1",
+	"udrgU6Dp3tGBFaw329+9owNyDqv1t9ZO8BrnpknyYT559Xv/nmh4P0pNzJ+nE14kCT1LwOgXRtOKhXcM",
+	"mZyHHhzH9JJc0KSA9oCtARIq1UcJAbgOqbRnXS2ZLJF4SSUpJDK9IBLra34Qyu5cbogWTUNLgpYw65T4",
+	"BhJQMEqAHYbNE6hGymVO/I0RjM0FMXfonGj6hsnzd6ByFgUk0hguWBRYyhv8nbixmgDMWQJyJRWkp8FH",
+	"64/ld6L7kmcwW8ymBK7Ud1NyNZfPg6xQX5dHgoXuzHf6G8n0R4fhmOFWBviZosnrlYIQjvU3IjMaoex/",
+	"hq3848e4+ut3wSeWPgsdo+pztcmgTemhWv/UbUwL1T4gtbW6rT5h/4Z3rwM7yuQ5kezf0JQ6NMzv2Ot1",
+	"7/Dp5C2/+IVa800cMz0PTY4a5OWD8JZfsFzwVAsXFzRnmn2EhKD2aX7LL+JfIJdB3Y794OgC+EVcmqys",
+	"XN859nRiVFztO0fEAbrGxgS/TYfNXD3SrJl1iHHZiXyx8sdcpAcpXYCvYouZHjtlnCqzlpRmmTUW0kvZ",
+	"xX19Rd10soiyroY/7R95DfNy5o7WwCGnSdnjeupwu3pvVf561dfTieAw4qr1wbye9rf1IR1s24RT49cf",
+	"oEUUEnJ9KveiSB/V/5EhajwxbYhtRP7n5MN7pPGf9o/uQQmod3GsEjCwnJAI3sRTCy0ZlfJS5AHZ4sh+",
+	"0fdaISvWk1fUdOsYKMf+HBi8kJCHL++P9st4UMNILWeYVngJYbVT9GmhV8ssEP+iBb2jHObsKoBn/B3l",
+	"Nc3yTA9yUWeM5t0j8i4R0ZvnpJgH5zG/33CerH8R+OBmDjuyNSSxiG6Ni6LwIfCFWgakXPy9H8Sui9kC",
+	"XJ9hGtiXEA41UzlkUkHc+UqnCaMhRZ3+eYw8GSUMuHJ6xSwHY8awgvnQK8T0Do6bFaUKo4+RlqqO66m+",
+	"ijwRpK+XJ6xc69Pb+b4zTii+xHLJkiSgeuh940FdhOi1enlN8RJPRb4aXtA71w77KBpTNWhgszTxzjVv",
+	"ehsMmva7BRv0g4B1sEolsZ1GY1UqTZPjFnmCbVsuAUNLLJX1qKAymigma5Dbd1yQKaAXAD4f8IiN0lJa",
+	"gH+p+g6rv30vBt8hpDyc/o54Z8ujr9rpcUfC4bhOwchVnGo8oLjU+GqRiLshYzgrFugTMxeT6eSS5nh/",
+	"okgaujQPxUK+YTlEKih/l588/bY1XVkt4RlYRyLcIwfGXOSXNNe/nNHoHP/Zmn06udrS7bcuKN6qUnes",
+	"wfNjOUrt59flkHYBJ6LIQy9d8/uaoOvdFjlFqSDTWyLR5jAefDPrqTdM9euRN+D1dPKORkvG4UBvVvuZ",
+	"khV7ebRkCiJV5BBWNlOvhVsoN0+LEM//kaYsWYWHmuO3EYO8E3GIMvUYqf40doj3QWGtGoZ7OpfwWM03",
+	"VblAD87GfNMWXs1GXJ0CTY0uJcBUgaYkxY/WSOHZadpqec9Y1H9jt8xHdo51LEiefeojD8levZNoUU93",
+	"M1rCZ85gIBmPgEAmouXzxnO4Q4eC8lNY1Ww9Auv6zNLD1IFjn/MLdgGc6IHzC+pZxI0DY6/BrI4HBxJu",
+	"b5T1qDJaHjDv9o9IJPicLYrc+FC1FRkdOtLqEfDOEy2a5i79ZRNdzYvd/wrh/j1c9hpRbmpICGkhP5t5",
+	"ewTfRFz+gfvIQf1hJggJwom4LFGgRAnJEojrPCO/anlGgkL3a5pImBKmyBks6QU4cSEFooWcDCI2XzG+",
+	"IDHw1YcC++zM8H/bO47KOKhLkZ/bXZ5VSz4TIgGKsiEtlDiihYSaHdVM3/a4EynVD9YkWZFMd6pLMcbU",
+	"hiKPNYj1zmgopDZviH3sC65ykci6J+g54zFRVL+CWnKgnmHLwie4A4Y8Q2tqDglcUOcZXgKDEllewHO7",
+	"D3YDkGzK4Uici8xt25YRe9AoC4TymNiLVBqzrfVYd2rkZ9T7awtbuMU8/wH96lPU9ykSiSTeOhNCSfIs",
+	"B/zH89r6UI7UktaMnBTRktAKLRHlXGiiMVDjsBCTsxVROZ3PWYSApoVURjAwn+EqS1jEVLKaEikQhnKc",
+	"SKRnjDv/DT3qMfaakTdm11Dnr1FHns2LJCEOLW5x3XRnBhopy+6VHfaRnO2TyClwB55D2Ox6OmE0HTnf",
+	"AU3xHWSYau+zKcpu+GKyB3Vkz/emdYUGCVFQdDrB3wlNEmKJMBJpWnDnM4s72nqAeZu03jvHcc9+05Fv",
+	"0Hcu9t+HRAZNVgm7CKr77Q0+W1/n/wDPKXuJ9BmIb89U6F9bBt5NZjNYQg2g0tfT5NXk//5Ot/69t/V/",
+	"drb+9sfW5///P0ZCEpAZ3lvLROMhkBRSQT6O1GzjoNwt0mCMyD7+7gYQebQEqXK0N3Qa1H90+swBf0T7",
+	"fkcvm7HmONPlxLgxwjqzyLLPuJnG2fK73jFp/fXWywi9poYhOpttXy9NDs68W2mP1nAFdaYywf2F1DDT",
+	"Yd2SpV4H3a2G57QNyYmbvMGAwrMYK8UBl4ryKMhMnc2F2TaV+nhwf6xP2AgkG4+6qs/+kvLFGP2antp5",
+	"q11SSRIqFYlM79Hvt4uR1s/+kxlyjGjjd+pxkxJD7WU3iK2i2PbprHOEDsqpFlmyofr5+Wy5n7GUhBzN",
+	"oyXE6GIYYAiHTCL/Mq2cSziLG4Q/3sn4ieU+sdx7Z7lPzPArYYY1ZjTMEUOsr2SnISbouXQ1Q91ip76T",
+	"Lc0jTWyQ0/7Rxz5aLduR0lt5JIWWPY1+osNlag+dneoz2Zfvmn5ZvpEy5OxVBTVXftfrn7soK44gjyB4",
+	"wjXC9eAFOqhnpp3xyh8zdszkuQy54CkT+GP30jiy02iJuovttPKIG+t873sCBu6zZbGAI7qAE/Zv6Ng2",
+	"/Qk3jUjGFwkQ3QeTG6y5a24ueQz6yIX8Ur28BrZNOZskz8wpUXiRK8KFIitQBF/EED9fFwoklWEKynKo",
+	"yLUCpoechiYOu+RWS68mYRzdUp6hyx/ZIvMcYOw6zck6HXSM5IZ1bHIMTa+P3U6S772xnf/Ixq6SNTbW",
+	"wXNqh7YNYMAE6yHIncoWjTT3LkTKoaPk2PZJecW2TbaF9C/o2Se+ReKcMi0qvKouTybJmSg4+lSdAZHL",
+	"QpFYXPIZOVDGM0KfBhpFkCnC4dKTOyiPTQupREaEFg4oelIwqeoJPmgOJBbcAKHvwvhsVYfBTKLYBSRm",
+	"Q6d4Eo3y0+WNwAwSNF7hzJHgivECCF6yfOF0qiZ9SOW+ReOVxr9dOd6IGOVi/ij4EmiilitzCWvARtpd",
+	"K/Qf2zmqX95Us1U/7vvzVj9/9CCofj1xsNQ22ggIt6auGYwTWF+Ca5wsO4BehVEX97gt1W0f/VbMW7J+",
+	"PKz+UyPrq/PiikVKWUBWfk2lPuP6oxcTX1rZrL2DSWttY2fJqLAP4BfNaK0GQvwoLLwJULDhF3Fdv367",
+	"Tly35VV1n75Ldg96sYk/V7YDjUq7XxU/JxeMkiwXV6vZ8A5u4NfUdEzqMjm1SaEysgVs6cgk4upSmrVe",
+	"M8D1QuK1TWBvbb/mYt14IbV75yCjDL9ulXYGMk/oIrxIZxc0JtSw9c/C0qUHuyknQrP8gTWs73UY5X9d",
+	"glpCXhrgnVFeP+org2i5YJHrZ4tdfJ0jz8h7Y/ikXGr5QY+gpQtvFAmqh3Q9zHwLrrD3zrDvwfP2Ed4I",
+	"CZtDtIqSsRb0w7L9/fsE39TC/eRS/ORSPMal2EL5dpGDlEdaYui6uk8+7P988r2RKvC4OsQB9p2RD4Uy",
+	"z9TT/SNEbsE5YB6bZS6KhckmYLob0R9vne0Y+MpmqmR88UNdcpek4PSS5jAjb5APbmGCS7xPxSXGK5Mc",
+	"UqGAvHl/Qp7tnf7v0X8bjvk8dH80rs04zoNXXW2ttpV+RiyFVK8ykSubN8aEuZJPEyNrwRVNswRmkUhf",
+	"vdj5r51PE9+Zx4uH6Qyf+pAZT0TiIHDhVM+Of9wnL/62+7fnU5LSK7L7/fdGmTIzyRVdFMzu99+vFQTV",
+	"nNC1vNGETd2NRXNLyNKPdi7UFtNYS4GXF3dFmD+K/LwzKDuq1MDuZTjtVKzNRX7uy12YDwrP/IzsJQl+",
+	"l+RMCFUlxkD/QeeYha5eNZ86JklEM1VoORx1KzksaB4nmlrEnCB4M/KWRksc3VjFIJZaNkI7HGE8hgx4",
+	"jHlMDO2LQkXCeJag7pdJm9/EaNCYktZHt/QiMtkLMfll+IE7OvfmjZ7bHC7bSL7J27tbJjdU4VJuNXIk",
+	"4O8aO4L7DsUatBl5e0UjLV/qb57ZsswYw6QWPV9V95m74MwGGuZbS6Y1tT2xJfOTd2HrwBvGxR+PyMNX",
+	"XgMjb5terB0YX74Gq3MLFfl5ImhsjYdqVX+fzcge4YJvQZqp1ZRc0ITFRn6TJKWZlfplYJim7N/2jcdR",
+	"xnsZnpr2AyvtcHqmRcyAh8JC9uwXd67KlSB8UyKVyNH10xAQlfp6uGAxxLPOJCvhXAm/1kbG6MbZoLGy",
+	"BNwf+vMwCnqj9ddA+KSdYZOmEJdo2jKLiWHOOM4lp+QcVsaXlpKIJgnkW9FSSL1kbKvvGW/hrSUc+vJ6",
+	"mGpLkZ5kImHRqgzd0bNW+r+5aJNd3aE2/NStyYeU+z7C4Xe64KcVAx2B3Q9l+/Z+l+D5w/bs+KFYhBOl",
+	"meuiHqGC+vmEcWjhBX8MjqO/9GVbe6CMaAjw5xoeOvLPzRlYR6GuA9HlAlQh+95z2D0UVhF+P9+cxV4d",
+	"03I41Vzd6JUXkRGYMPCu9QJd52nVl1UuEaGMO4e3MefgMw7nnvp4aODsl91jK7QFsTeUoq9kfno1ssTo",
+	"rWEvtBxvBe88rca4NDCux6DCoTZJMObunR+lNpaldXuMvG/7iozL8xJlxUcJ8VHUke6vzzNkngg/5aiL",
+	"YTMv917HhBhT+nTmHeo21uuOYc8DzBLUaZ7vNf/v02gZCtU07pbW8v8MnUXQN+r5+lP0YqPHb6F30DAi",
+	"3g14KnQP+ecM7lwj5NLTU3nnptoLb6s9wvKo1j8aHieqqz3DwYYfQskwnWcwtoCYxCCVrThhva5Qp1X6",
+	"K5g3vMGelgPPgFCyf/DmmJwlIjov1UD/NcP/bb/c/TR5PiWUnNEcyMFRqUNqNMRWIifUafmN6sU28tRJ",
+	"nyZT8mnyl1ntp+eouMAFuIytNLmkK4lxfkTTIcTmSXMBOYmBs6rpbC3PZ0TUUXGWsOjU4GQwDPHExFwS",
+	"VuP55OPxofRC7SvLhQkCdEFzXqafsKRt4zi799Yut9olVLtUewHhnX5TbYRxiuFCEVlkVgOju6DGMi+S",
+	"dZEIlZJ1fNrJTgXtdVsu+Bo1tN0awJRKp/r7u5CBnXYUthRSYWYiq9hHk9UZVIYlDOizAFuFUDApMO5p",
+	"n1izjnxlmdNxYexHTWJoZEKCfMuyAJVTLjX3NSTmyjQRJariTpZo/356erSt/++kXNaM/Awr582lx6t4",
+	"Ds3YrMVSWgzFcaIEMxgRtDo656+aR4/jnVu4xY7XajAzyFNmCvLUHL4ab6ke/Y2Pu/blVkOQjx+LFoeL",
+	"Cl8lf7XheQEllBt0vd0tYRmznFN/jo412TuoZ9PL1dmiXjapCuOL9qq8KmajX7x1wDR1ETuMhoZxvTbN",
+	"SfWdkrMYTFowC2NFhnu88jI0/b1E3vqWw6vOKLcTGkE8I5hEy9BulujdMkDJH4g0RTZykCIp0F1kSbMM",
+	"uLQG/C2pAbEIkcBjdDYULhB0Q/L7mGkZrMse9r6WLMC5sRTYx3CdZhm1GTk2a5W1rNtuX/G0lzhyysWm",
+	"GvZDypQyNI0PchIlQHNJWEDT/CQA3a4A9FUnrngSmL51gekxii8ez6s5nltupw9CwIwygkd/8DXtTe8i",
+	"ZMUdyU7wcUpEgfzS+aDbOjvomxfMiGZnRe/nTnt0Oi5BS2ldEM58rJl5IBVIPbVKKEkKky6JCsSo/yrz",
+	"otRMF6EEKUxVeVGmJBHSZE+uZWmZlleYrZACcorTiAw4cV76guM2o7sjU/YJx0tvPicUkGe2g2Yrxojy",
+	"/AffpDK18ru9YFTOFgvIrQUpP2Mqp3mZl2VKcpijT7m0KV3cJdtMsxJihz2EdQzzHOSyc5NjexUHVGm+",
+	"L2tnAY0zIOeQKULReF7Zx31D/cu/1iz16xnHTyz1rJnLvvQEwSu4tNo6XwfnmzQjB3M/gU7pWWUlF/1W",
+	"wMsrMXEgeOI11aB/gCm34x5otCxMZES1kjt45ZqkAhqjNwXWeEDBR48keIfRtBMtzstsrcyJlv4db4j7",
+	"mINlSN1FsL762iwBn7abJEsJOEaFMvke0SqPb1ffcEkEHK9nISB/ZWrZWSuhdGO5oQ3dGjOuW6E35fio",
+	"1HS1X4N5H21QU6vugr42jOzVrP3qHaIoKcyTCGhqWqMNgWJKsIWVt/XHLZkUi+10teVGeXWx+3wtma1e",
+	"4nZ0odoQsEssfDYjHzWXL6HeRmd3m43M8JpLzxmjdzH2WtZvDn0DXzIJ+nZNJDmj0bljQzm9JF7dXDsi",
+	"PYte7L4shxj22KjV8jXbFyLFUzBuOY2nG9anDsg2tliL4896ncHaRfKNE0H6nBuQIKwjrF1ZY0jvBTGm",
+	"BkoYmqrI8LCjbmiElp+sLUtsj7lFlr/qzxazTxWGOiMH//QFgiz1BItU3VLe10hwe4Gf+HdJOxtqFXJe",
+	"dfHcKBvHfYSB2k+4cxyUfIJVQq2DYwa5FUVGGa6fLKBDFtAAHQT2yFEecoEWz4LUBn8NYfitbugWXkgM",
+	"JB48nOP4ix1tgLmETpuB3qzQRqKF49jcERkILzZNb1DO1JYuHfQMMQqDWhSJ5oS6sxp3FteoAovZcSr3",
+	"Yvtg0sffpEDui+I7q8qADnFZtwVe5dBNg94GbtJKAVPDXhVt80DX6eZlKzYOP6NSnWT0kq+NLCSKm928",
+	"G0Svdbw43vuPjRLMZ0353AbI4ILKb/F6b4kMHQ6GJFj3cJDEtEfjFE9Wvm/B2SogXXqirdT7siknaO5M",
+	"j6fQRkFrofNg7EybEZLpuqGLqB+i5vjaqEg0u5k+w/CX4R/x5lmp7U+NbdfP47S8QBz11pmif/ng/dHt",
+	"hnl/pHdbNNG3UXY1/vqR89+8YPmYh8ad3ipWo7jBlXL/N8CccSaX663K9Rm9rE1YvbyJ0DCaFVWLujkf",
+	"qlhPmaCvk68EeFPrJPzIEviYJYIGzkSWgwzmgfOZwZwlyAic3tt2chbayLo0ts9/kQccXD/miRfxj2NX",
+	"5oMC4US1+SCeHOytBYe1jBsc/7ZeYWypeYRjUy/2wbryIxzpKwDWEkvyssb+IIC1ovw3PWj3cVMEzlU4",
+	"nKEG46FYyBuFNNwlKXSFM9RW0Gm0uXGSp03yiIjoHHJ96gNGxvKbpxTqnn6T2wAZ2H4ah2JrNWuLlhCd",
+	"Y6IOapLSwRVEBeru63JRleGrk1mgwik4F2pFbmmWW9Y/e/vTRUi/7D4OUtpk/31srZtQZxT+DCI6Ufey",
+	"F3Uj1EJNZM7Im7LbFB1sjPOhMS43Ehr41ZTuH/fj68zPyD7l1lwGhKIhD7XRkUgEJxIyimmQS2+6dLXl",
+	"+n6a6JdK7adXFy/Qoe5gjiMx6YaOp8apw5jslRGyCJXOsR/n9Q1w7nzShSTIgkchuL9EvvEUcAa68ui7",
+	"Az/+7r4D2m6SMTKu0Pmfi7IeYV/2MF+qvFyKxAnOlQCIAyFPzAveSDrRL2zOXTHxAC/UP7tayFSi76Zs",
+	"XzLdTHYeKlTeR/ftyuZ2FF9B3DS9WChuAOe3d71JBdmQhOW8PLFt33ytMzVGUj1RkAUlr4C5uy3bDuTG",
+	"bYHmnHPwb+Odc0mZTdvq0sl2Vzd1IBzCgkarASvEk83h1mWSJ4vBN2oxeNLXP+nrN9PX+28B+wxw+oTO",
+	"58A924nvnpeuY3B7pHa0Him+6ex7IyH+PhVh5UFoG5dwuT7tohwUEGcgC8tZzq++HbqVD+rM9vJFkWpe",
+	"XDlr69nXQSRGEvydyoDTrf7VYRCblZkRvJnab4D1nzh6qFt526hgsq3TVVa5dwehblIBJtby9vSULm6u",
+	"KNfkLyKGb+fKU17RxSgD2miByb7F3Vkb701FF2G/ND2i9ZMbQBsuxbthGu50BpcmpLJT2XpfjOo6AFKX",
+	"9vqh3SACnu11nvMrU8uqBN7DX5Q9lfhsCb6A4nqt16axXYcK9N3Ly+IhxfInp5wnIX+Ur0dIXOmS5Iel",
+	"d8NxDKvcoC4zXNajytYuznwLlZk7snoHd/3NmuFG5VDT7irOZgl7PO7ITNpVBMDGV1cKTxOrUcbrI1IN",
+	"AC6NYJmGYfqJm/QKLp7GxXj8g2Zs9qnY2XkZvd19/cebD+/2Dt7j3/CPGflg6v7bTJqOaj9xFy1i4ziN",
+	"mEZJVEglUvLs9f9+2H/uahf9QOgZOkCUkTZTwvgn7kI8JdQAstHDzBzcWsKGOvPbdLdVRyWCQstiJg+r",
+	"wbBGJ4bqUywEZaS1On7vmZoc8J9D8dFYy56p1Ym+Iw0leaUX9PJQXAWaQ/6jYy2GCf9hhm0KAn/5S2Ut",
+	"m/3lL6RWrKGemknvVyVXVNXGzkATXiouzIuBknmBYc45JEAlYEhXGVbSGPLZP37b2js62PoZVv94/ok7",
+	"Ix1SBAoCeEvgeipMLpVC/fNenDK+h+FAbun6TNlEKA6hrya/bWHLrVOLAXfJmUAiNxByuv5hdJMt3Kr2",
+	"EKPAMCsN9i/U8sgY1fLXuN5xuzmMJG/gmyxRkx+zbkSKKS21TN7uvtYb69U3fTXZmb2Y7WB23Aw4zdjk",
+	"1eTlbGe2YwM0kWa3zSK2qmTQWZnzqV9u3TcVh01UMPVo1bf6/mCYJy+J7plme3tHB3/8/PZ/n/uWYM2S",
+	"kRAP4smryZGQyjtOcmJOKkj1WsQrG+GjrHMYJu0xVLz9T+shZETXwfJscOnXS2kEirr0DvaJgtjZ3Xlx",
+	"a7PvW7GgCUFPzRYrSdQSoesd/s6AFZqtBH9bN9JtX+yMaPsCKef7nRFtdSOfJaK+v+sU/f75+vN0Ios0",
+	"pfnKIyNvlU7B8+r3SZ06P+tZ6hS7/YVW6Dt4c20oN4GQEfMN/q6psTFbnfZMM5/69vwp8PTkNAWFGZ46",
+	"TBtVk+0agGjiaFDUdwOFesx6brjpZpahtt/dz6a7nVhj0/W9sK0FIbn9xTgTXG/TjG2dw6rBttpMShJq",
+	"Im79KF6TFogmxFaixozqmAqmgx25m0me4vTmmpFtcggELSLVIJvHyPiSyZcBtXWmM/UYyFDE1+c744ze",
+	"e+NhGGMTgABia2HCwSMyhtft7Kx/nF6OafvyHo9eUwLrYLS1c0AlwYPlHz78e8Sh2/5i5JFRTPfGJ9Ay",
+	"5fAZ3LOAPPRZnA7fBQ7ScddAjca7r4G7ovFHQbf2rrgx3Rp9ynZEeWQKCXTcGPjdZM1ifCvLhcm7pt9Y",
+	"mc1w2FCnmmRxmDbSqNSGLw+jNzZzPYobpEaJO7fGyXHduFizVls8KMDOTzyqJmaTEqw5j1qwr5N0zZqR",
+	"lDySoaXmdSzplnkCtjFfWift/swSS7ntDAYbEGkZMv+zy9L2LVOpXa1e60gq1ZvhF936SqlUrzhANP1k",
+	"6kneC+hKbqkH9fm2bJHdT6AqOfpG+zvSkFVJlC17X/9ml2rZ9qLW3Pa7eF51KZd+/6yFkgAJtDRtTarA",
+	"DWxuXkkKbvs/X097X15WPeSPE2Y9HhE8PWZuQclzz0Q29NII047PSdZ6TjReE12vhaHXwYMI61+Pzub2",
+	"mUpAlu/kKlRFAfcoYwod2v8j3fmWt//22VLLrDuKM+0MUJ41MD9RXo3yLN2M40lLoIkxzQRlm7/jZxOv",
+	"EpJozPfJKJ6hJXOr/WCSmInX3K5rf5012HAxXMQwQk4zzQKreW8/9Er/oQr/aI5274F/FYBJxuyDwH41",
+	"Ac/39gYYJSPq9d5MOjSovL8Le0jAxz12+xuS5vHb9hf9H3v9BmnlJzDDYGHPTlJ5j6OszW3N5BN9vr9G",
+	"0hqiKJNNcTwdYXUBS4lf4ZvyvUcmTYrrfDEsKV8AkWUMGjUYCL0XboPS7spyImIwcXRmQXrPr8feBXi8",
+	"LAbQRRKHuL/L/Ludv41p+7e7VpwZUvCw0cG5apmiS6bV77hQXnmNMjEgjX/MT29PyfbF7rZfTL3DTeEn",
+	"qOWV7L0iy2KcyK+MV78StlyFn1UcqmothYT8v+lZ9KnY2dn9K82y/85yEWO8OBaGQV04j8mFqeCTFlKR",
+	"MyAfjw8J8EjY4g4hLpm6YqI+k3yQ+/YQiyiUddRvcvG2NvQuzSM3IP865U8fQLHTxlR1vurZ0Qe0Oy4T",
+	"fpk33/PTbbNt/7DckaKnKsh/r1qe2rQBGd9V+6/c3u/Njve1EqqlMa9ocYBAa5fAdlpVFOh+7dhGXnCg",
+	"fwq6GbwrVzDA5/dFmtItmwYEYizo5yV7JgdvMA3AAmqQTKYTuMoSLe+40K0Q27aD/MFi2WtN6Q4rSOnV",
+	"gfn4YmenwWynk4KzfxVgG+CZuVPJOFgO4mYs3/gNO0J4OlZh/u+IMS1pevhwfbH/HNDQGnOSd2xDqtly",
+	"40/cmGuL8SU0Y9WzDTbsrHePX032oOSC29nPg6fd6oJKQDhbEXx4d/PXOyKFW+dWmzzlZSXePhFYncBO",
+	"1rjfPRa0bYNhur0hjnEDZEmBsSloYVJt1SsDmhpTtYRbpjRaPCOnp4e6CQbRwZUCbl9VPdJtScn7Fsab",
+	"EvTtS8oWsrWk5Z2HkJZdXldXEOx6+lByu6WIb83/7mFlfFuZUG7IBOYiP+/mAD+K/Nw/6q+MXSQTjJsy",
+	"2Q3pkTBOsGgmecaUPvRnOYN5sir5gystVWYTYErWK0ia6o1lRUiIieDYiosYpuQcIMN6j0qSgzfYDovH",
+	"2SLGXIkiWkL8HL+YhyKJRMEVulF4DjrmuU2VV7PS8TvBDfdKFJaTsdzDlIQ9nxKgGAeY51jdFlgZPFy+",
+	"Sy0yrOMY5vMyc2U5XGDp07KIJeZZY3wxI3uEC761u/PCqS9ToNwETbo6lHPK0KXPlIumHL2Az80pVwrS",
+	"TI3nrHprHyFbtfBp6FyyhaD698Xt69FqUxv/tWFdWpPH+QSO+fGWGJh5Lskl6D1z2/SDISNT1SeHTOTK",
+	"EJ5u/J9Y5jUSKXwDquoHZY/IwDbljS7980i1uBbXHSnorkYZXlOEt4YfpxkvD+2hyWi98aGdBpM5Yox1",
+	"s+wUQmcYZJnippTIGScpSxJWVYAN6lr04GEjoktq0F/es2UBMGVmvZpjfVB2QJWwlNWhKlP+vNjZ2Vm3",
+	"Buk9vJdw1zd5LZkM8U9SU9eTyWXQX48tDOlIfT5QqYdGnO5O/egNDnhZLc4c7irhFs2VO+oYRnRBk6lX",
+	"x3faqAVdLeSOTnpoWMAqfv5BHbE04PFmC1sP5Hsx7TXK8G5q2vNZwj0odv9MHGRD/e82B3Xpnl6hytrO",
+	"3W4JxDYlkeBztvBLtdPm+0u/YfD9JWsluMFEYOVF4tT7+muZ97w28Ix8SJlCmWDOIIlJlADNJWEq8LIo",
+	"AlzsvV3Zo31bWAANhvdx7ePUNwGdeO28OcdR/7gFN+9Jqr8VX9QGjtc+g6iU6FZ+HOnPjer6Y17W2O/x",
+	"kj+C1/u2HmH7MfqcmibPaFwo93S/T3R+Mzo3FLjp8zWHeQ5yCbJPw49NahzLqOidjs0U0xYkYRcwkv6P",
+	"y3kf7RmwIK57ChrSlVnmPdmnHhdlOsLZnDalS4s3MlvSMfbYgB2bjo+QFg1g8eP3t+q22zyx9s0PEJLz",
+	"pufHqZkHM/cQSjLIJZOYXtF1q7wN7Zj/KcvHAlpgZuTEzeDudOdva40qdXOKSe6A85AzWAmr+RY5WzBM",
+	"UFJOk7A56EtlrJ2ihOPx3iYORO86udeTbKfHwpghnYDb9PvP8fMnsL9aH0uL47UPsj4KouhxwjgBY2m1",
+	"DSsNnnvx17g1SxJjDwVy5TRenmsxqxKO2vMwI/s0SUyWVSZJCmopYpIWiWJZAjZHsbiA/DJnyqoVTk8P",
+	"rRUUByykS9LqWEillLNZX52Vk1jLsSApUFnYKrFuabFTQYxkDacWd4+WMVgAbyRmSrv/bosdwTydxbZO",
+	"zlO8q5I2Os+jf4X2h3aWTb0E8IEUMD+B6rmteryRG6F2DR8ME99SwXC2IlIUeQSeR3Q4l9bwQJjcWuTk",
+	"4M2UCGxINdEputj6V0ETk+/Gq8PoOn+aTF0VRppu1z6UBRrdT7ZAY4fpwCYK7o6hGc4JltGFTSl9iLa9",
+	"tbq8hytlU4fej0q/dltvqtGXHp2ZxLc48W9bejlbZaLuECC2+fZv3sqv/1Su2x7uSuZQ/tZgDttf3D+H",
+	"vaWsLCA4HqlU5NB0OKJ44GLP5whvbyegufAzcan32KsyYKPV0NvnTOizy3gMGfAYuEpWvjifeuNpqRyF",
+	"PYilBmlOWdLo+oOR0423iZYN8F5n0vqkGFs/U9J6qpTCg9lkjM3ouK4dBkuC39DlqOz+5HPkvc9v7FP0",
+	"JPLfzKcoIPA3eAjmoBuX3yvoIHBqP9xPVq+b5/O6z4wNzUIBQ1TQkZqrFhWtm3o7V2UPHOPw4cfE9QmI",
+	"XnbATd09bC7AJ1+Pb8vXQxPFbTh6YIaee/HyGJ/B+Wtl9ac+LtdgFdspveplF0iN1psxxDpcuUITXuto",
+	"exxDeUevnnjKo+cp00B6i5xFWD9S/wsuoEYlmKHCBjp35KPIsXpWd0yzqz4eCW41dX/4gdsuNBo344+c",
+	"KggUIb9Tf9d39Mrngk9c72G4nnOzViO4n8lVsVH2mKpzkK1VH0co0sr8yF2HPVQPz6/ed78pW9zqbip0",
+	"Oxw9pPpmXVH8zjLtVgTjKLX6rZ6IZY26TL3ZWHwivQvFRK1s6FrWxd1bh+EQFjTqVEeYUsEYiBZFkCnn",
+	"+/XoMkfcIrWGU/ZWRTYDRFjjmdu2zuX2F/xHd9rA/SVE54TNveqbTC2tbGjqo8IVk6qfkdoyufifDqZa",
+	"zzlPbctugaKZRNVC5zrep+jgJsfllTWRh9ipvkVMRn9X23xloV+beh9dOZuHNYsjyaoWRQyeiaoOf2/6",
+	"6spATRfOwN0pTpg+5UE4pYu7Ytj1mfREa3HtkOOtXt83WrjmQSm0zKRtSVTRWigY/rc7fdse1qnXnZ7J",
+	"56aYbMVDsMh3r7xwhyRoINuYBF/cMiAQ+6AExQe6KMv+P1H4LVK4o9F+Cq+z3y9VRe6xVQQ65OMm061V",
+	"+l5TN1V2HZ+oqlao/DZqCXxjb6YG++t8NPXbrhpFmTpIwZdCb4kONvTw2MCX5D6E1l+ZWr62dbrWU3r5",
+	"7wGmpKv29eQUsqn6oMJghxKhqqrRr0Uo6yV06Q/0QHfCHu9OD2HWtJY8sTOCPXcX3PgKEk8+PCtvU9rN",
+	"9F/HYLQ5lI/Ufn0dxPv1KtG+asWYo6a1NGO+GOrqjn7B/1q5dCwtY34bvCvHvMrKSc1l/NpMeMeCil1W",
+	"SNLYDTNPg9AllcYM+02Qid2o5hv6hqTSTuHUMsTXZnQJYcbIrzUa2Sgx04Z0cr9JnKIil2h0/pqyOIWS",
+	"OJlZ7edNvAlilkOEa5iOZPuaKt6UvToHTuACixiPHvQQOwRQe2LiAsbs/jwXaZc3Bo6y1irNxPek48cz",
+	"p2cdrecPv5q8I/841UcdzPaBXaJCDPOmfNrWqFmDU3eV0Bri1CeuGs7D8OoDHsOVO6BlWFyJy87jWmbt",
+	"8eSoIC8RC/lhPpfQwRzXzm/3zbDvjbnsvbG0zgDeQVb2xL825V+t4lgjOdicJfqnJZXL/np/lJMiSwSN",
+	"ScL4uVOV0pzoEYgmIsq4xwPoCsy3sXLoj7rt36lc3pSnBVwAlmbYsR4AGgrH29wShp0AXtzNadJ4+YiY",
+	"73pv+/tyuYQcE93YH/F02V36BgxRX8FJxPNgsf/x+HD9I+lcBwbCbdBhYBODhTXa3qbx6g5dC0/p4qZx",
+	"BL7d8A7dZP8Mtti6jaHbEusnix4Rl95XduuX3W+5smJndHsJ6NmqHomrrG/QqCphyrCFzaI5T1TQtXc6",
+	"kWqV6B+0dPs12TAfvgzlrRg0p5Pftk6FosnWsa2FMtQZW7vG1iD6VAytqxia5g4Xu897cm705sIflVC7",
+	"S0HrcbuvNFv+V6loHXqq76wLc6kuHYPZDpBvRVHbQKVZBKpoUJFg47SKnM+I7k3OIBGXJomSaUBzIHAV",
+	"JUXcjdtbU/zuUwlbErhkil0AkcWZuSlJSlW0JIIj5ClISRfm1akZf8flBzSPljWwUnp1CHyhGcDu93+9",
+	"X89urwjCL7ubaXyfyiGML4cwgoWHo77Wj/H6ZffBory+MdnrtuPJbtF/7BsLw3xs0W7N43rXIW/1M3tf",
+	"/jq/7D52j52qSNxTVfJRGTNLZUgPATfvm5Z7uueNubbvpUfJ37b35Z0A0S2GPbl33ql758bnZcCPbl2v",
+	"ueDxeTi/uTu+hxAja91Cj8tt72GfFwHfvkEyfll/ZgzkOB+WW14+iNzy8qHkFguAY9QOkMclwvwZkqm0",
+	"xZ2XvXQvkiKFkWkDiWsdelyXn+7++WnmWvvxmaDFoL2aP1fcUW0bHVm4X7ojkBusrxwlzP08Yrh9zvce",
+	"Lh0F3G+IsZl1j8eexqGH3lz9gzbOnp5p3XzLp6w2eXo8a/uL+cf40OFuojWNLNn+YoddW6B08IyMG64R",
+	"i4sZpm1CeVIeByOJ+wll2ufZW3btdOu9S1LYeSiG5BL9PVHZuEycfXwIwc0vHDkUeTJ5NVkqlclX29s0",
+	"YzPYPZvRLEMCsP2/VIaFKpPal0ZxhvqPmPzO/xu3c0vp/a43zNjWOaxqv1lPqvLvUuD5fP3/AgAA//8=",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/packages/api/internal/handlers/snapshot_fork.go
+++ b/packages/api/internal/handlers/snapshot_fork.go
@@ -1,0 +1,208 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/e2b-dev/infra/packages/api/internal/api"
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	apiorch "github.com/e2b-dev/infra/packages/api/internal/orchestrator"
+	"github.com/e2b-dev/infra/packages/api/internal/sandbox"
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/clusters"
+	"github.com/e2b-dev/infra/packages/shared/pkg/ginutils"
+	"github.com/e2b-dev/infra/packages/shared/pkg/id"
+	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+	sharedUtils "github.com/e2b-dev/infra/packages/shared/pkg/utils"
+)
+
+// PostSnapshotsSnapshotIDFork creates count new sandboxes from a named
+// snapshot template. No running sandbox is required: the snapshot must exist
+// as a persistent snapshot template owned by the team. Each fork boots
+// independently from the same snapshot and succeeds or fails independently.
+func (a *APIStore) PostSnapshotsSnapshotIDFork(c *gin.Context, rawSnapshotID api.SnapshotID) {
+	ctx := c.Request.Context()
+
+	teamInfo := auth.MustGetTeamInfo(c)
+	teamID := teamInfo.Team.ID
+
+	// snapshotID may arrive URL-encoded when the alias contains a slash.
+	snapshotID, err := url.PathUnescape(rawSnapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid snapshot ID")
+		return
+	}
+
+	span := trace.SpanFromContext(ctx)
+	traceID := span.SpanContext().TraceID().String()
+	c.Set("traceID", traceID)
+
+	body, err := ginutils.ParseOptionalBody[api.PostSnapshotsSnapshotIDForkJSONRequestBody](ctx, c)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Error when parsing request: %s", err))
+		return
+	}
+
+	forkTimeout := sandbox.SandboxTimeoutDefault
+	if body.Timeout != nil {
+		forkTimeout = time.Duration(*body.Timeout) * time.Second
+		if forkTimeout > time.Duration(teamInfo.Limits.MaxLengthHours)*time.Hour {
+			a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Timeout cannot be greater than %d hours", teamInfo.Limits.MaxLengthHours))
+			return
+		}
+	}
+
+	forkCount := 1
+	if body.Count != nil {
+		forkCount = int(*body.Count)
+	}
+
+	if forkCount < 1 {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Count must be at least 1")
+		return
+	}
+
+	if forkCount > maxForkCount {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Count cannot be greater than %d", maxForkCount))
+		return
+	}
+
+	if int64(forkCount) >= teamInfo.Limits.SandboxConcurrency {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Count must be lower than the maximum number of concurrent sandboxes (%d)", teamInfo.Limits.SandboxConcurrency))
+		return
+	}
+
+	// Resolve snapshotID (may be templateID:tag or namespace/alias:tag).
+	identifier, tag, err := id.ParseName(snapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid snapshot ID: %s", err))
+		return
+	}
+
+	if err := id.ValidateNamespaceMatchesTeam(identifier, teamInfo.Slug); err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	aliasInfo, resolveErr := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Slug)
+	if resolveErr != nil {
+		apiErr := templatecache.ErrorToAPIError(resolveErr, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		return
+	}
+
+	if aliasInfo.TeamID != teamID {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	templateID := aliasInfo.TemplateID
+	tagStr := id.DefaultTag
+	if tag != nil {
+		tagStr = *tag
+	}
+
+	// Look up the source sandboxID for this snapshot template.
+	snapTemplates, dbErr := a.sqlcDB.ListTeamSnapshotTemplates(ctx, queries.ListTeamSnapshotTemplatesParams{
+		TeamID:     teamID,
+		EnvID:      &templateID,
+		Tag:        &tagStr,
+		CursorTime: time.Now().Add(24 * time.Hour),
+		CursorID:   maxSnapshotTemplateID,
+		PageLimit:  1,
+	})
+	if dbErr != nil {
+		telemetry.ReportCriticalError(ctx, "error looking up snapshot template", dbErr)
+		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error looking up snapshot")
+		return
+	}
+
+	if len(snapTemplates) == 0 {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	// Fetch build data via templateCache. This path uses env_build_assignments
+	// for the persistent template env — it does not depend on the ephemeral
+	// snapshot env (source='snapshot') which is soft-deleted when the original
+	// sandbox is killed.
+	clusterID := clusters.WithClusterFallback(teamInfo.Team.ClusterID)
+	env, build, cacheErr := a.templateCache.Get(ctx, templateID, &tagStr, teamID, clusterID)
+	if cacheErr != nil {
+		visible := aliasInfo.TeamID == teamID
+		ref := templatecache.TemplateRef{Identifier: aliasInfo.MatchedIdentifier, Visible: visible}
+		apiErr := ref.APIError(cacheErr)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		return
+	}
+
+	if vErr := sharedUtils.CheckEnvdVersionForSnapshot(sharedUtils.DerefOrDefault(build.EnvdVersion, "")); vErr != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, vErr.Error())
+		return
+	}
+
+	sourceSandboxID := snapTemplates[0].SandboxID
+	alias := ""
+	if len(env.Names) > 0 {
+		alias = env.Names[0]
+	}
+
+	sbxlogger.E(&sbxlogger.SandboxMetadata{
+		TemplateID: templateID,
+		TeamID:     teamID.String(),
+	}).Debug(ctx, fmt.Sprintf("Forking %d sandbox(es) from snapshot %s (source sandbox %s)", forkCount, snapshotID, sourceSandboxID))
+
+	// Boot all forks in parallel from the same immutable snapshot checkpoint.
+	results := make([]api.SandboxForkResult, forkCount)
+
+	wg := errgroup.Group{}
+	for i := range forkCount {
+		wg.Go(func() error {
+			forkedSandboxID := InstanceIDPrefix + id.Generate()
+
+			getSandboxData := func(_ context.Context) (apiorch.SandboxMetadata, *api.APIError) {
+				return apiorch.SandboxMetadata{
+					Build:          *build,
+					TemplateID:     env.TemplateID,
+					BaseTemplateID: env.TemplateID,
+					Alias:          alias,
+					// SnapshotSandboxID is set so that placement remapping on
+					// resume-timeout uses the right sandbox ID.
+					SnapshotSandboxID: sourceSandboxID,
+				}, nil
+			}
+
+			forkedSbx, createErr := a.startSandbox(
+				ctx,
+				forkedSandboxID,
+				forkTimeout,
+				teamInfo,
+				getSandboxData,
+				&c.Request.Header,
+				true, // isResume: restore checkpoint
+				nil,  // mcp
+			)
+			if createErr != nil {
+				telemetry.ReportError(ctx, "error creating sandbox from snapshot fork", createErr.Err, telemetry.WithSandboxID(forkedSandboxID))
+				results[i] = api.SandboxForkResult{Error: &api.Error{Code: int32(createErr.Code), Message: createErr.ClientMsg}}
+				//nolint:nilerr
+				return nil
+			}
+
+			results[i] = api.SandboxForkResult{Sandbox: forkedSbx}
+			return nil
+		})
+	}
+	_ = wg.Wait()
+
+	c.JSON(http.StatusCreated, results)
+}

--- a/packages/api/internal/handlers/snapshot_fork.go
+++ b/packages/api/internal/handlers/snapshot_fork.go
@@ -76,8 +76,8 @@ func (a *APIStore) PostSnapshotsSnapshotIDFork(c *gin.Context, rawSnapshotID api
 		return
 	}
 
-	if int64(forkCount) >= teamInfo.Limits.SandboxConcurrency {
-		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Count must be lower than the maximum number of concurrent sandboxes (%d)", teamInfo.Limits.SandboxConcurrency))
+	if int64(forkCount) > teamInfo.Limits.SandboxConcurrency {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Count must not exceed the maximum number of concurrent sandboxes (%d)", teamInfo.Limits.SandboxConcurrency))
 		return
 	}
 

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -2884,6 +2884,47 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /snapshots/{snapshotID}/fork:
+    post:
+      summary: Fork snapshot
+      description: >-
+        Create one or more sandboxes from a named snapshot. The snapshot must be
+        owned by the team. Each fork boots independently from the same snapshot
+        and succeeds or fails independently; the outcome of each is reported in
+        its entry of the response list.
+      tags: [snapshots]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/snapshotID"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SandboxForkRequest"
+      responses:
+        "201":
+          description: The forks were attempted; each entry reports one fork's outcome
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SandboxForkResult"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
   /v3/templates:
     post:
       summary: Create template (v3)


### PR DESCRIPTION
## Problem

RL/agent training workloads need to run many evaluation batches from a single checkpoint, but there was no way to do this efficiently.

The typical pattern (from issue #3424):

```
1. Create sandbox → install deps, load model weights  (expensive, done once)
2. POST /sandboxes/{id}/snapshots  →  "team/rl-checkpoint-v1"
3. DELETE /sandboxes/{id}          →  original no longer needed
4. For each training batch:
     POST /snapshots/team%2Frl-checkpoint-v1/fork?count=32
     ... run rollouts ...
     DELETE each episode sandbox
5. Repeat step 4 indefinitely from the same checkpoint
```

Before this PR, step 4 failed after step 3. The only alternatives were:

- **Keep the source alive** — wastes resources for the entire training run
- **Fork from running sandbox** (`POST /sandboxes/{id}/fork`) — requires source to still be running
- **Create N fresh sandboxes** — no shared checkpoint state; model weights must be loaded again every batch

## Solution

New endpoint: **`POST /snapshots/{snapshotID}/fork`**

```http
POST /snapshots/team%2Frl-checkpoint-v1/fork
X-API-Key: ...
Content-Type: application/json

{ "count": 32, "timeout": 300 }
```

Response (201) — one entry per fork, each independently succeeded or failed:

```json
[
  { "sandbox": { "sandboxID": "iabc...", "templateID": "xyz...", ... } },
  { "sandbox": { "sandboxID": "idef...", "templateID": "xyz...", ... } },
  ...
]
```

Partial batches are still useful — a single failed fork doesn't abort the others.

## Key implementation detail: why `templateCache` not `snapshotCache`

Ephemeral pause snapshots (`source = 'snapshot'` in the `envs` table) are **soft-deleted when the sandbox is killed** — `deleted_at` is set, `active_envs` JOIN returns nothing, and `snapshotCache.Get` returns 404.

Named snapshot templates (`source = 'snapshot_template'`) are **persistent** — they survive sandbox deletion and are never touched by the kill path. This handler resolves the alias via `templateCache.ResolveAlias` then fetches build data from `env_build_assignments` for the persistent template env. This is exactly the same code path `POST /sandboxes` uses to boot from a template, so cluster routing, envd-version checks, and placement logic are all inherited automatically.

## Verified end-to-end on dev

Full RL training simulation: create sandbox → snapshot → **kill original** → fork 3 batches (3 + 3 + 5 forks) from the same checkpoint:

```
Step 1: Create sandbox                     HTTP 201  sandboxID: i47hue0e3nf7gvp8m44bw
Step 2: Snapshot → 972963285/rl-checkpoint HTTP 201
Kill original sandbox                      HTTP 204

Batch 1: fork 3 sandboxes                 HTTP 201  forks=3 errors=0
  [kill 3]                                all 204
Batch 2: fork 3 sandboxes                 HTTP 201  forks=3 errors=0
  [kill 3]                                all 204
Batch 3: fork 5 sandboxes                 HTTP 201  forks=5 errors=0
  [kill 5]                                all 204

Checkpoint still listed after all batches: True
```

Fixes #3424 (Proposal B).

/cc @ben-fornefeld @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.