### PR TITLE
feat(api): Snapshot complete CRUD + enhanced SnapshotInfo

### DIFF
--- a/packages/api/internal/api/api.gen.go
+++ b/packages/api/internal/api/api.gen.go
@@ -1053,6 +1053,18 @@ type SandboxesWithMetrics struct {
 
 // SnapshotInfo defines model for SnapshotInfo.
 type SnapshotInfo struct {
+	// CpuCount CPU cores for the sandbox
+	CpuCount CPUCount `json:"cpuCount"`
+
+	// CreatedAt Time when the snapshot was created
+	CreatedAt time.Time `json:"createdAt"`
+
+	// DiskSizeMB Disk size for the sandbox in MiB
+	DiskSizeMB DiskSizeMB `json:"diskSizeMB"`
+
+	// MemoryMB Memory for the sandbox in MiB
+	MemoryMB MemoryMB `json:"memoryMB"`
+
 	// Names Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2)
 	Names []string `json:"names"`
 
@@ -1517,6 +1529,9 @@ type PaginationNextToken = string
 
 // SandboxID defines model for sandboxID.
 type SandboxID = string
+
+// SnapshotID Identifier of the snapshot (template ID)
+type SnapshotID = string
 
 // TeamID defines model for teamID.
 type TeamID = string
@@ -2103,6 +2118,12 @@ type ClientInterface interface {
 
 	// GetSnapshots request
 	GetSnapshots(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteSnapshotsSnapshotID request
+	DeleteSnapshotsSnapshotID(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetSnapshotsSnapshotID request
+	GetSnapshotsSnapshotID(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTeams request
 	GetTeams(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -2727,6 +2748,30 @@ func (c *Client) PostSandboxesSandboxIDTimeout(ctx context.Context, sandboxID Sa
 
 func (c *Client) GetSnapshots(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetSnapshotsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteSnapshotsSnapshotID(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteSnapshotsSnapshotIDRequest(c.Server, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetSnapshotsSnapshotID(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSnapshotsSnapshotIDRequest(c.Server, snapshotID)
 	if err != nil {
 		return nil, err
 	}
@@ -4588,6 +4633,74 @@ func NewGetSnapshotsRequest(server string, params *GetSnapshotsParams) (*http.Re
 	return req, nil
 }
 
+// NewDeleteSnapshotsSnapshotIDRequest generates requests for DeleteSnapshotsSnapshotID
+func NewDeleteSnapshotsSnapshotIDRequest(server string, snapshotID SnapshotID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "snapshotID", snapshotID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/snapshots/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetSnapshotsSnapshotIDRequest generates requests for GetSnapshotsSnapshotID
+func NewGetSnapshotsSnapshotIDRequest(server string, snapshotID SnapshotID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "snapshotID", snapshotID, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/snapshots/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetTeamsRequest generates requests for GetTeams
 func NewGetTeamsRequest(server string) (*http.Request, error) {
 	var err error
@@ -6256,6 +6369,12 @@ type ClientWithResponsesInterface interface {
 	// GetSnapshotsWithResponse request
 	GetSnapshotsWithResponse(ctx context.Context, params *GetSnapshotsParams, reqEditors ...RequestEditorFn) (*GetSnapshotsResponse, error)
 
+	// DeleteSnapshotsSnapshotIDWithResponse request
+	DeleteSnapshotsSnapshotIDWithResponse(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*DeleteSnapshotsSnapshotIDResponse, error)
+
+	// GetSnapshotsSnapshotIDWithResponse request
+	GetSnapshotsSnapshotIDWithResponse(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*GetSnapshotsSnapshotIDResponse, error)
+
 	// GetTeamsWithResponse request
 	GetTeamsWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetTeamsResponse, error)
 
@@ -7339,6 +7458,71 @@ func (r GetSnapshotsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetSnapshotsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteSnapshotsSnapshotIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteSnapshotsSnapshotIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteSnapshotsSnapshotIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteSnapshotsSnapshotIDResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetSnapshotsSnapshotIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SnapshotInfo
+	JSON401      *N401
+	JSON404      *N404
+	JSON500      *N500
+}
+
+// Status returns HTTPResponse.Status
+func (r GetSnapshotsSnapshotIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetSnapshotsSnapshotIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetSnapshotsSnapshotIDResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -8644,6 +8828,24 @@ func (c *ClientWithResponses) GetSnapshotsWithResponse(ctx context.Context, para
 		return nil, err
 	}
 	return ParseGetSnapshotsResponse(rsp)
+}
+
+// DeleteSnapshotsSnapshotIDWithResponse request returning *DeleteSnapshotsSnapshotIDResponse
+func (c *ClientWithResponses) DeleteSnapshotsSnapshotIDWithResponse(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*DeleteSnapshotsSnapshotIDResponse, error) {
+	rsp, err := c.DeleteSnapshotsSnapshotID(ctx, snapshotID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteSnapshotsSnapshotIDResponse(rsp)
+}
+
+// GetSnapshotsSnapshotIDWithResponse request returning *GetSnapshotsSnapshotIDResponse
+func (c *ClientWithResponses) GetSnapshotsSnapshotIDWithResponse(ctx context.Context, snapshotID SnapshotID, reqEditors ...RequestEditorFn) (*GetSnapshotsSnapshotIDResponse, error) {
+	rsp, err := c.GetSnapshotsSnapshotID(ctx, snapshotID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetSnapshotsSnapshotIDResponse(rsp)
 }
 
 // GetTeamsWithResponse request returning *GetTeamsResponse
@@ -10346,6 +10548,93 @@ func ParseGetSnapshotsResponse(rsp *http.Response) (*GetSnapshotsResponse, error
 	return response, nil
 }
 
+// ParseDeleteSnapshotsSnapshotIDResponse parses an HTTP response from a DeleteSnapshotsSnapshotIDWithResponse call
+func ParseDeleteSnapshotsSnapshotIDResponse(rsp *http.Response) (*DeleteSnapshotsSnapshotIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteSnapshotsSnapshotIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetSnapshotsSnapshotIDResponse parses an HTTP response from a GetSnapshotsSnapshotIDWithResponse call
+func ParseGetSnapshotsSnapshotIDResponse(rsp *http.Response) (*GetSnapshotsSnapshotIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetSnapshotsSnapshotIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SnapshotInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest N401
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest N404
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest N500
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetTeamsResponse parses an HTTP response from a GetTeamsWithResponse call
 func ParseGetTeamsResponse(rsp *http.Response) (*GetTeamsResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -11719,6 +12008,12 @@ type ServerInterface interface {
 	// List snapshots
 	// (GET /snapshots)
 	GetSnapshots(c *gin.Context, params GetSnapshotsParams)
+	// Delete snapshot
+	// (DELETE /snapshots/{snapshotID})
+	DeleteSnapshotsSnapshotID(c *gin.Context, snapshotID SnapshotID)
+	// Get snapshot
+	// (GET /snapshots/{snapshotID})
+	GetSnapshotsSnapshotID(c *gin.Context, snapshotID SnapshotID)
 	// List teams
 	// (GET /teams)
 	GetTeams(c *gin.Context)
@@ -12798,6 +13093,76 @@ func (siw *ServerInterfaceWrapper) GetSnapshots(c *gin.Context) {
 	}
 
 	siw.Handler.GetSnapshots(c, params)
+}
+
+// DeleteSnapshotsSnapshotID operation middleware
+func (siw *ServerInterfaceWrapper) DeleteSnapshotsSnapshotID(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "snapshotID" -------------
+	var snapshotID SnapshotID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "snapshotID", c.Param("snapshotID"), &snapshotID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter snapshotID: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(string(ApiKeyAuthScopes), []string{})
+
+	c.Set(string(AuthProviderBearerAuthScopes), []string{})
+
+	c.Set(string(AuthProviderTeamAuthScopes), []string{})
+
+	c.Set(string(AdminApiKeyAuthScopes), []string{})
+
+	c.Set(string(AdminTeamAuthScopes), []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.DeleteSnapshotsSnapshotID(c, snapshotID)
+}
+
+// GetSnapshotsSnapshotID operation middleware
+func (siw *ServerInterfaceWrapper) GetSnapshotsSnapshotID(c *gin.Context) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "snapshotID" -------------
+	var snapshotID SnapshotID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "snapshotID", c.Param("snapshotID"), &snapshotID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter snapshotID: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(string(ApiKeyAuthScopes), []string{})
+
+	c.Set(string(AuthProviderBearerAuthScopes), []string{})
+
+	c.Set(string(AuthProviderTeamAuthScopes), []string{})
+
+	c.Set(string(AdminApiKeyAuthScopes), []string{})
+
+	c.Set(string(AdminTeamAuthScopes), []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetSnapshotsSnapshotID(c, snapshotID)
 }
 
 // GetTeams operation middleware
@@ -14008,6 +14373,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/sandboxes/:sandboxID/snapshots", wrapper.PostSandboxesSandboxIDSnapshots)
 	router.POST(options.BaseURL+"/sandboxes/:sandboxID/timeout", wrapper.PostSandboxesSandboxIDTimeout)
 	router.GET(options.BaseURL+"/snapshots", wrapper.GetSnapshots)
+	router.DELETE(options.BaseURL+"/snapshots/:snapshotID", wrapper.DeleteSnapshotsSnapshotID)
+	router.GET(options.BaseURL+"/snapshots/:snapshotID", wrapper.GetSnapshotsSnapshotID)
 	router.GET(options.BaseURL+"/teams", wrapper.GetTeams)
 	router.GET(options.BaseURL+"/teams/:teamID/metrics", wrapper.GetTeamsTeamIDMetrics)
 	router.GET(options.BaseURL+"/teams/:teamID/metrics/max", wrapper.GetTeamsTeamIDMetricsMax)
@@ -14050,205 +14417,208 @@ var swaggerSpec = []string{
 	"mSCSMIWuF4QFxr0mgiBB/p0TqUg8+cQqS5hxkWI12htRpl7vjsZuTZQpMididKtXlWGBU6IsVnEUESkB",
 	"rUeH+geql5ZhtRiNRwynunu1zXik56eCxKM9JXLSjUOc0Z/Jsn1o93m1Uac5TeLWQd3X1cZkPCatQ9qP",
 	"q41Y7vMxTalqUtB7fEPTPEWsoCSqSCo1HQuicsFQRgTQ8GhsoPp3TsSyBCuBcX0oYjLDeaJGe692dsZN",
-	"gkjNjPZzSpn9K0AqPvyDjp5UWCgg+IRKhWaCpy1gs2K4bgRaum/dlfL7ahujCE5bB7UfVx0xzRKsSMeo",
-	"RYPVRr7iSZ62j1t8XmXUW91YZpxJAkzgu50d/Z+IM0UY0CkwpQj2fvtfksO+l+P9lyCz0d7o/9sumfW2",
-	"+Sq33wrBLaepEsobHDvONbodj77befXwc+7nakGYsqMiYtrpyV8//OTvuJjSOCbMzPjdw894whWa8ZzF",
-	"ZsYfHn7GA85mCY3Mjr7aABX9xBnRk32/CZI9J+KKCEc2t+5IwZnZ//X8jMypVGKp/8wEz4hQ1BwofC33",
-	"4dLUl1vcZJr7v54j0wD9TJbo6BDNuEBvD84QrlBseYW7szvWY+uJOQsPa75p+UEQYMZ6VGEh1fJGwiOs",
-	"SNwy9DmJBFEF8OE5TCN/BcPBNz/UR71YZlZOs4A2BiJMX1S/axhHn8cBRlmyv9/N13F9G4IL9BFajsun",
-	"/yKGqvfjlLI3WqI4wCwiyRlIks0tj+BrQuIDnjPVJS2CeCKRzAGGWZ4kS1T0Dght49EM0xUGVguskOmi",
-	"r2Uz9Ch4w/s4qy2gOutnh4lzc+X+TJNWTAyEthRqawBf0iQJokF/WGngCopN7348+LMEkCAlnbMLe5tf",
-	"4Lk8s3daAw8Kz2WA0vEcBDwMA+l/6UPqxAMtMGkRMHBrF4BjIfAS/sZiTlRoCv17MSaiDH0CeWFP4fmn",
-	"EbJSYe8hMsOPzULKxZPYX35z3Z5wXoXrKNYnekbNNullQ1ONCh5RzZTQNVXwepMEwayeCJvnNMi0wmh2",
-	"oMIwbro1sNzACQDllqiRArzhmM/fsuBVkJArkvTdQMd8fgztbsejlEipJf7Gko75HNmPyN17AXxIRbJm",
-	"53NFMk0IJdYzwYF9C5IA6i0lJnyOCCwlhGuaEqlwGpjgwn1yyPYHKjYxxops6VH6qa+YqkTJ2GKzQPu5",
-	"wiqXZwTb+76GerMp9q/iZfT753EAs8S0rKNDwgxImCk8uunazipJBE5u6x6/t/vrzkF1/jGKciEIU8kS",
-	"CZJxoSibI84ScwGDnGJ7rEgZHgvu3RkHvN6Fg9OPLfz44PQjirggEkCDpRi+PAo9SzseomMtZDISKXv1",
-	"BBgtTQnPVZgmea403UsScRZLeJUCNBaTSHdGeKaIQNcLanVHFlQkFzxPYkRuMipIJ+A7vfeKgzIkZBwI",
-	"ooluv1S0BAQM20b1nD2jrUFKj4KgkxGghpzB8YjGQ/i2P8cQHp1iedl3aMpZ3mN5Sdn8kChME6n7m8du",
-	"48rHKWmBqMm5wtqLiwVBVgIz6O0ZqLansFoAzs1g1zr2tutzucEXBKf7p0dWsF5vf/dPj9AlWa6+tXaC",
-	"NzA3TpIPs9He7917ouH9KDUxfx6PWJ4keJoQo18YTCsW3iFkchl6cJzha3SFk5w0B2wMkGCpPkoSgOsY",
-	"S3vW1YLKAonXWKJcAtMLIrG65keh7NblhmjRNLQkaAmzSomHJCGKDBJg+2HzBKqBcpkTf2MAY31BzB06",
-	"J5oeUnn5nihBo4BEGpMrGgWWcgi/IzdWHYAZTYhcSkXSi+Cj9V3xHem+6AWZzCdjRG7Ud2N0M5Mvg6xQ",
-	"X5ennIbuzPf6G8r0R4fhmMJWBviZwsmbpSIhHOtvSGY4Atl/Cq3840eZ+ut3wSeWPgsto+pztc6gdemh",
-	"XP/YbUwD1T4glbW6rT6n/yHv3wR2lMpLJOl/SF3q0DC/p29WvcPHo7fs6hdsbSVxTPU8ODmtkZcPwlt2",
-	"RQVnqRYurrCgmn2EhKDmaX7LruJfiJBB3Y794OiCsKu4sA9Zub517PHIqLiadw6PA3QNjRF8G/fblDqk",
-	"WTNrH+OyE/li5TvB06MUz4mvYoupHjulDCuzlhRnmbXM4WvZxn19Rd14NI+ytoY/HZx6DUUxc0trwojA",
-	"SdHjduxwuzyxKn+96tvxiDMy4Kr1wbwdd7f1Ie1tW4dT49cfoEEUkgh9KvejSB/V/5Uhajw3bZBthP73",
-	"/MMJ0PhPB6cbUALqXRyqBAwsJySC1/HUQEuGpbzmIiBbnNov+l7LZcl6RElN946BYuzPgcFzSUT48v5o",
-	"vwwHNYzUYoZxiZcQVltFnwZ6tcxC4l+0oHcqyIzeBPAMv4O8plme6YGuqozRvHu4aBMRvXnO81lwHvP7",
-	"HefJuhcBD27qsCMbQyKL6Ma4IAofEzZXi4CUC793g9h2MVuAqzOMA/sSwqFmKsdUKhK3vtJxQnFIUad/",
-	"HiJPRgklTDm9YiaIMWNYwbzvFWJ6B8fN8kKF0cVIC1XH7VhfRZ4I0tXLE1Zu9eltfd8Zjw9fYrmmSRJQ",
-	"PXS+8UhVhOi0enlN4RJPuVj2L+i9awd9FI6x6jWwWZp475rXTft9m9ch2IDTAVkFq1gi22kwVqXSNDls",
-	"kefQtuES0LfEQlkPCiqjiaKyArl9xwWZAngBwPMBjtggLaUF+Jeyb7/62/di8L0visPp74h3tjz6qpwe",
-	"dyQcjqsUDFzFqcYDikuNrwaJuBsyJtN8Dg4oMz4aj66xgPsTRNLQpXnM5/KQChKpoPxdfPL029Z0ZbWE",
-	"U2K9dmCPHBgzLq6x0L9McXQJ/2zMPh7dbOn2W1cYblWpO1bgeVeMUvn5TTGkXcA5z0XopWt+XxF0vdtc",
-	"YJAKMr0lEmwOw8E3s154w5S/nnoD3o5H73G0oIwc6c1qPlOyfF9EC6pIpHJBwspm7LVwC2XmaRHi+e9w",
-	"SpNleKgZfBswyHsehyhTj5HqT0OHOAkKa+UwzNO5hMeqv6mKBXpw1uYbN/BqNuLmguDU6FICTJXgFKXw",
-	"0RopPDtNUy3vGYu6b+yG+cjOsYoFybNPfWQh2atzEi3q6W5GS/jCGQwkZRFBJOPR4mXtOdyiQwH5Kaxq",
-	"tu53VX1m4c7pwLHP+Tm9IgzpgcUV9izixluw02BWxYMDCbY3yjpUGQ0PmPcHpyjibEbnuTA+VE1FRouO",
-	"tHwEvPdEi7q5S39ZR1fzavd/Qrg/IdedRpS7GhJCWsjPZt4OwTfh13/APjKi/jAThAThhF8XKFC8gGRB",
-	"kOs8Qb9qeUYSBb7OOJFkjKhCU7LAV8SJCylBWsjJSERnS8rmKCZs+SGHPjsT+N/2jqMyRtQ1F5d2lyfl",
-	"kqecJwSDbIhzxU9xLknFjmqmb3rc8RTrB2uSLFGmO1WlGGNqA5HHGsQ6ZzQUUpk3xD4OOFOCJ3YqhjO5",
-	"4ApdUhYjhfUrqCEH6hm2LHycOWDQC7CmCpKQK+zcsAtgQCITOXlp98FuAJBNMRyKBc/ctm0ZsQeMsgRh",
-	"FiN7kUpjtrXu4U6N/AJ7f21BC7eYlz+CE3sK+j6FIp7EW1POlUQvBIF/vKysD+RILWlN0HkeLRAu0RJh",
-	"xrgmGgM1DEtiNF0iJfBsRiMANM2lMoKB+UxusoRGVCXLMZIcYCjGiXg6pcz5b+hRz6DXBB2aXQOdv0Yd",
-	"ejHLkwQ5tLjFtdOdGWigLLtfdDgAcrZPIqfA7XkOQbPb8YjidOB8RziFd5Bhqp3Ppii744vJHtSBPU9M",
-	"6xINkkRB0ekcfkc4SZAlwoinac6czyzsaOMB5m3Sau8cxz27TUe+Qd/5s38fEhk0WSX0Kqjutzf4ZHWd",
-	"/yM8p+wl0mUgvj9ToX9tGXjXmc1gCTSASl9Po73R//0db/1nf+v/7Gz98MfW5///vwZCEpAZTqxlovYQ",
-	"SHKpiBhGarZxUO7maTAg4wB+dwNwES2IVALsDa0G9XdOn9njj2jf7+BlM9QcZ7qcGzdGssossugzbKZh",
-	"tvy2d0xafb11MkKvqWGIzmbb1UuTgzPvltqjFVxBnamMM38hFcy0WLdkodcBd6v+OW1DdO4mrzGg8CzG",
-	"SnHEpMIsCjJTZ3Ohtk2pPu7dH+sTNgDJxqOu7HOwwGw+RL+mp3beatdYogRLhSLTe/D77Wqg9bP7ZIYc",
-	"I5r4HXvcpMBQc9k1Yisptnk6qxyhhXLKRRZsqHp+PlvuZywlIUfzaEFicDEMMIRjKoF/mVbOJZzGNcIf",
-	"7mT8zHKfWe7GWe4zM/xKmGGFGfVzxBDrK9hpiAl6Ll31ULfYqe9kQ/OIExvkdHD6sYtWi3ao8FYeSKFF",
-	"T6OfaHGZ2gdnp+pM9uW7ol+Wb6QMOXuVEcSl3/Xq5y7K8lMiIhI84RrhevAcHNQz08545Q8ZO6byUoZc",
-	"8JQJ/LF7aRzZcbQA3cV2WnrEDXW+9z0BA/fZIp+TUzwn5/Q/pGXb9CfYNCQpmycE6T6QSWDFXXNzyTOi",
-	"j1zIL9VLImDbFLNJ9MKcEgUXuUKMK7QkCsGLmMQvV4UCSKWfgjJBSnItgekgp76Jwy655dLLSSgDt5QX",
-	"4PKHttBMEDJ0neZkXfQ6RjLDOtY5hqbXx3YnyRNvbOc/srarZIWNtfCcyqFtAhgwwXoIcqeyQSP1vQuR",
-	"cugoObZ9XlyxTZNtLv0LevKJbaFYYKpFhb3y8qQSTXnOwKdqSpBc5ArF/JpN0JEynhH6NOAoIplCjFx7",
-	"cgdmsWkhFc8Q18IBBk8KKlU1mwYWBMWcGSD0XRhPl1UYzCSKXpHEbOgYTqJRfrokDZCuAcdLmDniTFGW",
-	"EwSXLJs7narJ1VG6b+F4qfFvVw43IkS5mD9ytiA4UYuluYQ1YAPtriX6z+wc5S+H5Wzljwf+vOXPHz0I",
-	"yl/PHSyVjTYCwr2pa3rjBFaX4Gonyw6gV2HUxR1uS1XbR7cV856sH4+r/9TI+uq8uGKeYhqQld9gqc+4",
-	"/ujFxBdWNmvvoNJa2+g0GRT2QdhVPVqrhhA/CgtuAhBs2FVc1a/frxPXfXlVbdJ3ye5BJzbh59J2oFFp",
-	"96vk5+iKYpQJfrOc9O/gGn5NdcekNpNTkxRKI1vAlg5MIi4vpUnjNUOYXki8sgnsre1XX6wbL6R2bx1k",
-	"kOHXrdLOgGYJnocX6eyCxoQatv5ZWNr0YHflRGCWP7KG9f0Wo/yvC6IWRBQGeGeU14/60iBaLJgL/Wyx",
-	"i69y5Ak6MYZPzKSWH/QIWrrwRpFEdZCuh5lvwRV24wx7A563T/BGSOiMRMsoGWpBPy7ab94n+K4W7meX",
-	"4meX4iEuxRbKt3NBpDzVEkPb1X3+4eDn8++NVAHH1SGOQN8J+pAr80y9ODgF5OaMEchjsxA8n5tsAqa7",
-	"Ef3h1tmOCVvatJCUzX+sSu4S5QxfY0Em6BD44BZkk4T7lF9DvDISJOWKoMOTc/Ri/+Ifp38zHPNl6P6o",
-	"XZtxLIJXXWWttpV+Riy4VHsZF8rmjTFhrujTyMha5AanWUImEU/3Xu38z86nke/M48XDtIZPfciMJyJy",
-	"ELhwqhdn7w7Qqx92f3g5Rim+Qbvff2+UKROTydBFwex+//1KQVD1CV3LO01Y191YNDeELP1oZ1xtUY21",
-	"lLDi4i4J8x0Xl61B2VGpBnYvw3GrYm3GxaUvd0E+KDjzE7SfJPBdoinnqkyMAf6DzjELXL0qPnVUoghn",
-	"KtdyOOhWBJljESeaWvgMAXgT9BZHCxjdWMVILLVsBHY4RFlMMsJiyGNiaJ/nKuLGswR0v1Ta/CZGg0aV",
-	"tD66hReRyV4ImSbDD9zBiS7v9Nxm5LqJ5Lu8vdtlckMVLuVWLUcC/K6xw5nvUKxBm6C3NzjS8qX+5pkt",
-	"i4wxVGrRc6+8z9wFZzbQMN9KMq2x7QktqZ+8C1oH3jAu/nhAHr7iGhh423Ri7cj48tVYnVsoF5cJx7E1",
-	"Hqpl9X02QfuIcbZF0kwtx+gKJzQ28ptEKc6s1C8Dw9Rl/6ZvPIwy3MvwwrTvWWmL0zPOY0pYKCxk335x",
-	"56pYCcA3RlJxAa6fhoCw1NfDFY1JPGlNshLOlfBrZWSIbpz0GisLwP2hP/ejoDNafwWEj5oZNnFK4gJN",
-	"W2YxMZlRBnPJMbokS+NLi1GEk4SIrWjBpV4ytNX3jLfwxhKOfXk9TLWFSI8yntBoWYTu6FlL/d+MN8mu",
-	"6lAbfupW5EPMfB/h8Duds4uSgQ7A7oeifXO/C/D8YTt2/JjPw4nSzHVRjVAB/XxCGWngBX4MjqO/dGVb",
-	"e6SMaADw5woeWvLPzSixjkJtB6LNBahE9sZz2D0WVgF+P9+cxV4V07I/1VzV6CXyyAhMEHjXeIGu8rTq",
-	"yiqX8FDGneP7mLP3GQdzj3081HD2y+6ZFdqC2OtL0VcwP70aWWD03rAXWo63gveeVmNYGhjXo1fhUJkk",
-	"GHP33o9SG8rS2j1GTpq+IsPyvERZ/lGS+DRqSffX5RkyS7ifctTFsJmXe6djQgwpfVrzDrUb63XHsOcB",
-	"ZAlqNc93mv8PcLQIhWoad0tr+X8BziLgG/Vy9Sk6sdHht9A5aBgR73s8FdqH/HMGd64QcunpqbxzU+6F",
-	"t9UeYXlU6x8NjxNV1Z7hYMMPoWSYzjMYWpAYxUQqW97Bel2BTqvwVzBveIM9LQdOCcLo4OjwDE0THl0W",
-	"aqD/mcD/tl/vfhq9HCOMplgQdHRa6JBqDaEVFwg7Lb9RvdhGnjrp02iMPo3+Mqn89BIUF7AAl7EVJ9d4",
-	"KSHOD2k6JLF50lwRgWLCaNl0spLnMyDqNJ8mNLowOOkNQzw3MZeIVng++nh2LL1Q+9JyYYIAXdCcl+kn",
-	"LGnbOM72vbXLLXcJ1C7lXpDwTh+WG2GcYhhXSOaZ1cDoLqCxFHmyKhJJqWQdnnayVUF725QLvkYNbbsG",
-	"MMXSqf7+zmVgpx2FLbhUkJnIKvbBZDUlpWEJAvoswFYhFEwKDHvaJdasIl9Z5nSWG/tRnRhqmZCI2LIs",
-	"QAnMpOa+hsRcTSSkeFlJyRLt3y8uTrf1/50Xy5qgn8nSeXPp8UqegzM6abCUBkNxnCiBDEYIrI7O+avi",
-	"0eN45xZsseO1GsyMiJSa6jcVh6/aW6pDf+Pjrnm5VRDk48eixeGixFfBX214XkAJ5QZdbXcLWIYs58Kf",
-	"o2VN9g7q2PRidbaClk2qQtm8uSqvZNjgF28VME1dyA6joaFMr01zUn2nCBoTkxbMwliS4T4rvQxNfy+R",
-	"t77l4Kozyu0ERySeIEiiZWg3S/RuGaDkj0iaIhuCSJ7k4C6ywFlGmLQG/C2pAbEIkYTF4GzIXSDomuT3",
-	"MdMyWJs97KSSLMC5seTQx3Cdes2yCToza5WVrNtuX+G0FzhyysW6GvZDSpUyNA0PchQlBAuJaEDT/CwA",
-	"3a8A9FUnrngWmL51gekpii8ez6s4nltupw9CwIwygEd/8DXtde8iYMUtyU7gcYp4DvzS+aDbOjvgmxfM",
-	"iGZnBe/nVnt0OixBS2Fd4M58rJl5IBVINbVKKEkKlS6JColB/1XkRamYLkIJUqgq86KMUcKlyZ5cydIy",
-	"Lq4wWyGFyDFMwzPCkPPS5wy2GdwdqbJPOFZ48zmhAL2wHTRbMUaUlz/6JpWxld/tBaMEnc+JsBYkMaVK",
-	"YFHkZRkjQWbgUy5tShd3ydbTrITYYQdhnZGZIHLRusmxvYoDqjTfl7W1gMaUoEuSKYTBeF7ax31D/eu/",
-	"Viz1qxnHzy31rJjLvvAEgSu4sNo6XwfnmzRBRzM/gU7hWWUlF/1WgMsrMXEgcOI11YB/gCm34x5ouChM",
-	"ZES1gjt45ZqkIjgGbwqo8QCCjx6JsxajaStanJfZSpkTLf073hB3MQfLkNqLYH31tVkCPm13SZYScIwK",
-	"ZfI9xWUe37a+4ZIIMF7HQoj8lapFa62Ewo3ljjZ0a8y4bYTeFOODUtMeqXDeRxvU1Ki7oK8NI3s5Gm6c",
-	"TMqiJDdPIoJT0xpsCBhSgs2tvK0/bskkn2+nyy03yt7V7suVZDbXcaDraRewCyh8NkEfNZcvoN4GZ3eb",
-	"jczwmmvPGaNzMfZa1m8OfQNfU0n07ZpINMXRpWNDAl+X8Bwd2hHxNHq1+7oYot9jw8PE2G5fiBQviHHL",
-	"qT3doBh0QLaxxVocf9brDNYukodOBOlybgCCsI6wdmW1Ib0XxJAaKGFoyiLD/Y66oREafrK2LLE95hZZ",
-	"/qo/W8w+VxhqjRz80xcIstQTLFJ1T3lfI87sBX7u3yXNbKhlyHnZxXOjrB33AQZqP+HOWVDyCVYJtQ6O",
-	"GRFWFBlkuH62gPZZQAN0ENgjR3nABRo8i6Q2+KsPw291Q7fwXEIgce/hHMZf7Gg9zCV02gz0ZoU2Ei0c",
-	"x+aOSE94sWl6h3KmtnRpr2eIURhUokg0J9Sd1bCzuEIVWMiOU7oX2weTPv4mBXJXFN+0LAPax2XdFniV",
-	"Q9cNeuu5SUsFTAV7ZbTNI12n65etWDv8DEt1nuFrtjKygCjudvOuEb3W8uI48R8bBZgv6vK5DZCBBRXf",
-	"4tXeEhk4HPRJsO7hIJFpD8Yplix934LpMiBdeqKt1PuyLieo70yHp9BaQWuh82DsTOsRkum6pouoH6Lm",
-	"+NqgSDS7mT7D8JfhH/H6WansT4VtV8/juLhAHPVWmaJ/+cD90e6GuTnSuy+a6Noouxp//cD5716wfMhD",
-	"40FvFatRXONK2fwNMKOMysVqq3J9Bi9rHVYv7yI0DGZF5aLuzodK1lMk6GvlKwHe1DgJ72hCPmYJx4Ez",
-	"kQkig3ngfGYwowkwAqf3tp2chTayLo3N85+LgIPrR5F4Ef8wdmk+yAFOUJv34snB3lhwWMu4xvFv6hWG",
-	"lpoHONb1Yu+tKz/Akb4EYCWxRBQ19nsBrBTlv+tB28RNEThX4XCGCozHfC7vFNLwkKTQFs5QWUGr0ebO",
-	"SZ7WySPCo0si9KkPGBmLb55SqH36dW4DYGAHaRyKrdWsLVqQ6BISdWCTlI7ckCgH3X1VLiozfLUyC1A4",
-	"BecCrcg9zXLP+mdvf9oI6Zfdp0FK6+y/j61VE+oMwp9BRCvqXneiboBaqI7MCTosuo3BwcY4Hxrjci2h",
-	"gV9NafO4H15nfoIOMLPmMoIwGPJAGx3xhDMkSYYhDXLhTZcut1zfTyP9Uqn8tHf1ChzqjmYwEpVu6Hhs",
-	"nDqMyV4ZIQth6Rz7YV7fAOfOJ55LBCx4EIK7S+QbTwFnoCuOvjvww+/uB6DtOhkD4wqd/xkv6hF2ZQ/z",
-	"pcrrBU+c4FwKgDAQ8ESRs1rSiW5hc+aKiQd4of7Z1ULGEnw3ZfOSaWeys1Ch8i66b1Y2t6P4CuK66cVC",
-	"cQc4v73rTSqS9UlYzssT2nbN1zhTQyTVc0WyoOQVMHc3Zdue3LgN0JxzDvxtvHOuMbVpW1062fbqpg6E",
-	"YzLH0bLHCvFsc7h3meTZYvCNWgye9fXP+vr19PX+W8A+A5w+ofU5sGE78cPz0lUMbk/UjtYhxdedfe8k",
-	"xG9SEVYchKZxCZbr0y7IQQFxhmRhOcv51TdDt0SvzmxfzPNU8+LSWVvPvgoiIZLg71gGnG71rw6D0KzI",
-	"jODN1HwDrP7E0UPdy9tGBZNtXSyz0r07CHWdCiCxlrenF3h+d0W5Jn8eUXg7l57yCs8HGdAGC0z2Le7O",
-	"2nBvKjwP+6XpEa2fXA/aYCneDVNzpzO4NCGVrcrWTTGq2wBIbdrrx3aDCHi2V3nOr1QtyhJ4j39RdlTi",
-	"syX4AorrlV6bxnYdKtC3kZfFY4rlz045z0L+IF+PkLjSJsn3S++G4xhWuUZdZnJdjSpbuTjzPVRmbsnq",
-	"Hdz1wxXDjYqhxu1VnM0S9lnckpm0rQiAja8uFZ4mVqOI1wekGgBcGsEiDcP4EzPpFVw8jYvx+CfO6ORT",
-	"vrPzOnq7++aPww/v949O4G/yzwn6YOr+20yajmo/MRctYuM4jZiGUZRLxVP04s0/Phy8dLWLfkR4Cg4Q",
-	"RaTNGFH2ibkQT0kqANnoYWoObiVhQ5X5rbvbqqUSQa5lMZOH1WBYoxNC9TEUgjLSWhW/G6YmB/znUHw0",
-	"1LKnanmu70hDSV7pBb08EFcJFkS8c6zFMOE/zLB1QeAvfymtZZO//AVVijVUUzPp/SrlirLa2JRowkv5",
-	"lXkxYDTLIcxZkIRgSSCkqwgrqQ354p+/be2fHm39TJb/fPmJOSMdUAQIAnBLwHpKTC6UAv3zfpxStg/h",
-	"QG7p+kzZRCgOoXuj37ag5daFxYC75EwgkRsIOF33MLrJFmxVc4hBYJiVBvvnanFqjGriDax32G72I8kb",
-	"+C5L1ORHrRuRokpLLaO3u2/0xnr1TfdGO5NXkx3IjpsRhjM62hu9nuxMdmyAJtDstlnEVpkMOityPnXL",
-	"rQem4rCJCsYerfpW3x8N82QF0b3QbG//9OiPn9/+46VvCdYsGQjxKB7tjU65VN5xkiNzUolUb3i8tBE+",
-	"yjqHQdIeQ8Xb/7IeQkZ07S3PRq79eim1QFGX3sE+UQA7uzuv7m32AysW1CHoqNliJYlKInS9w98ZsEKz",
-	"FeBv60a67audAW1fAeV8vzOgrW7ks0TQ97edot8/334ej2SeplgsPTLyVukUPHu/j6rU+VnPUqXY7S+4",
-	"RN/R4a2h3ISEjJiH8LumxtpsVdozzXzq2/engNMjcEoUZHhqMW2UTbYrAIKJo0ZR3/UU6jHrueOmm1n6",
-	"2n63mU13O7HCput7YVsLQnL7i3EmuN3GGd26JMsa22oyKYmwibj1o3hNWiCcIFuJGjKqQyqYFnbkbiZ5",
-	"AdOba0Y2ySEQtAhUA2weIuMLJl8E1FaZzthjIH0RX58fjDN6743HYYx1AAKIrYQJB4/IEF63s7P6cXo9",
-	"pO3rDR69ugTWwmgr5wBLBAfLP3zw94BDt/3FyCODmO6dT6BlyuEzuG8BeeyzOO6/Cxykw66BCo23XwMP",
-	"ReNPgm7tXXFnujX6lO0Is8gUEmi5MeC7yZpF2VYmuMm7pt9Ymc1wWFOnmmRxkDbSqNT6Lw+jNzZzPYkb",
-	"pEKJO/fGyWHdsFizVls8KMDOzz2qRmaTEqg5D1qwr5N0zZqBlDySwYXmdSjpFnkCtiFfWivt/kwTS7nN",
-	"DAZrEGkRMv+zy9L2LVOpXa1e60Aq1ZvhF936SqlUrzhANN1k6knec9KW3FIP6vNt2SC7n4gq5eg77e9A",
-	"Q1YpUTbsfd2bXahlm4tacdsf4nnVplz6/bMWSgIk0NC01akCNrC+eQUpuO3/fDvufHlZ9ZA/Tpj1eETw",
-	"/Ji5ByXPhoms76URph2fk6z0nKi9JtpeC32vg0cR1r8enc39M5WALN/KVbCKAu5RxhTat/+nuvM9b//9",
-	"s6WGWXcQZ9rpoTxrYH6mvArlWboZxpMWBCfGNBOUbf4On028SkiiMd9Hg3iGlsyt9oNKZCZecbtu/XVW",
-	"YIPFMB6TAXKaaRZYzYn90Cn9hyr8gznavQf+nRNIMmYfBParCXje2BtgkIyo13s36dCgcnMXdp+AD3vs",
-	"9jckzcO37S/6P/b6DdLKT8QMA4U9W0nlBEZZmduayUf6fH+NpNVHUSab4nA6guoClhK/wjfliUcmdYpr",
-	"fTEsMJsTJIsYNGwwEHov3AelPZTlhMfExNGZBek9vx16F8DxshgAF0kYYnOX+Xc7Pwxp+8NDK84MKXjY",
-	"aOFclUzRBdPqdlworrxamRgijX/MT28v0PbV7rZfTL3FTeEnUskr2XlFFsU4gV8Zr37FbbkKP6s4Kau1",
-	"5JKIv+Fp9Cnf2dn9K86yv2WCxxAvDoVhQBfOYnRlKvikuVRoStDHs2NEWMRtcYcQl0xdMVGfST7KfXsM",
-	"RRSKOup3uXgbG/qQ5pE7kH+V8sePoNhpYqo8X9Xs6D3aHZcJv8ib7/npNtm2f1geSNFTFuTfqJanMm1A",
-	"xnfV/ku3943Z8b5WQrU05hUtDhBo5RLYTsuKAu2vHdvICw70T0E7g3flCnr4/AFPU7xl04CQGAr6ecme",
-	"0dEhpAGYkwoko/GI3GSJlndc6FaIbdtB/qCx7LSmtIcVpPjmyHx8tbNTY7bjUc7ov3NiG8CZeVDJOFgO",
-	"4m4s3/gNO0J4PlZh/u+IMS1ouv9wfbH/7NHQGnOSd2xDqtli48/dmCuL8QU0Q9WzNTbsrHdPX032qOQC",
-	"29nNg8ft6oJSQJguETy82/nrA5HCvXOrdZ7yshRvnwmsSmDnK9zvHgvatsEw7d4QZ7ABsqDA2BS0MKm2",
-	"qpUBTY2pSsItUxotnqCLi2PdBILoyI0izL6qOqTbgpIPLIx3Jej7l5QtZCtJyzuPIS27vK6uINjt+LHk",
-	"dksR35r/3ePK+LYyoVyTCcy4uGznAO+4uPSP+p6xi2ScMlMmuyY9IsoQFM1EL6jSh34qKJkly4I/uNJS",
-	"RTYBqmS1gqSp3lhUhCQx4gxaMR6TMbokJIN6j0qio0NoB8XjbBFjpngeLUj8Er6YhyKKeM4UuFF4Djrm",
-	"uY2VV7PS8TvODPdKFJSTsdzDlIS9HCOCIQ5QCKhuS2gRPFy8Sy0yrOMY5PMyc2WCXEHp06KIJeRZo2w+",
-	"QfuIcba1u/PKqS9TgpkJmnR1KGeYgkufKReNGXgBX5pTrhRJMzWcs+qtfYJs1cKnoXPJFoLq31f3r0er",
-	"TG381/p1aXUe5xM45MdbQGDmpUTXRO+Z26YfDRmZqj6CZFwoQ3i68X9DmdeIp+QbUFU/KnsEBrYub3Tp",
-	"nweqxbW47khBdzXK8IoivDH8MM14cWiPTUbrtQ/tOJjMEWKs62WnADrDIIsUN4VEThlKaZLQsgJsUNei",
-	"Bw8bEV1Sg+7yng0LgCkz69Uc64KyBaqEprQKVZHy59XOzs6qNUg38F6CXV/ntWQyxD9LTW1PJpdBfzW2",
-	"0Kcj9flAqR4acLpb9aN3OOBFtThzuMuEW1god9QhjOgKJ2Ovju+4Vgu6XMgDnfTQsASq+PkHdcDSCIvX",
-	"W9hqIG/EtFcrw7uuac9nCRtQ7P6ZOMia+t9tRtS1e3qFKms7d7sFQbYpijib0blfqh3X31/6DQPvL1kp",
-	"wU1MBJbIE6fe11+LvOeVgSfoQ0oVyAQzSpIYRQnBQiKqAi+LPMDFTuzKnuzbwgJoMHwAax+mvgnoxCvn",
-	"zTmO+sctuHnPUv29+KLWcLzyGQSlRLvy41R/rlXXH/Kyhn5Pl/wBvM639QDbj9HnVDR5RuOCmaf7fabz",
-	"u9G5ocB1n6+CzASRCyK7NPzQpMKxjIre6dhMMW2OEnpFBtL/WTHvkz0DFsRVT0FNujLL3JB96mlRpiOc",
-	"9WlTurR4A7MlnUGPNdix6fgEadEAFj99f6t2u80za1//AAE5r3t+nJq5N3MPwigjQlIJ6RVdt9Lb0I75",
-	"37J4LIAFZoLO3QzuTnf+ttaoUjWnmOQOMA+akiW3mm8u6JxCgpJimoTOiL5UhtopCjie7m3iQPSuk42e",
-	"ZDs9FMYM6QTcpm8+x8+fwP5qfSwtjlc+yPoo8LzDCeOcGEurbVhq8NyLv8KtaZIYeyhBN07j5bkW0zLh",
-	"qD0PE3SAk8RkWaUSpUQteIzSPFE0S4jNUcyviLgWVFm1wsXFsbWCwoC5dElaHQsplXI266uzciJrOeYo",
-	"JVjmtkqsW1rsVBADWcOFxd2TZQwWwDuJmdLuv9tiRzDPZ7Gpk/MU76qgjdbz6F+h3aGdRVMvAXwgBcxP",
-	"RHXcVh3eyLVQu5oPholvKWGYLpHkuYiI5xEdzqXVPxAkt+YCHR2OEYeGWBOdwvOtf+c4MfluvDqMrvOn",
-	"0dhVYcTpduVDUaDR/WQLNLaYDmyi4PYYmv6cYBme25TSx2DbW6nLCblRNnXoZlT6ldt6XY2+9OjMJL6F",
-	"iX/b0svZKhJ1hwCxzbd/81Z++6dy3fZwVzCH4jfDHCB/1LDcPEHj3oX9sJmMPHfPxbPJaOt6ku8+MmhJ",
-	"q1OJaNRNvZ0rM38NMdb68SxdzN3L7LWuqdbm8Xq2035bdlpNFPdhpIXsGhux0A7Pvvq18voLH5crsIrt",
-	"FN90sgugRuuJFGIdrtSYCY1ztD2MobzHN8885cnzlHEgNF3QCGq/6X+RK1KhEogut0GKLbHkAirftMcj",
-	"usrBEWf2lf2HH3TpwhphM/4QWJFAAeEH9VV7j298LvjM9R6H6zkXSTWA+5k487UyP5Sdg2yt/DjgEVzk",
-	"Nm077IML2m/orrfx+XcUuh2OHvPptaoo/mBZMkuCcZRa/lZNorBCTZXOTAo+kT6ECrBS8m8ly8DuvcNg",
-	"68W3mPpMmU8IIokikinnt/Hkor7vkVrD6TbLAnkBIqzwzG1bo277C/yjPeXXwYJEl4jOvMp5VC2sbGhq",
-	"G5IbKlU3I7UlLuE/LUy1mi8a25btAkU9AaKFznXcpOjgJoflFfVM+9ipvkVMNm5Xl3hpoV+Zep9cKYrH",
-	"NWkByaoGRfSeibKGdmfq2dK4hOfOONUqTpg+xUG4wPOHYtjVmfREK3Ht71qqh3+jRScelUKLLLiWRBWu",
-	"hHEUxc3DFtV9qDGtO72QL00hyEZJ9w554QFJ0EC2Ngm+umdASOyDEhQf8Lwsj/9M4fdH4Y5Guym8yn6/",
-	"lNV0h2YAb5GP60y3UqV3Rd1U0XV4kplKkeH7yAP+jb2Zauyv9dHUbbuqFVRpIQVfCr0nOljTOruGHXgT",
-	"QqtXxH5FpZf/HqBKuko9zwbdddUHJQZblAhlRvxuLUKR67xNf6AHehD2+HB6CLOmleSJnQHsuT1Z/leQ",
-	"NO7xWXmT0u6m/zojRpuD2UDt19dBvF+vEu2rVow5alpJM+aLoa5m4Bf4r5VLh9Iy5KaAu3LIq6yY1FzG",
-	"b8yEDyyo2GWFJI3dMPM0CF1gacyw3wSZ2I2qv6HvSCrN9CsNQ3xlRpfMYYj8WqGRtZKqrEknm03AEuVC",
-	"gtH5a8rAEkrAYma1n9fxJoipIBGsYTyQ7WuqOCx6tQ6ckCsoQDp40GPoEEDtufHpHbL7M8HTNm8MGGWl",
-	"VZqJN6TjhzOnZx2s5w+/mrwj/zTVRy3M9pFdokIM86582taXWIFTt5W/6ePU566SxePw6iMWkxt3QIuQ",
-	"lgKXrce1yLjhyVFBXsLn8sNsJkkLc1w5N9U3w77X5rIbY2mtwXe9rOyZf63LvxqFbQZysBlN9E8LLBfd",
-	"tbowQ3mWcByjhLJLpyrFAukRkCYiTJnHA/CSmG9D5dB3uu3fsVzclacFXAAWZtihHgAaCsfb3BL6nQBe",
-	"Pcxp0nj5CJhve2/7+3K9IAKSVNgf4XTZXfoGDFFfwUmE82Cx//HsePUj6VwHesJtwGFgHYOFNdrep/Hq",
-	"AV0LL/D8rnEEvt3wAd1k/wy22KqNod0S6yd6HRBT2lUy55fdb7kqWmtkagHodAm5kLlAKRemgh1gYlCF",
-	"H2XYwnqpFs9V0LV3PJJqmegftHT7NdkwH7+E3L0YNMej37YuuMLJ1pmtY9DXGVq7xtYg+lzIqK2QkeYO",
-	"V7svO+LlO/NYD0qG26ag9bjdV5rp+qtUtPY91XdWhblQlw7BbAvI96KoraHSLAJUNKBIsHFauWATpHuj",
-	"KUn4tUmAYhpgQRC5iZI8bsftvSl+D7AkW5IwSRW9IkjmU3NTohSraIE4A8hTIiWem1enZvwtlx/BIlpU",
-	"wErxzTFhc80Adr//62Y9u70E5r/srqfxfU5lPjyV+QAWHo76Wj3G65fdR4vy+sZkr/uOJ7tH/7FvLAzz",
-	"qUW71Y/rQ4e8Vc/spvx1ftl96h47ZYGn54rCg7LdFcqQDgKu3zcN93TPG3Nl30uPkr9t78sHAaJdDHt2",
-	"73xQ9861z0uPH92qXnPB4/N4fnMPfA8BRla6hZ6W297jPi8Cvn29ZPy6+szoyU/cL7e8fhS55fVjyS0W",
-	"AMeoHSBPS4T5MyRTaYo7rzvpnid5SgamDUSudehxXXx6+OenmWvlx2cCFoPmav5ccUeVbXRk4X5pj0Cu",
-	"sb5ilDD384jh/jnfCbl2FLDZEGMz6z6LPY1DB7253OVNnD0/09r5lk9ZTfL0eNb2F/OP4aHD7URrGlmy",
-	"/cUOu7JA6eAZGDdcIRYXM4ybhPKsPA5GEncTyrjLs7fo2urW+5CksPNYDMkl+numsmGZOLv4EIArrhw5",
-	"5CIZ7Y0WSmVyb3sbZ3RCdqcTnGVAALb/l9KwUGZS+1JLrF79EZLf+X/Ddm4pvd/VhhnduiTLym/Wk6r4",
-	"uxB4Pt/+vwAAAP//",
+	"gkjNjPZzSpn9K0AqPvyDjp5UWCgg+IRKhWaCpy1gs2K4bgRaum/dlfL7ahsjGc7kgqv2gcsGXSNXMXEU",
+	"E6bojJqd1Hhww6AXiqRZghVBR4cvy3PpgaQITlvBsR9XW6SbsmPUosFqI1/xJE/bxy0+rzLqrW4sM84k",
+	"Ab703c6O/k/EmSIMjg7wyQjIcftfkgMpluP9lyCz0d7o/9su749t81VuvxWCW+ZX3bE3OHbMdHQ7Hn23",
+	"8+rh59zP1ULTiRkVEdNOT/764Sd/x8WUxjFhZsbvHn7GE67QjOcsNjP+8PAzHnA2S2hkdvTVBqjoJ86I",
+	"nuz7TZDsORFXRDiyuXVHCs7M/q/nZ2ROpRJL/WcmeEaEouZA4Wu5D/e4vm/jJvfa//UcmQboZ7JER4do",
+	"xgV6e3CGcIVim9xrrMfWE3MWHtZ80yKNIMAX9ajCQqpFoIRHWJG4ZehzEgmiCuDDc5hG/gqGg29+qI96",
+	"scys6GgBbQxEmL47f9cwjj6HmHrJ/n43X8f1bQgu0EdoOS6f/osYqt6PU8reaCHnALOIJGcg3Da3PIKv",
+	"CYkPeM5UlwALEpNEMgcYZnmSLFHROyBHjkczTFcYWC2wQqaLlhTM0KOg0OHjrLaA6qyfHSbOjRTwM01a",
+	"MTEQ2lLOrgF8SZMkiAb9YaWBKyg2vfvx4M8SQIKUdM4u7G1+gefyzN5pDTwoPJcBSsdzkDkxDKT/pQ+p",
+	"Ew+0DKel0sCtXQCOhcBL+BuLOVGhKfTvxZiIMvQJ5IU9heefRsgKqr2HyAw/NgspF09if/nNdXvvhT6Z",
+	"DZpqVPCIaqaErqmCB6UkCGb1pOo8p0GmFUazAxWGcdOtgeUGTgAot0SNFOANx3z+lgWvgoRckaTvBjrm",
+	"82NodzsepURK/QhpLOmYz5H9iNy9F8CHVCRrdj5XJNOEUGI9ExzYtyAJoN5SYsLniMBSQrimKZEKp4EJ",
+	"Ltwnh2x/oGITY6zIlh6ln/qKqUqUjC02C7SfK6xyeUawve9rqDebYv8qHmu/fx4HMEtMyzo6JMyAhJnC",
+	"o5uu7aySRODktu7xe7u/7hxU5x+jKBeCMJUskSAZF4qyOeIsMRcwyCm2x4qU4bHg3p1xwOtdODj92MKP",
+	"D04/oogLIgE0WIrhy6PQS7njbTzWQiYjkbJXT4DR0pTwXIVpkudK070kEWexhIcyQGMxiXRnhGeKCHS9",
+	"oFadZUFFcsHzJEbkJqOCdAK+03uvOChDQsaBIJro9kvdT0DAsG1Uz9kzCiSk9CgIOhkBasgZHI9oPIRv",
+	"+3MM4dEplpd9h6ac5T2Wl5TND4nCNJG6v3nsNq58nJIWiJqcK6xQuVgQZCUwg96egWp7CqsF4NwMdq1j",
+	"b7s+lxt8QXC6f3pkBev19nf/9AhdkuXqW2sneANz4yT5MBvt/d69Jxrej1IT8+fxiOVJgqcJMfqFwbRi",
+	"4R1CJpehB8cZvkZXOMlJc8DGAAmW6qMkAbiOsbRnXS2oLJB4jSXKJTC9IBKra34Uym5dbogWTUNLgpYw",
+	"q5R4SBKiyCABth82T6AaKJc58TcGMNYXxNyhc6LpIZWX74kSNApIpDG5olFgKYfwO3Jj1QGY0YTIpVQk",
+	"vQg+Wt8V35Hui16QyXwyRuRGfTdGNzP5MsgK9XV5ymnoznyvv6FMf3QYjilsZYCfKZy8WSoSwrH+hmSG",
+	"I5D9p9DKP36Uqb9+F3xi6bPQMqo+V+sMWpceyvWP3cY0UO0DUlmr2+pz+h/y/k1gR6m8RJL+h9SlDg3z",
+	"e/pm1Tt8PHrLrn7B1nwTx1TPg5PTGnn5ILxlV1Rwlmrh4goLqtlHSAhqnua37Cr+hQgZ1O3YD44uCLuK",
+	"C5OVletbxx6PjIqreefwOEDX0BjBt3G/matDmjWz9jEuO5EvVr4TPD1K8Zz4KraY6rFTyrAya0lxlllj",
+	"Ib6WbdzXV9SNR/Moa2v408Gp11AUM7e0JowInBQ9bscOt8sTq/LXq74djzgjA65aH8zbcXdbH9LetnU4",
+	"NX79ARpEIYnQp3I/ivRR/V8ZosZz0wbZRuh/zz+cAI3/dHC6ASWg3sWhSsDAckIieB1PDbRkWMprLgKy",
+	"xan9ou+1XJasR5TUdO8YKMb+HBg8l0SEL++P9stwUMNILWYYl3gJYbVV9GmgV8ssJP5FC3qngszoTQDP",
+	"8DvIa5rlmR7oqsoYzbuHizYR0ZvnPJ8F5zG/33GerHsR8OCmDjuyMSSyiG6MC6LwMWFztQhIufB7N4ht",
+	"F7MFuDrDOLAvIRxqpnJMpSJx6ysdJxSHFHX65yHyZJRQwpTTK2aCGDOGFcz7XiGmd3DcLC9UGF2MtFB1",
+	"3I71VeSJIF29PGHlVp/e1vedcULxJZZrmiQB1UPnG49URYhOq5fXFC7xlItl/4Leu3bQR+EYq14Dm6WJ",
+	"96553dug17TfLtiAHwRZBatYIttpMFal0jQ5bJHn0LbhEtC3xEJZDwoqo4misgK5fccFmQJ4AcDzAY7Y",
+	"IC2lBfiXsm+/+tv3YvAdQorD6e+Id7Y8+qqcHnckHI6rFAxcxanGA4pLja8GibgbMibTfA4+MTM+Go+u",
+	"sYD7E0TS0KV5zOfykAoSqaD8XXzy9NvWdGW1hFNiHYlgjxwYMy6usdC/THF0Cf9szD4e3Wzp9ltXGG5V",
+	"qTtW4HlXjFL5+U0xpF3AOc9F6KVrfl8RdL3bXGCQCjK9JRJsDsPBN7NeeMOUv556A96OR+9xtKCMHOnN",
+	"aj5TsnxfRAuqSKRyQcLKZuy1cAtl5mkR4vnvcEqTZXioGXwbMMh7HocoU4+R6k9DhzgJCmvlMMzTuYTH",
+	"qr+pigV6cNbmGzfwajbi5oLg1OhSAkyV4BSl8NEaKTw7TVMt7xmLum/shvnIzrGKBcmzT31kIdmrcxIt",
+	"6uluRkv4whkMJGURQSTj0eJl7TncokMB+SmsarYegVV9ZuFh6sCxz/k5vSIM6YHFFfYs4saBsdNgVsWD",
+	"Awm2N8o6VBkND5j3B6co4mxG57kwPlRNRUaLjrR8BLz3RIu6uUt/WUdX82r3f0K4PyHXnUaUuxoSQlrI",
+	"z2beDsE34dd/wD4yov4wE4QE4YRfFyhQvIBkQZDrPEG/anlGEgXu1ziRZIyoQlOywFfEiQspQVrIyUhE",
+	"Z0vK5igmbPkhhz47E/jf9o6jMkbUNReXdpcn5ZKnnCcEg2yIc8VPcS5JxY5qpm963PEU6wdrkixRpjtV",
+	"pRhjagORxxrEOmc0FFKZN8Q+DjhTgiey6gl6SVmMFNavoIYcqGfYsvBx5oBBL8CaKkhCrrDzDC+AAYlM",
+	"5OSl3Qe7AUA2xXAoFjxz27ZlxB4wyhKEWYzsRSqN2dZ6rDs18gvs/bUFLdxiXv4IfvUp6PsUingSb005",
+	"VxK9EAT+8bKyPpAjtaQ1Qed5tEC4REuEGeOaaAzUMCyJ0XSJlMCzGY0A0DSXyggG5jO5yRIaUZUsx0hy",
+	"gKEYJ+LplDLnv6FHPYNeE3Rodg10/hp16MUsTxLk0OIW1053ZqCBsux+0eEAyNk+iZwCt+c5BM1uxyOK",
+	"04HzHeEU3kGGqXY+m6Lsji8me1AH9jwxrUs0SBIFRadz+B3hJEGWCCOepjlzPrOwo40HmLdJq71zHPfs",
+	"Nh35Bn3nYv99SGTQZJXQq6C6397gk9V1/o/wnLKXSJeB+P5Mhf61ZeBdZzaDJdAAKn09jfZG//d3vPWf",
+	"/a3/s7P1wx9bn////xoISUBmOLGWidpDIMmlImIYqdnGQbmbp8EYkQP43Q3ARbQgUgmwN7Qa1N85fWaP",
+	"P6J9v4OXzVBznOlybtwYySqzyKLPsJmG2fLb3jFp9fXWyQi9poYhOpttVy9NDs68W2qPVnAFdaYyzvyF",
+	"VDDTYt2ShV4H3K3657QN0bmbvMaAwrMYK8URkwqzKMhMnc2F2jal+rh3f6xP2AAkG4+6ss/BArP5EP2a",
+	"ntp5q11jiRIsFYpM78Hvt6uB1s/ukxlyjGjid+xxkwJDzWXXiK2k2ObprHKEFsopF1mwoer5+Wy5n7GU",
+	"hBzNowWJwcUwwBCOqQT+ZVo5l3Aa1wh/uJPxM8t9ZrkbZ7nPzPArYYYVZtTPEUOsr2CnISbouXTVQ91i",
+	"p76TDc0jTmyQ08Hpxy5aLdqhwlt5IIUWPY1+osVlah+cnaoz2Zfvin5ZvpEy5OxVBjWXftern7soy0+J",
+	"iEjwhGuE68FzcFDPTDvjlT9k7JjKSxlywVMm8MfupXFkx9ECdBfbaekRN9T53vcEDNxni3xOTvGcnNP/",
+	"kJZt059g05CkbJ4QpPtAcoMVd83NJc+IPnIhv1Qvr4FtU8wm0QtzShRc5AoxrtCSKAQvYhK/XBUKIJV+",
+	"CsoEKcm1BKaDnPomDrvklksvJ6EM3FJegMsf2kIzQcjQdZqTddHrGMkM61jnGJpeH9udJE+8sZ3/yNqu",
+	"khU21sJzKoe2CWDABOshyJ3KBo3U9y5EyqGj5Nj2eXHFNk22ufQv6MkntoVigakWFfbKy5NKNOU5A5+q",
+	"KUFykSsU82s2QUfKeEbo04CjiGQKMXLtyR2YxaaFVDxDXAsHGDwpqFTVBB9YEBRzZoDQd2E8XVZhMJMo",
+	"ekUSs6FjOIlG+enyRkAGCRwvYeaIM0VZThBcsmzudKomfUjpvoXjpca/XTnciBDlYv7I2YLgRC2W5hLW",
+	"gA20u5boP7NzlL8clrOVPx7485Y/f/QgKH89d7BUNtoICPemrumNE1hdgqudLDuAXoVRF3e4LVVtH91W",
+	"zHuyfjyu/lMj66vz4op5imlAVn6DpT7j+qMXE19Y2ay9g0prbaPTZFDYB2FX9WitGkL8KCy4CUCwYVdx",
+	"Vb9+v05c9+VVtUnfJbsHndiEn0vbgUal3a+Sn6MrilEm+M1y0r+Da/g11R2T2kxOTVIojWwBWzowibi8",
+	"lCaN1wxheiHxyiawt7ZffbFuvJDavXWQQYZft0o7A5oleB5epLMLGhNq2PpnYWnTg92VE4FZ/sga1vdb",
+	"jPK/LohaEFEY4J1RXj/qS4NosWAu9LPFLr7KkSfoxBg+MZNaftAjaOnCG0US1UG6Hma+BVfYjTPsDXje",
+	"PsEbIaEzEi2jZKgF/bhov3mf4LtauJ9dip9dioe4FFso384FkfJUSwxtV/f5h4Ofz783UgUcV4c4An0n",
+	"6EOuzDP14uAUkJszRiCPzULwfG6yCZjuRvSHW2c7JmxpM1VSNv+xKrlLlDN8jQWZoEPgg1uQ4BLuU34N",
+	"8cpIkJQrgg5PztGL/Yt/nP7NcMyXofujdm3GsQhedZW12lb6GbHgUu1lXCibN8aEuaJPIyNrkRucZgmZ",
+	"RDzde7XzPzufRr4zjxcP0xo+9SEznojIQeDCqV6cvTtAr37Y/eHlGKX4Bu1+/71RpkxMckUXBbP7/fcr",
+	"BUHVJ3Qt7zRhXXdj0dwQsvSjnXG1RTXWUsKKi7skzHdcXLYGZUelGti9DMetirUZF5e+3AX5oODMT9B+",
+	"ksB3iaacqzIxBvgPOscscPWq+NRRiSKcqVzL4aBbEWSORZxoauEzBOBN0FscLWB0YxUjsdSyEdjhEGUx",
+	"yQiLIY+JoX2eq4gbzxLQ/VJp85sYDRpV0vroFl5EJnshJL8MP3AH596803Obkesmku/y9m6XyQ1VuJRb",
+	"tRwJ8LvGDme+Q7EGbYLe3uBIy5f6m2e2LDLGUKlFz73yPnMXnNlAw3wrybTGtie0pH7yLmgdeMO4+OMB",
+	"efiKa2DgbdOJtSPjy1djdW6hXFwmHMfWeKiW1ffZBO0jxtkWSTO1HKMrnNDYyG8SpTizUr8MDFOX/Zu+",
+	"8TDKcC/DC9O+Z6UtTs84jylhobCQffvFnatiJQDfGEnFBbh+GgLCUl8PVzQm8aQ1yUo4V8KvlZEhunHS",
+	"a6wsAPeH/tyPgs5o/RUQPmpm2MQpiQs0bZnFxGRGGcwlx+iSLI0vLUYRThIitqIFl3rJ0FbfM97CG0s4",
+	"9uX1MNUWIj3KeEKjZRG6o2ct9X8z3iS7qkNt+KlbkQ8x832Ew+90zi5KBjoAux+K9s39LsDzh+3Y8WM+",
+	"DydKM9dFNUIF9PMJZaSBF/gxOI7+0pVt7ZEyogHAnyt4aMk/N6PEOgq1HYg2F6AS2RvPYfdYWAX4/Xxz",
+	"FntVTMv+VHNVo5fIIyMwQeBd4wW6ytOqK6tcwkMZd47vY87eZxzMPfbxUMPZL7tnVmgLYq8vRV/B/PRq",
+	"ZIHRe8NeaDneCt57Wo1haWBcj16FQ2WSYMzdez9KbShLa/cYOWn6igzL8xJl+UdJ4tOoJd1fl2fILOF+",
+	"ylEXw2Ze7p2OCTGk9GnNO9RurNcdw54HkCWo1Tzfaf4/wNEiFKpp3C2t5f8FOIuAb9TL1afoxEaH30Ln",
+	"oGFEvO/xVGgf8s8Z3LlCyKWnp/LOTbkX3lZ7hOVRrX80PE5UVXuGgw0/hJJhOs9gaEFiFBOpbMUJ63UF",
+	"Oq3CX8G84Q32tBw4JQijg6PDMzRNeHRZqIH+ZwL/2369+2n0cowwmmJB0NFpoUOqNYRWXCDstPxG9WIb",
+	"eeqkT6Mx+jT6y6Ty00tQXMACXMZWnFzjpYQ4P6TpkMTmSXNFBIoJo2XTyUqez4Co03ya0OjC4KQ3DPHc",
+	"xFwiWuH56OPZsfRC7UvLhQkCdEFzXqafsKRt4zjb99Yut9wlULuUe0HCO31YboRximFcIZlnVgOju4DG",
+	"UuTJqkgkpZJ1eNrJVgXtbVMu+Bo1tO0awBRLp/r7O5eBnXYUtuBSQWYiq9gHk9WUlIYlCOizAFuFUDAp",
+	"MOxpl1izinxlmdNZbuxHdWKoZUIiYsuyACUwk5r7GhJzZZqQ4mVxJ0u0f7+4ON3W/3deLGuCfiZL582l",
+	"xyt5Ds7opMFSGgzFcaIEMhghsDo656+KR4/jnVuwxY7XajAzIlJqCvJUHL5qb6kO/Y2Pu+blVkGQjx+L",
+	"FoeLEl8Ff7XheQEllBt0td0tYBmynAt/jpY12TuoY9OL1dmiXjapCmXz5qq8KmaDX7xVwDR1ITuMhoYy",
+	"vTbNSfWdImhMTFowC2NJhvus9DI0/b1E3vqWg6vOKLcTHJF4giCJlqHdLNG7ZYCSPyJpimwIInmSg7vI",
+	"AmcZYdIa8LekBsQiRBIWg7Mhd4Gga5Lfx0zLYG32sJNKsgDnxpJDH8N16mXUJujMrFVWsm67fYXTXuDI",
+	"KRfratgPKVXK0DQ8yFGUECwkogFN87MAdL8C0FeduOJZYPrWBaanKL54PK/ieG65nT4IATPKAB79wde0",
+	"172LgBW3JDuBxyniOfBL54Nu6+yAb14wI5qdFbyfW+3R6bAELYV1gTvzsWbmgVQg1dQqoSQpVLokKiQG",
+	"/VeRF6ViugglSKGqzIsyRgmXJntyJUvLuLjCbIUUIscwDc8IQ85LnzPYZnB3pMo+4VjhzeeEAvTCdtBs",
+	"xRhRXv7om1TGVn63F4wSdD4nwlqQxJQqgUWRl2WMBJmBT7m0KV3cJVtPsxJihx2EdUZmgshF6ybH9ioO",
+	"qNJ8X9bWAhpTgi5JphAG43lpH/cN9a//WrHUr2YcP7fUs2Iu+8ITBK7gwmrrfB2cb9IEHc38BDqFZ5WV",
+	"XPRbAS6vxMSBwInXVAP+Aabcjnug4aIwkRHVCu7glWuSiuAYvCmgxgMIPnokzlqMpq1ocV5mK2VOtPTv",
+	"eEPcxRwsQ2ovgvXV12YJ+LTdJVlKwDEqlMn3FJd5fNv6hksiwHgdCyHyV6oWrbUSCjeWO9rQrTHjthF6",
+	"U4wPSk1X+7Ut7+PK/sg9ZVS8u9Gd5mssPUfIYbrodb2e1/GotaFdjeoT+vI0Emi9Aq7HSqIkNw9DglPT",
+	"GiwpGBKjze2rQ3/ckkk+306XW26UvavdlytJrtVCv4PL9YaAXUD5twn6qO+6AuptcPm3OdkMx732XFI6",
+	"F2OFE/3y0nLINZVEyxiJRFMcXTpmLPA18qoH2xHxNHq1+7oYot9vpVLR2GzfIMdVr1JL4PxeEOPLVHvv",
+	"QlHvgEBoK9y4S02jJVjwSR46ua3LIwTox3oPW0TUhvSeXUMKx4ShKSsz93s3h0ZoOBfbWs6WN1pk+av+",
+	"bDH7XJapNdzyT19VyVJPsLLXPSXLjTizUs+5fwE3U8iWcfplF8/3tHbcB1j1/SxFZ0FxMVha1XqFZkRY",
+	"+W2Qtf/ZbNxnNg7QQWCPHOUBF2jwLJLaiLk+DL/VDd3CcwnR172Hcxh/saP1MJfQaTPQmxXa8L1w8J87",
+	"Ij0x2abpHWrA2nqvve40RstSCb3RnFB3VsPO4gqlcyGlUOmTbV+Z+vibvNFdoY/TsnZqH5d1W+CVW103",
+	"UnCwZF7B3qqS+b1fp+vX+lg7Zg9LdZ7ha7YysoAo7nbz3t8D5cR/mxRgvqiL8zaqCBZUfItXe3pk4KXR",
+	"J8G6d4ZEpj1Y9Fiy9B0ypsuAdOmJtlLvy7qcoL4zHe5Va0X6hc6DMc6tR0im65p+tX5cn+Nrg15BdjN9",
+	"huEvwz/i9bNS2Z8K266ex3FxgZTvM58p+pcP3B/tvqubI737oomujbKr8dcPnP/uVd6HPDQe9FaxatgN",
+	"KnvWvwFmlFG5WG1Vrs/gZa3D6uVdhIbBrKhc1N35UMl6iqyGrXwlwJsaJ+EdTcjHLOE4cCYyQWQweZ7P",
+	"DGY0AUbgjAW2kzNrR9YPtHn+cxHwCv4oEi9NAoxd2lxygBNsDb14crA3FhxWza5x/Jt6haH1+QGOdV3/",
+	"e4vxD4g+KAFYSSwxVfsHAVik7JI2k89dDtomborAuQrHgFRgPOZzeac4kIckhbYYkMoKWi1dd86MtU7y",
+	"FR5dEqFPfcAyW3zzlELt069zGwADO0jjUECyZm3RgkSXkN0Em0x+5IZEOaj6q3JRmRatlVmAwik4F2hF",
+	"7mmWe9Y/e/vTRki/7D4NUlpn/31srZqFaBD+DCJaUfe6E3UD1EJ1ZE7QYdFtDF5JxmPTWORrWSD8ElSb",
+	"x/3w4vwTdICZta4RhMHuB9roiCecIUkyDLmjCxfEdLnl+n4a6ZdK5ae9q1fghXg0g5GodEPHY+MJY/wc",
+	"lBGyEJYuGgLm9e117nziuUTAggchGEr+NwVIPYji1r3C2fOKo+8O/PC7+wFou07GwLhC53/GiyKOXSnX",
+	"fKnyesETJziXAiAMBDxR5KyWqaNb2Jy5CuwBXqh/dgWksQSHV9m8ZNqZ7CxU3b2L7pvl4O0ovoK4bnqx",
+	"UNwBzm/vepOKZH0SlnONhbZd8zXO1BBJ9VyRLCh5BczdTdm2J6FwAzTn0QR/G5ema0xtrluXg7e9JKwD",
+	"4ZjMcbTssUI82xzuXSZ5thh8oxaDZ339s75+PX29/xawzwCnT2h9DmzYTvzwvHQVg9sTtaN1SPF1D+k7",
+	"CfGbVIQVB6FpXILl+rQLclBAnCFZWM5ywQjNeDfRqzPbF/M81by49HDXs6+CSAi/+DuWAU9l/avDIDQr",
+	"0kl4MzXfAKs/cfRQ9/K2UcEMZRfLrPSJD0JdpwLIRubt6QWe311RrsmfRxTezmV4gcLzQQa0wQKTfYu7",
+	"szbcmwrPw35pekTrJ9eDNliKd8PU3OkMLk0caquydVOM6jYAUpv2+rHdIALhAFWe8ytVi7Ju4ONflB3l",
+	"C23dwoDieqXXprFdh6oabuRl8Zhi+bNTzrOQP8jXIySutEny/dK74TiGVa5RzJpcV0PxVq5ofQ/lrFtS",
+	"oQd3/XDFGK1iqHF76WuzhH0Wt6RzbaucYIPSS4WnidUokhwAUg0ALvdikbti/ImZnBQu/MbFePwTZ3Ty",
+	"Kd/ZeR293X3zx+GH9/tHJ/A3+ecEfdAHtUg/6qj2E3PRIjb41YhpGEW5VDxFL97848PBS1fw6UeEp+AA",
+	"UQTmjBFln5iLi5WkApANuabm4FayXFSZ37q7rVrKN+RaFjPJaw2GNTohvwGG6llGWqvid8PU5ID/HAoq",
+	"lyTKBVXLc31HGkry6lXo5YG4SrAg4p1jLYYJ/2GGrQsCf/lLaS2b/OUvqFLhoprPSu9XKVeUJdqmRBNe",
+	"yq/MiwGjWQ6x4YIkBEsCEWBFWEltyBf//G1r//Ro62ey/OfLT8wZ6YAiQBCAWwLWU2JyoRTon/fjlLJ9",
+	"CAdyS9dnymaPcQjdG/22BS23LiwG3CVnAoncQMDpuofRTbZgq5pDDALDrDTYP1eLU2NUE29gvcN2sx9J",
+	"3sB3WaImP2rdiBRVWmoZvd19ozfWKwq7N9qZvJrsQErhjDCc0dHe6PVkZ7Jjo1qBZrfNIrbKDNpZkSir",
+	"W249MGWaTSg19mjVt/r+aJgnK4juhWZ7+6dHf/z89h8vfUuwZslAiEfxaG90yqXyjpMcmZNKpHrD46WN",
+	"8FHWOQwyHRkq3v6X9RAyomtvTTty7ReZqUXXupwY9okC2NndeXVvsx9YsaAOQUehGytJVLLH6x3+zoAV",
+	"mq0Af1s30m1f7Qxo+woo5/udAW11I58lgr6/7RT9/vn283gk8zTFYumRkbdKp+DZ+31Upc7PepYqxW5/",
+	"wSX6jg5vDeUmJGTEPITfNTXWZqvSnmnmU9++PwWcHoFToiAtVotpo2yyXQEQTBw1ivqup7qRWc8dN93M",
+	"0tf2u81sutuJFTZd3wvbWhCS21+MM8HtNs7o1iVZ1thWk0lJhE3ErR/Fa3Ip4QTZ8t2Qhh7y57SwI3cz",
+	"yQuY3lwzskkOgaBFoBpg85BOoGDyRUBtlemMPQbSF/H1+cE4o/feeBzGWAcggNhKmHDwiAzhdTs7qx+n",
+	"10Pavt7g0atLYC2MtnIOsERwsPzDB38POHTbX4w8Mojp3vkEWqYcPoP7FpDHPovj/rvAQTrsGqjQePs1",
+	"8FA0/iTo1t4Vd6Zbo0/ZjjCLTPWFlhsDvptUY5RtZYKbZHX6jZXZtJA1darJsAe5No1Krf/yMHpjM9eT",
+	"uEEqlLhzb5wc1g2LNWu1FZcC7Pzco2pkNimBQv2gBfs6SdesGUjJIxlcaF6Hkm6RJ2Abksy10u7PNLGU",
+	"28xgsAaRFiHzP7vUdt8yldrV6rUOpFK9GX6lsq+USvWKA0TTTaae5D0nbRlB9aA+35YNsvuJqFKOvtP+",
+	"DjRklRJlw97XvdmFWra5qBW3/SGeV23Kpd8/a6EkQAINTVudKmAD65tXkILb/s+3486Xl1UP+eOEWY9H",
+	"BM+PmXtQ8myYyPpeGmHa8TnJSs+J2mui7bXQ9zp4FGH969HZ3D9TCcjyrVwFqyjgHmVMoX37f6o73/P2",
+	"3z9baph1B3GmnR7KswbmZ8qrUJ6lm2E8aUFwYkwzQdnm7/DZxKuEJBrzfTSIZ2jJ3Go/qERm4hW369Zf",
+	"ZwU2WAzjMRkgp5lmgdWc2A+d0n/TX8Oao9174N85gSRj9kFgv5qA5429AQbJiHq9d5MODSo3d2H3Cfiw",
+	"x25/Q9I8fNv+ov9jr98grfxEzDBQDbWVVE5glJW5rZl8pM/310hafRRlsikOpyMoyWAp8St8U554ZFKn",
+	"uNYXwwKzOUGyiEHDBgOh98J9UNpDWU54TEwcnVmQ3vPboXcBHC+LAXCRhCE2d5l/t/PDkLY/PLTizJCC",
+	"h40WzlVJr10wrW7HheLKq9XWIdL4x/z09gJtX+1u+xXoW9wUfiKVvJKdV2RRwRT4lfHqV9zW+PBTsZOy",
+	"xE0uifgbnkaf8p2d3b/iLPtbJngM8eJQTQd04SxGV6bsUZpLhaYEfTw7RoRF3FbECHHJ1FVg9Znko9y3",
+	"x1B5oig+f5eLt7GhD2keuQP5Vyl//AiKnSamyvNVTSnfo91x5QOKYgOen26TbfuH5YEUPQUhbVbLU5k2",
+	"IONbNHlu7xuz432thGppzKv0HCDQyiWwnZZlGNpfO7aRFxzon4J2Bu9qPPTw+QOepnjLpgEhMVRB9JI9",
+	"o6NDSAMwJxVIRuMRuckSLe+40K0Q27aD/EFj2WlNaQ8rSPHNkfn4amenxmzHo5zRf+fENoAz86CScbCG",
+	"xt1YvvEbdoTwfKzC/N8RY1rQdP/h+mL/2aOhNeYk79iGVLPFxp+7MVcW4wtohqpna2zYWe+evprsUckF",
+	"trObB4/b1QWlgDBdInh4t/PXByKFe+dW6zzlZSnePhNYlcDOV7jfPRa0bYNh2r0hzmADZEGBsSloYVJt",
+	"VcspmsJclYRbpp5cPEEXF8e6CQTRkRtFmH1VdUi3BSUfWBjvStD3LylbyFaSlnceQ1p2eV1dFbXb8WPJ",
+	"7ZYivjX/u8eV8W05R7kmE5hxcdnOAd5xcekf9T1jF8k4Zaa2eE16RJQhqDSKXlClD/1UUDJLlgV/cJWo",
+	"imwCVMlq2U1T8rIoo0lixBm0YjwmY3RJSAZFMpVER4fQDiru2crPTPE8WpD4JXwxD0UU8ZwpcKPwHHTM",
+	"cxsrr9Cn43ecGe6VKCgnY7mHqaN7OUYEQxygEFASmNAieLh4l1pkWMcxyOdl5soEuYJ6sUXlT8izRtl8",
+	"gvYR42xrd+eVU1+mBDMTNOmKd84wBZc+U2MbM/ACvjSnXCmSZmo4Z9Vb+wTZqoVPQ+eSLQTVv6/uX49W",
+	"mdr4r/Xr0uo8zidwyI+3gMDMS4muid4zt00/GjIyVX0EybhQhvB04/+G2rgRT8k3oKp+VPYIDGxd3ujS",
+	"Pw9Ui2tx3ZGC7mqU4RVFeGP4YZrx4tAem4zWax/acTCZI8RY18tOAXSGQRYpbgqJnDKU0iShZdncoK5F",
+	"Dx42IrqkBt01URsWAFOb16s51gVlC1QJTWkVqiLlz6udnZ1VC7du4L0Eu77Oa8lkiH+WmtqeTC6D/mps",
+	"oU9H6vOBUj004HS36kfvcMCLanHmcJcJt7BQ7qhDGNEVTsZe8eNxrYB2uZAHOumhYQlU8fMP6oClERav",
+	"t7DVQN6Iaa9Wu3hd057PEjag2P0zcZA19b/bjKhr9/QKlSN37nYLgmxTFHE2o3O/vj2uv7/0GwbeX7JS",
+	"t5yYCCyRJ069r78Wec8rA0/Qh5QqkAlmlCQxihKChURUBV4WeYCLndiVPdm3hQXQYPgA1j5MfRPQiVfO",
+	"m3Mc9Y9bcPOepfp78UWt4XjlMwhKiXblx6n+XFE+D3tZQ7+nS/4AXufbeoDtx+hzKpo8o3HBzNP9PtP5",
+	"3ejcUOC6z1dBZoLIBZFdGn5oUuFYRkXvdGymmDZHCb0iA+n/rJj3yZ4BC+Kqp6AmXZllbsg+9bQo0xHO",
+	"+rQpXVq8gdmSzqDHGuzYdHyCtGgAi5++v1W73eaZta9/gICc1z0/Ts3cm7kHYZQRIamE9IquW+ltaMf8",
+	"b1k8FsACM0HnbgZ3pzt/W2tUqZpTTHIHmAdNyZJbzTcXdE4hQUkxTUJnRF8qQ+0UBRxP9zZxIHrXyUZP",
+	"sp0eCmOGdAJu0zef4+dPYH+1PpYWxysfZH0UeN7hhHFOjKXVNiw1eO7FX+HWNEmMPZSgG6fx8lyLaZlw",
+	"1J6HCTrASWKyrFKJUqIWPEZpniiaJcTmKOZXRFwLqqxa4eLi2FpBYcBcuiStjoWUSjmb9dVZOZG1HHOU",
+	"EixzWyXWLS12KoiBrOHC4u7JMgYL4J3ETGn3322xI5jns9jUyXmKd1XQRut59K/Q7tDOoqmXAD6QAuYn",
+	"ojpuqw5v5FqoXc0Hw8S3lDBMl0jyXETE84gO59LqHwiSW3OBjg7HiENDrIlO4fnWv3OcmHw3Xh1G1/nT",
+	"aOyqMOJ0u/KhKNDofrIFGltMBzZRcHsMTX9OsAzPbUrpY7DtrdTlhNwomzp0Myr9ym29rkZfenRmEt/C",
+	"xL9t6eVsFYm6Q4DY5tu/eSu//VO5bnu4K5hD8VuNOWx/cf/s8do+JSLFGgWJy10hES4F7rL46VnD4X7G",
+	"xSWJ3TVNSycShAVBTP93NoO05RN0wkHyNi4lVjJ3cp0puAiTB29R6znullZQ4hr+wmXXYb7jhQyq35Nf",
+	"UWqPR6VWm+wjJFt65NrhPE6ZsWlSzhCeahELIy2sJeWg4FZufOm4QKZacde99mBEs7O591C7jdRh+pkY",
+	"G8QIXg3dlKgZJyTeG5bULEhoF/bDZlKZ3T2J2SbTVNSrI/QRQUs+skoouG7q7VyZMnGIl4sfCNglFXsp",
+	"Edf1cbEJEJ8dXL4tBxdNFPfh3QJpiTbi2jI8bfXXyukvfFyuwCq2U3zTyS6AGq0LZ4h1uBqNJqbY0fYw",
+	"hvIe3zzzlCfPU8aBnB6CRlA0U/+LXJEKlUBaDhvd3ZKEQ0DJsPZAbldyPeLMqif/8KPVXTw4bMYfAisS",
+	"qLz+oOLqe3zjc8Fnrvc4XM/5lqsB3M885ddKmVN2DrK18uMA7WGRFLrtsIeKAPolCzebp8at7q5Ct8PR",
+	"Y+qsVhXFHyy9cEkwjlLL36rZZ1YoRtWZgsYn0oewnVRqpa5kUt29dxiOyRxHrXFfpj4yRN9FEcmUc3h7",
+	"cuky7pFaw3mKy8qiASKs8MxtW9xz+wv8oz1X4sGCRJeIzrySo1QtrGxoisKSGypVNyO1tYH3rV4rxFSr",
+	"ifadBqxdoKhnjrXQuY6bFB3c5LC8ohB0HzvVt4gpY+AKui8t9CtT75Or4fO4vgBAsqpBEb1nwrTozdld",
+	"WuXx3Fn1W8UJ06c4CBd4/lAMuzqTnmglrh3yNtbr+0ar9TwFi0JBogpX4t/gv+056/ahOL/u9EK+NBV0",
+	"Sx4Clc075YUHJEED2dok+OqeASGxD0pQfMBzhG3bZwq/Rwp3NNpN4VX2+6UsQz60dEKLfFxnupXy5ivq",
+	"poquw7NzVaqz34eV9Rt7M9XYX+ujqdt2VatE1UIKvhR6T3SwplvLGg40mxBaf6Vq8cYWJ1tN6eW/B6iS",
+	"rsTZsyfMuuqDEoMtSoSylEi3FqEoEtGmP9ADPQh7fDg9hFnTSvLEzgD23F5l5CvItvn4rLxJaXfTf50R",
+	"o83BbKD26+sg3q9XifZVK8YcNa2kGfPFUFds9Qv818qlQ2kZkvrAXTnkVVZMai7jN2bCBxZU7LJCksZu",
+	"mHkahC6wNGbYb4JM7EbV39B3JJVm3qqGIb4yo8uCM0R+rdDIWtmo1qSTzWauinIhwej8NaWuCmWuMrPa",
+	"z+t4E8RUkAjWMB7I9jVVHBa9WgdOyBVUbh486DF0CKD23ARDDNn9meBpmzcGjLLSKs3EG9Lxw5nTsw7W",
+	"84dfTd6Rf5rqoxZm+8guUSGGeVc+bQvzrMCp2+qG9XHqc1cC6HF49RGLyY07oEUsYIHL1uNapCry5Kgg",
+	"L+Fz+WE2k6SFOa6c1O+bYd9rc9mNsbTVvfSV50fyzL/W4V+NimADOdiMJvqnBZaL7iKHmKE8SziOUULZ",
+	"pVOVYoH0CEgTEabM4wF4Scy3oXLoO93271gu7srTAi4ACzPsUA8ADYXjbW4J/U4Arx7mNGm8fATMt723",
+	"/X25XhAB2X3sj3C67C59A4aor+Akwnmw2P94drz6kXSuAz3hNuAwsI7Bwhpt79N49YCuhRd4ftc4At9u",
+	"+IBusn8GW2zVxtBuifUzZA8Ixu+qNfbL7rdcTrI1pL8AdLqEJPJcoJQLU/oTMDGoNJoybGG9HLXnKuja",
+	"Ox5JtUz0D1q6/ZpsmI9fe/NeDJrj0W9bF1zhZMsGnvd2htausTWIPleAa6sAp7nD1e7LjkQjnQUABmUR",
+	"b1PQetzuKy0R8FUqWvue6jurwlyoS4dgtgXke1HU1lBpFgEqGlAk2DitXLAJ0r3RlCT82uSsMA2wIIjc",
+	"REket+P23hS/B1iSLUmYpIpeESTzqbkpUYpVtECcAeQpkRLPzatTM/6Wy49gES0qYKX45piwuWYAu9//",
+	"dbOe3V7lh19219P4PteAGF4DYgALD0d9rR7j9cvuo0V5fWOy133Hk92j/9g3Fob51KLd6sf1oUPeqmd2",
+	"U/46v+w+dY+dsjLecyn2QWlCC2VIBwHX75uGe7rnjbmy76VHyd+29+WDANEuhj27dz6oe+fa56XHj25V",
+	"r7ng8Xk8v7kHvocAIyvdQk/Lbe9xnxcB375eMn5dfWb0JHbvl1teP4rc8vqx5BYLgGPUDpCnJcL8GZKp",
+	"NMWd1510z5M8JQPTBiLXOvS4Lj49/PPTzLXy4zMBi0FzNX+uuKPKNjqycL+0RyDXWF8xSpj7ecRw/5zv",
+	"hFw7CthsiLGZdZ/Fnsahg96K5MANnD0/09r5lk9ZTfL0eNb2F/OP4aHD7URrGlmy/cUOu7JA6eAZmpnZ",
+	"JxYXM4ybhPKsPA5GEncTyrjLs7fo2urW+5CksPNYDMkl+numsmGZOLv4EIArrhw55CIZ7Y0WSmVyb3sb",
+	"Z3RCdqcTnGVAALb/l9KwUGZS+1KrSFH9EZLf+X/Ddm4pvd/VhhnduiTLym/Wk6r4uxB4Pt/+vwAAAP//",
 }
 
 // decodeSpec returns the embedded OpenAPI spec as raw JSON bytes,

--- a/packages/api/internal/handlers/snapshot_delete.go
+++ b/packages/api/internal/handlers/snapshot_delete.go
@@ -1,0 +1,82 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/e2b-dev/infra/packages/api/internal/api"
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/shared/pkg/id"
+	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+)
+
+func (a *APIStore) DeleteSnapshotsSnapshotID(c *gin.Context, rawSnapshotID api.SnapshotID) {
+	ctx := c.Request.Context()
+	teamInfo := auth.MustGetTeamInfo(c)
+	teamID := teamInfo.Team.ID
+
+	snapshotID, err := url.PathUnescape(rawSnapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid snapshot ID")
+		return
+	}
+
+	span := trace.SpanFromContext(ctx)
+	traceID := span.SpanContext().TraceID().String()
+	c.Set("traceID", traceID)
+
+	identifier, _, err := id.ParseName(snapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid snapshot ID: %s", err))
+		return
+	}
+
+	if err := id.ValidateNamespaceMatchesTeam(identifier, teamInfo.Slug); err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	aliasInfo, resolveErr := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Slug)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, templatecache.ErrTemplateNotFound) {
+			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+			return
+		}
+		apiErr := templatecache.ErrorToAPIError(resolveErr, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		return
+	}
+
+	if aliasInfo.TeamID != teamID {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	templateID := aliasInfo.TemplateID
+
+	aliasKeys, err := a.softDeleteTemplate(ctx, teamID, templateID)
+	if err != nil {
+		telemetry.ReportCriticalError(ctx, "error deleting snapshot template", err)
+		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error deleting snapshot")
+		return
+	}
+	if aliasKeys == nil {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	a.templateCache.InvalidateAllTags(context.WithoutCancel(ctx), templateID)
+	a.templateCache.InvalidateAliasesByTemplateID(context.WithoutCancel(ctx), templateID, aliasKeys)
+
+	logger.L().Info(ctx, "Deleted snapshot template", logger.WithTemplateID(templateID), logger.WithTeamID(teamID.String()))
+
+	c.Status(http.StatusNoContent)
+}

--- a/packages/api/internal/handlers/snapshot_get.go
+++ b/packages/api/internal/handlers/snapshot_get.go
@@ -1,0 +1,106 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/e2b-dev/infra/packages/api/internal/api"
+	templatecache "github.com/e2b-dev/infra/packages/api/internal/cache/templates"
+	"github.com/e2b-dev/infra/packages/auth/pkg/auth"
+	"github.com/e2b-dev/infra/packages/db/queries"
+	"github.com/e2b-dev/infra/packages/shared/pkg/id"
+	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
+)
+
+func (a *APIStore) GetSnapshotsSnapshotID(c *gin.Context, rawSnapshotID api.SnapshotID) {
+	ctx := c.Request.Context()
+	teamInfo := auth.MustGetTeamInfo(c)
+	teamID := teamInfo.Team.ID
+
+	snapshotID, err := url.PathUnescape(rawSnapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, "Invalid snapshot ID")
+		return
+	}
+
+	span := trace.SpanFromContext(ctx)
+	traceID := span.SpanContext().TraceID().String()
+	c.Set("traceID", traceID)
+
+	identifier, tag, err := id.ParseName(snapshotID)
+	if err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, fmt.Sprintf("Invalid snapshot ID: %s", err))
+		return
+	}
+
+	if err := id.ValidateNamespaceMatchesTeam(identifier, teamInfo.Slug); err != nil {
+		a.sendAPIStoreError(c, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	aliasInfo, resolveErr := a.templateCache.ResolveAlias(ctx, identifier, teamInfo.Slug)
+	if resolveErr != nil {
+		if errors.Is(resolveErr, templatecache.ErrTemplateNotFound) {
+			a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+			return
+		}
+		apiErr := templatecache.ErrorToAPIError(resolveErr, identifier)
+		a.sendAPIStoreError(c, apiErr.Code, apiErr.ClientMsg)
+		return
+	}
+
+	if aliasInfo.TeamID != teamID {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	templateID := aliasInfo.TemplateID
+	tagStr := id.DefaultTag
+	if tag != nil {
+		tagStr = *tag
+	}
+
+	snapTemplates, dbErr := a.sqlcDB.ListTeamSnapshotTemplates(ctx, queries.ListTeamSnapshotTemplatesParams{
+		TeamID:     teamID,
+		EnvID:      &templateID,
+		Tag:        &tagStr,
+		CursorTime: time.Now().Add(24 * time.Hour),
+		CursorID:   maxSnapshotTemplateID,
+		PageLimit:  1,
+	})
+	if dbErr != nil {
+		telemetry.ReportCriticalError(ctx, "error looking up snapshot template", dbErr)
+		a.sendAPIStoreError(c, http.StatusInternalServerError, "Error looking up snapshot")
+		return
+	}
+
+	if len(snapTemplates) == 0 {
+		a.sendAPIStoreError(c, http.StatusNotFound, fmt.Sprintf("Snapshot '%s' not found", snapshotID))
+		return
+	}
+
+	snap := snapTemplates[0]
+	displayID := id.WithTag(snap.SnapshotID, snap.Tag)
+	if len(snap.Names) > 0 {
+		displayID = id.WithTag(snap.Names[0], snap.Tag)
+	}
+
+	diskMB := int32(0)
+	if snap.TotalDiskSizeMb != nil {
+		diskMB = int32(*snap.TotalDiskSizeMb)
+	}
+	c.JSON(http.StatusOK, api.SnapshotInfo{
+		SnapshotID: displayID,
+		Names:      snap.Names,
+		CpuCount:   int32(snap.Vcpu),
+		MemoryMB:   int32(snap.RamMb),
+		DiskSizeMB: diskMB,
+		CreatedAt:  snap.CreatedAt,
+	})
+}

--- a/packages/api/internal/handlers/snapshot_template_create.go
+++ b/packages/api/internal/handlers/snapshot_template_create.go
@@ -18,6 +18,8 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/ginutils"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
+	"time"
+
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	sharedUtils "github.com/e2b-dev/infra/packages/shared/pkg/utils"
 )
@@ -161,5 +163,9 @@ func (a *APIStore) PostSandboxesSandboxIDSnapshots(c *gin.Context, sandboxID api
 	c.JSON(http.StatusCreated, api.SnapshotInfo{
 		SnapshotID: snapshotID,
 		Names:      names,
+		CpuCount:   int32(sbx.VCpu),
+		MemoryMB:   int32(sbx.RamMB),
+		DiskSizeMB: int32(sbx.TotalDiskSizeMB),
+		CreatedAt:  time.Now(),
 	})
 }

--- a/packages/api/internal/handlers/snapshot_template_list.go
+++ b/packages/api/internal/handlers/snapshot_template_list.go
@@ -142,6 +142,10 @@ func (a *APIStore) GetSnapshots(c *gin.Context, params api.GetSnapshotsParams) {
 		return api.SnapshotInfo{
 			SnapshotID: snapshotID,
 			Names:      snap.Names,
+			CpuCount:   int32(snap.Vcpu),
+			MemoryMB:   int32(snap.RamMb),
+			DiskSizeMB: func() int32 { if snap.TotalDiskSizeMb != nil { return int32(*snap.TotalDiskSizeMb) }; return 0 }(),
+			CreatedAt:  snap.CreatedAt,
 		}
 	})
 

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -272,6 +272,10 @@ components:
       required:
         - snapshotID
         - names
+        - cpuCount
+        - memoryMB
+        - diskSizeMB
+        - createdAt
       properties:
         snapshotID:
           type: string
@@ -281,6 +285,16 @@ components:
           items:
             type: string
           description: Full names of the snapshot template including team namespace and tag (e.g. team-slug/my-snapshot:v2)
+        cpuCount:
+          $ref: "#/components/schemas/CPUCount"
+        memoryMB:
+          $ref: "#/components/schemas/MemoryMB"
+        diskSizeMB:
+          $ref: "#/components/schemas/DiskSizeMB"
+        createdAt:
+          type: string
+          format: date-time
+          description: Time when the snapshot was created
 
     EnvVars:
       additionalProperties:
@@ -2881,6 +2895,57 @@ paths:
                   $ref: "#/components/schemas/SnapshotInfo"
         "401":
           $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /snapshots/{snapshotID}:
+    get:
+      summary: Get snapshot
+      description: Get information about a single snapshot by its ID or alias
+      tags: [snapshots]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/snapshotID"
+      responses:
+        "200":
+          description: Successfully returned the snapshot
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+    delete:
+      summary: Delete snapshot
+      description: >-
+        Permanently deletes a snapshot template. Running sandboxes forked from
+        this snapshot are not affected. No new forks can be created after
+        deletion.
+      tags: [snapshots]
+      security:
+        - ApiKeyAuth: []
+        - AuthProviderBearerAuth: []
+          AuthProviderTeamAuth: []
+        - AdminApiKeyAuth: []
+          AdminTeamAuth: []
+      parameters:
+        - $ref: "#/components/parameters/snapshotID"
+      responses:
+        "204":
+          description: Snapshot was deleted successfully
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
 


### PR DESCRIPTION
## Summary

Fixes #3456
**Depends on #3441** (must merge first — this branch includes the fork endpoint commit as its parent)

- **`GET /snapshots/{snapshotID}`** — retrieve a single snapshot by ID or alias (404 if not found/not owned)
- **`DELETE /snapshots/{snapshotID}`** — soft-delete a snapshot template and release its aliases (204 on success)
- **Enhanced `SnapshotInfo`** — adds `cpuCount`, `memoryMB`, `diskSizeMB`, `createdAt` to both the new GET endpoint and the existing list endpoint

No new DB queries: all fields come from the existing `ListTeamSnapshotTemplates` row.

## Changes

| File | Change |
|---|---|
| `spec/openapi.yml` | Add `GET`/`DELETE` `/snapshots/{snapshotID}` paths; add 4 fields to `SnapshotInfo` schema |
| `api/internal/api/api.gen.go` | Update `SnapshotInfo` struct; add server/client interface methods, request builders, response parsers, and gin routes for both new endpoints |
| `handlers/snapshot_get.go` | New handler — alias resolution → `ListTeamSnapshotTemplates` (limit 1) → JSON response |
| `handlers/snapshot_delete.go` | New handler — alias resolution → `softDeleteTemplate` reuse → cache invalidation |
| `handlers/snapshot_template_list.go` | Populate 4 new `SnapshotInfo` fields in the list mapper |

## Test plan

- [x] `GET /snapshots/{snapshotID}` returns 200 with all fields populated
- [x] `GET /snapshots/{snapshotID}` returns 404 for unknown snapshot
- [x] `DELETE /snapshots/{snapshotID}` returns 204 and removes snapshot
- [x] `GET` after `DELETE` returns 404
- [x] Other snapshots unaffected after a targeted `DELETE`
- [x] `GET /snapshots` list now includes `cpuCount`, `memoryMB`, `diskSizeMB`, `createdAt`
