### PR TITLE
ci: run the full integration suite once, compression variants only where they matter

### DIFF
--- a/.github/actions/build-packages/action.yml
+++ b/.github/actions/build-packages/action.yml
@@ -7,12 +7,25 @@ runs:
     - name: Setup Go
       uses: ./.github/actions/go-setup-cache
 
+    # Built concurrently: the runner has 32 cores and 128 GB, while the two
+    # slow builds (api, orchestrator) are mostly serial link steps that leave
+    # the box idle. Output is buffered per package so logs stay readable.
     - name: Build Packages
       run: |
-        make -C tests/integration build-debug
-        make -C packages/db build-debug
-        make -C packages/orchestrator build-debug
-        make -C packages/api build-debug
-        make -C packages/envd build-debug
-        make -C packages/client-proxy build-debug
+        packages=(tests/integration packages/db packages/orchestrator packages/api packages/envd packages/client-proxy)
+
+        pids=()
+        for package in "${packages[@]}"; do
+          make -C "$package" build-debug >"${RUNNER_TEMP}/build-${package//\//_}.log" 2>&1 &
+          pids+=("$!")
+        done
+
+        status=0
+        for i in "${!packages[@]}"; do
+          wait "${pids[$i]}" || status=1
+          echo "::group::build ${packages[$i]}"
+          cat "${RUNNER_TEMP}/build-${packages[$i]//\//_}.log"
+          echo "::endgroup::"
+        done
+        exit "$status"
       shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v5
 
+      # The compressed configs only run what the allow-list names, so verify
+      # its stale-entry guard still bites before depending on it.
+      - name: Check Test Allow-list
+        run: make -C tests/integration check-tests-allowlist
+        shell: bash
+
       - name: Build Packages
         uses: ./.github/actions/build-packages
 
@@ -86,6 +92,11 @@ jobs:
           TESTS_ORCHESTRATOR_HOST: "localhost:5008"
           TESTS_ENVD_PROXY: "http://localhost:3002"
           TESTS_CLIENT_PROXY: "http://localhost:3002"
+          # The uncompressed config runs the whole suite. The compressed configs
+          # only re-run the tests whose subject is writing or reading back a
+          # snapshot, which is all the compression knobs can affect — the
+          # allow-list documents the criteria and the code paths involved.
+          TESTS_ONLY: ${{ matrix.compress_enabled == 'true' && 'scripts/compression-tests.tsv' || '' }}
         run: |
           # Run the integration tests
           make test-integration

--- a/tests/integration/Makefile
+++ b/tests/integration/Makefile
@@ -21,6 +21,28 @@ seed:
 		go run seed.go
 	@echo "Done"
 
+# TESTS_ONLY points at an allow-list file (see scripts/compression-tests.tsv)
+# and narrows the run to the tests it names. Overridable from the environment.
+TESTS_ONLY := $(strip $(TESTS_ONLY))
+
+# The compressed configs only run what the allow-list names, so a stale entry
+# would silently stop testing something. select-tests.sh rejects entries that
+# match no test; this proves it still does, for named tests and for the
+# package wildcards alike, before CI relies on it.
+.PHONY: check-tests-allowlist
+check-tests-allowlist:
+	@set -e; \
+	tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+	./scripts/select-tests.sh --only scripts/compression-tests.tsv ./internal/tests/... >/dev/null; \
+	printf 'internal/tests/orchestrator\t*\ninternal/tests/api/sandboxes\tTestNoSuchTestExists\n' >"$$tmp/named.tsv"; \
+	printf 'internal/tests/orchestrator\t*\ninternal/tests/no-such-package\t*\n' >"$$tmp/wildcard.tsv"; \
+	for kind in named wildcard; do \
+		if ./scripts/select-tests.sh --only "$$tmp/$$kind.tsv" ./internal/tests/... >/dev/null 2>&1; then \
+			echo "select-tests.sh accepted a stale $$kind entry" >&2; exit 1; \
+		fi; \
+	done; \
+	echo "allow-list resolves; stale named and wildcard entries are rejected"
+
 .PHONY: test
 test: test/.
 test/%:
@@ -35,14 +57,17 @@ test/%:
 	export TESTS_SANDBOX_USER_ID=$(TESTS_SANDBOX_USER_ID); \
 	go test -v ./internal/main_test.go -count=1 && \
 	TEST_PATH="./internal/tests/$(subst test/,,$@)"; \
+	TEST_PATH="$${TEST_PATH%/.}"; \
+	RUN=""; \
 	case "$${TEST_PATH}" in \
-		*.go:*) \
-			BASE=$${TEST_PATH%%:*}; \
-			TEST_FN=$${TEST_PATH#*:}; \
-			go tool gotestsum --rerun-fails=1 --packages="$$BASE" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 -timeout=20m -run "$${TEST_FN}" ;; \
-		*.go) go tool gotestsum --rerun-fails=1 --packages="$$TEST_PATH" --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 -timeout=20m ;; \
-		*) go tool gotestsum --rerun-fails=1 --packages="$$TEST_PATH/..." --format standard-verbose --junitfile=test-results.xml -- -count=1 -parallel=4 -timeout=20m ;; \
-	esac
+		*.go:*) PACKAGES="$${TEST_PATH%%:*}"; RUN="$${TEST_PATH#*:}" ;; \
+		*.go) PACKAGES="$${TEST_PATH}" ;; \
+		*) PACKAGES="$${TEST_PATH}/..." ;; \
+	esac; \
+	if [ -n "$(TESTS_ONLY)" ]; then RUN=$$(./scripts/select-tests.sh --only $(TESTS_ONLY) "$${PACKAGES}") || exit 1; fi; \
+	if [ -n "$${RUN}" ]; then set -- -run "$${RUN}"; else set --; fi; \
+	go tool gotestsum --rerun-fails=1 --packages="$${PACKAGES}" --format standard-verbose --junitfile=test-results.xml \
+		-- -count=1 -parallel=4 -timeout=20m "$$@"
 
 .PHONY: connect-orchestrator
 connect-orchestrator:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -9,6 +9,19 @@ Package for defining integration tests. Currently, there is a setup for API and 
 3. If necessary, run `make connect-orchestrator` to create a tunnel to one orchestrator client VM in GCP (you may need to run `make setup-ssh` the first time)
 4. Run `make test` in this folder or `make test-integration` from the root `infra/` folder.
 
+Narrow the run with `make test/<path under internal/tests>`, e.g. `make test/api/templates`
+or `make test/api/templates/build_template_test.go:TestTemplateBuildCOPY`.
+
+## What CI runs
+
+The `uncompressed` config runs the whole suite. The compressed configs (`zstd1`,
+`lz4`) re-run only `scripts/compression-tests.tsv`, the explicit allow-list of
+tests whose subject is writing or reading back a snapshot; that file documents
+the inclusion criteria and the code paths the compression knobs reach. Select it
+locally with `TESTS_ONLY=scripts/compression-tests.tsv make test`. An entry that
+no longer matches a real test is an error, so the list cannot rot into silently
+reduced coverage.
+
 ## Usage of clients (api, orchestrator, envd)
 
 All tests are in the folder internal/tests. You can see the usage of different clients in the tests. Here are just basics.

--- a/tests/integration/scripts/compression-tests.tsv
+++ b/tests/integration/scripts/compression-tests.tsv
@@ -1,0 +1,87 @@
+# package	test
+#
+# Allow-list of tests run under the compressed storage configs (zstd1, lz4).
+# The uncompressed config always runs the whole suite; this file only decides
+# what is worth running a *second* and *third* time with compression on.
+#
+# The compression knobs (COMPRESS_ENABLED/TYPE/LEVEL/FRAME_ENCODE_WORKERS,
+# TESTS_MEMFILE_DIFF_DEDUP_MODE, TESTS_DISABLE_MEMFD) reach the system at
+# exactly four points:
+#   1. template build layer upload  - storage.UseCaseBuild, layer_executor.go
+#   2. pause/snapshot upload        - storage.UseCasePause, server/sandboxes.go
+#   3. decompress on chunk read     - storage_cache_seekable.go
+#   4. snapshot diffing / guest memory backing - MemfileDiffDedupFlag and
+#      UseMemFdFlag in pkg/sandbox/sandbox.go
+#
+# So a test earns a slot here if its subject is writing or reading back a
+# snapshot: pause, resume, fork, auto-pause, snapshot templates, snapshot
+# content integrity, fsfreeze, persistent volumes, or a template build that
+# reads its own layers back. Tests whose subject is API surface, egress
+# firewall behaviour, proxy routing or the envd feature set are excluded: they
+# do start sandboxes and therefore decompress template chunks, but that read
+# path is already covered many times over by the entries below, so they only
+# add wall time. Frames are a fixed 2 MiB (storage.DefaultCompressFrameSize)
+# and must stay a multiple of the hugepage and rootfs block sizes, so the
+# compressed writer is agnostic to what a layer contains - a handful of builds
+# covers it, and 58 do not.
+#
+# "*" selects every test in the package. shard-tests.sh fails if an entry no
+# longer exists, so this list cannot rot into silently reduced coverage.
+
+# Snapshot/restore integrity suite - entirely on the pause/resume path.
+internal/tests/orchestrator	*
+
+# Auto-resume through the proxy resumes real paused sandboxes.
+internal/tests/proxies	*
+
+# Persistent volumes are a separate storage path.
+internal/tests/api/volumes	*
+
+# Snapshot templates: pause -> template -> new sandbox.
+internal/tests/api/sandboxes	TestSnapshotTemplateCreate
+internal/tests/api/sandboxes	TestSnapshotTemplateCreateSandbox
+internal/tests/api/sandboxes	TestSnapshotTemplateList
+internal/tests/api/sandboxes	TestSnapshotTemplateDelete
+internal/tests/api/sandboxes	TestSnapshotTemplateConcurrentOperations
+
+# Pause / resume / fork / auto-pause lifecycle.
+internal/tests/api/sandboxes	TestSandboxPause
+internal/tests/api/sandboxes	TestSandboxPauseNonFound
+internal/tests/api/sandboxes	TestSandboxResume
+internal/tests/api/sandboxes	TestSandboxResumeUnknownSandbox
+internal/tests/api/sandboxes	TestSandboxResumeWithSecuredEnvd
+internal/tests/api/sandboxes	TestSandboxResume_FilesystemOnlyReboots
+internal/tests/api/sandboxes	TestSandboxConnect_FilesystemOnlyResumes
+internal/tests/api/sandboxes	TestSandboxFork
+internal/tests/api/sandboxes	TestSandboxFork_Multiple
+internal/tests/api/sandboxes	TestSandboxFork_AlreadyPaused
+internal/tests/api/sandboxes	TestSandboxFork_NotFound
+internal/tests/api/sandboxes	TestSandboxFork_InvalidCount
+internal/tests/api/sandboxes	TestSandboxRapidSnapshotForkChain
+internal/tests/api/sandboxes	TestSandboxAutoPausePauseResume
+internal/tests/api/sandboxes	TestSandboxAutoPauseResumePersisted
+internal/tests/api/sandboxes	TestSandboxAutoPause_FilesystemOnly
+internal/tests/api/sandboxes	TestSandboxNotAutoPause
+
+# Plain create reads the base template's compressed chunks; the fuse tests
+# cover how the decompressed rootfs is presented in the guest.
+internal/tests/api/sandboxes	TestSandboxCreate
+internal/tests/api/sandboxes	TestFuseDevicePermissions
+internal/tests/api/sandboxes	TestFuseNonRootAccess
+
+# Template builds that write layers and read them back: cache reuse,
+# multi-level inheritance, a large COPY layer, a package-install RUN layer,
+# distinct source images, and a plain single-layer build.
+internal/tests/api/templates	TestTemplateBuildCache
+internal/tests/api/templates	TestTemplateBuildFromTemplate
+internal/tests/api/templates	TestTemplateBuildFromTemplateLayered
+internal/tests/api/templates	TestTemplateBuildCOPY
+internal/tests/api/templates	TestTemplateBuildRUN
+internal/tests/api/templates	TestTemplateBuildWithDifferentSourceImages
+
+# Guest filesystem state across freeze/snapshot/resume.
+internal/tests/envd	TestFsFreezeThaw
+internal/tests/envd	TestCACertRotationOnResume
+internal/tests/envd	TestSecureSandboxFilesystemOnlyResumeAuth
+internal/tests/envd	TestAccessAuthorizedPathWithResumedSandboxWithValidAccessToken
+internal/tests/envd	TestAccessAuthorizedPathWithResumedSandboxWithoutAccessToken

--- a/tests/integration/scripts/select-tests.sh
+++ b/tests/integration/scripts/select-tests.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Print the `go test -run` regex for the tests an allow-list selects.
+#
+#   select-tests.sh --only <allow-list> <package>...
+#
+# The allow-list holds "package<TAB>test" lines, or "package<TAB>*" for a whole
+# package — see compression-tests.tsv. Tests are enumerated from the source tree
+# at run time, and *every* entry must match at least one of them: a named test
+# that no longer exists and a wildcard whose package was renamed or emptied are
+# both hard errors, so a stale list fails loudly instead of quietly shrinking
+# coverage. `make check-tests-allowlist` proves that guard still bites.
+set -euo pipefail
+
+if [ "${1:-}" != "--only" ] || [ "$#" -lt 3 ]; then
+	echo "usage: $0 --only <allow-list> <package>..." >&2
+	exit 2
+fi
+
+only=$2
+shift 2
+
+if [ ! -r "$only" ]; then
+	echo "$0: cannot read allow-list: $only" >&2
+	exit 2
+fi
+
+dirs=()
+for pkg in "$@"; do
+	pkg=${pkg#./}
+	case "$pkg" in
+	*/...)
+		while IFS= read -r dir; do
+			dirs+=("${dir#./}")
+		done < <(find "${pkg%/...}" -type d | sort)
+		;;
+	*) dirs+=("$pkg") ;;
+	esac
+done
+
+names=$(
+	for dir in "${dirs[@]}"; do
+		compgen -G "${dir}/*_test.go" >/dev/null || continue
+		sed -n 's/^func \(Test[A-Za-z0-9_]*\)(.*/\1/p' "${dir}"/*_test.go |
+			sort -u | sed "s|^|${dir}\t|"
+	done
+)
+
+if [ -z "$names" ]; then
+	echo "no tests found in: $*" >&2
+	exit 1
+fi
+
+printf '%s\n' "$names" | awk -F'\t' -v list="$only" '
+	BEGIN {
+		while ((getline line < list) > 0) {
+			if (line ~ /^#/ || line == "") continue
+			split(line, f, "\t")
+			# Both kinds of entry start unmatched and must be hit below.
+			if (f[2] == "*") wildcard[f[1]] = 0; else named[f[1] SUBSEP f[2]] = 0
+		}
+	}
+	($1 in wildcard) { wildcard[$1]++; out = out (out ? "|" : "") $2; next }
+	(($1 SUBSEP $2) in named) { named[$1 SUBSEP $2]++; out = out (out ? "|" : "") $2 }
+	END {
+		for (k in wildcard) if (!wildcard[k]) { print list ": no tests in package: " k > "/dev/stderr"; bad = 1 }
+		for (k in named) if (!named[k]) { split(k, f, SUBSEP); print list ": no such test: " f[1] " " f[2] > "/dev/stderr"; bad = 1 }
+		if (bad) exit 1
+		if (out == "") { print list ": selected no tests" > "/dev/stderr"; exit 1 }
+		print "^(" out ")$"
+	}
+'


### PR DESCRIPTION
All three compression configs ran the entire suite, so CI spent **50 runner-minutes** re-running every API-surface, egress-firewall and envd test three times. The compression knobs (`COMPRESS_*`, `TESTS_MEMFILE_DIFF_DEDUP_MODE`, `TESTS_DISABLE_MEMFD`) reach only four code paths: template layer upload (`storage.UseCaseBuild`), pause/snapshot upload (`storage.UseCasePause`), decompress-on-read in the seekable chunk cache, and the dedup/memfd flags in `pkg/sandbox`. Frames are a fixed 2 MiB, so the compressed writer does not care what a layer contains. `uncompressed` still runs everything; `zstd1` and `lz4` re-run `scripts/compression-tests.tsv` — an explicit allow-list of tests whose subject is writing or reading back a snapshot, criteria documented in the file. Any entry matching zero tests is a hard error, and `make check-tests-allowlist` runs in CI to prove that guard still bites.

Measured on this PR: **50 -> 28.1 runner-minutes**, wall clock **20.1m -> 10.9m**, end-to-end **21.5m -> 11.1m**. 166 of 227 tests no longer re-run under compression; they still run in full under `uncompressed`. Safety evidence: when the Alpine/musl envd break landed on #3437, all three compression shards failed identically — compression-invariant tests gain nothing from the extra two runs. The 26 egress-firewall tests alone were 2560s of zstd1 time and are network-timeout bound.