### PR TITLE
test(integration): run the Alpine distro build with a musl-capable envd

### DIFF
--- a/packages/envd/Makefile
+++ b/packages/envd/Makefile
@@ -7,6 +7,7 @@ ENV := $(shell cat ../../.last_used_env || echo "not-set")
 BUILD := $(shell git rev-parse HEAD | cut -c1-7)
 LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD)"
 PROD_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -s -w -buildid="
+DEBUG_LDFLAGS=-ldflags "-X=main.commitSHA=$(BUILD) -linkmode external -extldflags=-static"
 
 AWS_BUCKET_PREFIX ?= $(PREFIX)$(AWS_ACCOUNT_ID)-
 GCP_BUCKET_PREFIX ?= $(GCP_PROJECT_ID)-
@@ -71,8 +72,12 @@ endif
 build:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(BUILD_ARCH) go build -trimpath -buildvcs=false -a -o bin/envd ${PROD_LDFLAGS}
 
+# This binary is injected into every sandbox guest, including musl ones, so it
+# must not need a dynamic loader; -race requires cgo, hence the static external
+# link. osusergo/netgo keep user and DNS lookups pure Go, as in the CGO_ENABLED=0
+# build above, so only the race instrumentation differs from what ships.
 build-debug:
-	CGO_ENABLED=1 go build -race -gcflags=all="-N -l" -o bin/debug/envd ${LDFLAGS}
+	CGO_ENABLED=1 go build -race -tags osusergo,netgo -gcflags=all="-N -l" -o bin/debug/envd ${DEBUG_LDFLAGS}
 
 start-docker:
 	make build

--- a/tests/integration/internal/tests/api/templates/distro_build_test.go
+++ b/tests/integration/internal/tests/api/templates/distro_build_test.go
@@ -22,7 +22,6 @@ func TestTemplateBuildDistroFamilies(t *testing.T) {
 		name         string
 		templateName string
 		fromImage    string
-		skipReason   string
 	}{
 		{
 			name:         "Debian family",
@@ -43,22 +42,12 @@ func TestTemplateBuildDistroFamilies(t *testing.T) {
 			name:         "Alpine on OpenRC",
 			templateName: "test-distro-alpine",
 			fromImage:    "alpine:3.24",
-			// The integration host installs the envd from `make build-debug`, and
-			// -race requires cgo, so that binary is glibc-linked and cannot exec
-			// on musl: envd never answers and the base layer times out. Released
-			// envd is built with CGO_ENABLED=0 and runs on Alpine. Drop this once
-			// the host installs a static envd.
-			skipReason: "host envd is glibc-linked; a musl guest cannot exec it",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
-			if tc.skipReason != "" {
-				t.Skip(tc.skipReason)
-			}
 
 			var logMessages []string
 			logHandler := func(alias string, entry api.BuildLogEntry) {


### PR DESCRIPTION
`make build-debug` builds envd with `-race`, which needs cgo, so the binary the integration host injects into every guest is dynamically linked against glibc — and a musl guest has no loader for it. envd never answers, the base layer times out and the build dies with a masked internal error, which is why the Alpine case was skipped. Linking it statically fixes that; `osusergo,netgo` keep user and DNS lookups pure Go as in the `CGO_ENABLED=0` binary we ship, so only the race instrumentation differs. The detector is intact (297 `__tsan` symbols; a deliberate racy program built with the same flags still reports on musl), and guest console output reaches `orchestrator.log`, so the workflow's data-race grep keeps covering envd.

Checked on a KVM dev stack, cold cache each time: with the old binary ubuntu/fedora/arch pass and alpine fails on `wait for envd: syncing took too long`; with the static one all four pass (alpine 30s). `envd -version` also runs under `alpine:3.24`, where the old binary gives `exec: no such file or directory`.
