### PR TITLE
fix(orchestrator): report the current network egress when listing sandboxes

### DIFF
--- a/packages/orchestrator/pkg/server/sandboxes.go
+++ b/packages/orchestrator/pkg/server/sandboxes.go
@@ -36,6 +36,7 @@ import (
 	"github.com/e2b-dev/infra/packages/shared/pkg/logger"
 	sbxlogger "github.com/e2b-dev/infra/packages/shared/pkg/logger/sandbox"
 	"github.com/e2b-dev/infra/packages/shared/pkg/retry"
+	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/storage"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 	"github.com/e2b-dev/infra/packages/shared/pkg/utils"
@@ -550,6 +551,50 @@ func applyNetworkEgress(cfg *sandbox.Config, egress *orchestrator.SandboxNetwork
 	}
 }
 
+// currentAPIStoredConfig returns the sandbox's API-stored config with the live
+// network egress overlaid. APIStoredConfig is a create-time snapshot: Update
+// publishes egress changes to sbx.Config (see transitionEgress) and never
+// touches it, so handing it out verbatim reports stale network settings — and
+// an API re-sync that repopulates its store from them loses the update on the
+// next pause/resume.
+//
+// The stored config is shared and handed out by reference, so it is cloned
+// before the overlay, and only when the two actually diverge.
+func currentAPIStoredConfig(sbx *sandbox.Sandbox) *orchestrator.SandboxConfig {
+	stored := sbx.APIStoredConfig
+
+	egress := sbx.Config.GetNetworkEgress()
+	if proto.Equal(egress, stored.GetNetwork().GetEgress()) {
+		return stored
+	}
+
+	cfg := proto.CloneOf(stored)
+
+	network := cfg.GetNetwork()
+	if network == nil {
+		network = &orchestrator.SandboxNetworkConfig{}
+		cfg.Network = network
+	}
+
+	network.Egress = egress
+
+	// allow_internet_access is the API's shorthand for a deny-all egress rule:
+	// it folds `false` into a 0.0.0.0/0 denied CIDR on create and on resume. A
+	// stale `false` would re-apply that deny-all on the next resume and undo an
+	// update that re-enabled the internet, so correct it once the live egress
+	// stops denying everything. The converse (unset/true alongside a deny-all)
+	// needs no fix: the deny-all is carried by the denied CIDRs themselves, and
+	// rewriting the field would report an explicit choice never made — unset
+	// means "not explicitly set" to the API.
+	//nolint:protogetter // unset must stay distinct from false
+	if allow := cfg.AllowInternetAccess; allow != nil && !*allow &&
+		!slices.Contains(egress.GetDeniedCidrs(), sandbox_network.AllInternetTrafficCIDR) {
+		cfg.AllowInternetAccess = new(true)
+	}
+
+	return cfg
+}
+
 func (s *Server) List(ctx context.Context, _ *emptypb.Empty) (*orchestrator.SandboxListResponse, error) {
 	_, childSpan := tracer.Start(ctx, "sandbox-list")
 	defer childSpan.End()
@@ -569,7 +614,7 @@ func (s *Server) List(ctx context.Context, _ *emptypb.Empty) (*orchestrator.Sand
 
 		startedAt := sbx.GetStartedAt()
 		sandboxes = append(sandboxes, &orchestrator.RunningSandbox{
-			Config:    sbx.APIStoredConfig,
+			Config:    currentAPIStoredConfig(sbx),
 			ClientId:  s.info.ClientId,
 			StartTime: timestamppb.New(startedAt),
 			EndTime:   timestamppb.New(sbx.GetEndAt()),

--- a/packages/orchestrator/pkg/server/sandboxes_test.go
+++ b/packages/orchestrator/pkg/server/sandboxes_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/e2b-dev/infra/packages/orchestrator/pkg/service"
 	"github.com/e2b-dev/infra/packages/shared/pkg/grpc/orchestrator"
 	"github.com/e2b-dev/infra/packages/shared/pkg/id"
+	sandbox_network "github.com/e2b-dev/infra/packages/shared/pkg/sandbox-network"
 	"github.com/e2b-dev/infra/packages/shared/pkg/telemetry"
 )
 
@@ -105,6 +107,179 @@ func Test_server_List(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newListSandbox builds a running-sandbox stand-in the way Create does: the
+// live config gets its own clone of the request network, so the create-time
+// APIStoredConfig snapshot and sbx.Config never share egress pointers.
+func newListSandbox(t *testing.T, stored *orchestrator.SandboxConfig) *sandbox.Sandbox {
+	t.Helper()
+
+	return &sandbox.Sandbox{
+		APIStoredConfig: stored,
+		Metadata: &sandbox.Metadata{
+			Runtime: sandbox.RuntimeMetadata{SandboxID: id.Generate()},
+			Config:  sandbox.NewConfig(sandbox.Config{Network: proto.CloneOf(stored.GetNetwork())}),
+		},
+		Resources: &sandbox.Resources{
+			Slot: &network.Slot{HostIP: net.IPv4(127, 0, 0, 1)},
+		},
+	}
+}
+
+// listOneConfig registers a single sandbox and returns the config List reports.
+func listOneConfig(t *testing.T, sbx *sandbox.Sandbox) *orchestrator.SandboxConfig {
+	t.Helper()
+
+	sbx.SetStartedAt(startTime)
+	sbx.SetEndAt(endTime)
+
+	sandboxes := sandbox.NewSandboxesMap()
+	sandboxes.AssignNetwork(t.Context(), sbx)
+	sandboxes.MarkRunning(t.Context(), sbx)
+
+	s := &Server{
+		sandboxFactory: &sandbox.Factory{Sandboxes: sandboxes},
+		info:           &service.ServiceInfo{},
+	}
+
+	got, err := s.List(t.Context(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Len(t, got.GetSandboxes(), 1)
+
+	return got.GetSandboxes()[0].GetConfig()
+}
+
+// Test_server_List_ReportsCurrentEgress covers EN-717: a network update
+// publishes the new egress to sbx.Config, never to the create-time
+// APIStoredConfig snapshot, so List has to report the live value. Otherwise an
+// API re-sync repopulates its store with the stale one and the next
+// pause/resume rebuilds the sandbox from it.
+func Test_server_List_ReportsCurrentEgress(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports the updated egress without mutating the stored config", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &orchestrator.SandboxConfig{
+			TemplateId: "template-id",
+			Network: &orchestrator.SandboxNetworkConfig{
+				Egress:  &orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"1.0.0.0/8"}},
+				Ingress: &orchestrator.SandboxNetworkIngressConfig{MaskRequestHost: new("example.test")},
+			},
+		}
+
+		sbx := newListSandbox(t, stored)
+		sbx.Config.SetNetworkEgress(&orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"9.9.9.9/32"}})
+
+		got := listOneConfig(t, sbx)
+
+		assert.Equal(t, []string{"9.9.9.9/32"}, got.GetNetwork().GetEgress().GetAllowedCidrs())
+		// Everything else survives the overlay.
+		assert.Equal(t, "template-id", got.GetTemplateId())
+		assert.Equal(t, "example.test", got.GetNetwork().GetIngress().GetMaskRequestHost())
+		// The stored config is shared and handed out by reference elsewhere, so
+		// the overlay must have gone to a copy.
+		assert.Equal(t, []string{"1.0.0.0/8"}, stored.GetNetwork().GetEgress().GetAllowedCidrs())
+	})
+
+	t.Run("reports egress cleared back to nil", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &orchestrator.SandboxConfig{
+			Network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"1.0.0.0/8"}},
+			},
+		}
+
+		sbx := newListSandbox(t, stored)
+		// An all-empty update collapses to nil (see applyNetworkEgress).
+		sbx.Config.SetNetworkEgress(nil)
+
+		got := listOneConfig(t, sbx)
+
+		assert.Nil(t, got.GetNetwork().GetEgress())
+		assert.Equal(t, []string{"1.0.0.0/8"}, stored.GetNetwork().GetEgress().GetAllowedCidrs())
+	})
+
+	t.Run("returns the stored config untouched when nothing changed", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &orchestrator.SandboxConfig{
+			Network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"1.0.0.0/8"}},
+			},
+		}
+
+		got := listOneConfig(t, newListSandbox(t, stored))
+
+		// No divergence, no clone.
+		assert.Same(t, stored, got)
+	})
+
+	t.Run("clears a stale allow_internet_access=false once the deny-all is gone", func(t *testing.T) {
+		t.Parallel()
+
+		// How the API models allow_internet_access=false at create time.
+		stored := &orchestrator.SandboxConfig{
+			AllowInternetAccess: new(false),
+			Network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{
+					DeniedCidrs: []string{sandbox_network.AllInternetTrafficCIDR},
+				},
+			},
+		}
+
+		sbx := newListSandbox(t, stored)
+		sbx.Config.SetNetworkEgress(&orchestrator.SandboxNetworkEgressConfig{AllowedCidrs: []string{"1.2.3.4/32"}})
+
+		got := listOneConfig(t, sbx)
+
+		// Left at false, the API would fold it back into a deny-all on resume.
+		assert.True(t, got.GetAllowInternetAccess())
+		assert.False(t, stored.GetAllowInternetAccess())
+	})
+
+	t.Run("keeps allow_internet_access=false while the deny-all stands", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &orchestrator.SandboxConfig{
+			AllowInternetAccess: new(false),
+			Network: &orchestrator.SandboxNetworkConfig{
+				Egress: &orchestrator.SandboxNetworkEgressConfig{
+					DeniedCidrs: []string{sandbox_network.AllInternetTrafficCIDR},
+				},
+			},
+		}
+
+		sbx := newListSandbox(t, stored)
+		sbx.Config.SetNetworkEgress(&orchestrator.SandboxNetworkEgressConfig{
+			AllowedCidrs: []string{"1.2.3.4/32"},
+			DeniedCidrs:  []string{sandbox_network.AllInternetTrafficCIDR},
+		})
+
+		got := listOneConfig(t, sbx)
+
+		assert.False(t, got.GetAllowInternetAccess())
+	})
+
+	t.Run("leaves an unset allow_internet_access unset", func(t *testing.T) {
+		t.Parallel()
+
+		// Nil means "never explicitly set" to the API; a deny-all reached the
+		// egress some other way (denyOut 0.0.0.0/0) and carries itself.
+		stored := &orchestrator.SandboxConfig{Network: &orchestrator.SandboxNetworkConfig{}}
+
+		sbx := newListSandbox(t, stored)
+		sbx.Config.SetNetworkEgress(&orchestrator.SandboxNetworkEgressConfig{
+			DeniedCidrs: []string{sandbox_network.AllInternetTrafficCIDR},
+		})
+
+		got := listOneConfig(t, sbx)
+
+		//nolint:protogetter // unset must stay distinct from false
+		assert.Nil(t, got.AllowInternetAccess)
+	})
 }
 
 func TestGetSandboxExecutionData(t *testing.T) {


### PR DESCRIPTION
### What was broken

Updating a sandbox's network via the API propagates correctly to the orchestrator, but the change was invisible to the orchestrator's gRPC sandbox list. Two consequences, both in the ticket:

- the sandbox detail API served outdated network information
- the API re-syncs its store from this list on redeploy, so an updated sandbox silently reverted to its create-time egress — and the next pause/resume rebuilt it from that stale config, losing the update for real

### Root cause

`List` returned `sbx.APIStoredConfig` verbatim. That field is a create-time snapshot (its own doc comment marks it deprecated, "used to store the config to allow API restarts"); it is assigned exactly twice — create and resume — and never updated.

The update path writes somewhere else entirely: `Update` → `transitionEgress` → `applyNetworkEgress` → `Config.SetNetworkEgress`, which sets `sandbox.Config.Network.Egress`. The two are provably distinct objects, not aliases: create does `network := proto.CloneOf(req.GetSandbox().GetNetwork())` for `sandbox.Config` while storing `req.GetSandbox()` as `APIStoredConfig`.

### Fix

`List` overlays the live egress onto the stored config. The stored config is shared and handed out by reference, so it is **cloned** before the overlay, and only when the two actually diverge — the unchanged case returns the same pointer as before, no allocation.

Fixed in `List` rather than in `applyNetworkEgress` deliberately: that function only receives `*sandbox.Config`, not the `*Sandbox`, and `Config.mu` does not protect `APIStoredConfig`, so a write-through would add an unsynchronised mutation of a pointer `List` hands out.

`allow_internet_access` is corrected in the same clone, narrowly. The API folds `false` into a `0.0.0.0/0` denied CIDR on create *and on every resume*, so a stale `false` would re-apply the deny-all and undo an update that re-enabled the internet — that is the "settings lost after pause/resume" half of the ticket. Only one case is corrected: stored `false` where the live egress no longer denies everything. The converse needs nothing (the deny-all rides in the denied CIDRs themselves), and `nil` stays `nil` because unset means "never explicitly set" in the public API.

`Checkpoint` was considered and deliberately left alone: it passes `sbx.Config` *and* `APIStoredConfig` to `ResumeSandbox`, which stores the same `*sandbox.Config` pointer on the resumed sandbox, so the live egress is already carried and `List` overlays it there too. Applying the helper there is provably a no-op.

### How verified

New `Test_server_List_ReportsCurrentEgress` in `sandboxes_test.go`, driving state directly through `sbx.Config.SetNetworkEgress` (not through `s.Update()` — `transitionEgress` always rolls back without a real netns). Before the fix, 3 of 6 subtests fail and 3 pass:

```
--- FAIL: .../reports_the_updated_egress_without_mutating_the_stored_config
        expected: []string{"9.9.9.9/32"}   actual: []string{"1.0.0.0/8"}
--- FAIL: .../reports_egress_cleared_back_to_nil
        Expected nil, but got: &SandboxNetworkEgressConfig{AllowedCidrs:["1.0.0.0/8"]}
--- FAIL: .../clears_a_stale_allow_internet_access=false_once_the_deny-all_is_gone
--- PASS: .../returns_the_stored_config_untouched_when_nothing_changed
--- PASS: .../keeps_allow_internet_access=false_while_the_deny-all_stands
--- PASS: .../leaves_an_unset_allow_internet_access_unset
```

The three passing ones guard against over-reach; the pre-existing `Test_server_List` passes throughout. All pass after.

Full `./pkg/server/...` suite green under `-race` — 25 tests, 0 skips. `go build`, `go vet`, `gofmt` clean; `golangci-lint` v2.11.4 (repo-pinned, installed in-container) reports 0 issues.

Not verified: run on linux/**arm64** rather than amd64 (local Docker constraint); no arch-specific code is involved. The end-to-end `Update → List` path is not exercised by a unit test for the rollback reason above — the link between them is `sbx.Config`, whose write side `sandboxes_update_test.go` already covers. The API-side consequence is reasoned from `create_instance.go` / `update_network.go`, not covered by a `packages/api` test.

Linear: https://linear.app/e2b/issue/EN-717/fix-sandbox-list-in-orch-grpc-to-return-current-network-setup
