### PR TITLE
chore: teach the AI reviewers repo-specific review rules

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -47,3 +47,5 @@ Don't output final summaries, or final lists of action items.
   maintainer deliberately removed.
 - Terraform modules consumed via release-please tag refs are pinned by design; never flag tag
   pins as mutable-ref issues.
+- No speculative nil-guard or defensive-boilerplate suggestions without a concrete, reachable
+  failure path. State the commit SHA the review ran against.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -21,3 +21,29 @@ Be constructive and helpful in your feedback and be **very conscise**.
 Skip general recommendations, skip summarizing the changes, and don't make any recommendations on code style.
 Also skip any summarization about why the PR was done well, focus only on the code changes and the potential issues.
 Don't output final summaries, or final lists of action items.
+
+## Repo-specific review rules
+
+<!-- Generated from the E2B architecture record, 2026-08-03. Regenerated periodically. -->
+
+- Contract surfaces (`spec/openapi.yml`, any `.proto`, `packages/**/migrations/**`, and the
+  semantics of values persisted and consumed elsewhere — network/transform rules, routing
+  keys, token claims): ask where consumer-side behavior was confirmed. SDKs consume the spec
+  via a pinned copy, dashboard/console carry synced mirrors, and closed-source runtime
+  components consume orchestrator-side contracts — "no active consumer in this repo" is not
+  verification, because the consumer that matters may not live in this repository.
+- Accepting a broader input shape (wildcards, prefixes, normalization) for a value another
+  component looks up by exact match turns a loud create-time error into a silent runtime
+  no-op. Flag the mismatch and ask for the consumer's matching semantics.
+- A new migration must be versioned above main's newest; a `NOT NULL` column added to a table
+  other systems copy is consumer-breaking until shown otherwise.
+- Changes near envd versioning or its wire surface must address already-running sandboxes
+  with older envd.
+- Nomad `type = "system"` jobs have no `update` stanza, so `progress_deadline` reasoning does
+  not apply to them; do not flag `kill_timeout` against it.
+- Do not post claims about the outside world (a release exists, an upstream tool rejects a
+  config) without stating how they were verified.
+- Before requesting tests, check the file's recent PR history — do not re-request tests a
+  maintainer deliberately removed.
+- Terraform modules consumed via release-please tag refs are pinned by design; never flag tag
+  pins as mutable-ref issues.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@ Output style rules (strict, override any defaults):
 - Do not post claims about the outside world (a release exists, an upstream tool rejects a config) without stating how they were verified.
 - Before requesting tests, check the file's recent PR history — do not re-request tests a maintainer deliberately removed.
 - Terraform modules consumed via release-please tag refs are pinned by design; never flag tag pins as mutable-ref issues.
+- No speculative nil-guard or defensive-boilerplate suggestions without a concrete, reachable failure path. State the commit SHA the review ran against.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,16 @@ Output style rules (strict, override any defaults):
 - Skip style/nit comments — `golangci-lint` covers those.
 - Skip test-coverage comments — Codecov covers those.
 - Focus on: race conditions, nil-deref, error handling, auth/authz, request routing, resource leaks, SQL/migration correctness, and gRPC/proto compatibility.
+
+## Repo-specific review checks
+
+<!-- Generated from the E2B architecture record, 2026-08-03. Regenerated periodically. -->
+
+- Contract surfaces (`spec/openapi.yml`, any `.proto`, `packages/**/migrations/**`, and the semantics of values persisted and consumed elsewhere — network/transform rules, routing keys, token claims): ask where consumer-side behavior was confirmed. SDKs consume the spec via a pinned copy, dashboard/console carry synced mirrors, and closed-source runtime components consume orchestrator-side contracts. "No active consumer in this repo" is not verification — the consumer that matters may not live in this repository.
+- Accepting a broader input shape (wildcards, prefixes, normalization) for a value another component looks up by exact match turns a loud create-time error into a silent runtime no-op. Ask for the consumer's matching semantics.
+- A new migration must be versioned above main's newest; a `NOT NULL` column added to a table other systems copy is consumer-breaking until shown otherwise.
+- Changes near envd versioning or its wire surface must address already-running sandboxes with older envd.
+- Nomad `type = "system"` jobs have no `update` stanza — `progress_deadline` reasoning does not apply to them.
+- Do not post claims about the outside world (a release exists, an upstream tool rejects a config) without stating how they were verified.
+- Before requesting tests, check the file's recent PR history — do not re-request tests a maintainer deliberately removed.
+- Terraform modules consumed via release-please tag refs are pinned by design; never flag tag pins as mutable-ref issues.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -51,8 +51,11 @@
   demanding tests.
 - Pre-existing issues on lines the diff didn't modify (mention only if the diff makes them
   worse).
+- Speculative nil-guards or defensive boilerplate with no concrete failure path — if there is
+  no reachable trigger, there is no finding.
 
 ## Style
 
 Terse, concrete, no summaries of the diff, no closing action-item lists, no emojis.
-One thread per distinct issue.
+One thread per distinct issue; one substantive finding is worth more than five nits.
+State the commit SHA the review ran against.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,58 @@
+# REVIEW.md — e2b-dev/infra
+<!-- Generated from the E2B architecture record, 2026-08-03. Regenerated periodically —
+     propose rule changes upstream rather than hand-editing here. -->
+
+## Severity
+
+- **Important** is reserved for: correctness bugs, contract/wire/schema compatibility,
+  migrations, security, and regressions for existing callers. Everything else is a nit.
+- At most **5 nits** per review; mention the rest as a count.
+- After the first review of a PR, post **Important findings only** on re-reviews.
+
+## Verification bar
+
+- Any behavior claim needs a `file:line` citation from this repository.
+- Any claim about the outside world (a release exists, an upstream API behaves a certain way,
+  a tool rejects a config) must state how it was verified. If it cannot be verified from this
+  repository, phrase it as a question, not a finding.
+
+## Always check
+
+1. **Contract surfaces** — `spec/openapi.yml`, any `*.proto`, `packages/**/migrations/**`,
+   and the semantics of values that are persisted and consumed elsewhere (network/transform
+   rules, routing keys, token claims). For any such change: name the downstream consumers
+   (SDKs consume the spec via a pinned copy; dashboard and console carry synced spec mirrors;
+   closed-source runtime components consume orchestrator-side contracts) and require the PR to
+   state where consumer-side behavior was confirmed. Treat "this field has no active consumer
+   in this repo" as **unverified until the PR names where consumers were checked** — the
+   consumer that matters may not live in this repository.
+2. **Matching-semantics changes** — accepting a broader input shape (wildcards, prefixes,
+   normalization) for a value that another component looks up by exact match turns a loud
+   create-time error into a silent runtime no-op. Flag the mismatch class explicitly and ask
+   for the consumer's matching semantics.
+3. **Migrations** — new migration versioned above main's newest; a `NOT NULL` column added to
+   a table that other systems copy or mirror is a consumer-breaking change until shown
+   otherwise.
+4. **envd compatibility** — changes near envd versioning or its wire surface must address
+   already-running sandboxes with older envd.
+5. **Nomad jobs** — `type = "system"` jobs have no `update` stanza: `progress_deadline`
+   reasoning does not apply to them; do not flag `kill_timeout` against it.
+
+## Do not flag
+
+- Anything the linters/typecheckers/CI already catch (golangci-lint, terraform validate,
+  generated-code checks); code style and formatting.
+- Generated files (`*.gen.go`, generated clients) and lockfiles.
+- Terraform modules consumed by release-please **tag refs** — tag pins are by design, never a
+  mutable-ref finding.
+- Release-please PRs whose changes are only CHANGELOG/manifest.
+- Test-coverage demands for behavior covered by the integration suites, and re-requests for
+  tests that a recent PR deliberately removed — check the file's recent PR history before
+  demanding tests.
+- Pre-existing issues on lines the diff didn't modify (mention only if the diff makes them
+  worse).
+
+## Style
+
+Terse, concrete, no summaries of the diff, no closing action-item lists, no emojis.
+One thread per distinct issue.


### PR DESCRIPTION
Adds REVIEW.md (Claude Code Review configuration) and extends .cursor/BUGBOT.md and AGENTS.md with repo-specific review rules distilled from our architecture record: naming downstream consumers on contract-surface changes, exact-match vs wildcard semantics, migration and envd compatibility, an external-world verification bar, and known-false-positive suppressions (system-job progress_deadline, tag-pinned modules, re-requesting deliberately removed tests). Existing output-style rules are unchanged; the generated sections will be regenerated as the record evolves.