### PR TITLE
fix(api): add structured logs for sandbox delete 500/404 paths

### DIFF
--- a/packages/api/internal/handlers/sandbox_kill.go
+++ b/packages/api/internal/handlers/sandbox_kill.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"go.uber.org/zap"
 
 	"github.com/e2b-dev/infra/packages/api/internal/db"
 	"github.com/e2b-dev/infra/packages/api/internal/orchestrator"
@@ -69,12 +70,26 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	case err == nil:
 		killedOrRemoved = true
 	case errors.Is(err, orchestrator.ErrSandboxNotFound):
-		logger.L().Debug(ctx, "Running sandbox not found", logger.WithSandboxID(sandboxID))
+		logger.L().Info(ctx, "Running sandbox not found, checking for snapshot",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTeamID(teamID.String()),
+		)
 	case errors.Is(err, orchestrator.ErrSandboxOperationFailed):
+		logger.L().Error(ctx, "Failed to kill sandbox on orchestrator node",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTeamID(teamID.String()),
+			zap.Error(err),
+		)
+		telemetry.ReportError(ctx, "error killing sandbox on node", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error killing sandbox: %s", err))
 
 		return
 	default:
+		logger.L().Error(ctx, "Unexpected error removing sandbox",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTeamID(teamID.String()),
+			zap.Error(err),
+		)
 		telemetry.ReportError(ctx, "error killing sandbox", err)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error killing sandbox: %s", err))
 
@@ -87,7 +102,12 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	case errors.Is(deleteSnapshotErr, db.ErrSnapshotNotFound):
 		// no snapshot found, nothing to do
 	case deleteSnapshotErr != nil:
-		telemetry.ReportError(ctx, "error deleting sandbox", deleteSnapshotErr)
+		logger.L().Error(ctx, "Failed to delete sandbox snapshot from DB",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTeamID(teamID.String()),
+			zap.Error(deleteSnapshotErr),
+		)
+		telemetry.ReportError(ctx, "error deleting sandbox snapshot", deleteSnapshotErr)
 		a.sendAPIStoreError(c, http.StatusInternalServerError, fmt.Sprintf("Error deleting sandbox: %s", deleteSnapshotErr))
 
 		return
@@ -98,7 +118,10 @@ func (a *APIStore) DeleteSandboxesSandboxID(
 	if killedOrRemoved {
 		c.Status(http.StatusNoContent)
 	} else {
-		logger.L().Debug(ctx, "Sandbox not found for deletion", logger.WithSandboxID(sandboxID))
+		logger.L().Info(ctx, "Sandbox not found: not running and no snapshot",
+			logger.WithSandboxID(sandboxID),
+			logger.WithTeamID(teamID.String()),
+		)
 		a.sendAPIStoreError(c, http.StatusNotFound, utils.SandboxNotFoundMsg(sandboxID))
 	}
 }


### PR DESCRIPTION
Fixes #3529

## Problem

`DeleteSandboxesSandboxID` has three logging gaps:

1. **`ErrSandboxOperationFailed` → 500 with no log or telemetry** — the most common 500 cause (node unreachable, gRPC error) emits nothing to Loki and records no span error.
2. **`deleteSnapshot` failure message is ambiguous** — `"error deleting sandbox"` does not distinguish kill failure from DB failure.
3. **404 logged at `Debug` level, no `teamID`** — suppressed in production; 404 frequency per team is invisible.

## Changes

`packages/api/internal/handlers/sandbox_kill.go`:

| Branch | Before | After |
|---|---|---|
| `ErrSandboxOperationFailed` | no log | `Error` + `sandbox_id` + `team_id` + `zap.Error` + `telemetry.ReportError` |
| `deleteSnapshot != nil` | `telemetry.ReportError` only | `Error` log with distinct message "Failed to delete sandbox snapshot from DB" |
| `default` unexpected error | `telemetry.ReportError` only | `Error` log added |
| `ErrSandboxNotFound` | `Debug` | `Info` + `team_id` |
| final 404 | `Debug`, no `team_id` | `Info` + `team_id`, message "not running and no snapshot" |

## Why this is not a duplicate

Searched open PRs for `sandbox delete log`, `sandbox kill log`, `sandbox 500 log` — no existing PR covers this.

## Test plan

- [ ] `go build ./packages/api/internal/handlers/` passes
- [ ] `go vet ./packages/api/...` passes
- [ ] Manually trigger a 500 (sandbox on unreachable node) → confirm `"Failed to kill sandbox on orchestrator node"` in Loki with `sandbox_id` and `team_id`
- [ ] Manually trigger a 404 (non-existent sandbox) → confirm `"Sandbox not found: not running and no snapshot"` at `Info` level

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.