### PR TITLE
fix(orch): validate copy-build -gdb buckets before the snapshot copy

### DIFF
--- a/packages/orchestrator/cmd/copy-build/main.go
+++ b/packages/orchestrator/cmd/copy-build/main.go
@@ -299,10 +299,17 @@ func main() {
 	if *teamID != "" && *envdVersion == "" {
 		log.Fatal("-envd-version is required when -team is set")
 	}
-	// Validate -gdb's gs:// precondition up front (deriveArtifactBuckets needs it), so a
-	// wrong invocation fails instantly rather than after the multi-GB snapshot copy.
-	if *gdb && (!strings.HasPrefix(*from, "gs://") || !strings.HasPrefix(*to, "gs://")) {
-		log.Fatal("-gdb requires gs:// -from and -to (it stages debug artifacts between bucket environments)")
+	// Validate the -gdb bucket preconditions up front, so a wrong invocation fails
+	// instantly rather than after the multi-GB snapshot copy. deriveArtifactBuckets
+	// checks both the gs:// scheme and the *-fc-templates suffix it needs to map the
+	// template bucket to its versions/kernels siblings.
+	if *gdb {
+		if _, _, err := deriveArtifactBuckets(*from); err != nil {
+			log.Fatalf("-gdb -from: %s", err)
+		}
+		if _, _, err := deriveArtifactBuckets(*to); err != nil {
+			log.Fatalf("-gdb -to: %s", err)
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "Copying build '%s' from '%s' to '%s'\n", *buildId, *from, *to)


### PR DESCRIPTION
## Why

Follow-up to #3108. The `-gdb` fail-fast precondition sits next to `flag.Parse()` specifically so a misconfigured invocation fails **before** the multi-GB snapshot copy. It only checked the `gs://` scheme, but `copyGdbArtifacts` → `deriveArtifactBuckets` has a second precondition: the bucket must end in `-fc-templates` (to map the template bucket to its `-fc-versions`/`-fc-kernels` siblings). That suffix check only fired deep inside the run, so `copy-build -gdb -from gs://a-fc-templates -to gs://some-other-bucket` passed the up-front check, copied the entire snapshot chain, printed "Build copied", and *then* `log.Fatal`ed — the exact wasted-bandwidth pattern the scheme hoist was meant to prevent.

Impact is bounded (a developer-only side tool; wasted time/bandwidth, no data or production impact), so this is a consistency fix rather than a bug fix — completing the fail-fast for the sibling precondition.

## What

Replace the scheme-only check with `deriveArtifactBuckets(*from)`/`(*to)` up front. That single validator covers **both** the `gs://` scheme and the `*-fc-templates` suffix, and its error names the offending side (`-gdb -from:` / `-gdb -to:`). The redundant scheme check is dropped.

## Validation

- `go build` / `go vet` / `golangci-lint` (0 issues) / `gofmt` clean.
- Manual, confirming failure now precedes any copy:
  - `-to gs://my-custom-bucket` → `-gdb -to: cannot derive versions/kernels buckets from "gs://my-custom-bucket" (expected a *-fc-templates bucket)` — before "Copying build".
  - `-to /local/out` → `-gdb -to: -gdb requires a gs:// location, got "/local/out"`.
  - Both `*-fc-templates` → validation passes, proceeds to the copy as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
