### PR TITLE
fix(template-build): create trailing-slash COPY targets before moving files

### DIFF
--- a/packages/orchestrator/pkg/template/build/commands/copy_script.sh
+++ b/packages/orchestrator/pkg/template/build/commands/copy_script.sh
@@ -41,7 +41,13 @@ fi
 # Check type BEFORE applying ownership/permissions to avoid dereferencing symlinks
 if [ -L "$entry" ]; then
     # It's a symlink – create parent folders and move+rename it to the exact path
-    mkdir -p "$(dirname "$targetPath")"
+    if [[ "$targetPath" == */ ]]; then
+        # Docker COPY semantics: a trailing slash means the target is a
+        # directory — create it and move the entry inside under its own name
+        mkdir -p "$targetPath"
+    else
+        mkdir -p "$(dirname "$targetPath")"
+    fi
     # Change ownership of the symlink itself (not the target)
     chown -h "$owner" "$entry"
     # Note: chmod on symlinks affects the target, not the link itself in most systems
@@ -53,7 +59,13 @@ elif [ -f "$entry" ]; then
     if [ -n "$permissions" ]; then
         chmod "$permissions" "$entry"
     fi
-    mkdir -p "$(dirname "$targetPath")"
+    if [[ "$targetPath" == */ ]]; then
+        # Docker COPY semantics: a trailing slash means the target is a
+        # directory — create it and move the entry inside under its own name
+        mkdir -p "$targetPath"
+    else
+        mkdir -p "$(dirname "$targetPath")"
+    fi
     mv "$entry" "$targetPath"
 elif [ -d "$entry" ]; then
     # It's a directory – apply ownership/permissions recursively, then merge

--- a/packages/orchestrator/pkg/template/build/commands/copy_test.go
+++ b/packages/orchestrator/pkg/template/build/commands/copy_test.go
@@ -441,6 +441,48 @@ func TestCopyScriptBehavior(t *testing.T) { //nolint:paralleltest // no idea why
 			},
 		},
 		{
+			name:        "single_file_to_new_nested_directory_trailing_slash",
+			description: "COPY file /a/b/c/ must create the directory chain and place the file inside (Docker semantics)",
+			files: map[string]string{
+				"test.sh": "file",
+			},
+			copyFrom:      "test.sh",
+			copyTo:        "a/b/c/",
+			shouldSucceed: true,
+			expectedPaths: map[string]string{
+				"a/b/c/test.sh": "file",
+			},
+		},
+		{
+			name:        "single_file_to_preexisting_directory_no_slash",
+			description: "COPY file /existing-dir (no trailing slash, dir exists) places the file inside it",
+			files: map[string]string{
+				"test.sh": "file",
+			},
+			preexistingTargetPaths: map[string]string{
+				"dest/": "dir",
+			},
+			copyFrom:      "test.sh",
+			copyTo:        "dest",
+			shouldSucceed: true,
+			expectedPaths: map[string]string{
+				"dest/test.sh": "file",
+			},
+		},
+		{
+			name:        "symlink_to_new_directory_trailing_slash",
+			description: "COPY symlink /newdir/ must create the directory and place the symlink inside (Docker semantics)",
+			files: map[string]string{
+				"link.txt": "symlink",
+			},
+			copyFrom:      "link.txt",
+			copyTo:        "newdir/",
+			shouldSucceed: true,
+			expectedPaths: map[string]string{
+				"newdir/link.txt": "symlink",
+			},
+		},
+		{
 			name:        "multiple_files_root_level",
 			description: "Multiple files at root, copied to target directory",
 			files: map[string]string{
@@ -869,8 +911,12 @@ func TestCopyScriptBehavior(t *testing.T) { //nolint:paralleltest // no idea why
 			// This mimics how copy.go constructs the path: filepath.Join(sbxUnpackPath, sourcePath)
 			sourcePath := filepath.Join(unpackDir, tc.copyFrom)
 
-			// Make target path absolute
+			// Make target path absolute, preserving a trailing slash
+			// (filepath.Join strips it, but Docker COPY semantics depend on it)
 			targetPathOrFile := filepath.Join(targetBaseDir, tc.copyTo)
+			if strings.HasSuffix(tc.copyTo, "/") {
+				targetPathOrFile += "/"
+			}
 
 			// Set owner if not specified
 			owner := tc.owner


### PR DESCRIPTION
## Problem

`COPY file /newdir/` fails during template builds when `/newdir` doesn't already exist in the base image:

```
[builder 4/11] COPY test.sh /tests/
[unpack] [stderr]: mv: cannot move 'test.sh' to '/tests/': Not a directory
Build failed: failed to move files in sandbox: exit status 1
```

Docker's COPY semantics: a destination ending in `/` is a directory — created on demand, with the file placed inside under its own name. In `copy_script.sh`, the file and symlink branches prepare the destination with `mkdir -p "$(dirname "$targetPath")"` — but `dirname "/tests/"` resolves to `/` (dirname yields the *parent*, discarding the trailing slash first), so the directory is never created and `mv` fails.

Impact is wider than it looks: the SDK splits multi-source `COPY a b c /dest/` into one step per file, so **every multi-file COPY into a not-yet-existing directory fails on its first file**. It presents as image-dependent flakiness ("works on ubuntu, fails on my base image") because it only bites when the directory isn't already present in the base image.

Found running [ReactBench](https://github.com/millionco/reactbench) tasks on [Harbor](https://github.com/laude-institute/harbor)'s E2B backend — its verifier Dockerfiles COPY six grading tools into `/tests/`. Related: e2b-dev/E2B#1624 (ARG-in-FROM substitution, the other blocker for the same Dockerfiles).

## Fix

Branch-local in `copy_script.sh` (file + symlink branches): if the target ends in `/`, `mkdir -p` the target itself; otherwise create its parent as before. No filename rewriting — `mv` natively places the entry into the directory under its own name, which also avoids mis-nesting when a same-named entry exists at the destination.

## Tests

`TestCopyScriptBehavior` couldn't express this case: the harness builds the target with `filepath.Join`, which **strips trailing slashes** — while production passes the raw target string through. Fixed the harness to preserve the slash, and added three rows:

| row | before | after |
|---|---|---|
| file → `a/b/c/` (new nested dir) | FAIL | PASS |
| symlink → `newdir/` (new dir) | FAIL | PASS |
| file → existing `dest` (no slash) | PASS | PASS (locks in current behavior) |

Full `TestCopyScriptBehavior` suite passes with the fix (Linux, Go 1.26.5); existing rows untouched.

## Known divergence, deliberately out of scope

When the destination already contains a *directory* named like the copied file, Docker errors ("cannot replace directory with non-directory") while `mv` silently nests into it (`/dest/test.sh/test.sh`). This is pre-existing behavior, unreachable through anything this fix newly enables (a freshly created directory is empty), and matching Docker would add new failure behavior to currently-"working" paths — so it's left as a conscious maintainer decision. Happy to follow up with a Docker-strict collision check if wanted.