### PR TITLE
fix(docker-reverse-proxy): restore resp.Body after io.ReadAll in ModifyResponse

### DIFF
--- a/packages/docker-reverse-proxy/internal/handlers/store.go
+++ b/packages/docker-reverse-proxy/internal/handlers/store.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -56,10 +57,10 @@ func NewStore(ctx context.Context) *APIStore {
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		if resp.StatusCode == http.StatusUnauthorized {
 			respBody, _ := io.ReadAll(resp.Body)
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			log.Printf("Unauthorized request:[%s] %s\n", resp.Request.Method, respBody)
 		}
 
-		// You can also modify the response here if needed
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #3540

## Problem

The `ModifyResponse` hook in `store.go` calls `io.ReadAll(resp.Body)` to log 401 error bodies, but never restores `resp.Body`. After the read, the body is at EOF. When `httputil.ReverseProxy` subsequently tries to copy the body to the downstream client, it reads zero bytes — but the transport's keep-alive reuse logic requires the body to be drained through the proxy's own copy path. Because it wasn't, the upstream TCP connection is marked non-reusable and abandoned.

One TCP connection leaks per 401 response from GCP Artifact Registry.

## Fix

Restore `resp.Body` with `io.NopCloser(bytes.NewReader(respBody))` immediately after `io.ReadAll`, so `ReverseProxy` can stream the body normally and return the connection to the pool.

```diff
 respBody, _ := io.ReadAll(resp.Body)
+resp.Body = io.NopCloser(bytes.NewReader(respBody))
 log.Printf("Unauthorized request:[%s] %s\n", resp.Request.Method, respBody)
```

This is the standard pattern for `ModifyResponse` hooks that need to inspect the response body (documented in the `httputil.ReverseProxy` source).

## Testing

- `go build ./packages/docker-reverse-proxy/...` passes
- `go vet ./packages/docker-reverse-proxy/...` passes