### PR TITLE
feat(shared): add typed object IDs (ProjectID, WorkspaceID)

### DIFF
--- a/packages/shared/pkg/id/object.go
+++ b/packages/shared/pkg/id/object.go
@@ -1,0 +1,227 @@
+// Typed object IDs: a kind tag, an underscore, and the object's UUID in the
+// encoding objectid.go defines.
+//
+//	prj_uk75vf2v7iagp2kgn7pfze3car
+//	wrk_imkhttdroeagp2kgn7t53cvkiw
+//
+// The tag is there for the reader and for the parser: it says what the ID
+// names, so a project ID pasted where a workspace ID belongs is rejected at
+// the edge with a message that says which is which, rather than becoming a
+// lookup that finds nothing.
+//
+// # Width
+//
+// Every ID is exactly ObjectIDLen characters: prefixLen for the tag, one for
+// the separator, encodedLen for the body. Nothing about it varies, so the
+// parser reads by position rather than by searching for the separator, and a
+// storage column can be a fixed 30. Holding the width means holding the
+// prefixes to prefixLen, which the compile-time assertions below do: a
+// two- or four-character prefix does not build.
+//
+// In Go the tag is carried in the type, not in the value. ObjectID is generic
+// over a phantom type that names one ObjectKind, and ProjectID and
+// WorkspaceID are that generic instantiated: distinct types, so assigning one
+// to the other does not compile, sharing one copy of the parsing and
+// formatting. The underlying type is uuid.UUID, so conversion in either
+// direction is a conversion and needs no accessor:
+//
+//	pid := ProjectID(uuid.Must(uuid.NewV7()))
+//	u := uuid.UUID(pid)
+//
+// Conversion between two ObjectIDs compiles too, since their underlying types
+// are identical. That is deliberate: crossing kinds should be possible, but
+// only by writing it down.
+
+package id
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+)
+
+// ObjectKind enumerates the kinds of object an ID can name. The zero value is
+// no kind; every valid kind has a prefix.
+type ObjectKind uint8
+
+const (
+	KindProject ObjectKind = iota + 1
+	KindWorkspace
+)
+
+// The prefixes. Three lowercase letters each, one per kind, none of them a
+// prefix of another since they are all the same width.
+const (
+	projectPrefix   = "prj"
+	workspacePrefix = "wrk"
+)
+
+const (
+	// prefixLen is how many characters a kind tag takes. Fixed, so the
+	// whole ID is fixed.
+	prefixLen = 3
+
+	// prefixSeparator divides the tag from the body. It is not in the
+	// body's alphabet ("a-z2-7") and not in any prefix, so the one at
+	// separatorIndex is the only one an ID can contain.
+	prefixSeparator = '_'
+
+	// separatorIndex is where that character must be, and bodyIndex where
+	// the encoded UUID starts.
+	separatorIndex = prefixLen
+	bodyIndex      = separatorIndex + 1
+
+	// ObjectIDLen is the width of every object ID: 3 + 1 + 26 = 30. It
+	// does not vary by kind, by UUID version, or over time.
+	ObjectIDLen = bodyIndex + encodedLen
+)
+
+// The width above holds only if every prefix is exactly prefixLen
+// characters. These are the check, made by the compiler rather than by a
+// test: an array of one length does not satisfy a declaration of another, so
+// a prefix of the wrong width fails to build.
+var (
+	_ [prefixLen]byte = [len(projectPrefix)]byte{}
+	_ [prefixLen]byte = [len(workspacePrefix)]byte{}
+)
+
+var (
+	// ErrNoPrefix means the string carries no kind tag at all: there is no
+	// separator where one must be.
+	ErrNoPrefix = errors.New("id: missing kind prefix")
+
+	// ErrWrongKind means the string is a well-formed ID of another kind.
+	ErrWrongKind = errors.New("id: wrong kind")
+)
+
+// Prefix returns the tag that leads an ID of this kind, or "" if k is not a
+// kind this package defines.
+func (k ObjectKind) Prefix() string {
+	switch k {
+	case KindProject:
+		return projectPrefix
+	case KindWorkspace:
+		return workspacePrefix
+	default:
+		return ""
+	}
+}
+
+// String is the prefix, which is the name these objects go by outside Go.
+func (k ObjectKind) String() string {
+	if p := k.Prefix(); p != "" {
+		return p
+	}
+
+	return "ObjectKind(" + strconv.Itoa(int(k)) + ")"
+}
+
+// kind constrains ObjectID's type parameter. Its method is unexported, so the
+// set of kinds is closed to this package: no other package can instantiate
+// ObjectID with a type of its own.
+type kind interface{ objectKind() ObjectKind }
+
+type (
+	projectKind   struct{}
+	workspaceKind struct{}
+)
+
+func (projectKind) objectKind() ObjectKind   { return KindProject }
+func (workspaceKind) objectKind() ObjectKind { return KindWorkspace }
+
+// ObjectID is a UUID that knows, in its type, what it names. Use the aliases
+// below rather than naming it directly.
+type ObjectID[K kind] uuid.UUID
+
+type (
+	ProjectID   = ObjectID[projectKind]
+	WorkspaceID = ObjectID[workspaceKind]
+)
+
+// Kind is the kind this ID names, the same for every value of the type.
+func (o ObjectID[K]) Kind() ObjectKind {
+	var k K
+
+	return k.objectKind()
+}
+
+// String is the external form: prefix, underscore, 26 base32 characters,
+// ObjectIDLen in all. It is what ParseProjectID and ParseWorkspaceID accept,
+// and the only spelling they accept.
+func (o ObjectID[K]) String() string {
+	return o.Kind().Prefix() + string(prefixSeparator) + Encode(uuid.UUID(o))
+}
+
+// ParseProjectID reads a project ID. It rejects IDs of any other kind, and
+// anything whose body is not exactly what Encode produces.
+func ParseProjectID(s string) (ProjectID, error) {
+	return parseObjectID[projectKind](s)
+}
+
+// ParseWorkspaceID reads a workspace ID, under the same rules.
+func ParseWorkspaceID(s string) (WorkspaceID, error) {
+	return parseObjectID[workspaceKind](s)
+}
+
+// MustParseProjectID is ParseProjectID for IDs fixed in the source, where a
+// failure is a bug in the program rather than in its input. It panics.
+func MustParseProjectID(s string) ProjectID {
+	return mustParseObjectID(ParseProjectID(s))
+}
+
+// MustParseWorkspaceID is MustParseProjectID for workspaces.
+func MustParseWorkspaceID(s string) WorkspaceID {
+	return mustParseObjectID(ParseWorkspaceID(s))
+}
+
+// ConvertTeamIDToProjectID names a team by the word the outside world uses.
+// A project is a row in public.teams: the same identity under two names, one
+// internal and older than the other. The UUID is carried across unchanged;
+// what changes is only how it is written and what it is called.
+//
+// It is a conversion, so it cannot fail, and it is spelled out as a function
+// rather than left to ProjectID(teamID) so that the places where the rename
+// is crossed can be found by searching for it.
+func ConvertTeamIDToProjectID(teamID uuid.UUID) ProjectID {
+	return ProjectID(teamID)
+}
+
+func parseObjectID[K kind](s string) (ObjectID[K], error) {
+	var zero ObjectID[K]
+	want := zero.Kind()
+
+	// Width first, so the two slices below are always in range and so the
+	// commonest kind of bad input is rejected by one comparison.
+	if len(s) != ObjectIDLen {
+		return zero, fmt.Errorf("%w: %q is %d characters, want %d (%q, %q, %d more)",
+			ErrBadLength, s, len(s), ObjectIDLen, want, prefixSeparator, encodedLen)
+	}
+	if s[separatorIndex] != prefixSeparator {
+		return zero, fmt.Errorf("%w: %q has %q at index %d, want %q",
+			ErrNoPrefix, s, s[separatorIndex], separatorIndex, prefixSeparator)
+	}
+	if prefix := s[:prefixLen]; prefix != want.Prefix() {
+		return zero, fmt.Errorf("%w: %q is a %q id, want %q", ErrWrongKind, s, prefix, want)
+	}
+
+	// The body's own errors (ErrNotCanonical, base32 membership) are
+	// wrapped rather than restated: they are more precise than anything
+	// this layer knows. Its length check cannot fire, the width above
+	// having settled it.
+	u, err := Decode(s[bodyIndex:])
+	if err != nil {
+		return zero, fmt.Errorf("%q is not a %s id: %w", s, want, err)
+	}
+
+	return ObjectID[K](u), nil
+}
+
+func mustParseObjectID[K kind](o ObjectID[K], err error) ObjectID[K] {
+	if err != nil {
+		panic(err)
+	}
+
+	return o
+}

--- a/packages/shared/pkg/id/object_test.go
+++ b/packages/shared/pkg/id/object_test.go
@@ -1,0 +1,355 @@
+package id
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// nonCanonical is a 26-character body that decodes but is not what Encode
+// emits: 'b' is digit value 1, and at slackIndex the low slackBits must be
+// zero. Encode(uuid.Nil) is 26 'a's, so this is that string with the one
+// digit that matters changed.
+var nonCanonical = strings.Repeat("a", slackIndex) + "b" + strings.Repeat("a", encodedLen-slackIndex-1)
+
+// allKinds is every kind the package defines. A kind added without being
+// added here is a kind these tests do not check, so it is also listed in
+// TestAllKindsAreListed.
+var allKinds = []ObjectKind{KindProject, KindWorkspace}
+
+// TestWidthIsFixed is the claim the parser rests on: every ID of every kind
+// is ObjectIDLen characters, made of a prefixLen tag, the separator, and a
+// body of encodedLen. If this fails the parser is indexing into strings on
+// an assumption that no longer holds.
+func TestWidthIsFixed(t *testing.T) {
+	t.Parallel()
+
+	if ObjectIDLen != 30 {
+		t.Errorf("ObjectIDLen = %d, want 30", ObjectIDLen)
+	}
+	if ObjectIDLen != prefixLen+1+encodedLen {
+		t.Errorf("ObjectIDLen %d is not %d + 1 + %d", ObjectIDLen, prefixLen, encodedLen)
+	}
+	if separatorIndex != prefixLen || bodyIndex != prefixLen+1 {
+		t.Errorf("separator at %d and body at %d do not follow a prefix of %d",
+			separatorIndex, bodyIndex, prefixLen)
+	}
+
+	// The extremes and a real v7, as both kinds: nothing about the width
+	// depends on the value.
+	for _, u := range []uuid.UUID{uuid.Nil, uuid.Max, uuid.MustParse(goldenV7[0].id)} {
+		for _, s := range []string{ProjectID(u).String(), WorkspaceID(u).String()} {
+			if len(s) != ObjectIDLen {
+				t.Errorf("%q is %d characters, want %d", s, len(s), ObjectIDLen)
+			}
+			if s[separatorIndex] != prefixSeparator {
+				t.Errorf("%q has %q at index %d, want %q",
+					s, s[separatorIndex], separatorIndex, prefixSeparator)
+			}
+			if strings.Count(s, string(prefixSeparator)) != 1 {
+				t.Errorf("%q has more than one %q", s, prefixSeparator)
+			}
+		}
+	}
+}
+
+// TestAllKindsAreListed catches a kind added to the enum but not to allKinds,
+// which would otherwise silently go untested. It walks past the last known
+// kind rather than trusting the list.
+func TestAllKindsAreListed(t *testing.T) {
+	t.Parallel()
+
+	for k := ObjectKind(1); int(k) <= len(allKinds)+8; k++ {
+		defined := k.Prefix() != ""
+		listed := slices.Contains(allKinds, k)
+		if defined != listed {
+			t.Errorf("ObjectKind(%d): prefix %q, in allKinds: %v", k, k.Prefix(), listed)
+		}
+	}
+}
+
+// TestPrefixesAreUsable holds the prefix table to what the format needs: each
+// kind has a tag of exactly prefixLen letters, and they differ.
+func TestPrefixesAreUsable(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]ObjectKind{}
+	for _, k := range allKinds {
+		p := k.Prefix()
+		if len(p) != prefixLen {
+			t.Errorf("ObjectKind(%d) has prefix %q of width %d, want %d", k, p, len(p), prefixLen)
+
+			continue
+		}
+		// Letters only: no separator, no digit, no case to normalize,
+		// nothing that has to be escaped in a URL or a log line.
+		for i := range len(p) {
+			if p[i] < 'a' || p[i] > 'z' {
+				t.Errorf("prefix %q has %q at index %d, want a lowercase letter", p, p[i], i)
+			}
+		}
+		if other, dup := seen[p]; dup {
+			t.Errorf("ObjectKind(%d) and ObjectKind(%d) share the prefix %q", other, k, p)
+		}
+		seen[p] = k
+		if k.String() != p {
+			t.Errorf("ObjectKind(%d).String() = %q, want the prefix %q", k, k.String(), p)
+		}
+	}
+
+	// The zero value is no kind, and says so rather than passing for one.
+	var zero ObjectKind
+	if zero.Prefix() != "" {
+		t.Errorf("the zero ObjectKind has prefix %q, want none", zero.Prefix())
+	}
+	if zero.String() != "ObjectKind(0)" {
+		t.Errorf("the zero ObjectKind prints as %q", zero.String())
+	}
+}
+
+// TestStringIsPrefixedEncoding is the external form, against the golden UUIDs
+// the codec's own tests pin: the same 26 characters, behind a tag that
+// depends only on the type.
+func TestStringIsPrefixedEncoding(t *testing.T) {
+	t.Parallel()
+
+	for _, g := range goldenV7 {
+		u := uuid.MustParse(g.id)
+
+		if got, want := ProjectID(u).String(), "prj_"+g.want; got != want {
+			t.Errorf("ProjectID(%v).String() = %q, want %q", u, got, want)
+		}
+		if got, want := WorkspaceID(u).String(), "wrk_"+g.want; got != want {
+			t.Errorf("WorkspaceID(%v).String() = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestKindIsInTheType(t *testing.T) {
+	t.Parallel()
+
+	if got := (ProjectID{}).Kind(); got != KindProject {
+		t.Errorf("ProjectID.Kind() = %v, want %v", got, KindProject)
+	}
+	if got := (WorkspaceID{}).Kind(); got != KindWorkspace {
+		t.Errorf("WorkspaceID.Kind() = %v, want %v", got, KindWorkspace)
+	}
+
+	// Distinct types, so one cannot be assigned to the other by accident.
+	// The compiler enforces this; the test records it, since a careless
+	// edit could collapse both aliases onto one instantiation and nothing
+	// else here would notice.
+	p, w := reflect.TypeFor[ProjectID](), reflect.TypeFor[WorkspaceID]()
+	if p == w {
+		t.Fatalf("ProjectID and WorkspaceID are the same type %v", p)
+	}
+	if p.Kind() != reflect.Array || p.Size() != reflect.TypeFor[uuid.UUID]().Size() {
+		t.Errorf("ProjectID is %v of size %d, want a uuid", p.Kind(), p.Size())
+	}
+}
+
+// TestConvertTeamIDToProjectID: the UUID is untouched, only the name and the
+// spelling change. Checked over the corpus, since a conversion that dropped
+// or reordered bytes would still compile.
+func TestConvertTeamIDToProjectID(t *testing.T) {
+	t.Parallel()
+
+	for _, teamID := range corpus(t, 11, 500) {
+		p := ConvertTeamIDToProjectID(teamID)
+		if uuid.UUID(p) != teamID {
+			t.Fatalf("ConvertTeamIDToProjectID(%v) = %v, want the same uuid", teamID, uuid.UUID(p))
+		}
+		if p.Kind() != KindProject {
+			t.Fatalf("ConvertTeamIDToProjectID(%v).Kind() = %v, want %v", teamID, p.Kind(), KindProject)
+		}
+
+		// And the round trip the other way: the string parses back to
+		// the team ID it started as.
+		back, err := ParseProjectID(p.String())
+		if err != nil {
+			t.Fatalf("ParseProjectID(%q): %v", p, err)
+		}
+		if uuid.UUID(back) != teamID {
+			t.Fatalf("ParseProjectID(%q) = %v, want %v", p, uuid.UUID(back), teamID)
+		}
+	}
+}
+
+// TestRoundTripThroughStrings is the property both parsers exist for, over
+// the codec's corpus: whatever String writes, Parse reads back unchanged.
+func TestRoundTripThroughStrings(t *testing.T) {
+	t.Parallel()
+
+	for _, u := range corpus(t, 7, 2000) {
+		p := ProjectID(u)
+		gotP, err := ParseProjectID(p.String())
+		if err != nil {
+			t.Fatalf("ParseProjectID(%q): %v", p, err)
+		}
+		if gotP != p {
+			t.Fatalf("ParseProjectID(%q) = %v, want %v", p, uuid.UUID(gotP), u)
+		}
+
+		w := WorkspaceID(u)
+		gotW, err := ParseWorkspaceID(w.String())
+		if err != nil {
+			t.Fatalf("ParseWorkspaceID(%q): %v", w, err)
+		}
+		if gotW != w {
+			t.Fatalf("ParseWorkspaceID(%q) = %v, want %v", w, uuid.UUID(gotW), u)
+		}
+	}
+}
+
+// TestParseRejects is the list of things that are not an ID of the kind
+// asked for. Each case is run against both parsers, with the prefix
+// substituted, since neither should be laxer than the other.
+func TestParseRejects(t *testing.T) {
+	t.Parallel()
+
+	body := goldenV7[0].want
+
+	cases := []struct {
+		name string
+		in   string // %s is the kind's own prefix, %S that prefix uppercased
+		want error
+	}{
+		// Anything that is not ObjectIDLen characters is refused on width
+		// alone, before its parts are looked at.
+		{"empty", "", ErrBadLength},
+		{"no separator", "%s" + body, ErrBadLength},
+		{"bare body", body, ErrBadLength},
+		{"prefix only", "%s", ErrBadLength},
+		{"prefix and separator only", "%s_", ErrBadLength},
+		{"body one short", "%s_" + body[1:], ErrBadLength},
+		{"body one long", "%s_" + body + "a", ErrBadLength},
+		{"two-character prefix", "pr_" + body, ErrBadLength},
+		{"leading space", " %s_" + body, ErrBadLength},
+		{"trailing newline", "%s_" + body + "\n", ErrBadLength},
+		{"empty prefix", "_" + body, ErrBadLength},
+		{"uuid instead of body", "%s_019fa519-bf79-724d-8811-a2bfda9755fa", ErrBadLength},
+
+		// Right width, separator missing or in the wrong place. The
+		// parser reads position separatorIndex and nowhere else, so a
+		// separator elsewhere in the string does not stand in for it.
+		{"no separator at all", "%sa" + body, ErrNoPrefix},
+		{"separator at the end", "%sa" + body[:25] + "_", ErrNoPrefix},
+		{"separator one early", "pr_a" + body, ErrNoPrefix},
+
+		// Right shape, wrong tag.
+		{"other kind", "zzz_" + body, ErrWrongKind},
+		{"uppercase prefix", "%S_" + body, ErrWrongKind},
+		{"prefix with space", " pr_" + body, ErrWrongKind},
+
+		// Right shape and tag, body the codec refuses.
+		{"non-canonical body", "%s_" + nonCanonical, ErrNotCanonical},
+		{"uppercase body", "%s_" + strings.ToUpper(body), nil},
+		{"digit outside alphabet", "%s_" + body[:25] + "9", nil},
+		{"separator in body", "%s_" + body[:25] + "_", nil},
+		{"hyphen in body", "%s_" + body[:25] + "-", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, k := range allKinds {
+				in := strings.NewReplacer("%s", k.Prefix(), "%S", strings.ToUpper(k.Prefix())).Replace(tc.in)
+
+				var err error
+				switch k {
+				case KindProject:
+					_, err = ParseProjectID(in)
+				case KindWorkspace:
+					_, err = ParseWorkspaceID(in)
+				}
+
+				if err == nil {
+					t.Errorf("Parse%sID(%q) = no error, want one", k, in)
+
+					continue
+				}
+				if tc.want != nil && !errors.Is(err, tc.want) {
+					t.Errorf("Parse%sID(%q) = %v, want %v", k, in, err, tc.want)
+				}
+				if !strings.Contains(err.Error(), "id: ") {
+					t.Errorf("Parse%sID(%q) = %v, which does not name the package", k, in, err)
+				}
+			}
+		})
+	}
+}
+
+// TestParseRejectsTheOtherKind is the reason the prefix is there: a
+// well-formed ID naming the wrong thing is refused, and the message says
+// both what it got and what it wanted, so the caller can see the mixup.
+func TestParseRejectsTheOtherKind(t *testing.T) {
+	t.Parallel()
+
+	u := uuid.MustParse(goldenV7[0].id)
+	project, workspace := ProjectID(u).String(), WorkspaceID(u).String()
+
+	_, err := ParseProjectID(workspace)
+	if !errors.Is(err, ErrWrongKind) {
+		t.Errorf("ParseProjectID(%q) = %v, want %v", workspace, err, ErrWrongKind)
+	}
+	if !strings.Contains(err.Error(), `"wrk"`) || !strings.Contains(err.Error(), `"prj"`) {
+		t.Errorf("ParseProjectID(%q) = %v, which does not name both kinds", workspace, err)
+	}
+
+	if _, err = ParseWorkspaceID(project); !errors.Is(err, ErrWrongKind) {
+		t.Errorf("ParseWorkspaceID(%q) = %v, want %v", project, err, ErrWrongKind)
+	}
+}
+
+// TestParseFailsToTheZeroValue: a rejected string yields nothing usable, so a
+// caller that ignores the error gets an obviously empty ID rather than a
+// partly filled one.
+func TestParseFailsToTheZeroValue(t *testing.T) {
+	t.Parallel()
+
+	p, err := ParseProjectID("prj_" + nonCanonical)
+	if err == nil {
+		t.Fatalf("ParseProjectID(%q) = %v, want an error", "prj_"+nonCanonical, uuid.UUID(p))
+	}
+	if uuid.UUID(p) != uuid.Nil {
+		t.Errorf("failed ParseProjectID returned %v, want the nil uuid", uuid.UUID(p))
+	}
+}
+
+func TestMustParse(t *testing.T) {
+	t.Parallel()
+
+	u := uuid.MustParse(goldenV7[0].id)
+
+	if got := MustParseProjectID(ProjectID(u).String()); got != ProjectID(u) {
+		t.Errorf("MustParseProjectID = %v, want %v", uuid.UUID(got), u)
+	}
+	if got := MustParseWorkspaceID(WorkspaceID(u).String()); got != WorkspaceID(u) {
+		t.Errorf("MustParseWorkspaceID = %v, want %v", uuid.UUID(got), u)
+	}
+
+	for _, tc := range []struct {
+		name string
+		call func()
+	}{
+		{"project", func() { MustParseProjectID("nope") }},
+		{"workspace", func() { MustParseWorkspaceID("nope") }},
+		{"wrong kind", func() { MustParseProjectID(WorkspaceID(u).String()) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			defer func() {
+				if recover() == nil {
+					t.Error("did not panic")
+				}
+			}()
+			tc.call()
+		})
+	}
+}

--- a/packages/shared/pkg/id/objectid.go
+++ b/packages/shared/pkg/id/objectid.go
@@ -88,7 +88,8 @@ const (
 )
 
 var (
-	// ErrBadLength means the string is not encodedLen bytes.
+	// ErrBadLength means the string is not the width the format fixes:
+	// encodedLen for a bare body, ObjectIDLen for a prefixed object ID.
 	ErrBadLength = errors.New("id: wrong length")
 
 	// ErrNotCanonical means the string decodes, but is not the spelling


### PR DESCRIPTION
## What

Adds typed object IDs to `packages/shared/pkg/id`, on top of the codec from #3464: a kind tag in front of the encoded UUID, and the same kind in the Go type.

```
prj_uk75vf2v7iagp2kgn7pfze3car   a project
wrk_imkhttdroeagp2kgn7t53cvkiw   a workspace
```

New files:

- `packages/shared/pkg/id/object.go` — the types, the parsers, the width invariant
- `packages/shared/pkg/id/object_test.go` — its test suite

One edit outside them: `ErrBadLength`'s doc comment in `objectid.go` now covers the full ID width as well as a bare body, since both are reported through it.

No existing code paths are touched; nothing calls the new types yet.

## API

```go
type ObjectKind uint8
const ( KindProject ObjectKind = iota + 1; KindWorkspace )
func (ObjectKind) Prefix() string   // "prj" / "wrk", "" for the zero value
func (ObjectKind) String() string

const ObjectIDLen = 30

type ObjectID[K kind] uuid.UUID
type ProjectID   = ObjectID[projectKind]
type WorkspaceID = ObjectID[workspaceKind]

func (ObjectID[K]) Kind() ObjectKind
func (ObjectID[K]) String() string

func ParseProjectID(string)   (ProjectID, error)
func ParseWorkspaceID(string) (WorkspaceID, error)
func MustParseProjectID(string)   ProjectID
func MustParseWorkspaceID(string) WorkspaceID

func ConvertTeamIDToProjectID(uuid.UUID) ProjectID
```

## The kind lives in the type

`ObjectID` is generic over a phantom type parameter that names one `ObjectKind`, and `ProjectID` / `WorkspaceID` are that generic instantiated. They are therefore distinct types that share one copy of the parsing and formatting:

```go
var p ProjectID
var w WorkspaceID
w = p   // cannot use p (variable of array type ProjectID) as WorkspaceID value
```

The constraint's method is unexported, so the set of kinds is closed to this package — no other package can instantiate `ObjectID` with a kind of its own.

The underlying type is `uuid.UUID`, so getting in and out is a conversion and needs no constructor and no accessor:

```go
pid := ProjectID(uuid.Must(uuid.NewV7()))
u := uuid.UUID(pid)
```

Conversion between two `ObjectID`s compiles too, their underlying types being identical. That is deliberate: crossing kinds should be possible, but only by writing it down.

## The width is fixed, and enforced

Every ID is exactly `ObjectIDLen` = 30 characters: `prefixLen` (3) for the tag, one for the separator, `encodedLen` (26) for the body. Nothing about it varies by kind, by UUID version, or over time, so a storage column can be a fixed 30.

Holding the width means holding the prefixes to three characters, which the compiler does rather than a test:

```go
var (
	_ [prefixLen]byte = [len(projectPrefix)]byte{}
	_ [prefixLen]byte = [len(workspacePrefix)]byte{}
)
```

A four-character prefix gives `cannot use [4]byte{} as [3]byte value`; a two-character one gives `[2]byte`. Both were checked by temporarily breaking the constants. Adding a kind means adding a line here, and forgetting is a build failure.

Because the width is fixed, `parseObjectID` reads by position instead of searching for the separator:

```go
if len(s) != ObjectIDLen         { ... ErrBadLength }
if s[separatorIndex] != prefixSeparator { ... ErrNoPrefix }
if prefix := s[:prefixLen]; prefix != want.Prefix() { ... ErrWrongKind }
u, err := Decode(s[bodyIndex:])
```

The width gate runs first, so both slices are always in range and `Decode`'s own length check can no longer fire. A 30-character string whose underscore is somewhere other than index 3 is rejected, which a `strings.Cut` version would have accepted the prefix of.

## Errors

Two new sentinels, `ErrNoPrefix` and `ErrWrongKind`, joining `ErrBadLength` and `ErrNotCanonical` from the codec. All four are wrapped, so `errors.Is` works on any of them; the body's own errors are wrapped rather than restated, being more precise than anything the outer layer knows. A rejected string returns the zero ID, not a partly filled one.

The point of the tag is the message it makes possible: `ParseProjectID` on a workspace ID reports `id: wrong kind: "wrk_..." is a "wrk" id, want "prj"`, naming both sides, rather than becoming a lookup that finds nothing.

## `ConvertTeamIDToProjectID`

A project is a row in `public.teams` — the same identity under two names, one internal and older than the other (`docs/ARCHITECTURE.md:214`). The function is a conversion: it cannot fail and moves no bits. It is spelled out rather than left to `ProjectID(teamID)` so the places that cross the rename can be found by searching for it. The inverse is `uuid.UUID(pid)` and is just as free, so it has no named helper.

## Tests

11 tests, 164 subtests, reusing the codec suite's `goldenV7` vectors and its `corpus` generator (`uuid.Nil`, `uuid.Max`, every power of two ±1 across all 128 bits, and thousands of random v4/v7/unversioned values):

- **Golden strings** — `ProjectID(u).String()` is `"prj_"` plus the exact 26 characters the codec's independently computed vectors pin, and likewise for workspaces, so the external form is held to the same compatibility contract.
- **Width** — `ObjectIDLen == 30`, that it equals `prefixLen + 1 + encodedLen`, that the indices follow from `prefixLen`, and that `String()` on the extremes and a real v7 is 30 characters containing exactly one underscore, at index 3.
- **Prefixes** — each is exactly `prefixLen` lowercase letters (`a`–`z` only: no digit, no separator, no case to fold), they differ, and the zero `ObjectKind` has no prefix and prints as `ObjectKind(0)` rather than passing for one.
- **Kind coverage** — walks past the last known kind, so a kind added to the enum but not to the test list fails rather than going silently unchecked.
- **Round trip** — over the corpus, both kinds: whatever `String` writes, `Parse` reads back unchanged.
- **Rejection**, 22 cases run against both parsers with the prefix substituted, so neither can be laxer than the other: wrong widths (empty, no separator, bare body, prefix only, body ±1, two-character prefix, leading space, trailing newline, empty prefix, a raw UUID as the body), right width with the separator missing or misplaced (three cases), right width with the wrong tag (other kind, uppercase prefix, space in prefix), and right shape with a body the codec refuses (non-canonical, uppercase, `9`, `_`, `-`). Every case also has to name the package in its message.
- **Cross-kind** — each parser refuses the other's ID with `ErrWrongKind`, and the message names both kinds.
- **Zero on failure** — a rejected parse returns the nil UUID, so a caller that ignores the error gets an obviously empty ID.
- **Type distinctness** — recorded with `reflect`, since a careless edit could collapse both aliases onto one instantiation and nothing else would notice.
- **`ConvertTeamIDToProjectID`** — over the corpus: the UUID survives byte for byte, the kind is `KindProject`, and the printed form parses back to the team ID it started as.
- **`MustParse`** — both succeed on valid input and panic on garbage and on the wrong kind.

## Verification

- `go test -race -count=1 ./pkg/id/` — pass, including the pre-existing `id.go` and codec suites
- `go vet ./pkg/id/` — clean
- `golangci-lint run ./pkg/id/...` — 0 issues
- Compile failures confirmed by hand for a mis-width prefix (both directions) and for `WorkspaceID = ProjectID`

No `docs/ARCHITECTURE.md` change: this adds an unwired shared type and alters no service, port, protocol, data store, flow, or topology.
