### PR TITLE
test(integration): cover the premade NixOS base image in the distro matrix

### DIFF
--- a/tests/integration/internal/tests/api/templates/distro_build_test.go
+++ b/tests/integration/internal/tests/api/templates/distro_build_test.go
@@ -15,6 +15,9 @@ import (
 // own package names under set -e, links its own init binary and regenerates its
 // own CA bundle, so a build that reaches ready with the start and ready commands
 // executed proves the whole profile resolves and that envd boots under it.
+//
+// NixOS installs nothing — see its case below — so there the same assertions
+// prove the boot path rather than the package set.
 func TestTemplateBuildDistroFamilies(t *testing.T) {
 	t.Parallel()
 
@@ -42,6 +45,22 @@ func TestTemplateBuildDistroFamilies(t *testing.T) {
 			name:         "Alpine on OpenRC",
 			templateName: "test-distro-alpine",
 			fromImage:    "alpine:3.24",
+		},
+		// Premade, so the profile declares no packages and a PkgInstall that
+		// exits 1: everything provisioning installs elsewhere is baked into the
+		// image's own NixOS configuration. Reaching ready therefore proves the
+		// parts that are still ours — the busybox Bootstrap standing in for the
+		// FHS userland the image has no /bin/sh for before its first activation,
+		// the /sbin/e2b-nixos-init activation shim, and the drop-in removal that
+		// lets setup-etc take over /etc/systemd/system.
+		//
+		// Pinned to the immutable tag, never :latest: the base-layer cache key is
+		// the image reference as written (phases/base/hash.go), so a republished
+		// :latest would keep building from the stale cached layer.
+		{
+			name:         "NixOS premade",
+			templateName: "test-distro-nixos",
+			fromImage:    "e2bdev/nixos:26.05-20260731",
 		},
 	}
 


### PR DESCRIPTION
Adds the premade NixOS image to `TestTemplateBuildDistroFamilies`, so CI catches a base image that doesn't boot. The tar-only publish gate in `nixos-base-image.yml` provably can't: the pre-shim 26.05 image passed every tar assertion and still froze at boot with no units. The profile installs nothing, so reaching ready proves exactly the parts that are ours — the busybox `Bootstrap`, the `/sbin/e2b-nixos-init` shim (#3478), and the `rm -rf /etc/systemd/system` that lets `setup-etc` take over.

**Immutable tag, never `:latest`** — `phases/base/hash.go` keys the base layer on `Config.FromImage` as written, so a republished `:latest` would keep building from the stale cached layer and a failure wouldn't reproduce.

**Cost, measured on this run.** Lands in `templates-builds-2` (`Distro` misses `TEMPLATE_BUILDS_SHARD1_RE`). The subtest is **156s** — 515 MB compressed / 1.05 GiB unpacked, cold pull every time. Package wall 166s → 255s, job **5.7 → 7.2 min** against a 30 min cap. It grows the wall by more than 156/4 because the pull and unpack also slow its three concurrent neighbours (utilisation 3.7× → 3.0×). That makes shard 2 the long pole against shard 1's 4m52s; leaving `TEMPLATE_BUILDS_SHARD1_RE` alone — that 2.3 min gap wants its own measuring run, the way #3479 did it.

**`compression-tests.tsv`: no change.** The test is already absent; the documented criterion is reading a snapshot back, and provisioning is compression-invariant like the other four cases. Entries are per top-level test anyway, so a subtest couldn't be listed on its own.
