### PR TITLE
updating envd to use release-please

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,13 +2,9 @@
   "packages/docker-reverse-proxy": "0.0.1",
   "packages/client-proxy": "0.0.1",
   "packages/clickhouse": "0.0.1",
-<<<<<<< Updated upstream
-  "packages/envd": "0.0.1"
-=======
   "packages/envd": "0.6.13",
   "packages/orchestrator": "0.0.0",
   "packages/api": "0.0.0",
   "packages/dashboard-api": "0.0.0",
   "packages/nomad-nodepool-apm": "0.0.0"
->>>>>>> Stashed changes
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -2,5 +2,13 @@
   "packages/docker-reverse-proxy": "0.0.1",
   "packages/client-proxy": "0.0.1",
   "packages/clickhouse": "0.0.1",
+<<<<<<< Updated upstream
   "packages/envd": "0.0.1"
+=======
+  "packages/envd": "0.6.13",
+  "packages/orchestrator": "0.0.0",
+  "packages/api": "0.0.0",
+  "packages/dashboard-api": "0.0.0",
+  "packages/nomad-nodepool-apm": "0.0.0"
+>>>>>>> Stashed changes
 }

--- a/packages/envd/pkg/version.go
+++ b/packages/envd/pkg/version.go
@@ -1,3 +1,3 @@
 package pkg
 
-const Version = "0.6.13"
+const Version = "0.6.13" // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,6 +28,34 @@
       "release-type": "go",
       "component": "envd",
       "include-v-in-tag": true,
+<<<<<<< Updated upstream
+=======
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": ["pkg/version.go"]
+    },
+    "packages/orchestrator": {
+      "release-type": "go",
+      "component": "orchestrator",
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/api": {
+      "release-type": "go",
+      "component": "api",
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/dashboard-api": {
+      "release-type": "go",
+      "component": "dashboard-api",
+      "include-v-in-tag": true,
+      "changelog-path": "CHANGELOG.md"
+    },
+    "packages/nomad-nodepool-apm": {
+      "release-type": "go",
+      "component": "nomad-nodepool-apm",
+      "include-v-in-tag": true,
+>>>>>>> Stashed changes
       "changelog-path": "CHANGELOG.md"
     }
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,8 +28,6 @@
       "release-type": "go",
       "component": "envd",
       "include-v-in-tag": true,
-<<<<<<< Updated upstream
-=======
       "changelog-path": "CHANGELOG.md",
       "extra-files": ["pkg/version.go"]
     },
@@ -55,7 +53,6 @@
       "release-type": "go",
       "component": "nomad-nodepool-apm",
       "include-v-in-tag": true,
->>>>>>> Stashed changes
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
1. .release-please-manifest.json — set packages/envd to 0.6.13 to match the real current version in version.go. Release-please treats the manifest as the source of truth for "last released version," so the next release PR will compute the next version from this (e.g. 0.6.14 for fixes, 0.7.0 for feats, per conventional commits).
2. release-please-config.json — added "extra-files": ["pkg/version.go"] to the envd package. Paths in extra-files are relative to the package directory, so this points at packages/envd/pkg/version.go.
3. packages/envd/pkg/version.go — appended the magic comment release-please's generic updater looks for:
const Version = "0.6.13" // x-release-please-version
3. On every release PR, release-please scans files listed in extra-files and rewrites the semver string on any line tagged with that comment. So the PR will bump the changelog, the manifest, and this constant together, and merging the PR keeps everything in sync automatically. Developers never touch the file again.

Two things to be aware of:

- Release-please determines the commit range for the changelog by looking for the tag matching the manifest version — envd-v0.6.13 with your config. If your past releases weren't tagged that way (the manifest previously said 0.0.1), the first release PR after this change may pull older commits into the changelog. That's cosmetic and self-corrects after one release, but you can also push an envd-v0.6.13 tag at the appropriate commit to get a clean range.
- The same pattern works for the other packages (orchestrator, api, etc.) if they grow version files — just add extra-files and the annotation.