### PR TITLE
fix(orch): pin nixpkgs to a supported release for the NixOS base image

### DIFF
--- a/.github/workflows/nixos-base-image.yml
+++ b/.github/workflows/nixos-base-image.yml
@@ -189,7 +189,8 @@ jobs:
           fi
 
           # 2./3. The boot chain the nixos profile points the kernel at:
-          #    /sbin/init -> /nix/var/nix/profiles/system/init -> <toplevel>/init.
+          #    /sbin/init -> /sbin/e2b-nixos-init (the activation shim, checked
+          #    below) -> systemd, with the profile symlink resolving the closure.
           system_target=""
           if ! system_target=$(symlink_target nix/var/nix/profiles/system); then
             fail "nix/var/nix/profiles/system is missing or is not a symlink"

--- a/.github/workflows/nixos-base-image.yml
+++ b/.github/workflows/nixos-base-image.yml
@@ -197,10 +197,23 @@ jobs:
             fail "nix/var/nix/profiles/system points at ${system_target}, expected a /nix/store path"
           fi
 
+          # Not $toplevel/init: from NixOS 25.05 that is the systemd binary and
+          # runs no activation, so the image boots through a shim instead.
           if ! init_target=$(symlink_target sbin/init); then
             fail "sbin/init is missing or is not a symlink"
-          elif [[ "${init_target}" != "/nix/var/nix/profiles/system/init" ]]; then
-            fail "sbin/init points at ${init_target}, expected /nix/var/nix/profiles/system/init"
+          elif [[ "${init_target}" != "/sbin/e2b-nixos-init" ]]; then
+            fail "sbin/init points at ${init_target}, expected /sbin/e2b-nixos-init"
+          fi
+
+          # The shim is what actually activates the system. If it is missing the
+          # sandbox boots into a systemd with an empty /etc and freezes.
+          if ! shim=$(tar -xOf "${tar_path}" sbin/e2b-nixos-init 2>/dev/null); then
+            fail "sbin/e2b-nixos-init is missing from the rootfs tar"
+          else
+            grep -q '/activate$' <<<"${shim}" ||
+              fail "sbin/e2b-nixos-init never runs the activation script:"$'\n'"${shim}"
+            grep -q '^export PATH=' <<<"${shim}" ||
+              fail "sbin/e2b-nixos-init sets no PATH; mount/install/ln resolve to nothing pre-activation"
           fi
 
           # 4. The closure itself has to be in the tar, or the chain above

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/distro.go
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/distro.go
@@ -152,7 +152,13 @@ var Profiles = []Profile{
 		Packages:     nil,
 		PkgQueryBody: "true",
 		PkgInstall:   `echo "[provision] ERROR: NixOS images are premade — packages must be declared in the image's NixOS configuration" >&2; exit 1`,
-		InitBinary:   "/nix/var/nix/profiles/system/init",
+		// Not $toplevel/init: from NixOS 25.05 that IS the systemd binary, and
+		// activation moved into the systemd stage-1 initrd. We boot the rootfs
+		// directly with no initrd, so PID 1 would start against an unpopulated
+		// /etc and freeze on "Unit default.target not found". The image ships
+		// this shim, which activates and then execs systemd — what the pre-25.05
+		// stage-2 init did (nixos-base-image/build.sh).
+		InitBinary:   "/sbin/e2b-nixos-init",
 		TimeSyncUnit: "chronyd",
 		// Left empty on purpose: services.openssh is declared in the image's
 		// configuration, and the NixOS init setup never enables units.

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/README.md
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/README.md
@@ -15,8 +15,9 @@ override. The orchestrator's `nixos` profile then only verifies and boots
 defaults to `127.0.0.1:5000`):
 
 1. evaluates the NixOS system closure with `nix` inside a `nixos/nix`
-   container (`nixpkgs` channel pinned in the script), from the
-   `configuration.nix` committed next to the script,
+   container, against the exact `nixpkgs` revision pinned in the script (see
+   [nixpkgs pin](#nixpkgs-pin)), from the `configuration.nix` committed next
+   to the script,
 2. packs the closure into a single-layer OCI rootfs tar, adding the three
    pieces of glue the boot path needs:
    - `/sbin/init -> /nix/var/nix/profiles/system/init` (the stage-2 init the
@@ -31,6 +32,32 @@ The base-layer cache key includes the image reference as written in the
 Dockerfile — republishing under the same tag silently reuses the previously
 cached base layer (observed; same "default tag" ambiguity called out in
 `phases/base/hash.go`).
+
+## nixpkgs pin
+
+`build.sh` pins an exact nixpkgs revision:
+
+| | |
+|---|---|
+| `NIXPKGS_REV` | `21ea275a7c46aef9d4d6ddc962e6d562e9d94183` |
+| release | `nixos-26.05.6503`, 2026-07-30 |
+
+It is a revision and not `channel:nixos-XX.YY` on purpose. A channel resolves
+at build time, so the same commit would evaluate to a different closure on
+every run — the image could not be reproduced or bisected, and "what changed"
+would have no answer. `system.stateVersion` in `configuration.nix` tracks this
+pin.
+
+**Bumping it is how the image gets security updates**, and it is the whole
+maintenance story for this file: pick a revision from a release branch
+upstream still maintains, update `NIXPKGS_REV`/`NIXPKGS_RELEASE` and
+`stateVersion`, rebuild, and re-run the boot checks — the boot glue
+(`/sbin/init` chain, the systemd `/etc` symlink handling in `../init.go`) is
+the part that breaks across releases, and a tar-level check will not catch it.
+
+Do not let the pin drift onto an unmaintained branch. NixOS releases get about
+seven months of support; `nixos-24.05`, which this image used until it was
+moved to 26.05, stopped receiving commits on 2024-12-30.
 
 ## Boot-path notes (all observed on real KVM)
 

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/README.md
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/README.md
@@ -58,10 +58,15 @@ host with docker; the registry defaults to `127.0.0.1:5000`, so a bare
    container, against the exact `nixpkgs` revision pinned in the script (see
    [nixpkgs pin](#nixpkgs-pin)), from the `configuration.nix` committed next
    to the script,
-2. packs the closure into a single-layer OCI rootfs tar, adding the three
+2. packs the closure into a single-layer OCI rootfs tar, adding the four
    pieces of glue the boot path needs:
-   - `/sbin/init -> /nix/var/nix/profiles/system/init` (the stage-2 init the
-     `nixos` profile points the kernel at),
+   - `/sbin/e2b-nixos-init`, the activation shim the `nixos` profile points the
+     kernel at (`InitBinary` in `../distro.go`). It mounts `/proc` and `/sys`,
+     runs the system's `activate`, then execs systemd — what NixOS's own
+     stage-2 script did until 25.05 replaced `$toplevel/init` with the systemd
+     binary itself. Booting `$toplevel/init` directly, with no initrd to
+     activate for us, lands in PID 1 with an empty `/etc`,
+   - `/sbin/init -> /sbin/e2b-nixos-init`,
    - `/nix/var/nix/profiles/system -> <toplevel store path>`,
    - a static `/etc/os-release` with `ID=nixos` so the distro selector can
      identify the image *before* the first activation generates the real one,
@@ -90,7 +95,8 @@ reproducible reference.
 
 | | |
 |---|---|
-| `NIXPKGS_REV` | `21ea275a7c46aef9d4d6ddc962e6d562e9d94183` |
+| `NIXOS_SERIES` | `26.05` |
+| `NIXPKGS_RELEASE` | `nixos-26.05.6503.21ea275a7c46` |
 | release | `nixos-26.05.6503`, 2026-07-30 |
 
 It is a revision and not `channel:nixos-XX.YY` on purpose. A channel resolves
@@ -101,7 +107,7 @@ pin.
 
 **Bumping it is how the image gets security updates**, and it is the whole
 maintenance story for this file: pick a revision from a release branch
-upstream still maintains, update `NIXPKGS_REV`/`NIXPKGS_RELEASE` and
+upstream still maintains, update `NIXOS_SERIES`/`NIXPKGS_RELEASE` and
 `stateVersion`, rebuild, and re-run the boot checks — the boot glue
 (`/sbin/init` chain, the systemd `/etc` symlink handling in `../init.go`) is
 the part that breaks across releases, and a tar-level check will not catch it.

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
@@ -25,10 +25,25 @@ mkdir -p "$work"
 cp "$here/configuration.nix" "$work/configuration.nix"
 rm -f "$work/result"
 
+# nixpkgs is pinned to one exact channel release, not to a channel name.
+# `channel:nixos-XX.YY` resolves at build time, so the same commit would
+# evaluate to a different closure on every run — the image could not be
+# reproduced or bisected. The release URL is immutable (it carries the release
+# id), so this is a real pin while still being the artifact the channel serves.
+#
+# Bumping these three is the whole maintenance story, and is how the image
+# picks up security updates. Keep the series on a release upstream still
+# maintains: NixOS releases get ~7 months, and nixos-24.05 (used here until
+# this pin) stopped receiving commits on 2024-12-30.
+NIXOS_SERIES=${NIXOS_SERIES:-26.05}
+NIXPKGS_RELEASE=${NIXPKGS_RELEASE:-nixos-26.05.6503.21ea275a7c46}
+NIXPKGS_URL=${NIXPKGS_URL:-https://releases.nixos.org/nixos/$NIXOS_SERIES/$NIXPKGS_RELEASE/nixexprs.tar.xz}
+
 # Build the toplevel closure with nix inside the nixos/nix container.
+echo "nixpkgs pin: $NIXPKGS_RELEASE"
 docker run --rm -v "$work:/build" nixos/nix:2.35.1 sh -c "
 set -e
-nix-build -I nixpkgs=channel:nixos-24.05 -I nixos-config=/build/configuration.nix \
+nix-build -I nixpkgs=$NIXPKGS_URL -I nixos-config=/build/configuration.nix \
   '<nixpkgs/nixos>' -A config.system.build.toplevel -o /build/result
 top=\$(readlink /build/result)
 echo \"TOPLEVEL=\$top\"
@@ -44,11 +59,14 @@ ln -s \$top \$staging/nix/var/nix/profiles/system
 # first boot can load it, otherwise nix-env and friends reject every path.
 nix-store --dump-db \$(cat /build/closure.txt) > \$staging/nix/var/nix/db-registration
 ln -s /nix/var/nix/profiles/system/init \$staging/sbin/init
+# Derived from NIXOS_SERIES so it cannot drift from the pin above: this is the
+# pre-activation os-release, and the only field the distro selector reads is
+# ID, so a stale version here is invisible to every automated check.
 cat > \$staging/etc/os-release <<OSR
 NAME=NixOS
 ID=nixos
-VERSION_ID=\"24.05\"
-PRETTY_NAME=\"NixOS 24.05 (E2B sandbox base)\"
+VERSION_ID=\"$NIXOS_SERIES\"
+PRETTY_NAME=\"NixOS $NIXOS_SERIES (E2B sandbox base)\"
 OSR
 tar -rf /build/nixos-rootfs.tar -C \$staging sbin etc nix
 echo PACKED

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
@@ -73,6 +73,10 @@ nix-store --dump-db \$(cat /build/closure.txt) > \$staging/nix/var/nix/db-regist
 bash_bin=\$(readlink -f \$top/sw/bin/bash)
 cat > \$staging/sbin/e2b-nixos-init <<INIT
 #!\$bash_bin
+# Deliberately NOT 'set -e'. NixOS's activate exits non-zero when any snippet
+# failed, including ones that are non-fatal here, and aborting PID 1 on that
+# panics the kernel instead of booting a sandbox that is fine — observed: with
+# set -e the template build fails outright. Failures are visible on the console.
 # There is no FHS userland yet -- /bin and /usr/bin appear only once activation
 # has run -- so every command below needs the system profile on PATH. Without
 # it the shim silently does nothing but run activate: mount, install and ln are

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
@@ -58,7 +58,38 @@ ln -s \$top \$staging/nix/var/nix/profiles/system
 # /nix/var/nix/db, which the closure does not carry. Ship the registration so
 # first boot can load it, otherwise nix-env and friends reject every path.
 nix-store --dump-db \$(cat /build/closure.txt) > \$staging/nix/var/nix/db-registration
-ln -s /nix/var/nix/profiles/system/init \$staging/sbin/init
+# Activation shim. Up to NixOS 24.11 \$toplevel/init was the stage-2 shell
+# script, which ran \$toplevel/activate (populating /etc from the store) and
+# only then exec'd systemd. From 25.05 \$toplevel/init IS the systemd binary --
+# activation moved into the systemd stage-1 initrd. E2B boots the rootfs
+# directly with no initrd, so booting \$toplevel/init now lands in PID 1 with an
+# empty /etc: no units, 'Unit default.target not found', and systemd freezes.
+# Do what stage 2 used to do. The interpreter is resolved from the closure so
+# the shim works before anything is activated.
+# Activation runs before systemd, so nothing has mounted /proc or /sys yet --
+# stage 2 used to do it. Without /proc the activation snippets that read it fail:
+# nix-store reads /proc/self/exe, so --load-db (the e2bNixDb snippet) errors out
+# and, because it is deliberately non-fatal, the store DB silently never loads.
+bash_bin=\$(readlink -f \$top/sw/bin/bash)
+cat > \$staging/sbin/e2b-nixos-init <<INIT
+#!\$bash_bin
+# There is no FHS userland yet -- /bin and /usr/bin appear only once activation
+# has run -- so every command below needs the system profile on PATH. Without
+# it the shim silently does nothing but run activate: mount, install and ln are
+# all simply not found. Stage 2 set an explicit PATH for the same reason.
+export PATH=/nix/var/nix/profiles/system/sw/bin:/nix/var/nix/profiles/system/sw/sbin
+[ -e /proc/self/exe ] || mount -t proc -o nosuid,noexec,nodev proc /proc
+[ -e /sys/kernel ] || mount -t sysfs -o nosuid,noexec,nodev sysfs /sys
+install -m 0755 -d /etc
+install -m 01777 -d /tmp
+/nix/var/nix/profiles/system/activate
+ln -sfn /nix/var/nix/profiles/system /run/booted-system
+# Stop systemd's first-boot heuristic from trying to populate /etc itself.
+: >> /etc/machine-id
+exec /nix/var/nix/profiles/system/systemd/lib/systemd/systemd \"\\\$@\"
+INIT
+chmod +x \$staging/sbin/e2b-nixos-init
+ln -s /sbin/e2b-nixos-init \$staging/sbin/init
 # Derived from NIXOS_SERIES so it cannot drift from the pin above: this is the
 # pre-activation os-release, and the only field the distro selector reads is
 # ID, so a stale version here is invisible to every automated check.

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/build.sh
@@ -65,12 +65,11 @@ nix-store --dump-db \$(cat /build/closure.txt) > \$staging/nix/var/nix/db-regist
 # activation moved into the systemd stage-1 initrd. E2B boots the rootfs
 # directly with no initrd, so booting \$toplevel/init now lands in PID 1 with an
 # empty /etc: no units, 'Unit default.target not found', and systemd freezes.
-# Do what stage 2 used to do. The interpreter is resolved from the closure so
-# the shim works before anything is activated.
-# Activation runs before systemd, so nothing has mounted /proc or /sys yet --
-# stage 2 used to do it. Without /proc the activation snippets that read it fail:
-# nix-store reads /proc/self/exe, so --load-db (the e2bNixDb snippet) errors out
-# and, because it is deliberately non-fatal, the store DB silently never loads.
+# Do what stage 2 used to do, including mounting /proc: activation runs before
+# systemd, and nix-store reads /proc/self/exe, so without it the e2bNixDb
+# snippet that loads the store registration errors out and — being deliberately
+# non-fatal — leaves the store DB silently unloaded. The interpreter is
+# resolved from the closure so the shim works before anything is activated.
 bash_bin=\$(readlink -f \$top/sw/bin/bash)
 cat > \$staging/sbin/e2b-nixos-init <<INIT
 #!\$bash_bin

--- a/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/configuration.nix
+++ b/packages/orchestrator/pkg/template/build/phases/base/distro/nixos-base-image/configuration.nix
@@ -179,5 +179,10 @@
     shadow socat curl git jq less fuse3 iptables nftables iputils nfs-utils
   ];
 
-  system.stateVersion = "24.05";
+  # Tracks the nixpkgs pin in build.sh, and is meant to. The usual "never
+  # change stateVersion" rule protects persistent state across an upgrade of a
+  # running system; this image has none — every publish builds it from scratch
+  # and every sandbox boots it fresh — so leaving it behind the pin would just
+  # opt the image into compatibility shims for a release it never ran.
+  system.stateVersion = "26.05";
 }


### PR DESCRIPTION
The premade NixOS base image built from `channel:nixos-24.05`, whose nixpkgs branch stopped receiving commits on **2024-12-30** — long EOL. Same defect class as E2B#1625 (`from_fedora_image` defaulting to an EOL Fedora), one layer down, and it would otherwise have been the first tag ever pushed to `e2bdev/nixos`. This pins an exact channel release instead of a channel name: a channel resolves at build time, so the same commit evaluated to a different closure every run. The release URL is immutable, so it is a real pin. Bumping `NIXOS_SERIES`/`NIXPKGS_RELEASE` is now the whole maintenance story.

Pinning alone doesn't boot. Up to 24.11 `$toplevel/init` was the stage-2 script — it mounted `/proc`, ran `activate` to populate `/etc`, then exec'd systemd. From 25.05 that file **is** the systemd binary (md5-identical to `systemd-260.2/lib/systemd/systemd`); activation moved into the stage-1 initrd. We boot the rootfs directly with no initrd, so PID 1 came up against an empty `/etc` and froze on `Unit default.target not found`. The image now ships `/sbin/e2b-nixos-init`, which does what stage 2 did, and the `nixos` profile points `InitBinary` at it. Two silent traps: it needs an explicit `PATH` (no FHS userland pre-activation, so `mount`/`install`/`ln` aren't found), and it must mount `/proc` before activating — `nix-store` reads `/proc/self/exe`, so the non-fatal `e2bNixDb` snippet was failing and leaving the store DB unloaded.

Also fixes the pre-activation `/etc/os-release`, which still hardcoded `24.05` — invisible to every check, since `ID` is the only field read.

**Verified on real KVM (x86_64, KVM slot): C1–C11 all pass on 26.05** — envd active and 49983 connected, unit parity + GOMEMLIMIT, chrony, sshd, CA bundle + `https_code=200`, default user + NOPASSWD sudo, hostname, firewall clear, **C9 `check_validity=OK` / 568 valid paths**, `os_release=nixos/NixOS 26.05 (Yarara)`, and C11 raw-envd exec resolving git/jq/sh with reclaim and guestSync replicas `rc=0`. The container build reproduced the host preflight toplevel byte-for-byte.

> Includes a merge of `main` to pick up #3477, whose rootfs check asserted the old `sbin/init` target; the assertion now covers the shim.
