### PR TITLE
fix(envd): return error when concurrent /init races on NFS mount

### DIFF
--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -335,6 +335,12 @@ func writeInitError(w http.ResponseWriter, logger zerolog.Logger, err error) {
 	switch {
 	case errors.Is(err, ErrAccessTokenMismatch), errors.Is(err, ErrAccessTokenResetNotAuthorized):
 		w.WriteHeader(http.StatusUnauthorized)
+	case errors.Is(err, ErrConcurrentNFSInit):
+		// Transient: a previous /init is still mounting NFS (setupNFS uses
+		// context.WithoutCancel so it outlives a request cancelled by EnvdInitRequestTimeout).
+		// The orchestrator retries on 503.
+		logger.Warn().Err(err).Msg("NFS mount already in progress, retrying")
+		w.WriteHeader(http.StatusServiceUnavailable)
 	case errors.Is(err, host.ErrCAInstallInProgress):
 		// Not a failure, a concurrent install still holds the CA lock.
 		logger.Warn().Err(err).Msg("CA initialization still in progress, retrying")

--- a/packages/envd/internal/api/init.go
+++ b/packages/envd/internal/api/init.go
@@ -33,6 +33,7 @@ var pinMMDSWarnLimit = ratelimit.New(10 * time.Second)
 var (
 	ErrAccessTokenMismatch           = errors.New("access token validation failed")
 	ErrAccessTokenResetNotAuthorized = errors.New("access token reset not authorized")
+	ErrConcurrentNFSInit             = errors.New("NFS mount already in progress")
 )
 
 const (
@@ -371,7 +372,7 @@ func (a *API) setupNFS(ctx context.Context, logger zerolog.Logger, lifecycleID *
 	if !a.isMountingNFS.CompareAndSwap(false, true) {
 		logger.Debug().Msg("NFS volumes already mounting")
 
-		return e
+		return ErrConcurrentNFSInit
 	}
 	defer a.isMountingNFS.Store(false)
 

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.13" // x-release-please-version
+const Version = "0.6.14" // x-release-please-version

--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -118,7 +118,14 @@ func (s *Sandbox) doRequestWithInfiniteRetries(
 		cancel()
 
 		if err == nil {
-			return response, requestCount, nil
+			// Treat 503 as a transient failure and retry: envd returns 503 when a
+			// concurrent /init is still in progress (e.g. an NFS mount outlived the
+			// previous per-request timeout). Discard the body and loop.
+			if response.StatusCode == http.StatusServiceUnavailable {
+				response.Body.Close()
+			} else {
+				return response, requestCount, nil
+			}
 		}
 
 		select {


### PR DESCRIPTION
When two concurrent `/init` requests race on `isMountingNFS`, the `CompareAndSwap` guard in `setupNFS` returns the named error value `e`, which is `nil`. The second caller proceeds as if NFS mounted successfully — sandbox starts with no volume mounts and no error surfaced to the caller.

**Fix:** return a package-level sentinel `ErrConcurrentNFSInit` so the caller receives a 500 and can retry. Using a sentinel (rather than `fmt.Errorf`) allows callers to match the error with `errors.Is()`, consistent with `ErrAccessTokenMismatch` and other sentinels in the same file.

## Change

```go
// before
if !a.isMountingNFS.CompareAndSwap(false, true) {
    logger.Debug().Msg("NFS volumes already mounting")
    return e  // nil — silent failure
}

// after
var ErrConcurrentNFSInit = errors.New("NFS mount already in progress")

if !a.isMountingNFS.CompareAndSwap(false, true) {
    logger.Debug().Msg("NFS volumes already mounting")
    return ErrConcurrentNFSInit
}
```

1 file, 2 lines changed.

/cc @ben-fornefeld @jakubno @dobrac @ValentaTomas @arkamar @tvi Looking forward to your code review.