### PR TITLE
fix(orchestrator): remove 100-char truncation from envd error response bodies

### DIFF
--- a/packages/orchestrator/pkg/sandbox/envd.go
+++ b/packages/orchestrator/pkg/sandbox/envd.go
@@ -179,7 +179,7 @@ func (s *Sandbox) callEnvdCollapse(ctx context.Context, timeout time.Duration) (
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 
-		return envd.CollapseResult{}, fmt.Errorf("collapse returned %d: %s", resp.StatusCode, utils.Truncate(string(body), 100))
+		return envd.CollapseResult{}, fmt.Errorf("collapse returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var result envd.CollapseResult
@@ -205,7 +205,7 @@ func (s *Sandbox) postEnvd(ctx context.Context, timeout time.Duration, path stri
 	if resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
 
-		return fmt.Errorf("%s returned %d: %s", path, resp.StatusCode, utils.Truncate(string(body), 100))
+		return fmt.Errorf("%s returned %d: %s", path, resp.StatusCode, string(body))
 	}
 
 	return nil
@@ -284,7 +284,7 @@ func (s *Sandbox) CallEnvdUpgrade(ctx context.Context, localSrcPath, guestBinPat
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
 
-		return false, fmt.Errorf("upgrade returned %d: %s", resp.StatusCode, utils.Truncate(string(body), 100))
+		return false, fmt.Errorf("upgrade returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	// envd answered instead of exec'ing — no swap happened, exec not confirmed.
@@ -493,7 +493,7 @@ func (s *Sandbox) initEnvd(ctx context.Context, startType StartType, recordMetri
 			logger.WithSandboxID(s.Runtime.SandboxID),
 			logger.WithEnvdVersion(s.Config.Envd.Version),
 			zap.Int("status_code", response.StatusCode),
-			zap.String("response_body", utils.Truncate(string(body), 100)),
+			zap.String("response_body", string(body)),
 		)
 
 		return fmt.Errorf("unexpected status code: %d", response.StatusCode)


### PR DESCRIPTION
Fixes #3480.

## What

Remove `utils.Truncate(string(body), 100)` from the four error-path call sites in `packages/orchestrator/pkg/sandbox/envd.go`:

- `callEnvdCollapse` — error returned on non-200
- `postEnvd` — error returned on non-204 (covers `/init`, `/pause`, `/resume`, and other endpoints)
- `CallEnvdUpgrade` — error returned on non-200/204
- `initEnvd` — `response_body` log field on non-204

## Why

The truncated string is embedded directly in `fmt.Errorf` calls, so it propagates through the full error chain and is visible to callers. For NFS volume mount failures the full error body is ~300 chars; the 100-char cutpoint falls mid-path, stripping the actual cause (`no such file or directory`, permission denied, etc.).

Before:
```
failed to init new envd: /init returned 400: failed to mount "uuid": failed to chroot into "/data1/orchestrator/vo
```

After:
```
failed to init new envd: /init returned 400: failed to mount "uuid": failed to chroot into "/data1/orchestrator/volumes/team-f079…/vol-885b…": failed to bind mount "…": no such file or directory
```

envd error response bodies are short server-generated diagnostic strings, not arbitrary user data, so removing the cap carries no log-explosion risk.

## Not a duplicate

No existing open PR addresses this truncation. The related volume-locality issue is tracked separately in #3195 / #3196.

## Testing

- `go build ./packages/orchestrator/...` — passes
- Change is logging/error-message only; no behaviour is modified