### PR TITLE
fix(ci): harden composite action inputs in run scripts

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -87,7 +87,9 @@ runs:
     - name: Build alternate orchestrator
       if: inputs.orchestrator-make-path != 'packages/orchestrator'
       shell: bash
-      run: make -C "${{ inputs.orchestrator-make-path }}" build-debug
+      env:
+        ORCHESTRATOR_MAKE_PATH: ${{ inputs.orchestrator-make-path }}
+      run: make -C "$ORCHESTRATOR_MAKE_PATH" build-debug
 
     - name: Initialize Host
       uses: ./.github/actions/host-init
@@ -121,9 +123,11 @@ runs:
     - name: Verify the alternate orchestrator is running
       if: inputs.orchestrator-make-path != 'packages/orchestrator'
       shell: bash
+      env:
+        ORCHESTRATOR_MAKE_PATH: ${{ inputs.orchestrator-make-path }}
       run: |
-        if ! sudo pgrep -af "${{ inputs.orchestrator-make-path }}/bin/"; then
-          echo "::error::No orchestrator process from ${{ inputs.orchestrator-make-path }} is running."
+        if ! sudo pgrep -af "$ORCHESTRATOR_MAKE_PATH/bin/"; then
+          echo "::error::No orchestrator process from $ORCHESTRATOR_MAKE_PATH is running."
           echo "::error::The start-services action probably ignored orchestrator-make-path (version without this input)."
           exit 1
         fi

--- a/.github/actions/unit-tests/action.yml
+++ b/.github/actions/unit-tests/action.yml
@@ -94,15 +94,19 @@ runs:
       if: inputs.sudo == 'true'
       shell: bash
       working-directory: ${{ inputs.package }}
+      env:
+        TEST_PATH: ${{ inputs.test-path }}
       run: |
         trap 'sudo chown "$(id -u):$(id -g)" coverage.txt junit.xml 2>/dev/null || true' EXIT
         sudo -E env "PATH=$PATH" gotestsum --junitfile=junit.xml --format=standard-verbose \
-          -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ inputs.test-path }}
+          -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic $TEST_PATH
 
     - name: Run tests
       if: inputs.sudo != 'true'
       shell: bash
       working-directory: ${{ inputs.package }}
+      env:
+        TEST_PATH: ${{ inputs.test-path }}
       run: |
         gotestsum --junitfile=junit.xml --format=standard-verbose \
-          -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic ${{ inputs.test-path }}
+          -- -timeout 20m -coverprofile=coverage.txt -covermode=atomic $TEST_PATH


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/actions/integration-tests` and `unit-tests` composites.
- Bind free-string inputs (`orchestrator-make-path`, `test-path`) under `env:` before `run:` script use.
- `working-directory:` / `with:` / `if:` expressions left as-is (not shell script text).
- Defense-in-depth for Actions composites — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing integration/unit workflows still invoke the composites


Made with [Cursor](https://cursor.com)