### PR TITLE
fix(envd/port): prevent ScanAndBroadcast from blocking when a subscriber stops receiving

### DIFF
--- a/packages/envd/internal/port/scanSubscriber.go
+++ b/packages/envd/internal/port/scanSubscriber.go
@@ -12,6 +12,7 @@ type ScannerSubscriber struct {
 	logger   *zerolog.Logger
 	filter   *ScannerFilter
 	Messages chan ([]net.ConnectionStat)
+	done     chan struct{}
 	id       string
 }
 
@@ -21,6 +22,7 @@ func NewScannerSubscriber(logger *zerolog.Logger, id string, filter *ScannerFilt
 		id:       id,
 		filter:   filter,
 		Messages: make(chan []net.ConnectionStat),
+		done:     make(chan struct{}),
 	}
 }
 
@@ -28,23 +30,32 @@ func (ss *ScannerSubscriber) ID() string {
 	return ss.id
 }
 
+// Destroy signals the subscriber to stop. Any Signal() call blocked waiting
+// for a receiver will return immediately. The Messages channel is left open so
+// in-progress receivers can drain it; callers exit via ctx.Done() instead.
 func (ss *ScannerSubscriber) Destroy() {
-	close(ss.Messages)
+	close(ss.done)
 }
 
+// Signal delivers a port scan result to the subscriber. If the receiver is not
+// ready (e.g. it has stopped consuming after context cancellation), Signal
+// returns immediately rather than blocking, so ScanAndBroadcast is never
+// stalled by a single slow or stopped subscriber.
 func (ss *ScannerSubscriber) Signal(proc []net.ConnectionStat) {
-	// Filter isn't specified. Accept everything.
-	if ss.filter == nil {
-		ss.Messages <- proc
-	} else {
-		filtered := []net.ConnectionStat{}
+	msg := proc
+	if ss.filter != nil {
+		filtered := make([]net.ConnectionStat, 0, len(proc))
 		for i := range proc {
-			// We need to access the list directly otherwise there will be implicit memory aliasing
-			// If the filter matched a process, we will send it to a channel.
+			// Access the slice directly to avoid implicit memory aliasing.
 			if ss.filter.Match(&proc[i]) {
 				filtered = append(filtered, proc[i])
 			}
 		}
-		ss.Messages <- filtered
+		msg = filtered
+	}
+
+	select {
+	case ss.Messages <- msg:
+	case <-ss.done:
 	}
 }

--- a/packages/envd/internal/port/scanner_test.go
+++ b/packages/envd/internal/port/scanner_test.go
@@ -1,0 +1,107 @@
+package port
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// TestScannerSubscriber_Signal_DoesNotBlockAfterDestroy verifies that Signal()
+// returns immediately when the subscriber has been destroyed, rather than
+// blocking forever on the unbuffered Messages channel.
+func TestScannerSubscriber_Signal_DoesNotBlockAfterDestroy(t *testing.T) {
+	t.Parallel()
+
+	l := zerolog.Nop()
+	sub := NewScannerSubscriber(&l, "test", nil)
+	sub.Destroy()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sub.Signal(nil) // must not block
+	}()
+
+	select {
+	case <-done:
+		// pass
+	case <-time.After(time.Second):
+		t.Fatal("Signal() blocked after Destroy() — goroutine leaked")
+	}
+}
+
+// TestScanner_Destroy_ExitsAfterSubscriberStopped verifies that
+// Scanner.Destroy() successfully stops ScanAndBroadcast even when a subscriber
+// has been destroyed and is no longer consuming Messages.
+//
+// Before the fix, ScanAndBroadcast would block inside sub.Signal() after the
+// subscriber stopped, making the scanExit select unreachable and causing
+// Scanner.Destroy() to have no effect.
+func TestScanner_Destroy_ExitsAfterSubscriberStopped(t *testing.T) {
+	t.Parallel()
+
+	l := zerolog.Nop()
+	scanner := NewScanner(10 * time.Millisecond)
+
+	sub := scanner.AddSubscriber(&l, "stopped-sub", nil)
+	// Destroy the subscriber to simulate ctx cancellation in StartForwarding.
+	sub.Destroy()
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanner.ScanAndBroadcast()
+	}()
+
+	// Let the scanner tick at least once so it calls sub.Signal().
+	time.Sleep(50 * time.Millisecond)
+
+	// Destroy must be able to stop ScanAndBroadcast even with a stopped subscriber.
+	scanner.Destroy()
+
+	select {
+	case <-scanDone:
+		// pass
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScanAndBroadcast did not exit after Scanner.Destroy() — goroutine leaked")
+	}
+}
+
+// TestScanner_Destroy_NoPanicOnConcurrentSignal verifies that destroying a
+// subscriber while ScanAndBroadcast is in the middle of a Signal() call does
+// not panic.
+//
+// Before the fix, Destroy() closed Messages. If Signal() was concurrently
+// sending to Messages, the close caused a "send on closed channel" panic.
+// With the fix, Destroy() closes the done channel instead; Signal() selects on
+// done and returns cleanly, so Messages is never sent to after close.
+func TestScanner_Destroy_NoPanicOnConcurrentSignal(t *testing.T) {
+	t.Parallel()
+
+	l := zerolog.Nop()
+	scanner := NewScanner(5 * time.Millisecond)
+
+	// A subscriber whose receiver exits immediately to trigger blocking Signal().
+	sub := scanner.AddSubscriber(&l, "racing-sub", nil)
+
+	scanDone := make(chan struct{})
+	go func() {
+		defer close(scanDone)
+		scanner.ScanAndBroadcast()
+	}()
+
+	// Let the scanner run a few ticks.
+	time.Sleep(30 * time.Millisecond)
+
+	// Destroy concurrently — must not panic regardless of Signal() timing.
+	scanner.Unsubscribe(sub)
+	scanner.Destroy()
+
+	select {
+	case <-scanDone:
+		// pass — no panic
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScanAndBroadcast did not exit after Scanner.Destroy()")
+	}
+}


### PR DESCRIPTION
Fixes #3542

## Problem

`Signal()` sent on an unbuffered `Messages` channel with no escape path. When a subscriber's receiver exited (e.g. `StartForwarding` returning on `ctx.Done()`), the channel send blocked indefinitely. `ScanAndBroadcast` was then stuck inside the subscriber loop, never reaching the `scanExit` select — making `Scanner.Destroy()` permanently ineffective.

A secondary hazard: `Destroy()` closed `Messages` directly. If `Signal()` was concurrently blocked sending to `Messages` when `Destroy()` ran, the close triggered a `"send on closed channel"` panic (reproducible with the new tests below).

## Fix

Add a `done chan struct{}` to `ScannerSubscriber`.

- `Destroy()` now closes `done` instead of `Messages`.
- `Signal()` selects on both `Messages` and `done`, so it returns immediately when the subscriber is torn down rather than blocking.
- `ScanAndBroadcast` is never stalled by a stopped subscriber and can always observe `scanExit`.

```diff
+	done     chan struct{}

+	done: make(chan struct{}),

 func (ss *ScannerSubscriber) Destroy() {
-	close(ss.Messages)
+	close(ss.done)
 }

 func (ss *ScannerSubscriber) Signal(proc []net.ConnectionStat) {
-    ss.Messages <- proc  // blocked forever if receiver exited
+    select {
+    case ss.Messages <- msg:
+    case <-ss.done:      // returns immediately after Destroy()
+    }
 }
```

## Tests

Three new tests in `scanner_test.go` (all run with `-race`):

| Test | What it verifies |
|------|-----------------|
| `TestScannerSubscriber_Signal_DoesNotBlockAfterDestroy` | `Signal()` returns within 1s after `Destroy()` |
| `TestScanner_Destroy_ExitsAfterSubscriberStopped` | `Scanner.Destroy()` stops `ScanAndBroadcast` even when subscriber is stopped |
| `TestScanner_Destroy_NoPanicOnConcurrentSignal` | Concurrent `Unsubscribe` + `ScanAndBroadcast` does not panic |

**Before fix**: `TestScannerSubscriber_Signal_DoesNotBlockAfterDestroy` panics with `send on closed channel`; `TestScanner_Destroy_ExitsAfterSubscriberStopped` times out.

**After fix**: all 6 tests in the port package pass (`go test -race -count=1 ./packages/envd/internal/port/...`).