### PR TITLE
fix(envd): guard nil tty in Wait() for non-PTY processes

### DIFF
--- a/packages/envd/internal/services/process/handler/handler.go
+++ b/packages/envd/internal/services/process/handler/handler.go
@@ -572,7 +572,9 @@ func (p *Handler) Wait() {
 
 	err := p.cmd.Wait()
 
-	p.tty.Close()
+	if p.tty != nil {
+		p.tty.Close()
+	}
 
 	var errMsg *string
 


### PR DESCRIPTION
Fixes #3538

## Problem

`handler.Wait()` called `p.tty.Close()` unconditionally. For non-PTY processes, `p.tty` is never assigned in `handler.New()` and remains `nil`, causing a nil pointer dereference panic when the process exits.

The panic kills the entire `envd` daemon, taking down all sessions in the microVM. Non-PTY launches are the common case.

## Fix

Add the same `if p.tty != nil` guard that every other `p.tty` access in the file already uses.

```diff
- p.tty.Close()
+ if p.tty != nil {
+     p.tty.Close()
+ }
```

## Testing

- `go build ./packages/envd/...` passes
- Manually verified: `handler.New()` only assigns `h.tty` at line 339 (PTY branch); the `else` branch at line 340 leaves `h.tty == nil`
- All other `p.tty` calls in the file (`ResizeTty`, `WriteStdin`, `CloseStdin`, `WriteTty`) already guard with `if p.tty == nil`

/cc @jakubno @dobrac @ValentaTomas @arkamar @tvi @tomassrnka Looking forward to your code review.