### PR TITLE
fix(envd): fail closed privileged routes when access token unset

### DIFF
--- a/packages/envd/internal/api/auth.go
+++ b/packages/envd/internal/api/auth.go
@@ -79,6 +79,18 @@ func (a *API) WithAuthorization(handler http.Handler) http.Handler {
 			jsonError(w, http.StatusUnauthorized, errors.New("envd not initialized"))
 
 			return
+
+		case a.initialized.Load() && !allowedPath:
+			// After /init, if no access token is configured, fail CLOSED for
+			// privileged routes (including POST /upgrade) instead of allowing
+			// unauthenticated access. Allowlisted paths in authExcludedPaths
+			// (health, files, init) still proceed.
+			a.logger.Error().Msg("Trying to access secured envd without access token configured")
+
+			err := errors.New("unauthorized access, please provide a valid access token or method signing if supported")
+			jsonError(w, http.StatusUnauthorized, err)
+
+			return
 		}
 
 		handler.ServeHTTP(w, req)

--- a/packages/envd/internal/api/auth_test.go
+++ b/packages/envd/internal/api/auth_test.go
@@ -146,3 +146,58 @@ func TestValidateSigningRejectsInvalidAccessTokenHeader(t *testing.T) {
 	err := api.validateSigning(r, nil, nil, nil, "/files", SigningReadOperation)
 	assert.EqualError(t, err, "access token present in header but does not match")
 }
+
+func TestWithAuthorizationFailClosedWhenTokenUnsetAfterInit(t *testing.T) {
+	t.Parallel()
+	logger := zerolog.Nop()
+	api := &API{accessToken: &SecureToken{}, logger: &logger}
+	api.initialized.Store(true)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := api.WithAuthorization(next)
+
+	// Privileged route must be rejected when token unset post-init.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/upgrade", nil)
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	// Allowlisted paths still pass.
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/health"},
+		{http.MethodGet, "/files"},
+		{http.MethodPost, "/files"},
+		{http.MethodPost, "/init"},
+	} {
+		rr = httptest.NewRecorder()
+		req = httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+		h.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code, "%s %s", tc.method, tc.path)
+	}
+}
+
+func TestWithAuthorizationRequiresTokenWhenSet(t *testing.T) {
+	t.Parallel()
+	api := newAuthTestAPI(t, "secret")
+	api.initialized.Store(true)
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h := api.WithAuthorization(next)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/upgrade", nil)
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/upgrade", nil)
+	req.Header.Set(accessTokenHeader, "secret")
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}


### PR DESCRIPTION
## Summary
- Secure-by-default hardening for `envd` auth after `/init`.
- When no access token is configured, reject non-allowlisted privileged routes (including `POST /upgrade`) instead of falling open.
- Keeps existing behavior when a token *is* set, and keeps handover pre-init fail-closed for non-init/health paths.
- Defense-in-depth / secure defaults — not framed as a vulnerability ticket.

## Test plan
- [ ] Code review of `WithAuthorization` branches
- [ ] Existing envd auth tests (if any) still pass
- [ ] Confirm `/upgrade` returns 401 when token unset post-init


Made with [Cursor](https://cursor.com)